### PR TITLE
Initial Conformance Tests for Gateway API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,12 @@ vet:
 
 # Run go test against code
 test:
-	go test ./...
+	go test -v ./apis/...
+
+# Run conformance tests against controller implementation
+.PHONY: conformance
+conformance:
+	go test -v ./conformance/...
 
 # Install CRD's and example resources to a pre-existing cluster.
 .PHONY: install

--- a/conformance/gatewayclass.yaml
+++ b/conformance/gatewayclass.yaml
@@ -1,0 +1,7 @@
+kind: GatewayClass
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: gateway-conformance
+spec:
+  controller: istio.io/gateway-controller
+

--- a/conformance/scenarios/httpgateway/httpgateway.feature
+++ b/conformance/scenarios/httpgateway/httpgateway.feature
@@ -1,0 +1,22 @@
+@sig-network @conformance @v1alpha1
+Feature: HTTP Gateway
+  A Gateway may define routing rules based on the request host.
+  
+  If the HTTP request host matches one of the hosts in the Gateway objects, the
+  traffic is routed through a selected HTTPRoute to a backend service.
+
+  Background:
+    Given a new random namespace
+    Given a self-signed TLS secret named "conformance-tls" for the "foo.bar.com" hostname
+    Given the "httpgateway" YAML scenario
+    Then The Gateway status should include Scheduled and Ready conditions set to "True"
+    Then The Gateway status should include 1 Listener with a Ready condition set to "True"
+
+  Scenario: A request to the specified host should be routed to the designated Service
+    (host foo.bar.com matches request foo.bar.com)
+
+    When I send a "GET" request to "https://foo.bar.com"
+    Then the secure connection must verify the "foo.bar.com" hostname
+    And the response status-code must be 200
+    And the response must be served by the "foo-bar-com" service
+    And the request host must be "foo.bar.com"

--- a/conformance/scenarios/httpgateway/httpgateway.yaml
+++ b/conformance/scenarios/httpgateway/httpgateway.yaml
@@ -1,0 +1,45 @@
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: my-gateway
+spec:
+  gatewayClassName: gateway-conformance
+  listeners:
+  - protocol: HTTP
+    port: 8080
+    routes:
+      kind: HTTPRoute
+      selector:
+        matchLabels:
+          app: foo
+      namespaces:
+        from: "Same"
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-1
+  labels:
+    app: foo
+spec:
+  hostnames:
+  - "foo.com"
+  rules:
+  - matches:
+    - path:
+        type: Prefix
+        value: /bar
+    forwardTo:
+    - serviceName: my-service1
+      port: 8080
+  - matches:
+    - headers:
+        type: Exact
+        values:
+          magic: foo
+      path:
+        type: Prefix
+        value: /some/thing
+    forwardTo:
+    - serviceName: my-service2
+      port: 8080

--- a/conformance/scenarios/httpgateway/httpgateway_test.go
+++ b/conformance/scenarios/httpgateway/httpgateway_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpgateway
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/gateway-api/apis/v1alpha1"
+	"sigs.k8s.io/gateway-api/conformance/utils"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func TestHttpGateway(t *testing.T) {
+	// Test Setup
+	c, sc, err := utils.LoadClientset()
+	if err != nil {
+		t.Fatalf("error loading clientset: %v", err)
+	}
+	err = utils.DynamicApply(utils.DynamicParams{Path: "../../../config/crd/bases"})
+	if err != nil {
+		t.Fatalf("error installing gateway-api CRDs: %v", err)
+	}
+	ns, err := utils.NewNamespace(c)
+	if err != nil {
+		t.Fatalf("error creating namespace: %v", err)
+	}
+
+	dp := utils.DynamicParams{
+		Path:      "httpgateway.yaml",
+		Namespace: ns,
+	}
+	err = utils.DynamicApply(dp)
+	if err != nil {
+		t.Fatalf("error installing gateway-api examples: %v", err)
+	}
+
+	t.Run("Gateway.Status.Conditions Scheduled condition should be set to true within 3 minutes", func(t *testing.T) {
+		t.Parallel()
+		waitErr := wait.PollImmediate(5*time.Second, 3*time.Minute, func() (bool, error) {
+			gwc, getErr := sc.NetworkingV1alpha1().Gateways(ns).Get(context.TODO(), "my-gateway", metav1.GetOptions{})
+			if err != nil {
+				return false, fmt.Errorf("error fetching Gateway: %w", getErr)
+			}
+
+			for _, cond := range gwc.Status.Conditions {
+				if cond.Type == string(v1alpha1.GatewayConditionScheduled) && cond.Status == "True" {
+					return true, nil
+				}
+			}
+
+			return false, nil
+		})
+		if err != nil {
+			t.Errorf("Gateway.Status.Conditions Scheduled condition was not set to true: %v", waitErr)
+		}
+	})
+
+	t.Run("Gateway.Status.Conditions Ready condition should be set to true within 3 minutes", func(t *testing.T) {
+		t.Parallel()
+		waitErr := wait.PollImmediate(5*time.Second, 3*time.Minute, func() (bool, error) {
+			gwc, getErr := sc.NetworkingV1alpha1().Gateways(ns).Get(context.TODO(), "my-gateway", metav1.GetOptions{})
+			if err != nil {
+				return false, fmt.Errorf("error fetching Gateway: %w", getErr)
+			}
+
+			for _, cond := range gwc.Status.Conditions {
+				if cond.Type == string(v1alpha1.GatewayConditionReady) && cond.Status == "True" {
+					return true, nil
+				}
+			}
+
+			return false, nil
+		})
+		if err != nil {
+			t.Errorf("Gateway.Status.Conditions Ready condition was not set to true: %v", waitErr)
+		}
+	})
+
+	t.Run("Gateway.Status.Listeners[0].Conditions Ready condition should be set to true within 3 minutes", func(t *testing.T) {
+		t.Parallel()
+		waitErr := wait.PollImmediate(5*time.Second, 3*time.Minute, func() (bool, error) {
+			gwc, getErr := sc.NetworkingV1alpha1().Gateways(ns).Get(context.TODO(), "my-gateway", metav1.GetOptions{})
+			if err != nil {
+				return false, fmt.Errorf("error fetching Gateway: %w", getErr)
+			}
+
+			if len(gwc.Status.Listeners) == 0 {
+				return false, nil
+			}
+
+			if len(gwc.Status.Listeners) > 1 {
+				return false, fmt.Errorf("Expected 1 listener entry in status, got %d", len(gwc.Status.Listeners))
+			}
+
+			for _, cond := range gwc.Status.Listeners[0].Conditions {
+				if cond.Type == string(v1alpha1.ListenerConditionReady) && cond.Status == "True" {
+					return true, nil
+				}
+			}
+
+			return false, nil
+		})
+		if waitErr != nil {
+			t.Errorf("Gateway.Status.Listeners[0].Conditions Ready was not set to true: %v", waitErr)
+		}
+	})
+
+	// Cleanup
+	t.Cleanup(func() {
+		dp.Delete = true
+		err = utils.DynamicApply(dp)
+		if err != nil {
+			t.Fatalf("error deleting gateway-api examples: %v", err)
+		}
+		err = utils.CleanupNamespaces(c)
+		if err != nil {
+			t.Fatalf("error cleaning up namespaces: %v", err)
+		}
+	})
+}

--- a/conformance/utils/kubernetes.go
+++ b/conformance/utils/kubernetes.go
@@ -1,0 +1,390 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"text/template"
+	"time"
+
+	saclientset "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+
+	// ensure auth plugins are loaded
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)
+
+// LoadClientset returns clientsets for connecting to kubernetes clusters.
+func LoadClientset() (*clientset.Clientset, *saclientset.Clientset, error) {
+	config, err := kubeConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client, err := clientset.NewForConfig(config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	saclient, err := saclientset.NewForConfig(config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return client, saclient, nil
+}
+
+// DynamicParams are used to call DynamicApply.
+type DynamicParams struct {
+	Path      string
+	Namespace string
+	Delete    bool
+	Params    map[string]string
+}
+
+// DynamicApply creates or updates Kubernetes resources defined with YAML at the
+// provided path. This supports references to directories or individual files.
+func DynamicApply(dp DynamicParams) error {
+	path, err := filepath.Abs(dp.Path)
+	if err != nil {
+		return fmt.Errorf("error calculating filepath: %w", err)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if fi.IsDir() {
+		files, ioErr := ioutil.ReadDir(path)
+		if err != nil {
+			return ioErr
+		}
+		for _, file := range files {
+			applyErr := DynamicApply(DynamicParams{
+				Path:      dp.Path + "/" + file.Name(),
+				Namespace: dp.Namespace,
+				Delete:    dp.Delete,
+			})
+			if applyErr != nil {
+				return applyErr
+			}
+		}
+		return nil
+	}
+
+	klog.V(5).Infof("Applying YAML in %s", path)
+	config, err := kubeConfig()
+	if err != nil {
+		return fmt.Errorf("error getting kubeconfig: %w", err)
+	}
+
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("error reading %s file: %w", path, err)
+	}
+
+	if len(dp.Params) > 0 {
+		tmpl, tmplErr := template.New("dynamic").Parse(string(b))
+		if tmplErr != nil {
+			return fmt.Errorf("error templating %s file: %w", path, tmplErr)
+		}
+		out := bytes.Buffer{}
+		err = tmpl.Execute(&out, dp.Params)
+		if err != nil {
+			return fmt.Errorf("error executing template for %s file: %w", path, err)
+		}
+		b = out.Bytes()
+	}
+
+	dd, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("error initializing dynamic client: %w", err)
+	}
+
+	dc, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return fmt.Errorf("error initializing discovery client: %w", err)
+	}
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
+
+	decoder := yamlutil.NewYAMLOrJSONDecoder(bytes.NewReader(b), 4096)
+	for {
+		uObj := unstructured.Unstructured{}
+		if err := decoder.Decode(&uObj); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			klog.Infof("manifest: %s", string(b))
+			return fmt.Errorf("error parsing manifest: %w", err)
+		}
+		if len(uObj.Object) == 0 {
+			// klog.Warningf("Found empty object in %s, continuing", path)
+			continue
+		}
+		gvk := uObj.GroupVersionKind()
+		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil {
+			return err
+		}
+
+		var dri dynamic.ResourceInterface
+		if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+			if uObj.GetNamespace() == "" {
+				uObj.SetNamespace(dp.Namespace)
+			}
+			dri = dd.Resource(mapping.Resource).Namespace(uObj.GetNamespace())
+		} else {
+			dri = dd.Resource(mapping.Resource)
+		}
+
+		if dp.Delete {
+			delErr := dri.Delete(context.TODO(), uObj.GetName(), metav1.DeleteOptions{})
+			if delErr != nil {
+				if !apierrors.IsNotFound(delErr) {
+					return fmt.Errorf("error deleting resource: %w", delErr)
+				}
+			}
+			continue
+		}
+
+		res, err := dri.Get(context.TODO(), uObj.GetName(), metav1.GetOptions{})
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("error getting resource: %w", err)
+			}
+			klog.V(5).Infof("Creating %s %s", uObj.GetName(), gvk.Kind)
+			_, err = dri.Create(context.TODO(), &uObj, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("error creating resource: %w", err)
+			}
+			continue
+		}
+		uObj.SetResourceVersion(res.GetResourceVersion())
+		klog.Infof("Updating %s %s", uObj.GetName(), gvk.Kind)
+		_, err = dri.Update(context.TODO(), &uObj, metav1.UpdateOptions{})
+
+		if err != nil {
+			return fmt.Errorf("error updating resource: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// NewNamespace creates a new namespace using gateway-api-conformance- as
+// prefix.
+func NewNamespace(c kubernetes.Interface) (string, error) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "gateway-api-conformance-",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "gateway-api-conformance",
+			},
+		},
+	}
+
+	var err error
+
+	ns, err = c.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("unable to create namespace: %w", err)
+	}
+
+	return ns.Name, nil
+}
+
+// DeleteNamespace deletes a namespace and all the objects inside
+func DeleteNamespace(c kubernetes.Interface, namespace string) error {
+	grace := int64(0)
+	pb := metav1.DeletePropagationBackground
+
+	return c.CoreV1().Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{
+		GracePeriodSeconds: &grace,
+		PropagationPolicy:  &pb,
+	})
+}
+
+// CleanupNamespaces removes namespaces created by conformance tests
+func CleanupNamespaces(c kubernetes.Interface) error {
+	namespaces, err := c.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=gateway-api-conformance",
+	})
+
+	if err != nil {
+		return err
+	}
+
+	for _, namespace := range namespaces.Items {
+		err := DeleteNamespace(c, namespace.Name)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// NewSelfSignedSecret creates a self signed SSL certificate and store it in a secret
+func NewSelfSignedSecret(c clientset.Interface, namespace, secretName string, hosts []string) error {
+	if len(hosts) == 0 {
+		return fmt.Errorf("require a non-empty hosts for Subject Alternate Name values")
+	}
+
+	var serverKey, serverCert bytes.Buffer
+
+	host := strings.Join(hosts, ",")
+
+	if err := generateRSACert(host, &serverKey, &serverCert); err != nil {
+		return err
+	}
+
+	data := map[string][]byte{
+		corev1.TLSCertKey:       serverCert.Bytes(),
+		corev1.TLSPrivateKeyKey: serverKey.Bytes(),
+	}
+
+	newSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: secretName,
+		},
+		Data: data,
+	}
+
+	if _, err := c.CoreV1().Secrets(namespace).Create(context.TODO(), newSecret, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const (
+	rsaBits  = 2048
+	validFor = 365 * 24 * time.Hour
+)
+
+// generateRSACert generates a basic self signed certificate valir for a year
+func generateRSACert(host string, keyOut, certOut io.Writer) error {
+	priv, err := rsa.GenerateKey(rand.Reader, rsaBits)
+	if err != nil {
+		return fmt.Errorf("failed to generate key: %w", err)
+	}
+	notBefore := time.Now()
+	notAfter := notBefore.Add(validFor)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+
+	if err != nil {
+		return fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   "default",
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	hosts := strings.Split(host, ",")
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+
+	if err != nil {
+		return fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		return fmt.Errorf("failed creating cert: %w", err)
+	}
+
+	if err := pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}); err != nil {
+		return fmt.Errorf("failed creating key: %w", err)
+	}
+
+	return nil
+}
+
+func kubeConfig() (*restclient.Config, error) {
+	config, err := restclient.InClusterConfig()
+	if err != nil {
+		// Attempt to use local KUBECONFIG
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
+		// use the current context in kubeconfig
+		var err error
+
+		config, err = kubeconfig.ClientConfig()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// TODO: add version information?
+	config.UserAgent = fmt.Sprintf(
+		"%s (%s/%s) gateway-api-conformance",
+		filepath.Base(os.Args[0]),
+		runtime.GOOS,
+		runtime.GOARCH,
+	)
+
+	return config, nil
+}

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
 cloud.google.com/go v0.52.0/go.mod h1:pXajvRH/6o3+F9jDHZWQ5PbGhn+o8w9qiu/CffaVdO4=
 cloud.google.com/go v0.53.0/go.mod h1:fp/UouUEsRkN6ryDKNW/Upv/JBKnv6WDthjR6+vze6M=
+cloud.google.com/go v0.54.0 h1:3ithwDMr7/3vpAMXiH+ZQnYbuIsh+OPhUPMFC9enmn0=
 cloud.google.com/go v0.54.0/go.mod h1:1rq2OEkV3YMf6n/9ZvGWI3GWw0VoqH/1x2nd8Is/bPc=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
@@ -23,15 +24,22 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
+github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.1/go.mod h1:JFgpikqFJ/MleTTxwepExTKnFUKKszPS8UavbQYUMuw=
+github.com/Azure/go-autorest/autorest v0.11.12 h1:gI8ytXbxMfI+IVbI9mP2JGCTXIuhHLgRlvQ9X4PsnHE=
 github.com/Azure/go-autorest/autorest v0.11.12/go.mod h1:eipySxLmqSyC5s5k1CLupqet0PSENBEDP93LQ9a8QYw=
 github.com/Azure/go-autorest/autorest/adal v0.9.0/go.mod h1:/c022QCutn2P7uY+/oQWWNcK9YU+MH96NgK+jErpbcg=
+github.com/Azure/go-autorest/autorest/adal v0.9.5 h1:Y3bBUV4rTuxenJJs41HU3qmqsb+auo+a3Lz+PlJPpL0=
 github.com/Azure/go-autorest/autorest/adal v0.9.5/go.mod h1:B7KF7jKIeC9Mct5spmyCB/A8CG/sEz1vwIRGv/bbw7A=
+github.com/Azure/go-autorest/autorest/date v0.3.0 h1:7gUk1U5M/CQbp9WoqinNzJar+8KY+LPI6wiWrP/myHw=
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
 github.com/Azure/go-autorest/autorest/mocks v0.4.0/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
+github.com/Azure/go-autorest/autorest/mocks v0.4.1 h1:K0laFcLE6VLTOwNgSxaGbUcLPuGXlNkbVvq4cW4nIHk=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
+github.com/Azure/go-autorest/logger v0.2.0 h1:e4RVHVZKC5p6UANLJHkM4OfR1UKZPj8Wt8Pcx+3oqrE=
 github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
+github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
@@ -95,6 +103,7 @@ github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
@@ -218,6 +227,7 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.10 h1:6q5mVkdH/vYmqngx7kZQTjJ5HRsx+ImorDIEQ+beJgc=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
@@ -403,6 +413,7 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 h1:/ZScEX8SfEmUGRHs0gxpqteO5nfNW6axyZbBdw9A12g=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/site-src/concepts/guidelines.md
+++ b/site-src/concepts/guidelines.md
@@ -112,3 +112,20 @@ default values. These fields are considered optional but are not pointers
 since they will never be empty.
 
 [1]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md
+
+### Conformance Tests
+
+Conformance tests are actively being developed to ensure that implementations of
+this API are conformant with the spec. Use `make conformance` to run these tests
+with the Kubernetes cluster you are currently connected to. These tests require
+the `CONTROLLER_NAME` environment variable to be set. This will be used to set
+the `controller` field on GatewayClass resources created for the conformance
+tests.
+
+Conformance tests are defined with scenarios. Each scenario includes:
+
+* A YAML file with Service APIs resource manifests.
+* A Go test file describing what a controller should do with those resources.
+
+These tests are currently in an alpha state. Please file a GitHub issue or ask
+in Slack if these are not working as expected.

--- a/site-src/v1alpha2/concepts/guidelines.md
+++ b/site-src/v1alpha2/concepts/guidelines.md
@@ -112,3 +112,20 @@ default values. These fields are considered optional but are not pointers
 since they will never be empty.
 
 [1]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md
+
+### Conformance Tests
+
+Conformance tests are actively being developed to ensure that implementations of
+this API are conformant with the spec. Use `make conformance` to run these tests
+with the Kubernetes cluster you are currently connected to. These tests require
+the `CONTROLLER_NAME` environment variable to be set. This will be used to set
+the `controller` field on GatewayClass resources created for the conformance
+tests.
+
+Conformance tests are defined with scenarios. Each scenario includes:
+
+* A YAML file with Service APIs resource manifests.
+* A Go test file describing what a controller should do with those resources.
+
+These tests are currently in an alpha state. Please file a GitHub issue or ask
+in Slack if these are not working as expected.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This adds some very simple initial conformance tests for Service APIs projects. I originally spent a decent chunk of time trying to get this to fit into the ingress-controller-conformance framework but that ended up being more complex than initially thought. Some examples of that complexity:

* The core clientsets used heavily there don't work for Service APIs resources
* The inline YAML in test definitions got rather messy with the much more verbose Service APIs spec
* Adopting that framework would require additional custom codegen here
* The extra layer of indirection with godog felt like it could get increasingly complicated as the scale of our tests grew
* Debugging test failures was rather complex and it was difficult to improve output to be more helpful

Although I have some work in progress to try to make some improvements on that front, I didn't want that to block progress on conformance tests here. The approach I've started with here is incredibly simple, there's not a whole lot to it. The idea is that we'll define "scenarios" that include YAML manifests and simple go tests to describe how controllers should handle those manifests. 

I believe this is close enough in concept to the original ingress-controller-conformance tests that it will be relatively simple for them to meet in the middle sometime in the not too distant future. In both cases, the vast majority of the logic will live in helper functions, and the tests will follow the same pattern of "apply yaml + test behavior".

For now I wanted to prioritize simplicity and debuggability, I think this general approach accomplishes that. With that said, this is all very much a WIP and rather inelegant. I'm hoping that opening this PR up relatively early in the process will help get some discussion going around this or other potential approaches we could use here.

**Which issue(s) this PR fixes**:
Fixes #20 

**Does this PR introduce a user-facing change?**:
```release-note
Initial conformance tests have been added.
```

/cc @hbagdi @bowei @jpeach 
