### PR TITLE
Renaming Service APIs to Gateway API

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Report a bug encountered with the service-apis project
+about: Report a bug encountered with the gateway-api project
 labels: kind/bug
 
 ---

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,6 +1,6 @@
 ---
 name: Enhancement Request
-about: Suggest an enhancement to the service-apis project
+about: Suggest an enhancement to the gateway-api project
 labels: kind/feature
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 <!--  Thanks for sending a pull request! Here are some tips for you:
 
-1. If this is your first time contributing to Service APIs, please read our
-   developer guide (https://kubernetes-sigs.github.io/service-apis/devguide/)
-   and our community page (https://kubernetes-sigs.github.io/service-apis/community/).
+1. If this is your first time contributing to Gateway API, please read our
+   developer guide (https://kubernetes-sigs.github.io/gateway-api/devguide/)
+   and our community page (https://kubernetes-sigs.github.io/gateway-api/community/).
 2. If this is your first time contributing to a Kubernetes project, please read
    our contributor guidelines:
    https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,7 @@ linters-settings:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
   goimports:
-    local-prefixes: sigs.k8s.io/service-apis
+    local-prefixes: sigs.k8s.io/gateway-api
   golint:
     min-confidence: 0.9
   govet:

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ docs:
 	# Generate API docs first
 	./hack/api-docs/generate.sh docs-src/spec.md
 	# The docs image must be built locally until issue #141 is fixed.
-	docker build --tag k8s.gcr.io/service-apis-mkdocs:latest -f mkdocs.dockerfile .
+	docker build --tag k8s.gcr.io/gateway-api-mkdocs:latest -f mkdocs.dockerfile .
 	$(MAKE) -f docs.mk
 
 # Serve the docs site locally at http://localhost:8000.

--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
-# See the OWNERS_ALIASES file at https://github.com/kubernetes-sigs/service-apis/blob/master/OWNERS_ALIASES for a list of members for each alias. 
+# See the OWNERS_ALIASES file at https://github.com/kubernetes-sigs/gateway-api/blob/master/OWNERS_ALIASES for a list of members for each alias.
 
 approvers:
   - sig-network-leads
-  - service-apis-admins
-  - service-apis-maintainers
+  - gateway-api-admins
+  - gateway-api-maintainers
 
 reviewers:
-  - service-apis-maintainers
+  - gateway-api-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,11 +9,11 @@ aliases:
     - thockin
 
   # Reference: https://github.com/kubernetes/org/blob/master/config/kubernetes-sigs/sig-network/teams.yaml
-  service-apis-admins:
+  gateway-api-admins:
     - bowei
     - thockin
 
-  service-apis-maintainers:
+  gateway-api-maintainers:
     - bowei
     - danehans
     - hbagdi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Kubernetes Service APIs
+# Kubernetes Gateway API
 
-The Service APIs is a part of the [SIG Network][sn], and this repository
+The Gateway API is a part of the [SIG Network][sn], and this repository
 contains the specification and Custom Resource Definitions (CRDs).
 
 ## Documentation
@@ -8,7 +8,7 @@ contains the specification and Custom Resource Definitions (CRDs).
 ### Website
 
 The API specification and detailed documentation is available on the project
-website: [https://kubernetes-sigs.github.io/service-apis][ghp].
+website: [https://kubernetes-sigs.github.io/gateway-api][ghp].
 
 ### Get started
 
@@ -27,30 +27,30 @@ the API.
 A complete API reference, please refer to:
 
 - [API reference][spec]
-- [Go docs for the package](https://pkg.go.dev/sigs.k8s.io/service-apis/apis/v1alpha1)
+- [Go docs for the package](https://pkg.go.dev/sigs.k8s.io/gateway-api/apis/v1alpha1)
 
 ## Contributing
 
 Community meeting schedule, notes and developer guide can be found on the
 [community page][cm].
-Our Kubernetes Slack channel is [#sig-network-service-apis][slack].
+Our Kubernetes Slack channel is [#sig-network-gateway-api][slack].
 
 ## Technical Leads
 
 - @bowei
-- @thockin 
+- @thockin
 
 ### Code of conduct
 
 Participation in the Kubernetes community is governed by the
 [Kubernetes Code of Conduct](code-of-conduct.md).
 
-[ghp]: https://kubernetes-sigs.github.io/service-apis/
+[ghp]: https://kubernetes-sigs.github.io/gateway-api/
 [sn]: https://github.com/kubernetes/community/tree/master/sig-network
-[cm]: https://kubernetes-sigs.github.io/service-apis/community
-[slack]: https://kubernetes.slack.com/messages/sig-network-service-apis
-[guides]: https://kubernetes-sigs.github.io/service-apis/guides
-[spec]: https://kubernetes-sigs.github.io/service-apis/spec
-[concepts]: https://kubernetes-sigs.github.io/service-apis/api-overview
-[security-model]: https://kubernetes-sigs.github.io/service-apis/security-model
+[cm]: https://kubernetes-sigs.github.io/gateway-api/community
+[slack]: https://kubernetes.slack.com/messages/sig-network-gateway-api
+[guides]: https://kubernetes-sigs.github.io/gateway-api/guides
+[spec]: https://kubernetes-sigs.github.io/gateway-api/spec
+[concepts]: https://kubernetes-sigs.github.io/gateway-api/api-overview
+[security-model]: https://kubernetes-sigs.github.io/gateway-api/security-model
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-The Service APIs project is an API project that has the following two components:
+The Gateway API project is an API project that has the following two components:
 - Kubernetes Custom Resource Definitions (CRDs)
-- Corresponding Go API in the form of `sigs.k8s.io/service-apis` Go package
+- Corresponding Go API in the form of `sigs.k8s.io/gateway-api` Go package
 
 This repository is the home for both of the above components.
 
@@ -12,7 +12,7 @@ This repository is the home for both of the above components.
 The versioning strategy for this project is covered in detail in [the release
 documentation].
 
-[the release documentation]: https://kubernetes-sigs.github.io/service-apis/releases/#versioning
+[the release documentation]: https://kubernetes-sigs.github.io/gateway-api/releases/#versioning
 
 ## Releasing a new version
 
@@ -21,8 +21,8 @@ documentation].
   Approval of the PR indicates community consensus for a new release.
 - Once the above PR is merged, the author must publish a new Git tag. This can
   be done using the `git` CLI or Github's [release][release]
-  page. This step can be performed only by [Service APIs maintainers][service-apis-team].
+  page. This step can be performed only by [Gateway API maintainers][gateway-api-team].
 
-[release]: https://github.com/kubernetes-sigs/service-apis/releases
-[service-apis-team]: https://github.com/kubernetes/org/blob/master/config/kubernetes-sigs/sig-network/teams.yaml
+[release]: https://github.com/kubernetes-sigs/gateway-api/releases
+[gateway-api-team]: https://github.com/kubernetes/org/blob/master/config/kubernetes-sigs/sig-network/teams.yaml
 

--- a/docs-src/api-overview.md
+++ b/docs-src/api-overview.md
@@ -1,10 +1,10 @@
 # API Overview
 
-This document provides an overview of Service APIs.
+This document provides an overview of Gateway API.
 
 ## Roles and personas.
 
-There are 3 primary roles in Service APIs:
+There are 3 primary roles in Gateway API:
 
 - Infrastructure Provider
 - Cluster Operator
@@ -12,7 +12,7 @@ There are 3 primary roles in Service APIs:
 
 There could be a fourth role of Application Admin in some use cases.
 
-Please refer to the [roles and personas](security-model.md#roles-and-personas) 
+Please refer to the [roles and personas](security-model.md#roles-and-personas)
 section in the Security model for details.
 
 ## Resource model
@@ -23,10 +23,10 @@ section in the Security model for details.
 
 There are three main types of objects in our resource model:
 
-*GatewayClass* defines a set of gateways with a common configuration and 
+*GatewayClass* defines a set of gateways with a common configuration and
 behavior.
 
-*Gateway* requests a point where traffic can be translated to Services within 
+*Gateway* requests a point where traffic can be translated to Services within
 the cluster.
 
 *Routes* describe how traffic coming via the Gateway maps to the Services.
@@ -56,8 +56,8 @@ A Gateway describes how traffic can be translated to Services within the
 cluster. That is, it defines a request for a way to translate traffic from
 somewhere that does not know about Kubernetes to somewhere that does. For
 example, traffic sent to a Kubernetes Service by a cloud load balancer, an
-in-cluster proxy, or an external hardware load balancer. While many use cases 
-have client traffic originating “outside” the cluster, this is not a 
+in-cluster proxy, or an external hardware load balancer. While many use cases
+have client traffic originating “outside” the cluster, this is not a
 requirement.
 
 It defines a request for a specific load balancer config that implements the
@@ -95,7 +95,7 @@ Some backend configuration may vary depending on the Route that is targeting the
 backend. In those cases, configuration fields will be placed on Routes and not
 BackendPolicy. For more information on what may be configured with this resource
 in the future, refer to the related [GitHub
-issue](https://github.com/kubernetes-sigs/service-apis/issues/196).
+issue](https://github.com/kubernetes-sigs/gateway-api/issues/196).
 
 ### Route binding
 
@@ -113,23 +113,23 @@ are exposed and on which Gateways. Consider the following example:
 > and as long as their Route rules do not conflict with each other they can
 > continue operating in isolation. Team C has special networking needs (perhaps
 > performance, security, or criticality) and they need a dedicated Gateway to
-> proxy their application to the outside world. Team C deploys their own Gateway 
-> “dedicated-gw”  in the “C” Namespace that can only be used by apps in the "C" 
+> proxy their application to the outside world. Team C deploys their own Gateway
+> “dedicated-gw”  in the “C” Namespace that can only be used by apps in the "C"
 > Namespace.
 
 <!-- source: https://docs.google.com/presentation/d/1neBkFDTZ__vRoDXIWvAcxk2Pb7-evdBT6ykw_frf9QQ/edit?usp=sharing -->
 ![route binding](images/gateway-route-binding.png)
 
 There is a lot of flexibility in how Routes can bind to Gateways to achieve
-different organizational policies and scopes of responsibility. These are 
+different organizational policies and scopes of responsibility. These are
 different relationships that Gateways and Routes can have:
 
-- **One-to-one** - A Gateway and Route may be deployed and used by a single 
-  owner and have a one-to-one relationship. Team C is an example of this. 
+- **One-to-one** - A Gateway and Route may be deployed and used by a single
+  owner and have a one-to-one relationship. Team C is an example of this.
 - **One-to-many** - A Gateway can have many Routes bound to it that are owned by
-  different teams from across different Namespaces. Teams A and B are an example 
+  different teams from across different Namespaces. Teams A and B are an example
   of this.
-- **Many-to-one** - Routes can also be bound to more than one Gateway, allowing 
+- **Many-to-one** - Routes can also be bound to more than one Gateway, allowing
   a single Route to control application exposure simultaneously across different
   IPs, load balancers, or networks.
 
@@ -148,19 +148,19 @@ namespace, and labels of Route resources. Routes are actually bound to specific
 listeners within the Gateway so each listener has a `listener.routes` field
 which selects Routes by one or more of the following criterea:
 
-- **Label** - A Gateway can select Routes via labels that exist on the 
+- **Label** - A Gateway can select Routes via labels that exist on the
 resource (similar to how Services select Pods via Pod labels).
-- **Kind** - A Gateway listener can only select a single type of Route 
+- **Kind** - A Gateway listener can only select a single type of Route
 resource. This could be an HTTPRoute, TCPRoute, or a custom Route type.
 - **Namespace** - A Gateway can also control from which Namespaces Routes can be
 selected via the `namespaces.from` field. It supports three possible values:
-    - `SameNamespace` is the default option. Only Routes in the same namespace 
-      as this Gateway will be selected. 
+    - `SameNamespace` is the default option. Only Routes in the same namespace
+      as this Gateway will be selected.
     - `All` will select Routes from all Namespaces.
-    - `Selector` means that Routes from a subset of Namespaces selected by a 
-      Namespace label selector will be selected by this Gateway. When `Selector` 
-      is used then the `listeners.routes.namespaces.selector` field can be used 
-      to specify label selectors. This field is not supported with `All` or 
+    - `Selector` means that Routes from a subset of Namespaces selected by a
+      Namespace label selector will be selected by this Gateway. When `Selector`
+      is used then the `listeners.routes.namespaces.selector` field can be used
+      to specify label selectors. This field is not supported with `All` or
       `SameNamespace`.
 
 The below Gateway will select all HTTPRoute resources with the `expose:
@@ -170,12 +170,12 @@ prod-web-gw` across all Namespaces in the cluster.
 kind: Gateway
 ...
 spec:
-  listeners:  
+  listeners:
   - routes:
       kind: HTTPRoute
       selector:
         matchLabels:
-          expose: prod-web-gw 
+          expose: prod-web-gw
       namespaces:
         from: All
 ```
@@ -185,18 +185,18 @@ spec:
 Routes can determine how they are exposed through Gateways. The `gateways.allow`
 field supports three values:
 
-- `All` is the default value if none is specified. This leaves all binding 
-to the Route label and Namespace selectors on the Gateway. 
-- `SameNamespace` only allows this Route to bind with Gateways from the 
+- `All` is the default value if none is specified. This leaves all binding
+to the Route label and Namespace selectors on the Gateway.
+- `SameNamespace` only allows this Route to bind with Gateways from the
 same Namespace.
-- `FromList` allows an explicit list of Gateways to be specifiied that a 
-Route will bind with. `gateways.gatewayRefs` is only supported with this option. 
+- `FromList` allows an explicit list of Gateways to be specifiied that a
+Route will bind with. `gateways.gatewayRefs` is only supported with this option.
 
 The following `my-route` Route selects only the `foo-gateway` in the
 `foo-namespace` and will not be able to bind with any other Gateways. Note that
 `foo-gateway` is in a different Namespace. If the `foo-gateway` allows
 cross-Namespace binding and also selects this Route then `my-route` will bind to
-it. 
+it.
 
 ```yaml
 kind: HTTPRoute
@@ -246,7 +246,7 @@ reverse proxy is:
  5. Optionally, the reverse proxy can perform request header and/or path
  matching based on `match` rules of the `HTTPRoute`.
  6. Optionally, the reverse proxy can modify the request, i.e. add/remove
- headers, based on `filter` rules of the `HTTPRoute`. 
+ headers, based on `filter` rules of the `HTTPRoute`.
  7. Lastly, the reverse proxy forwards the request to one or more objects, i.e.
  `Service`, in the cluster based on `forwardTo` rules of the `HTTPRoute`.
 
@@ -272,7 +272,7 @@ Here is a summary of extension points in the API:
 - **XForwardTo.BackendRef**: This extension point should be used for forwarding
   traffic to network endpoints other than core Kubernetes Service resource.
   Examples include an S3 bucket, Lambda function, a file-server, etc.
-- **HTTPRouteFilter**: This API type in HTTPRoute provides a way to hook into 
+- **HTTPRouteFilter**: This API type in HTTPRoute provides a way to hook into
 the request/response lifecycle of an HTTP request.
 - **Custom Routes**: If none of the above extensions points suffice for a use
   case, Implementers can chose to create custom Route resources for protocols

--- a/docs-src/community.md
+++ b/docs-src/community.md
@@ -7,14 +7,14 @@ discussions around the APIs.
 
 Feedback and bug reports should be filed as [Github Issues][gh-issues] on this repo.
 
-[gh-issues]: https://github.com/kubernetes-sigs/service-apis/issues/new/choose
+[gh-issues]: https://github.com/kubernetes-sigs/gateway-api/issues/new/choose
 
 ## Communications
 
 Major discussions and notifications will be sent on the [SIG-NETWORK mailing
 list][signetg].
 
-We also have a [Slack channel (sig-network-service-apis)][slack] on k8s.io for day-to-day
+We also have a [Slack channel (sig-network-gateway-api)][slack] on k8s.io for day-to-day
 questions, discussions.
 
 [signetg]: https://groups.google.com/forum/#!forum/kubernetes-sig-network
@@ -22,9 +22,9 @@ questions, discussions.
 
 ## Meetings
 
-Meetings discussing the evolution of the service APIs will alternate times to
+Meetings discussing the evolution of the Gateway API will alternate times to
 accommodate participants from various time zones. This calendar includes all
-Service APIs meetings as well as any other SIG-Network meetings.
+Gateway API meetings as well as any other SIG-Network meetings.
 
 <iframe
   src="https://calendar.google.com/calendar/embed?src=88fe1l3qfn2b6r11k8um5am76c%40group.calendar.google.com"

--- a/docs-src/devguide.md
+++ b/docs-src/devguide.md
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-## Developing Service APIs
+## Developing Gateway API
 
 You must have a working [Go environment] and then clone the repo:
 
 ```
 mkdir -p $GOPATH/src/sigs.k8s.io
 cd $GOPATH/src/sigs.k8s.io
-git clone https://github.com/kubernetes-sigs/service-apis
-cd service-apis
+git clone https://github.com/kubernetes-sigs/gateway-api
+cd gateway-api
 ```
 
 This project works with Go modules; you can chose to setup your environment
@@ -44,9 +44,9 @@ Issues labeled `good first issue` and `help wanted` are especially good for a
 first contribution.
 We use [milestones][gh-milestones] to track our progress towards releases. Looking at our current milestone can help identify our highest priority issues.
 
-[gh-issues]: https://github.com/kubernetes-sigs/service-apis/issues
-[gh-dashboard]: https://github.com/kubernetes-sigs/service-apis/projects/1
-[gh-milestones]: https://github.com/kubernetes-sigs/service-apis/milestones
+[gh-issues]: https://github.com/kubernetes-sigs/gateway-api/issues
+[gh-dashboard]: https://github.com/kubernetes-sigs/gateway-api/projects/1
+[gh-milestones]: https://github.com/kubernetes-sigs/gateway-api/milestones
 
 ## Building the code
 
@@ -61,7 +61,7 @@ make
 
 ## Install CRDs
 
-To install service-apis CRDs into a Kubernetes cluster:
+To install gateway-api CRDs into a Kubernetes cluster:
 
 ```shell
 make install
@@ -75,7 +75,7 @@ make uninstall
 
 ## Submitting a Pull Request
 
-Service APIs follows a similar pull request process as [Kubernetes].
+Gateway API follows a similar pull request process as [Kubernetes].
 Merging a pull request requires the following steps to be completed before the
 pull request will be merged automatically.
 
@@ -94,7 +94,7 @@ verification fails.
 make verify
 ```
 
-[prow-setup]: https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/service-apis
+[prow-setup]: https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/gateway-api
 
 ## Documentation
 
@@ -127,7 +127,7 @@ documentation, generate the new documentation and make the generated code a
 self-contained commit (e.g. the changes to `docs/`). This will keep the code
 reviews simple and clearly delineate user vs generated content.
 
-[ghp]: https://kubernetes-sigs.github.io/service-apis/
+[ghp]: https://kubernetes-sigs.github.io/gateway-api/
 [mkdocs]: https://www.mkdocs.org/
 [Go environment]: https://golang.org/doc/install
 [Kubernetes]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md

--- a/docs-src/enhancement-requests.md
+++ b/docs-src/enhancement-requests.md
@@ -9,7 +9,7 @@ require approval from a maintainer to accept the enhancement into the project.
 
 ## Quick start
 
-1. Create an [Issue](https://github.com/kubernetes-sigs/service-apis/issues/new/choose) and select
+1. Create an [Issue](https://github.com/kubernetes-sigs/gateway-api/issues/new/choose) and select
 "Enhancement Request".
 2. Follow the instructions in the enhancement request template and submit the Issue.
 

--- a/docs-src/faq.md
+++ b/docs-src/faq.md
@@ -1,17 +1,17 @@
 # Frequently Asked Questions (FAQ)
 
-*   **Q: How can I get involved with Service API?<br>**
+*   **Q: How can I get involved with Gateway API?<br>**
     A: The [community](/community) page keeps track of how to get
     involved with the project.
 
-*   **Q: Will Service API replace the Ingress API?<br>**
+*   **Q: Will Gateway API replace the Ingress API?<br>**
     A: No. The Ingress API is GA since Kubernetes 1.19. There are no
     plans to deprecate this API and we expect most Ingress controllers
     to support it indefinitely.
 
-*   **Q: What are the differences between Ingress and Service API?<br>**
+*   **Q: What are the differences between Ingress and Gateway API?<br>**
     A: Ingress primarily targets exposing HTTP applications with a
-    simple, declarative syntax. Service API exposes a more general API
+    simple, declarative syntax. Gateway API exposes a more general API
     for proxying that can be used for more protocols than just HTTP,
     and models more infrastucture components to provide better
     deployment and management options for cluster operators.
@@ -21,14 +21,14 @@
     implementation. You will see the controller code in this repo be
     used for testing the support libraries.
 
-*   **Q: How can I expose custom capabilities through Service API?<br>**
+*   **Q: How can I expose custom capabilities through Gateway API?<br>**
     A: There is a lot of diversity in the networking and proxying
     ecosystem, and many products will have features that are not directly
     supported in the API.  However, there are a few mechanisms available
     for extending the API with implementation-specific capabilities:
 
-    * Decorate Service API objects with implementation-specific objects. A
-      policy or configuration object could match the Service API object either
+    * Decorate Gateway API objects with implementation-specific objects. A
+      policy or configuration object could match the Gateway API object either
       by name or by using an explicit object reference.
 
         For example, given a `Gateway` object with name "inbound",
@@ -36,14 +36,14 @@
         could cause an implementation to attach a specified access
         control policy. This is an example of matching the object by name.
 
-        Service API uses this decorator pattern with the
+        Gateway API uses this decorator pattern with the
         [`BackendPolicy`](/spec/#networking.x-k8s.io/v1alpha1.BackendPolicy)
         resource, which modifies how a `Gateway` should forward traffic
         to a backend target (commonly a Kubernetes `Service`). This is
         an example of using explicit object references.
 
     * Use implementation-specific values for string fields. In many
-      places, the fields of Service API resources have the type
+      places, the fields of Gateway API resources have the type
       "string". This allows an implementation to support custom values
       for those fields in addition to any values specified in the API.
 
@@ -56,17 +56,17 @@
       API objects have explicit [extension points](api-overview.md#extension-points)
       for implementations to use.
 
-*  **Q: Where can I find Service API releases?<br>**
-   A: Service API releases are tags of the [Github repository][1].
+*  **Q: Where can I find Gateway API releases?<br>**
+   A: Gateway API releases are tags of the [Github repository][1].
    The [Github releases][2] page shows all the releases.
 
 * **Q: How should I think about the alpha release?<br>**
-  A: The `v1alpha1` release will be the first Service API release. As
+  A: The `v1alpha1` release will be the first Gateway API release. As
   various projects begin implementing the API, and operators start using
   it, the working group will collect feedback and issues, which will
   guide what revisions are needed for the next release. It is possible
   that the next release will contain breaking changes.
 
 
-[1]: https://github.com/kubernetes-sigs/service-apis
-[2]: https://github.com/kubernetes-sigs/service-apis/releases
+[1]: https://github.com/kubernetes-sigs/gateway-api
+[2]: https://github.com/kubernetes-sigs/gateway-api/releases

--- a/docs-src/gatewayclass.md
+++ b/docs-src/gatewayclass.md
@@ -135,5 +135,5 @@ acme.io/gateway/v2   // Use version 2
 acme.io/gateway      // Use the default version
 ```
 
-[gatewayclass]: https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.GatewayClass
+[gatewayclass]: https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.GatewayClass
 [ingress-class-api]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190125-ingress-api-group.md#ingressclass-resource

--- a/docs-src/getting-started.md
+++ b/docs-src/getting-started.md
@@ -8,7 +8,7 @@ be installed into any Kubernetes (>= 1.16) cluster.
 To install the CRDs, please execute:
 
 ```
-kubectl kustomize "github.com/kubernetes-sigs/service-apis/config/crd?ref=v0.1.0" \
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.1.0" \
 | kubectl apply -f -
 ```
 
@@ -21,7 +21,7 @@ setup for your cluster.
 ## Sample Gateway
 
 Once you have the CRDs and an implementation installed, you are ready to
-use Service APIs.
+use Gateway API.
 
 In this example, we are installing three resources:
 
@@ -56,6 +56,6 @@ your cluster. If you have been using these resources for any other purpose do
 not uninstall these CRDs.
 
 ```
-kubectl kustomize "github.com/kubernetes-sigs/service-apis/config/crd?ref=v0.1.0" \
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.1.0" \
 | kubectl delete -f -
 ```

--- a/docs-src/http-routing.md
+++ b/docs-src/http-routing.md
@@ -1,17 +1,17 @@
 # HTTP routing
 
-The [HTTPRoute resource](httproute.md) allows you to match on HTTP traffic and 
+The [HTTPRoute resource](httproute.md) allows you to match on HTTP traffic and
 direct it to Kubernetes backends. This guide shows how the HTTPRoute matches
-traffic on host, header, and path fields and forwards it to different 
+traffic on host, header, and path fields and forwards it to different
 Kubernetes Services.
 
 The following diagram describes a required traffic flow across three different
 Services:
 
-- Traffic to `foo.example.com/login` is forwarded to `foo-svc` 
-- Traffic to `bar.example.com/*` with a `env: canary` header is forwarded 
+- Traffic to `foo.example.com/login` is forwarded to `foo-svc`
+- Traffic to `bar.example.com/*` with a `env: canary` header is forwarded
 to `bar-svc-canary`
-- Traffic to `bar.example.com/*` without the header is forwarded to `bar-svc` 
+- Traffic to `bar.example.com/*` without the header is forwarded to `bar-svc`
 
 ![HTTP Routinng](./images/http-routing.png)
 
@@ -19,20 +19,20 @@ The dotted lines show the Gateway resources deployed to configure this routing
 behavior. There are two HTTPRoute resources that create routing rules on the
 same `prod-web` Gateway. This illustrates how more than one Route can bind to a
 Gateway which allows Routes to merge on a Gateway as
-long as they don't conflict. 
+long as they don't conflict.
 
 The following `prod-web` Gateway is defined from the `acme-lb` GatewayClass.
 `prod-web` listens for HTTP traffic on port 80 and will bind to all Routes in
 the same Namespace that have the matching `gateway: prod-web-gw` label.
-Route labels and Gateway label selectors allow Routes and Gateways to be 
+Route labels and Gateway label selectors allow Routes and Gateways to be
 bound to each other by their respective owners.
 
-```yaml 
-{% include 'http-routing/gateway.yaml' %}  
+```yaml
+{% include 'http-routing/gateway.yaml' %}
 ```
 
 An HTTPRoute can match against a [single set of
-hostnames](https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteSpec).
+hostnames](https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteSpec).
 These hostnames are matched before any other matching within the HTTPRoute takes
 place. Since `foo.example.com` and `bar.example.com` are separate hosts with
 different routing requirements, each is deployed as its own HTTPRoute -
@@ -44,8 +44,8 @@ only one match specified, only `foo.example.com/login/*` traffic will be
 forwarded. Traffic to any other paths that do not begin with `/login` will not
 be matched by this Route.
 
-```yaml 
-{% include 'http-routing/foo-httproute.yaml' %}  
+```yaml
+{% include 'http-routing/foo-httproute.yaml' %}
 ```
 
 Similarly, the `bar-route` HTTPRoute matches traffic for `bar.example.com`. All
@@ -54,7 +54,7 @@ specific match will take precedence which means that any traffic with the `env:
 canary` header will be forwarded to `bar-svc-canary` and if the header is
 missing or not `canary` then it'll be forwarded to `bar-svc`.
 
-```yaml 
-{% include 'http-routing/bar-httproute.yaml' %}  
+```yaml
+{% include 'http-routing/bar-httproute.yaml' %}
 ```
 

--- a/docs-src/httproute.md
+++ b/docs-src/httproute.md
@@ -1,6 +1,6 @@
 # HTTPRoute
 
-[HTTPRoute][httproute] is a Service APIs type for specifying routing behavior
+[HTTPRoute][httproute] is a Gateway API type for specifying routing behavior
 of HTTP requests from a Gateway listener to an API object, i.e. Service.
 
 ## Spec
@@ -44,7 +44,7 @@ Possible values for `allow` are:
 - `FromList`: Only Gateways specified in `gatewayRefs` may use this route.
 - `SameNamespace` (default): Only Gateways in the same namespace may use this
   route.
-	
+
 If `allow` results in preventing the selection of an HTTPRoute by a Gateway, an
 “Admitted: false” condition must be set on the Gateway for this Route.
 
@@ -160,7 +160,7 @@ Conformance levels are defined by the filter type:
  - "Custom" filters have no API guarantees across implementations.
 
 Specifying a core filter multiple times has unspecified or custom conformance.
-	
+
 #### ForwardTo (optional)
 
 ForwardTo defines API objects where matching requests should be sent. If
@@ -228,12 +228,12 @@ A maximum of 100 Gateways can be represented in this list. If this list is full,
 there may be additional Gateways using this Route that are not included in the
 list.
 
-[httproute]: https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.HTTPRoute
-[gateways]: https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.RouteGateways
-[httprouterule]: https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteRule
-[hostname]: https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.Hostname
-[tls-config]: https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.RouteTLSConfig
+[httproute]: https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.HTTPRoute
+[gateways]: https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.RouteGateways
+[httprouterule]: https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteRule
+[hostname]: https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.Hostname
+[tls-config]: https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.RouteTLSConfig
 [rfc-3986]: https://tools.ietf.org/html/rfc3986
-[matches]: https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteMatch
-[filters]: https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteFilter
-[forwardto]: https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteForwardTo
+[matches]: https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteMatch
+[filters]: https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteFilter
+[forwardto]: https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteForwardTo

--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -1,51 +1,51 @@
 # Introduction
 
-Service APIs is an open source project managed by the [SIG-NETWORK][sig-network]
+Gateway API is an open source project managed by the [SIG-NETWORK][sig-network]
 community. The project's goal is to evolve service networking APIs within the
-Kubernetes ecosystem. Service APIs provide interfaces to expose Kubernetes
-applications - Services, Ingress, and more. 
+Kubernetes ecosystem. Gateway API provide interfaces to expose Kubernetes
+applications - Services, Ingress, and more.
 
-### What is the goal of Service APIs?
+### What is the goal of Gateway API?
 
-Service APIs aims to improve service networking by providing expressive,
+Gateway API aims to improve service networking by providing expressive,
 extensible, role-oriented interfaces that are implemented by many vendors and
-have broad industry support. 
+have broad industry support.
 
-Service APIs is a collection of API resources - `Service`, `GatewayClass`,
+Gateway API is a collection of API resources - `Service`, `GatewayClass`,
 `Gateway`, `HTTPRoute`, `TCPRoute`, etc. Together these resources model a wide
 variety of networking use-cases.
 
-![Service API Model](./images/api-model.png)
+![Gateway API Model](./images/api-model.png)
 
 
-How do Service APIs improve upon current standards like Ingress?
+How do Gateway API improve upon current standards like Ingress?
 
 - **More expressive** - They express more core functionality for things like
 header-based matching, traffic weighting, and other capabilities that were only
-possible in Ingress through custom means.    
+possible in Ingress through custom means.
 - **More extensible** - They allow for custom resources to be linked at various
 layers of the API. This allows for more granular customization at the
 appropriate places within the API structure.
 - **Role oriented** - They are separated into different API resources that map
-to the common roles for running applications on Kubernetes.    
+to the common roles for running applications on Kubernetes.
 - **Generic** - This isn't an improvement but rather something
 that should stay the same. Just as Ingress is a universal specification with
 [numerous implementations](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/),
-Service APIs are designed to be a portable specification supported by many
+Gateway API are designed to be a portable specification supported by many
 implementations.
 
 Some other notable capabilities include …
 
 - **Shared Gateways** - They allow the sharing of load balancers and VIPs by
 permitting independent Route resources to bind to the same Gateway. This allows
-teams to share infrastructure safely without requiring direct coordination.  
+teams to share infrastructure safely without requiring direct coordination.
 - **Typed backend references** - With typed backend references Routes can
 reference Kubernetes Services, but also any kind of Kubernetes resource that is
-designed to be a Gateway backend.  
-- **Cross-Namespace references** - Routes across different Namespaces can bind  
-to Gateways. This allows for shared networking infrastructure despite Namespace  
-segmentation for workloads.  
-- **Classes** - GatewayClasses formalize types of load balancing implementations. 
+designed to be a Gateway backend.
+- **Cross-Namespace references** - Routes across different Namespaces can bind
+to Gateways. This allows for shared networking infrastructure despite Namespace
+segmentation for workloads.
+- **Classes** - GatewayClasses formalize types of load balancing implementations.
 These classes make it easy and explicit for users to understand what kind of
 capabilities are available as a resource model itself.
 
@@ -61,16 +61,16 @@ of the API.
 
 For a complete API reference, please refer to:
 
-- [API reference](spec.md) 
-- [Go docs for the package](https://pkg.go.dev/sigs.k8s.io/service-apis/apis/v1alpha1)
+- [API reference](spec.md)
+- [Go docs for the package](https://pkg.go.dev/sigs.k8s.io/gateway-api/apis/v1alpha1)
 
 ### How to get involved
 
 This project has many contributors, and we welcome anybody and everybody to get
 involved. Join our weekly meetings, file issues, or ask questions in Slack. No
-contribution is too small - even opinions matter! 
+contribution is too small - even opinions matter!
 
-- [Weekly meeting schedule](community.md#meetings) 
-- [Service APIs Slack](https://kubernetes.slack.com/messages/sig-network-service-apis) 
-- [Enhancement requests](enhancement-requests.md)  
-- [Project owners](https://raw.githubusercontent.com/kubernetes-sigs/service-apis/master/OWNERS)
+- [Weekly meeting schedule](community.md#meetings)
+- [Gateway API Slack](https://kubernetes.slack.com/messages/sig-network-gateway-api)
+- [Enhancement requests](enhancement-requests.md)
+- [Project owners](https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/master/OWNERS)

--- a/docs-src/multiple-ns.md
+++ b/docs-src/multiple-ns.md
@@ -1,9 +1,9 @@
 # Routes in multiple namespaces
 
-With the Service APIs, a single Gateway can target routes across multiple
-namespaces. 
+With the Gateway API, a single Gateway can target routes across multiple
+namespaces.
 
-This guide assumes that you have installed Service APIs CRDs and a conformant
+This guide assumes that you have installed Gateway API CRDs and a conformant
 controller.
 
 In the following example:
@@ -14,7 +14,7 @@ In the following example:
   on port 80 which selects routes that have the label `product: baz` in any
   namespace.  Notice how the `routes.namespaces.from` field in the listener is
   set to `All`.
-- `service-apis-example-ns1` and `service-apis-example-ns2` Namespaces: These
+- `gateway-api-example-ns1` and `gateway-api-example-ns2` Namespaces: These
   are the namespaces in which route resources are instantiated.
 - `http-app-1` and `http-app-2` HTTPRoutes: These are two resources that are
   installed in separate namespaces. These routes will be bound to Gateway

--- a/docs-src/releases.md
+++ b/docs-src/releases.md
@@ -1,15 +1,15 @@
 # Releases
 
-Although Service APIs are an official Kubernetes project, and represent official
+Although Gateway API are an official Kubernetes project, and represent official
 APIs, these APIs will not be installed by default on Kubernetes clusters at this
 time. This project will use Custom Resource Definitions (CRDs) to represent the
-new API types that Service APIs include.
+new API types that Gateway API include.
 
 Similar to other Kubernetes APIs, these will go through a formal Kubernetes
-Enhancement Proposal (KEP) review. Unlike other Kubernetes APIs, Service API
+Enhancement Proposal (KEP) review. Unlike other Kubernetes APIs, Gateway API
 releases will be independent from Kubernetes releases initially.
 
-Service API releases will include four components:
+Gateway API releases will include four components:
 
 * Custom Resource Definitions to define the API.
 * Go client libraries.
@@ -42,7 +42,7 @@ fixes. New minor releases may include new fields or resources in addition to bug
 fixes. New API versions will be released with new minor or major versions.
 
 Our changelog and release notes will always include both the semantic version
-and API version(s) included in the release. 
+and API version(s) included in the release.
 
 [Kubernetes API Versioning]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
 [Semantic Versioning]: https://semver.org/
@@ -61,7 +61,7 @@ this project.
 ## Installation
 
 This project will be responsible for providing straightforward and reliable ways
-to install releases of Service APIs.
+to install releases of Gateway API.
 
 ## Other Official Custom Resources
 
@@ -69,5 +69,5 @@ This is a relatively new concept, and there is only one previous example of
 official custom resources being used:
 [VolumeSnapshots](https://kubernetes.io/blog/2018/10/09/introducing-volume-snapshot-alpha-for-kubernetes/).
 Although VolumeSnapshot CRDs can be installed directly by CSI drivers that
-support them, Service APIs must support multiple controllers per cluster, so the
+support them, Gateway API must support multiple controllers per cluster, so the
 CRDs will live in and be installed from this repo.

--- a/docs-src/security-model.md
+++ b/docs-src/security-model.md
@@ -1,11 +1,11 @@
 # Security Model
 
 ## Introduction
-The Service APIs have been designed to enable granular authorization for each
-role in a typical organization. 
+The Gateway API have been designed to enable granular authorization for each
+role in a typical organization.
 
 ## Resources
-The Service APIs have 3 primary API resources:
+The Gateway API have 3 primary API resources:
 
 * **GatewayClass** defines a set of gateways with a common configuration and
   behavior.
@@ -30,7 +30,7 @@ their users.
 
 We have found that the self-service model does not fully capture some of the
 more complex deployment and team structures that our users are seeing. The
-Service APIs are designed to target the following personas:
+Gateway API are designed to target the following personas:
 
 * **Infrastructure provider**: The infrastructure provider (infra) is
   responsible for the overall environment that the cluster(s) are operating in.
@@ -59,7 +59,7 @@ For example, giving the user all the above roles replicates the self-service
 model.
 
 ## The Security Model
-There are two primary components to the Service APIs security model: RBAC and
+There are two primary components to the Gateway API security model: RBAC and
 namespace restrictions.
 
 ## RBAC
@@ -69,14 +69,14 @@ resources in specific scopes. RBAC can be used to enable each of the roles
 defined above. In most cases, it will be desirable to have all resources be
 readable by most roles, so instead we'll focus on write access for this model.
 
-### Write Permissions for Simple 3 Tier Model 
+### Write Permissions for Simple 3 Tier Model
 | | GatewayClass | Gateway | Route |
 |-|-|-|-|
 | Infrastructure Provider | Yes | Yes | Yes |
 | Cluster Operators | No | Yes | Yes |
 | Application Developers | No | No | Yes |
 
-### Write Permissions for Advanced 4 Tier Model 
+### Write Permissions for Advanced 4 Tier Model
 | | GatewayClass | Gateway | Route |
 |-|-|-|-|
 | Infrastructure Provider | Yes | Yes | Yes |
@@ -88,25 +88,25 @@ readable by most roles, so instead we'll focus on write access for this model.
 Some infrastructure providers or cluster operators may wish to limit the
 namespaces where a GatewayClass can be used. At this point, we do not have a
 solution for this built into the API. We continue to [explore
-options](https://github.com/kubernetes-sigs/service-apis/issues/375) to improve
+options](https://github.com/kubernetes-sigs/gateway-api/issues/375) to improve
 support for this. Until then, we recommend using a policy agent such as Open
 Policy Agent and [Gatekeeper](https://github.com/open-policy-agent/gatekeeper)
 to enforce these kinds of policies. For reference, we've created an [example of
 configuration](https://github.com/open-policy-agent/gatekeeper-library/pull/24)
 that could be used for this.
-  
+
 ## Route Namespaces
-Service APIs allow Gateways to select Routes across multiple Namespaces.
+Gateway API allow Gateways to select Routes across multiple Namespaces.
 Although this can be remarkably powerful, this capability needs to be used
 carefully. Gateways include a `RouteNamespaces` field that allows selecting
 multiple namespaces with a label selector. By default, this is limited to Routes
 in the same namespace as the Gateway. Additionally, Routes include a `Gateways`
 field that allows them to restrict which Gateways use them. If the Gateways
 field is not specified (i.e. its empty), then the Route will default to allowing
-selection by Gateways in the same namespace. 
+selection by Gateways in the same namespace.
 
 ## Controller Requirements
-To be considered conformant with the Service APIs spec, controllers need to:
+To be considered conformant with the Gateway API spec, controllers need to:
 
 * Populate status fields on Gateways and Resources to indicate if they are
   compatible with the corresponding GatewayClass configuration.
@@ -139,7 +139,7 @@ Instead of having the `routeNamespaceSelector` field on GatewayClass, we would
 use a boolean `multiNamespaceRoutes` field to indicate if Gateways of this class
 can target routes in multiple namespaces. This would default to false. A false
 value here would indicate that routes could only be targeted in the current
-namespace. 
+namespace.
 
 **Benefits**
 
@@ -155,15 +155,15 @@ namespace.
 ### Validating Webhook
 A validating webhook could potentially handle some of the cross-resource
 validation necessary for this security model and provide more immediate feedback
-to end users. 
+to end users.
 
 **Benefits**
 
 * Immediate validation feedback.
-* More validation logic stays in core Service APIs codebase.
+* More validation logic stays in core Gateway API codebase.
 
 **Downsides**
 
 * Imperfect solution for cross-resource validation. For example, a change to a
   GatewayClass could affect the validity of corresponding Gateway.
-* Additional complexity involved in installing Service APIs in a cluster.
+* Additional complexity involved in installing Gateway API in a cluster.

--- a/docs-src/tcp.md
+++ b/docs-src/tcp.md
@@ -1,4 +1,4 @@
-Service APIs is designed to work with multiple protocols.
+Gateway API is designed to work with multiple protocols.
 [TCPRoute](spec/#networking.x-k8s.io/v1alpha1.TCPRoute) is one such route which
 allows for managing TCP traffic.
 

--- a/docs-src/tls.md
+++ b/docs-src/tls.md
@@ -1,6 +1,6 @@
 # TLS details
 
-Service APIs allow for a variety of ways to configure TLS. This document lays
+Gateway API allow for a variety of ways to configure TLS. This document lays
 out various TLS settings and gives general guidelines on how to use them
 effectively.
 
@@ -13,8 +13,8 @@ For Gateways, there are two connections involved:
 - **downstream**: This is the connection between the client and the Gateway.
 - **upstream**: This is the connection between the Gateway and backend resources
    specified by routes. These backend resources will usually be Services.
-  
-With Service APIs, TLS configuration of downstream and
+
+With Gateway API, TLS configuration of downstream and
 upstream connections is managed independently.
 
 Please note that in case of `Passthrough` TLS mode, no TLS settings take
@@ -26,7 +26,7 @@ which is the default setting.
 
 Downstream TLS settings are configured using listeners at the Gateway level.
 
-### Listeners and TLS 
+### Listeners and TLS
 
 Listeners expose the TLS setting on a per domain or sub-domain basis.
 TLS settings of a listener are applied to all domains that satisfy the

--- a/docs.mk
+++ b/docs.mk
@@ -17,7 +17,7 @@
 # `make help` for a summary of top-level targets.
 
 DOCKER ?= docker
-MKDOCS_IMAGE ?= k8s.gcr.io/service-apis-mkdocs:latest
+MKDOCS_IMAGE ?= k8s.gcr.io/gateway-api-mkdocs:latest
 MKDOCS ?= mkdocs
 SERVE_BIND_ADDRESS ?= 127.0.0.1
 

--- a/docs/404.html
+++ b/docs/404.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>Kubernetes Service APIs</title>
+        <title>Kubernetes Gateway API</title>
       
     
     
@@ -80,7 +80,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href="/." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href="/." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -93,7 +93,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -114,7 +114,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -141,12 +141,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href="/." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href="/." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -155,7 +155,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub

--- a/docs/api-overview/index.html
+++ b/docs/api-overview/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>API overview - Kubernetes Service APIs</title>
+        <title>API overview - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -818,16 +818,16 @@
                 
                 
                 <h1 id="api-overview">API Overview</h1>
-<p>This document provides an overview of Service APIs.</p>
+<p>This document provides an overview of Gateway API.</p>
 <h2 id="roles-and-personas">Roles and personas.</h2>
-<p>There are 3 primary roles in Service APIs:</p>
+<p>There are 3 primary roles in Gateway API:</p>
 <ul>
 <li>Infrastructure Provider</li>
 <li>Cluster Operator</li>
 <li>Application Developer</li>
 </ul>
 <p>There could be a fourth role of Application Admin in some use cases.</p>
-<p>Please refer to the <a href="../security-model/#roles-and-personas">roles and personas</a> 
+<p>Please refer to the <a href="../security-model/#roles-and-personas">roles and personas</a>
 section in the Security model for details.</p>
 <h2 id="resource-model">Resource model</h2>
 <blockquote>
@@ -836,9 +836,9 @@ Custom Resource Definitions (CRDs). Unqualified resource names will implicitly
 be in this API group.</p>
 </blockquote>
 <p>There are three main types of objects in our resource model:</p>
-<p><em>GatewayClass</em> defines a set of gateways with a common configuration and 
+<p><em>GatewayClass</em> defines a set of gateways with a common configuration and
 behavior.</p>
-<p><em>Gateway</em> requests a point where traffic can be translated to Services within 
+<p><em>Gateway</em> requests a point where traffic can be translated to Services within
 the cluster.</p>
 <p><em>Routes</em> describe how traffic coming via the Gateway maps to the Services.</p>
 <h3 id="gatewayclass">GatewayClass</h3>
@@ -861,8 +861,8 @@ IngressClass object.</p>
 cluster. That is, it defines a request for a way to translate traffic from
 somewhere that does not know about Kubernetes to somewhere that does. For
 example, traffic sent to a Kubernetes Service by a cloud load balancer, an
-in-cluster proxy, or an external hardware load balancer. While many use cases 
-have client traffic originating “outside” the cluster, this is not a 
+in-cluster proxy, or an external hardware load balancer. While many use cases
+have client traffic originating “outside” the cluster, this is not a
 requirement.</p>
 <p>It defines a request for a specific load balancer config that implements the
 GatewayClass’ configuration and behaviour contract. The resource MAY be created
@@ -890,7 +890,7 @@ more advanced policies such as health checking.</p>
 <p>Some backend configuration may vary depending on the Route that is targeting the
 backend. In those cases, configuration fields will be placed on Routes and not
 BackendPolicy. For more information on what may be configured with this resource
-in the future, refer to the related <a href="https://github.com/kubernetes-sigs/service-apis/issues/196">GitHub
+in the future, refer to the related <a href="https://github.com/kubernetes-sigs/gateway-api/issues/196">GitHub
 issue</a>.</p>
 <h3 id="route-binding">Route binding</h3>
 <p>When a Route binds to a Gateway it represents configuration that is applied on
@@ -907,23 +907,23 @@ respectively) bind their Routes to this Gateway. They are unaware of each other
 and as long as their Route rules do not conflict with each other they can
 continue operating in isolation. Team C has special networking needs (perhaps
 performance, security, or criticality) and they need a dedicated Gateway to
-proxy their application to the outside world. Team C deploys their own Gateway 
-“dedicated-gw”  in the “C” Namespace that can only be used by apps in the "C" 
+proxy their application to the outside world. Team C deploys their own Gateway
+“dedicated-gw”  in the “C” Namespace that can only be used by apps in the "C"
 Namespace.</p>
 </blockquote>
 <!-- source: https://docs.google.com/presentation/d/1neBkFDTZ__vRoDXIWvAcxk2Pb7-evdBT6ykw_frf9QQ/edit?usp=sharing -->
 
 <p><img alt="route binding" src="../images/gateway-route-binding.png" /></p>
 <p>There is a lot of flexibility in how Routes can bind to Gateways to achieve
-different organizational policies and scopes of responsibility. These are 
+different organizational policies and scopes of responsibility. These are
 different relationships that Gateways and Routes can have:</p>
 <ul>
-<li><strong>One-to-one</strong> - A Gateway and Route may be deployed and used by a single 
-  owner and have a one-to-one relationship. Team C is an example of this. </li>
+<li><strong>One-to-one</strong> - A Gateway and Route may be deployed and used by a single
+  owner and have a one-to-one relationship. Team C is an example of this.</li>
 <li><strong>One-to-many</strong> - A Gateway can have many Routes bound to it that are owned by
-  different teams from across different Namespaces. Teams A and B are an example 
+  different teams from across different Namespaces. Teams A and B are an example
   of this.</li>
-<li><strong>Many-to-one</strong> - Routes can also be bound to more than one Gateway, allowing 
+<li><strong>Many-to-one</strong> - Routes can also be bound to more than one Gateway, allowing
   a single Route to control application exposure simultaneously across different
   IPs, load balancers, or networks.</li>
 </ul>
@@ -940,19 +940,19 @@ namespace, and labels of Route resources. Routes are actually bound to specific
 listeners within the Gateway so each listener has a <code>listener.routes</code> field
 which selects Routes by one or more of the following criterea:</p>
 <ul>
-<li><strong>Label</strong> - A Gateway can select Routes via labels that exist on the 
+<li><strong>Label</strong> - A Gateway can select Routes via labels that exist on the
 resource (similar to how Services select Pods via Pod labels).</li>
-<li><strong>Kind</strong> - A Gateway listener can only select a single type of Route 
+<li><strong>Kind</strong> - A Gateway listener can only select a single type of Route
 resource. This could be an HTTPRoute, TCPRoute, or a custom Route type.</li>
 <li><strong>Namespace</strong> - A Gateway can also control from which Namespaces Routes can be
 selected via the <code>namespaces.from</code> field. It supports three possible values:<ul>
-<li><code>SameNamespace</code> is the default option. Only Routes in the same namespace 
-  as this Gateway will be selected. </li>
+<li><code>SameNamespace</code> is the default option. Only Routes in the same namespace
+  as this Gateway will be selected.</li>
 <li><code>All</code> will select Routes from all Namespaces.</li>
-<li><code>Selector</code> means that Routes from a subset of Namespaces selected by a 
-  Namespace label selector will be selected by this Gateway. When <code>Selector</code> 
-  is used then the <code>listeners.routes.namespaces.selector</code> field can be used 
-  to specify label selectors. This field is not supported with <code>All</code> or 
+<li><code>Selector</code> means that Routes from a subset of Namespaces selected by a
+  Namespace label selector will be selected by this Gateway. When <code>Selector</code>
+  is used then the <code>listeners.routes.namespaces.selector</code> field can be used
+  to specify label selectors. This field is not supported with <code>All</code> or
   <code>SameNamespace</code>.</li>
 </ul>
 </li>
@@ -962,12 +962,12 @@ prod-web-gw</code> across all Namespaces in the cluster.</p>
 <pre><code>kind: Gateway
 ...
 spec:
-  listeners:  
+  listeners:
   - routes:
       kind: HTTPRoute
       selector:
         matchLabels:
-          expose: prod-web-gw 
+          expose: prod-web-gw
       namespaces:
         from: All
 </code></pre>
@@ -976,18 +976,18 @@ spec:
 <p>Routes can determine how they are exposed through Gateways. The <code>gateways.allow</code>
 field supports three values:</p>
 <ul>
-<li><code>All</code> is the default value if none is specified. This leaves all binding 
-to the Route label and Namespace selectors on the Gateway. </li>
-<li><code>SameNamespace</code> only allows this Route to bind with Gateways from the 
+<li><code>All</code> is the default value if none is specified. This leaves all binding
+to the Route label and Namespace selectors on the Gateway.</li>
+<li><code>SameNamespace</code> only allows this Route to bind with Gateways from the
 same Namespace.</li>
-<li><code>FromList</code> allows an explicit list of Gateways to be specifiied that a 
-Route will bind with. <code>gateways.gatewayRefs</code> is only supported with this option. </li>
+<li><code>FromList</code> allows an explicit list of Gateways to be specifiied that a
+Route will bind with. <code>gateways.gatewayRefs</code> is only supported with this option.</li>
 </ul>
 <p>The following <code>my-route</code> Route selects only the <code>foo-gateway</code> in the
 <code>foo-namespace</code> and will not be able to bind with any other Gateways. Note that
 <code>foo-gateway</code> is in a different Namespace. If the <code>foo-gateway</code> allows
 cross-Namespace binding and also selects this Route then <code>my-route</code> will bind to
-it. </p>
+it.</p>
 <pre><code class="yaml">kind: HTTPRoute
 metadata:
   name: my-route
@@ -1030,7 +1030,7 @@ reverse proxy is:</p>
 <li>Optionally, the reverse proxy can perform request header and/or path
  matching based on <code>match</code> rules of the <code>HTTPRoute</code>.</li>
 <li>Optionally, the reverse proxy can modify the request, i.e. add/remove
- headers, based on <code>filter</code> rules of the <code>HTTPRoute</code>. </li>
+ headers, based on <code>filter</code> rules of the <code>HTTPRoute</code>.</li>
 <li>Lastly, the reverse proxy forwards the request to one or more objects, i.e.
  <code>Service</code>, in the cluster based on <code>forwardTo</code> rules of the <code>HTTPRoute</code>.</li>
 </ol>
@@ -1050,7 +1050,7 @@ purpose API.</p>
 <li><strong>XForwardTo.BackendRef</strong>: This extension point should be used for forwarding
   traffic to network endpoints other than core Kubernetes Service resource.
   Examples include an S3 bucket, Lambda function, a file-server, etc.</li>
-<li><strong>HTTPRouteFilter</strong>: This API type in HTTPRoute provides a way to hook into 
+<li><strong>HTTPRouteFilter</strong>: This API type in HTTPRoute provides a way to hook into
 the request/response lifecycle of an HTTP request.</li>
 <li><strong>Custom Routes</strong>: If none of the above extensions points suffice for a use
   case, Implementers can chose to create custom Route resources for protocols

--- a/docs/community/index.html
+++ b/docs/community/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>Community - Kubernetes Service APIs</title>
+        <title>Community - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -751,16 +751,16 @@
 <p>This page contains links to all of the meeting notes, design docs and related
 discussions around the APIs.</p>
 <h2 id="feedback-and-bug-reports">Feedback and Bug Reports</h2>
-<p>Feedback and bug reports should be filed as <a href="https://github.com/kubernetes-sigs/service-apis/issues/new/choose">Github Issues</a> on this repo.</p>
+<p>Feedback and bug reports should be filed as <a href="https://github.com/kubernetes-sigs/gateway-api/issues/new/choose">Github Issues</a> on this repo.</p>
 <h2 id="communications">Communications</h2>
 <p>Major discussions and notifications will be sent on the <a href="https://groups.google.com/forum/#!forum/kubernetes-sig-network">SIG-NETWORK mailing
 list</a>.</p>
-<p>We also have a <a href="https://kubernetes.slack.com/archives/CR0H13KGA">Slack channel (sig-network-service-apis)</a> on k8s.io for day-to-day
+<p>We also have a <a href="https://kubernetes.slack.com/archives/CR0H13KGA">Slack channel (sig-network-gateway-api)</a> on k8s.io for day-to-day
 questions, discussions.</p>
 <h2 id="meetings">Meetings</h2>
-<p>Meetings discussing the evolution of the service APIs will alternate times to
+<p>Meetings discussing the evolution of the Gateway API will alternate times to
 accommodate participants from various time zones. This calendar includes all
-Service APIs meetings as well as any other SIG-Network meetings.</p>
+Gateway API meetings as well as any other SIG-Network meetings.</p>
 <p><iframe
   src="https://calendar.google.com/calendar/embed?src=88fe1l3qfn2b6r11k8um5am76c%40group.calendar.google.com"
   style="border: 0" width="800" height="600" frameborder="0"

--- a/docs/devguide/index.html
+++ b/docs/devguide/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>Developer guide - Kubernetes Service APIs</title>
+        <title>Developer guide - Kubernetes Gateway API</title>
       
     
     
@@ -75,7 +75,7 @@
     <input class="md-toggle" data-md-toggle="search" type="checkbox" id="__search" autocomplete="off">
     <label class="md-overlay" data-md-component="overlay" for="__drawer"></label>
     
-      <a href="#developing-service-apis" tabindex="1" class="md-skip">
+      <a href="#developing-gateway-api" tabindex="1" class="md-skip">
         Skip to content
       </a>
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -596,12 +596,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<h2 id="developing-service-apis">Developing Service APIs</h2>
+<h2 id="developing-gateway-api">Developing Gateway API</h2>
 <p>You must have a working <a href="https://golang.org/doc/install">Go environment</a> and then clone the repo:</p>
 <pre><code>mkdir -p $GOPATH/src/sigs.k8s.io
 cd $GOPATH/src/sigs.k8s.io
-git clone https://github.com/kubernetes-sigs/service-apis
-cd service-apis
+git clone https://github.com/kubernetes-sigs/gateway-api
+cd gateway-api
 </code></pre>
 
 <p>This project works with Go modules; you can chose to setup your environment
@@ -612,12 +612,12 @@ outside $GOPATH as well.</p>
 <p>We are using the Github issues and project dashboard to manage the list of TODOs
 for this project:</p>
 <ul>
-<li><a href="https://github.com/kubernetes-sigs/service-apis/issues">Open issues</a></li>
-<li><a href="https://github.com/kubernetes-sigs/service-apis/projects/1">Project dashboard</a></li>
+<li><a href="https://github.com/kubernetes-sigs/gateway-api/issues">Open issues</a></li>
+<li><a href="https://github.com/kubernetes-sigs/gateway-api/projects/1">Project dashboard</a></li>
 </ul>
 <p>Issues labeled <code>good first issue</code> and <code>help wanted</code> are especially good for a
 first contribution.
-We use <a href="https://github.com/kubernetes-sigs/service-apis/milestones">milestones</a> to track our progress towards releases. Looking at our current milestone can help identify our highest priority issues.</p>
+We use <a href="https://github.com/kubernetes-sigs/gateway-api/milestones">milestones</a> to track our progress towards releases. Looking at our current milestone can help identify our highest priority issues.</p>
 <h2 id="building-the-code">Building the code</h2>
 <p>The project uses <code>make</code> to drive the build.
 <code>make</code> will run code generators, and run static analysis against the code and
@@ -627,7 +627,7 @@ You can kick off an overall build from the top-level makefile:</p>
 </code></pre>
 
 <h2 id="install-crds">Install CRDs</h2>
-<p>To install service-apis CRDs into a Kubernetes cluster:</p>
+<p>To install gateway-api CRDs into a Kubernetes cluster:</p>
 <pre><code class="shell">make install
 </code></pre>
 
@@ -636,7 +636,7 @@ You can kick off an overall build from the top-level makefile:</p>
 </code></pre>
 
 <h2 id="submitting-a-pull-request">Submitting a Pull Request</h2>
-<p>Service APIs follows a similar pull request process as <a href="https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md">Kubernetes</a>.
+<p>Gateway API follows a similar pull request process as <a href="https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md">Kubernetes</a>.
 Merging a pull request requires the following steps to be completed before the
 pull request will be merged automatically.</p>
 <ul>
@@ -647,7 +647,7 @@ pull request will be merged automatically.</p>
 </ul>
 <h3 id="verify">Verify</h3>
 <p>Make sure you run the static analysis over the repo before submitting your
-changes. The <a href="https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/service-apis">Prow presubmit</a> will not let your change merge if
+changes. The <a href="https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/gateway-api">Prow presubmit</a> will not let your change merge if
 verification fails.</p>
 <pre><code class="shell">make verify
 </code></pre>
@@ -669,7 +669,7 @@ Github Pages.</p>
 </code></pre>
 
 <h3 id="publishing">Publishing</h3>
-<p>The docs are published automatically to <a href="https://kubernetes-sigs.github.io/service-apis/">Github pages</a>. When making changes to the
+<p>The docs are published automatically to <a href="https://kubernetes-sigs.github.io/gateway-api/">Github pages</a>. When making changes to the
 documentation, generate the new documentation and make the generated code a
 self-contained commit (e.g. the changes to <code>docs/</code>). This will keep the code
 reviews simple and clearly delineate user vs generated content.</p>

--- a/docs/enhancement-requests/index.html
+++ b/docs/enhancement-requests/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>Enhancement requests - Kubernetes Service APIs</title>
+        <title>Enhancement requests - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -689,7 +689,7 @@ enhancement process will evolve over time as the project matures.</p>
 require approval from a maintainer to accept the enhancement into the project.</p>
 <h2 id="quick-start">Quick start</h2>
 <ol>
-<li>Create an <a href="https://github.com/kubernetes-sigs/service-apis/issues/new/choose">Issue</a> and select
+<li>Create an <a href="https://github.com/kubernetes-sigs/gateway-api/issues/new/choose">Issue</a> and select
 "Enhancement Request".</li>
 <li>Follow the instructions in the enhancement request template and submit the Issue.</li>
 </ol>

--- a/docs/faq/index.html
+++ b/docs/faq/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>FAQ - Kubernetes Service APIs</title>
+        <title>FAQ - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -581,20 +581,20 @@
                 <h1 id="frequently-asked-questions-faq">Frequently Asked Questions (FAQ)</h1>
 <ul>
 <li>
-<p><strong>Q: How can I get involved with Service API?<br></strong>
+<p><strong>Q: How can I get involved with Gateway API?<br></strong>
     A: The <a href="/community">community</a> page keeps track of how to get
     involved with the project.</p>
 </li>
 <li>
-<p><strong>Q: Will Service API replace the Ingress API?<br></strong>
+<p><strong>Q: Will Gateway API replace the Ingress API?<br></strong>
     A: No. The Ingress API is GA since Kubernetes 1.19. There are no
     plans to deprecate this API and we expect most Ingress controllers
     to support it indefinitely.</p>
 </li>
 <li>
-<p><strong>Q: What are the differences between Ingress and Service API?<br></strong>
+<p><strong>Q: What are the differences between Ingress and Gateway API?<br></strong>
     A: Ingress primarily targets exposing HTTP applications with a
-    simple, declarative syntax. Service API exposes a more general API
+    simple, declarative syntax. Gateway API exposes a more general API
     for proxying that can be used for more protocols than just HTTP,
     and models more infrastucture components to provide better
     deployment and management options for cluster operators.</p>
@@ -606,21 +606,21 @@
     used for testing the support libraries.</p>
 </li>
 <li>
-<p><strong>Q: How can I expose custom capabilities through Service API?<br></strong>
+<p><strong>Q: How can I expose custom capabilities through Gateway API?<br></strong>
     A: There is a lot of diversity in the networking and proxying
     ecosystem, and many products will have features that are not directly
     supported in the API.  However, there are a few mechanisms available
     for extending the API with implementation-specific capabilities:</p>
 <ul>
 <li>
-<p>Decorate Service API objects with implementation-specific objects. A
-  policy or configuration object could match the Service API object either
+<p>Decorate Gateway API objects with implementation-specific objects. A
+  policy or configuration object could match the Gateway API object either
   by name or by using an explicit object reference.</p>
 <p>For example, given a <code>Gateway</code> object with name "inbound",
 creating a <code>AccessPolicy</code> object that also has the name "inbound"
 could cause an implementation to attach a specified access
 control policy. This is an example of matching the object by name.</p>
-<p>Service API uses this decorator pattern with the
+<p>Gateway API uses this decorator pattern with the
 <a href="/spec/#networking.x-k8s.io/v1alpha1.BackendPolicy"><code>BackendPolicy</code></a>
 resource, which modifies how a <code>Gateway</code> should forward traffic
 to a backend target (commonly a Kubernetes <code>Service</code>). This is
@@ -628,7 +628,7 @@ an example of using explicit object references.</p>
 </li>
 <li>
 <p>Use implementation-specific values for string fields. In many
-  places, the fields of Service API resources have the type
+  places, the fields of Gateway API resources have the type
   "string". This allows an implementation to support custom values
   for those fields in addition to any values specified in the API.</p>
 </li>
@@ -646,13 +646,13 @@ an example of using explicit object references.</p>
 </ul>
 </li>
 <li>
-<p><strong>Q: Where can I find Service API releases?<br></strong>
-   A: Service API releases are tags of the <a href="https://github.com/kubernetes-sigs/service-apis">Github repository</a>.
-   The <a href="https://github.com/kubernetes-sigs/service-apis/releases">Github releases</a> page shows all the releases.</p>
+<p><strong>Q: Where can I find Gateway API releases?<br></strong>
+   A: Gateway API releases are tags of the <a href="https://github.com/kubernetes-sigs/gateway-api">Github repository</a>.
+   The <a href="https://github.com/kubernetes-sigs/gateway-api/releases">Github releases</a> page shows all the releases.</p>
 </li>
 <li>
 <p><strong>Q: How should I think about the alpha release?<br></strong>
-  A: The <code>v1alpha1</code> release will be the first Service API release. As
+  A: The <code>v1alpha1</code> release will be the first Gateway API release. As
   various projects begin implementing the API, and operators start using
   it, the working group will collect feedback and issues, which will
   guide what revisions are needed for the next release. It is possible

--- a/docs/gateway/index.html
+++ b/docs/gateway/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>Gateway - Kubernetes Service APIs</title>
+        <title>Gateway - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub

--- a/docs/gatewayclass/index.html
+++ b/docs/gatewayclass/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>GatewayClass - Kubernetes Service APIs</title>
+        <title>GatewayClass - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -654,7 +654,7 @@
                 
                 
                 <h1 id="gatewayclass">GatewayClass</h1>
-<p><a href="https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.GatewayClass">GatewayClass</a> is cluster-scoped resource defined by the
+<p><a href="https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.GatewayClass">GatewayClass</a> is cluster-scoped resource defined by the
 infrastructure provider. This resource represents a class of Gateways that can
 be instantiated.</p>
 <blockquote>

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>Getting started - Kubernetes Service APIs</title>
+        <title>Getting started - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -672,7 +672,7 @@
 <p>This project provides a collection of Custom Resource Definitions (CRDs) that can
 be installed into any Kubernetes (&gt;= 1.16) cluster.</p>
 <p>To install the CRDs, please execute:</p>
-<pre><code>kubectl kustomize &quot;github.com/kubernetes-sigs/service-apis/config/crd?ref=v0.1.0&quot; \
+<pre><code>kubectl kustomize &quot;github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.1.0&quot; \
 | kubectl apply -f -
 </code></pre>
 
@@ -682,7 +682,7 @@ You will need to either install an implementation or verify that one is already
 setup for your cluster.</p>
 <h2 id="sample-gateway">Sample Gateway</h2>
 <p>Once you have the CRDs and an implementation installed, you are ready to
-use Service APIs.</p>
+use Gateway API.</p>
 <p>In this example, we are installing three resources:</p>
 <ul>
 <li>An <code>acme-lb</code> GatewayClass which is being managed by a <code>acme.io/gateway-controller</code>
@@ -772,7 +772,7 @@ spec:
 command. Note that this will remove all GatewayClass and Gateway resources in
 your cluster. If you have been using these resources for any other purpose do
 not uninstall these CRDs.</p>
-<pre><code>kubectl kustomize &quot;github.com/kubernetes-sigs/service-apis/config/crd?ref=v0.1.0&quot; \
+<pre><code>kubectl kustomize &quot;github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.1.0&quot; \
 | kubectl delete -f -
 </code></pre>
                 

--- a/docs/guidelines/index.html
+++ b/docs/guidelines/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>Implementation Guidelines - Kubernetes Service APIs</title>
+        <title>Implementation Guidelines - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>Introduction - Kubernetes Service APIs</title>
+        <title>Introduction - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub

--- a/docs/http-routing/index.html
+++ b/docs/http-routing/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>HTTP routing - Kubernetes Service APIs</title>
+        <title>HTTP routing - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -581,28 +581,28 @@
                 
                 
                 <h1 id="http-routing">HTTP routing</h1>
-<p>The <a href="../httproute/">HTTPRoute resource</a> allows you to match on HTTP traffic and 
+<p>The <a href="../httproute/">HTTPRoute resource</a> allows you to match on HTTP traffic and
 direct it to Kubernetes backends. This guide shows how the HTTPRoute matches
-traffic on host, header, and path fields and forwards it to different 
+traffic on host, header, and path fields and forwards it to different
 Kubernetes Services.</p>
 <p>The following diagram describes a required traffic flow across three different
 Services:</p>
 <ul>
-<li>Traffic to <code>foo.example.com/login</code> is forwarded to <code>foo-svc</code> </li>
-<li>Traffic to <code>bar.example.com/*</code> with a <code>env: canary</code> header is forwarded 
+<li>Traffic to <code>foo.example.com/login</code> is forwarded to <code>foo-svc</code></li>
+<li>Traffic to <code>bar.example.com/*</code> with a <code>env: canary</code> header is forwarded
 to <code>bar-svc-canary</code></li>
-<li>Traffic to <code>bar.example.com/*</code> without the header is forwarded to <code>bar-svc</code> </li>
+<li>Traffic to <code>bar.example.com/*</code> without the header is forwarded to <code>bar-svc</code></li>
 </ul>
 <p><img alt="HTTP Routinng" src="../images/http-routing.png" /></p>
 <p>The dotted lines show the Gateway resources deployed to configure this routing
 behavior. There are two HTTPRoute resources that create routing rules on the
 same <code>prod-web</code> Gateway. This illustrates how more than one Route can bind to a
 Gateway which allows Routes to merge on a Gateway as
-long as they don't conflict. </p>
+long as they don't conflict.</p>
 <p>The following <code>prod-web</code> Gateway is defined from the <code>acme-lb</code> GatewayClass.
 <code>prod-web</code> listens for HTTP traffic on port 80 and will bind to all Routes in
 the same Namespace that have the matching <code>gateway: prod-web-gw</code> label.
-Route labels and Gateway label selectors allow Routes and Gateways to be 
+Route labels and Gateway label selectors allow Routes and Gateways to be
 bound to each other by their respective owners.</p>
 <pre><code class="yaml">kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
@@ -617,10 +617,10 @@ spec:
       kind: HTTPRoute
       selector:
         matchLabels:
-          gateway: prod-web-gw  
+          gateway: prod-web-gw
 </code></pre>
 
-<p>An HTTPRoute can match against a <a href="https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteSpec">single set of
+<p>An HTTPRoute can match against a <a href="https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteSpec">single set of
 hostnames</a>.
 These hostnames are matched before any other matching within the HTTPRoute takes
 place. Since <code>foo.example.com</code> and <code>bar.example.com</code> are separate hosts with
@@ -647,7 +647,7 @@ spec:
         value: /login
     forwardTo:
     - serviceName: foo-svc
-      port: 8080  
+      port: 8080
 </code></pre>
 
 <p>Similarly, the <code>bar-route</code> HTTPRoute matches traffic for <code>bar.example.com</code>. All
@@ -675,7 +675,7 @@ spec:
       port: 8080
   - forwardTo:
     - serviceName: bar-svc
-      port: 8080  
+      port: 8080
 </code></pre>
                 
                   

--- a/docs/httproute/index.html
+++ b/docs/httproute/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>HTTPRoute - Kubernetes Service APIs</title>
+        <title>HTTPRoute - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -814,19 +814,19 @@
                 
                 
                 <h1 id="httproute">HTTPRoute</h1>
-<p><a href="https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.HTTPRoute">HTTPRoute</a> is a Service APIs type for specifying routing behavior
+<p><a href="https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.HTTPRoute">HTTPRoute</a> is a Gateway API type for specifying routing behavior
 of HTTP requests from a Gateway listener to an API object, i.e. Service.</p>
 <h2 id="spec">Spec</h2>
 <p>The specification of an HTTPRoute consists of:</p>
 <ul>
-<li><a href="https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.RouteGateways">Gateways</a>- Define which Gateways can use this HTTPRoute.</li>
-<li><a href="https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.Hostname">Hostnames</a> (optional)- Define a list of hostnames to use for
+<li><a href="https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.RouteGateways">Gateways</a>- Define which Gateways can use this HTTPRoute.</li>
+<li><a href="https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.Hostname">Hostnames</a> (optional)- Define a list of hostnames to use for
   matching the Host header of HTTP requests.</li>
-<li><a href="https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.RouteTLSConfig">TLS</a> (optional)- Defines the TLS certificate to use for
+<li><a href="https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.RouteTLSConfig">TLS</a> (optional)- Defines the TLS certificate to use for
   Hostnames defined in this Route.</li>
-<li><a href="https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteRule">Rules</a>- Define a list of rules to perform actions against
+<li><a href="https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteRule">Rules</a>- Define a list of rules to perform actions against
   matching HTTP requests. Each rule consists
-  of <a href="https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteMatch">matches</a>, <a href="https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteFilter">filters</a> (optional), and <a href="https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteForwardTo">forwardTo</a>
+  of <a href="https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteMatch">matches</a>, <a href="https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteFilter">filters</a> (optional), and <a href="https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteForwardTo">forwardTo</a>
   (optional) fields.</li>
 </ul>
 <p>The following illustrates an HTTPRoute that sends all traffic to one Service:
@@ -1156,7 +1156,7 @@ spec:
       weight: 50
 </code></pre>
 
-<p>Reference the <a href="https://kubernetes-sigs.github.io/service-apis/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteForwardTo">forwardTo</a> API documentation for additional details
+<p>Reference the <a href="https://kubernetes-sigs.github.io/gateway-api/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteForwardTo">forwardTo</a> API documentation for additional details
 of <code>weight</code> and other fields.</p>
 <h2 id="status">Status</h2>
 <p>Status defines the observed state of HTTPRoute.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>Kubernetes Service APIs</title>
+        <title>Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href="." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href="." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href="." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href="." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -202,8 +202,8 @@
     <ul class="md-nav__list" data-md-scrollfix>
       
         <li class="md-nav__item">
-  <a href="#what-is-the-goal-of-service-apis" class="md-nav__link">
-    What is the goal of Service APIs?
+  <a href="#what-is-the-goal-of-gateway-api" class="md-nav__link">
+    What is the goal of Gateway API?
   </a>
   
 </li>
@@ -614,8 +614,8 @@
     <ul class="md-nav__list" data-md-scrollfix>
       
         <li class="md-nav__item">
-  <a href="#what-is-the-goal-of-service-apis" class="md-nav__link">
-    What is the goal of Service APIs?
+  <a href="#what-is-the-goal-of-gateway-api" class="md-nav__link">
+    What is the goal of Gateway API?
   </a>
   
 </li>
@@ -652,46 +652,46 @@
                 
                 
                 <h1 id="introduction">Introduction</h1>
-<p>Service APIs is an open source project managed by the <a href="https://github.com/kubernetes/community/tree/master/sig-network">SIG-NETWORK</a>
+<p>Gateway API is an open source project managed by the <a href="https://github.com/kubernetes/community/tree/master/sig-network">SIG-NETWORK</a>
 community. The project's goal is to evolve service networking APIs within the
-Kubernetes ecosystem. Service APIs provide interfaces to expose Kubernetes
-applications - Services, Ingress, and more. </p>
-<h3 id="what-is-the-goal-of-service-apis">What is the goal of Service APIs?</h3>
-<p>Service APIs aims to improve service networking by providing expressive,
+Kubernetes ecosystem. Gateway API provide interfaces to expose Kubernetes
+applications - Services, Ingress, and more.</p>
+<h3 id="what-is-the-goal-of-gateway-api">What is the goal of Gateway API?</h3>
+<p>Gateway API aims to improve service networking by providing expressive,
 extensible, role-oriented interfaces that are implemented by many vendors and
-have broad industry support. </p>
-<p>Service APIs is a collection of API resources - <code>Service</code>, <code>GatewayClass</code>,
+have broad industry support.</p>
+<p>Gateway API is a collection of API resources - <code>Service</code>, <code>GatewayClass</code>,
 <code>Gateway</code>, <code>HTTPRoute</code>, <code>TCPRoute</code>, etc. Together these resources model a wide
 variety of networking use-cases.</p>
-<p><img alt="Service API Model" src="images/api-model.png" /></p>
-<p>How do Service APIs improve upon current standards like Ingress?</p>
+<p><img alt="Gateway API Model" src="images/api-model.png" /></p>
+<p>How do Gateway API improve upon current standards like Ingress?</p>
 <ul>
 <li><strong>More expressive</strong> - They express more core functionality for things like
 header-based matching, traffic weighting, and other capabilities that were only
-possible in Ingress through custom means.    </li>
+possible in Ingress through custom means.</li>
 <li><strong>More extensible</strong> - They allow for custom resources to be linked at various
 layers of the API. This allows for more granular customization at the
 appropriate places within the API structure.</li>
 <li><strong>Role oriented</strong> - They are separated into different API resources that map
-to the common roles for running applications on Kubernetes.    </li>
+to the common roles for running applications on Kubernetes.</li>
 <li><strong>Generic</strong> - This isn't an improvement but rather something
 that should stay the same. Just as Ingress is a universal specification with
 <a href="https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/">numerous implementations</a>,
-Service APIs are designed to be a portable specification supported by many
+Gateway API are designed to be a portable specification supported by many
 implementations.</li>
 </ul>
 <p>Some other notable capabilities include …</p>
 <ul>
 <li><strong>Shared Gateways</strong> - They allow the sharing of load balancers and VIPs by
 permitting independent Route resources to bind to the same Gateway. This allows
-teams to share infrastructure safely without requiring direct coordination.  </li>
+teams to share infrastructure safely without requiring direct coordination.</li>
 <li><strong>Typed backend references</strong> - With typed backend references Routes can
 reference Kubernetes Services, but also any kind of Kubernetes resource that is
-designed to be a Gateway backend.  </li>
-<li><strong>Cross-Namespace references</strong> - Routes across different Namespaces can bind<br />
-to Gateways. This allows for shared networking infrastructure despite Namespace<br />
-segmentation for workloads.  </li>
-<li><strong>Classes</strong> - GatewayClasses formalize types of load balancing implementations. 
+designed to be a Gateway backend.</li>
+<li><strong>Cross-Namespace references</strong> - Routes across different Namespaces can bind
+to Gateways. This allows for shared networking infrastructure despite Namespace
+segmentation for workloads.</li>
+<li><strong>Classes</strong> - GatewayClasses formalize types of load balancing implementations.
 These classes make it easy and explicit for users to understand what kind of
 capabilities are available as a resource model itself.</li>
 </ul>
@@ -703,18 +703,18 @@ please follow one of our <a href="guides/">guides</a> to dive deeper into differ
 of the API.</p>
 <p>For a complete API reference, please refer to:</p>
 <ul>
-<li><a href="spec/">API reference</a> </li>
-<li><a href="https://pkg.go.dev/sigs.k8s.io/service-apis/apis/v1alpha1">Go docs for the package</a></li>
+<li><a href="spec/">API reference</a></li>
+<li><a href="https://pkg.go.dev/sigs.k8s.io/gateway-api/apis/v1alpha1">Go docs for the package</a></li>
 </ul>
 <h3 id="how-to-get-involved">How to get involved</h3>
 <p>This project has many contributors, and we welcome anybody and everybody to get
 involved. Join our weekly meetings, file issues, or ask questions in Slack. No
-contribution is too small - even opinions matter! </p>
+contribution is too small - even opinions matter!</p>
 <ul>
-<li><a href="community/#meetings">Weekly meeting schedule</a> </li>
-<li><a href="https://kubernetes.slack.com/messages/sig-network-service-apis">Service APIs Slack</a> </li>
-<li><a href="enhancement-requests/">Enhancement requests</a>  </li>
-<li><a href="https://raw.githubusercontent.com/kubernetes-sigs/service-apis/master/OWNERS">Project owners</a></li>
+<li><a href="community/#meetings">Weekly meeting schedule</a></li>
+<li><a href="https://kubernetes.slack.com/messages/sig-network-gateway-api">Gateway API Slack</a></li>
+<li><a href="enhancement-requests/">Enhancement requests</a></li>
+<li><a href="https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/master/OWNERS">Project owners</a></li>
 </ul>
                 
                   

--- a/docs/multiple-ns/index.html
+++ b/docs/multiple-ns/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>Multiple namespaces and routes - Kubernetes Service APIs</title>
+        <title>Multiple namespaces and routes - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -581,9 +581,9 @@
                 
                 
                 <h1 id="routes-in-multiple-namespaces">Routes in multiple namespaces</h1>
-<p>With the Service APIs, a single Gateway can target routes across multiple
-namespaces. </p>
-<p>This guide assumes that you have installed Service APIs CRDs and a conformant
+<p>With the Gateway API, a single Gateway can target routes across multiple
+namespaces.</p>
+<p>This guide assumes that you have installed Gateway API CRDs and a conformant
 controller.</p>
 <p>In the following example:</p>
 <ul>
@@ -593,7 +593,7 @@ controller.</p>
   on port 80 which selects routes that have the label <code>product: baz</code> in any
   namespace.  Notice how the <code>routes.namespaces.from</code> field in the listener is
   set to <code>All</code>.</li>
-<li><code>service-apis-example-ns1</code> and <code>service-apis-example-ns2</code> Namespaces: These
+<li><code>gateway-api-example-ns1</code> and <code>gateway-api-example-ns2</code> Namespaces: These
   are the namespaces in which route resources are instantiated.</li>
 <li><code>http-app-1</code> and <code>http-app-2</code> HTTPRoutes: These are two resources that are
   installed in separate namespaces. These routes will be bound to Gateway
@@ -641,13 +641,13 @@ spec:
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: service-apis-example-ns1
+  name: gateway-api-example-ns1
 ---
 kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: http-app-1
-  namespace: service-apis-example-ns1
+  namespace: gateway-api-example-ns1
   labels:
     product: baz
 spec:
@@ -678,13 +678,13 @@ spec:
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: service-apis-example-ns2
+  name: gateway-api-example-ns2
 ---
 kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: http-app-2
-  namespace: service-apis-example-ns2
+  namespace: gateway-api-example-ns2
   labels:
     product: baz
 spec:

--- a/docs/releases/index.html
+++ b/docs/releases/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>Releases - Kubernetes Service APIs</title>
+        <title>Releases - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -668,14 +668,14 @@
                 
                 
                 <h1 id="releases">Releases</h1>
-<p>Although Service APIs are an official Kubernetes project, and represent official
+<p>Although Gateway API are an official Kubernetes project, and represent official
 APIs, these APIs will not be installed by default on Kubernetes clusters at this
 time. This project will use Custom Resource Definitions (CRDs) to represent the
-new API types that Service APIs include.</p>
+new API types that Gateway API include.</p>
 <p>Similar to other Kubernetes APIs, these will go through a formal Kubernetes
-Enhancement Proposal (KEP) review. Unlike other Kubernetes APIs, Service API
+Enhancement Proposal (KEP) review. Unlike other Kubernetes APIs, Gateway API
 releases will be independent from Kubernetes releases initially.</p>
-<p>Service API releases will include four components:</p>
+<p>Gateway API releases will include four components:</p>
 <ul>
 <li>Custom Resource Definitions to define the API.</li>
 <li>Go client libraries.</li>
@@ -703,7 +703,7 @@ resources.</p>
 fixes. New minor releases may include new fields or resources in addition to bug
 fixes. New API versions will be released with new minor or major versions.</p>
 <p>Our changelog and release notes will always include both the semantic version
-and API version(s) included in the release. </p>
+and API version(s) included in the release.</p>
 <blockquote>
 <p>The first release candidate was tagged as <code>v1alpha1-rc1</code>. It predates this
 documentation and is an exception.</p>
@@ -716,13 +716,13 @@ release is published. For the best results, use the latest published release of
 this project.</p>
 <h2 id="installation">Installation</h2>
 <p>This project will be responsible for providing straightforward and reliable ways
-to install releases of Service APIs.</p>
+to install releases of Gateway API.</p>
 <h2 id="other-official-custom-resources">Other Official Custom Resources</h2>
 <p>This is a relatively new concept, and there is only one previous example of
 official custom resources being used:
 <a href="https://kubernetes.io/blog/2018/10/09/introducing-volume-snapshot-alpha-for-kubernetes/">VolumeSnapshots</a>.
 Although VolumeSnapshot CRDs can be installed directly by CSI drivers that
-support them, Service APIs must support multiple controllers per cluster, so the
+support them, Gateway API must support multiple controllers per cluster, so the
 CRDs will live in and be installed from this repo.</p>
                 
                   

--- a/docs/security-model/index.html
+++ b/docs/security-model/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>Security Model - Kubernetes Service APIs</title>
+        <title>Security Model - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -859,10 +859,10 @@
                 
                 <h1 id="security-model">Security Model</h1>
 <h2 id="introduction">Introduction</h2>
-<p>The Service APIs have been designed to enable granular authorization for each
-role in a typical organization. </p>
+<p>The Gateway API have been designed to enable granular authorization for each
+role in a typical organization.</p>
 <h2 id="resources">Resources</h2>
-<p>The Service APIs have 3 primary API resources:</p>
+<p>The Gateway API have 3 primary API resources:</p>
 <ul>
 <li><strong>GatewayClass</strong> defines a set of gateways with a common configuration and
   behavior.</li>
@@ -885,7 +885,7 @@ Ingresses control all aspects of defining and exposing their applications to
 their users.</p>
 <p>We have found that the self-service model does not fully capture some of the
 more complex deployment and team structures that our users are seeing. The
-Service APIs are designed to target the following personas:</p>
+Gateway API are designed to target the following personas:</p>
 <ul>
 <li><strong>Infrastructure provider</strong>: The infrastructure provider (infra) is
   responsible for the overall environment that the cluster(s) are operating in.
@@ -912,7 +912,7 @@ responsibility and separation.</p>
 For example, giving the user all the above roles replicates the self-service
 model.</p>
 <h2 id="the-security-model">The Security Model</h2>
-<p>There are two primary components to the Service APIs security model: RBAC and
+<p>There are two primary components to the Gateway API security model: RBAC and
 namespace restrictions.</p>
 <h2 id="rbac">RBAC</h2>
 <p>RBAC (role-based access control) is the standard used for Kubernetes
@@ -991,7 +991,7 @@ readable by most roles, so instead we'll focus on write access for this model.</
 <h2 id="limiting-namespaces-where-a-gatewayclass-can-be-used">Limiting Namespaces Where a GatewayClass Can Be Used</h2>
 <p>Some infrastructure providers or cluster operators may wish to limit the
 namespaces where a GatewayClass can be used. At this point, we do not have a
-solution for this built into the API. We continue to <a href="https://github.com/kubernetes-sigs/service-apis/issues/375">explore
+solution for this built into the API. We continue to <a href="https://github.com/kubernetes-sigs/gateway-api/issues/375">explore
 options</a> to improve
 support for this. Until then, we recommend using a policy agent such as Open
 Policy Agent and <a href="https://github.com/open-policy-agent/gatekeeper">Gatekeeper</a>
@@ -999,16 +999,16 @@ to enforce these kinds of policies. For reference, we've created an <a href="htt
 configuration</a>
 that could be used for this.</p>
 <h2 id="route-namespaces">Route Namespaces</h2>
-<p>Service APIs allow Gateways to select Routes across multiple Namespaces.
+<p>Gateway API allow Gateways to select Routes across multiple Namespaces.
 Although this can be remarkably powerful, this capability needs to be used
 carefully. Gateways include a <code>RouteNamespaces</code> field that allows selecting
 multiple namespaces with a label selector. By default, this is limited to Routes
 in the same namespace as the Gateway. Additionally, Routes include a <code>Gateways</code>
 field that allows them to restrict which Gateways use them. If the Gateways
 field is not specified (i.e. its empty), then the Route will default to allowing
-selection by Gateways in the same namespace. </p>
+selection by Gateways in the same namespace.</p>
 <h2 id="controller-requirements">Controller Requirements</h2>
-<p>To be considered conformant with the Service APIs spec, controllers need to:</p>
+<p>To be considered conformant with the Gateway API spec, controllers need to:</p>
 <ul>
 <li>Populate status fields on Gateways and Resources to indicate if they are
   compatible with the corresponding GatewayClass configuration.</li>
@@ -1043,7 +1043,7 @@ resources might be look something like:</p>
 use a boolean <code>multiNamespaceRoutes</code> field to indicate if Gateways of this class
 can target routes in multiple namespaces. This would default to false. A false
 value here would indicate that routes could only be targeted in the current
-namespace. </p>
+namespace.</p>
 <p><strong>Benefits</strong></p>
 <ul>
 <li>Helpful for multi-tenant use cases with many isolated Gateways.</li>
@@ -1058,17 +1058,17 @@ namespace. </p>
 <h3 id="validating-webhook">Validating Webhook</h3>
 <p>A validating webhook could potentially handle some of the cross-resource
 validation necessary for this security model and provide more immediate feedback
-to end users. </p>
+to end users.</p>
 <p><strong>Benefits</strong></p>
 <ul>
 <li>Immediate validation feedback.</li>
-<li>More validation logic stays in core Service APIs codebase.</li>
+<li>More validation logic stays in core Gateway API codebase.</li>
 </ul>
 <p><strong>Downsides</strong></p>
 <ul>
 <li>Imperfect solution for cross-resource validation. For example, a change to a
   GatewayClass could affect the validity of corresponding Gateway.</li>
-<li>Additional complexity involved in installing Service APIs in a cluster.</li>
+<li>Additional complexity involved in installing Gateway API in a cluster.</li>
 </ul>
                 
                   

--- a/docs/simple-gateway/index.html
+++ b/docs/simple-gateway/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>Simple Gateway - Kubernetes Service APIs</title>
+        <title>Simple Gateway - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>API specification - Kubernetes Service APIs</title>
+        <title>API specification - Kubernetes Gateway API</title>
       
     
     
@@ -80,7 +80,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -93,7 +93,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -114,7 +114,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -141,12 +141,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -155,7 +155,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub

--- a/docs/tcp/index.html
+++ b/docs/tcp/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>TCP routing - Kubernetes Service APIs</title>
+        <title>TCP routing - Kubernetes Gateway API</title>
       
     
     
@@ -80,7 +80,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -93,7 +93,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -114,7 +114,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -141,12 +141,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -155,7 +155,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -561,7 +561,7 @@
                 
                   <h1>TCP routing</h1>
                 
-                <p>Service APIs is designed to work with multiple protocols.
+                <p>Gateway API is designed to work with multiple protocols.
 <a href="spec/#networking.x-k8s.io/v1alpha1.TCPRoute">TCPRoute</a> is one such route which
 allows for managing TCP traffic.</p>
 <p>In this example, we have one Gateway resource and two TCPRoute resources that

--- a/docs/tls/index.html
+++ b/docs/tls/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>TLS - Kubernetes Service APIs</title>
+        <title>TLS - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -802,7 +802,7 @@
                 
                 
                 <h1 id="tls-details">TLS details</h1>
-<p>Service APIs allow for a variety of ways to configure TLS. This document lays
+<p>Gateway API allow for a variety of ways to configure TLS. This document lays
 out various TLS settings and gives general guidelines on how to use them
 effectively.</p>
 <h2 id="clientserver-and-tls">Client/Server and TLS</h2>
@@ -813,7 +813,7 @@ effectively.</p>
 <li><strong>upstream</strong>: This is the connection between the Gateway and backend resources
    specified by routes. These backend resources will usually be Services.</li>
 </ul>
-<p>With Service APIs, TLS configuration of downstream and
+<p>With Gateway API, TLS configuration of downstream and
 upstream connections is managed independently.</p>
 <p>Please note that in case of <code>Passthrough</code> TLS mode, no TLS settings take
 effect as the TLS session from the client is NOT terminated at the Gateway.

--- a/docs/traffic-splitting/index.html
+++ b/docs/traffic-splitting/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>HTTP traffic splitting - Kubernetes Service APIs</title>
+        <title>HTTP traffic splitting - Kubernetes Gateway API</title>
       
     
     
@@ -84,7 +84,7 @@
   <nav class="md-header-nav md-grid">
     <div class="md-flex">
       <div class="md-flex__cell md-flex__cell--shrink">
-        <a href=".." title="Kubernetes Service APIs" class="md-header-nav__button md-logo">
+        <a href=".." title="Kubernetes Gateway API" class="md-header-nav__button md-logo">
           
             <i class="md-icon"></i>
           
@@ -97,7 +97,7 @@
         <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
           
             <span class="md-header-nav__topic">
-              Kubernetes Service APIs
+              Kubernetes Gateway API
             </span>
             <span class="md-header-nav__topic">
               
@@ -118,7 +118,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub
@@ -145,12 +145,12 @@
                   <div class="md-sidebar__inner">
                     <nav class="md-nav md-nav--primary" data-md-level="0">
   <label class="md-nav__title md-nav__title--site" for="__drawer">
-    <a href=".." title="Kubernetes Service APIs" class="md-nav__button md-logo">
+    <a href=".." title="Kubernetes Gateway API" class="md-nav__button md-logo">
       
         <i class="md-icon"></i>
       
     </a>
-    Kubernetes Service APIs
+    Kubernetes Gateway API
   </label>
   
     <div class="md-nav__source">
@@ -159,7 +159,7 @@
 
   
 
-<a href="http://sigs.k8s.io/service-apis" title="Go to repository" class="md-source" data-md-source="">
+<a href="http://sigs.k8s.io/gateway-api" title="Go to repository" class="md-source" data-md-source="">
   
   <div class="md-source__repository">
     GitHub

--- a/examples/routes-in-multiple-namespaces.yaml
+++ b/examples/routes-in-multiple-namespaces.yaml
@@ -29,13 +29,13 @@ spec:
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: service-apis-example-ns1
+  name: gateway-api-example-ns1
 ---
 kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: http-app-1
-  namespace: service-apis-example-ns1
+  namespace: gateway-api-example-ns1
   labels:
     product: baz
 spec:
@@ -66,13 +66,13 @@ spec:
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: service-apis-example-ns2
+  name: gateway-api-example-ns2
 ---
 kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: http-app-2
-  namespace: service-apis-example-ns2
+  namespace: gateway-api-example-ns2
   labels:
     product: baz
 spec:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/service-apis
+module sigs.k8s.io/gateway-api
 
 go 1.15
 

--- a/hack/api-docs/generate.sh
+++ b/hack/api-docs/generate.sh
@@ -49,5 +49,5 @@ fi
 
 gendoc::build
 gendoc::exec \
-    -api-dir sigs.k8s.io/service-apis/apis/v1alpha1 \
+    -api-dir sigs.k8s.io/gateway-api/apis/v1alpha1 \
     -out-file "$1"

--- a/hack/delete-crds.sh
+++ b/hack/delete-crds.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Delete all CR and CRDs installed by service-apis.
+# Delete all CR and CRDs installed by gateway-api.
 
 RESOURCES=$(kubectl api-resources --api-group=networking.x-k8s.io -o name)
 

--- a/hack/install-examples.sh
+++ b/hack/install-examples.sh
@@ -18,5 +18,5 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Install all example service-apis resources.
+# Install all example gateway-api resources.
 kubectl apply -f examples

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -30,11 +30,11 @@ export GO111MODULE GOFLAGS GOPATH
 # a traditional GOPATH directory, so fake on up to point to the current
 # workspace.
 mkdir -p "$GOPATH/src/sigs.k8s.io"
-ln -s "${SCRIPT_ROOT}" "$GOPATH/src/sigs.k8s.io/service-apis"
+ln -s "${SCRIPT_ROOT}" "$GOPATH/src/sigs.k8s.io/gateway-api"
 
-readonly OUTPUT_PKG=sigs.k8s.io/service-apis/pkg/client
-readonly FQ_APIS=sigs.k8s.io/service-apis/apis/v1alpha1
-readonly APIS_PKG=sigs.k8s.io/service-apis
+readonly OUTPUT_PKG=sigs.k8s.io/gateway-api/pkg/client
+readonly FQ_APIS=sigs.k8s.io/gateway-api/apis/v1alpha1
+readonly APIS_PKG=sigs.k8s.io/gateway-api
 readonly CLIENTSET_NAME=versioned
 readonly CLIENTSET_PKG_NAME=clientset
 

--- a/hack/verify-examples-kind.sh
+++ b/hack/verify-examples-kind.sh
@@ -21,7 +21,7 @@ set -o pipefail
 readonly GO111MODULE="on"
 readonly GOFLAGS="-mod=readonly"
 readonly GOPATH="$(mktemp -d)"
-readonly CLUSTER_NAME="verify-service-apis"
+readonly CLUSTER_NAME="verify-gateway-api"
 readonly KUBECONFIG="${GOPATH}/.kubeconfig"
 
 export GOFLAGS GO111MODULE GOPATH
@@ -54,7 +54,7 @@ kind create cluster --name "${CLUSTER_NAME}" --kubeconfig "${KUBECONFIG}" || res
 # Install CRDs
 kubectl apply --kubeconfig "${KUBECONFIG}" -f config/crd/bases || res=$?
 
-# Install all example service-apis resources.
+# Install all example gateway-api resources.
 kubectl apply --kubeconfig "${KUBECONFIG}" -f examples || res=$?
 
 # Clean up and exit

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: Kubernetes Service APIs
-repo_url: http://sigs.k8s.io/service-apis
+site_name: Kubernetes Gateway API
+repo_url: http://sigs.k8s.io/gateway-api
 repo_name: GitHub
 site_dir: docs
 docs_dir: docs-src
@@ -22,7 +22,7 @@ nav:
       - Introduction: guides.md
       - Getting started: getting-started.md
       - Simple Gateway: simple-gateway.md
-      - HTTP routing: http-routing.md 
+      - HTTP routing: http-routing.md
       - HTTP traffic splitting: traffic-splitting.md
       - Multiple namespaces and routes: multiple-ns.md
       - TLS: tls.md

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -24,7 +24,7 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
-	networkingv1alpha1 "sigs.k8s.io/service-apis/pkg/client/clientset/versioned/typed/apis/v1alpha1"
+	networkingv1alpha1 "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1alpha1"
 )
 
 type Interface interface {

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
-	clientset "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
-	networkingv1alpha1 "sigs.k8s.io/service-apis/pkg/client/clientset/versioned/typed/apis/v1alpha1"
-	fakenetworkingv1alpha1 "sigs.k8s.io/service-apis/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake"
+	clientset "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+	networkingv1alpha1 "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1alpha1"
+	fakenetworkingv1alpha1 "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -24,7 +24,7 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	networkingv1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	networkingv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 var scheme = runtime.NewScheme()

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -24,7 +24,7 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	networkingv1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	networkingv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 var Scheme = runtime.NewScheme()

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/apis_client.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/apis_client.go
@@ -20,8 +20,8 @@ package v1alpha1
 
 import (
 	rest "k8s.io/client-go/rest"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
-	"sigs.k8s.io/service-apis/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+	"sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/scheme"
 )
 
 type NetworkingV1alpha1Interface interface {

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/backendpolicy.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/backendpolicy.go
@@ -26,8 +26,8 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
-	scheme "sigs.k8s.io/service-apis/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+	scheme "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/scheme"
 )
 
 // BackendPoliciesGetter has a method to return a BackendPolicyInterface.

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_apis_client.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_apis_client.go
@@ -21,7 +21,7 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
-	v1alpha1 "sigs.k8s.io/service-apis/pkg/client/clientset/versioned/typed/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1alpha1"
 )
 
 type FakeNetworkingV1alpha1 struct {

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_backendpolicy.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_backendpolicy.go
@@ -27,7 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // FakeBackendPolicies implements BackendPolicyInterface

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_gateway.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_gateway.go
@@ -27,7 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // FakeGateways implements GatewayInterface

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_gatewayclass.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_gatewayclass.go
@@ -27,7 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // FakeGatewayClasses implements GatewayClassInterface

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_httproute.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_httproute.go
@@ -27,7 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // FakeHTTPRoutes implements HTTPRouteInterface

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_tcproute.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_tcproute.go
@@ -27,7 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // FakeTCPRoutes implements TCPRouteInterface

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_tlsroute.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_tlsroute.go
@@ -27,7 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // FakeTLSRoutes implements TLSRouteInterface

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_udproute.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_udproute.go
@@ -27,7 +27,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // FakeUDPRoutes implements UDPRouteInterface

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/gateway.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/gateway.go
@@ -26,8 +26,8 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
-	scheme "sigs.k8s.io/service-apis/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+	scheme "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/scheme"
 )
 
 // GatewaysGetter has a method to return a GatewayInterface.

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/gatewayclass.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/gatewayclass.go
@@ -26,8 +26,8 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
-	scheme "sigs.k8s.io/service-apis/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+	scheme "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/scheme"
 )
 
 // GatewayClassesGetter has a method to return a GatewayClassInterface.

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/httproute.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/httproute.go
@@ -26,8 +26,8 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
-	scheme "sigs.k8s.io/service-apis/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+	scheme "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/scheme"
 )
 
 // HTTPRoutesGetter has a method to return a HTTPRouteInterface.

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/tcproute.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/tcproute.go
@@ -26,8 +26,8 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
-	scheme "sigs.k8s.io/service-apis/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+	scheme "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/scheme"
 )
 
 // TCPRoutesGetter has a method to return a TCPRouteInterface.

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/tlsroute.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/tlsroute.go
@@ -26,8 +26,8 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
-	scheme "sigs.k8s.io/service-apis/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+	scheme "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/scheme"
 )
 
 // TLSRoutesGetter has a method to return a TLSRouteInterface.

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/udproute.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/udproute.go
@@ -26,8 +26,8 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
-	scheme "sigs.k8s.io/service-apis/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+	scheme "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/scheme"
 )
 
 // UDPRoutesGetter has a method to return a UDPRouteInterface.

--- a/pkg/client/informers/externalversions/apis/interface.go
+++ b/pkg/client/informers/externalversions/apis/interface.go
@@ -19,8 +19,8 @@ limitations under the License.
 package apis
 
 import (
-	v1alpha1 "sigs.k8s.io/service-apis/pkg/client/informers/externalversions/apis/v1alpha1"
-	internalinterfaces "sigs.k8s.io/service-apis/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis/v1alpha1"
+	internalinterfaces "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to each of this group's versions.

--- a/pkg/client/informers/externalversions/apis/v1alpha1/backendpolicy.go
+++ b/pkg/client/informers/externalversions/apis/v1alpha1/backendpolicy.go
@@ -26,10 +26,10 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
-	apisv1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
-	versioned "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
-	internalinterfaces "sigs.k8s.io/service-apis/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "sigs.k8s.io/service-apis/pkg/client/listers/apis/v1alpha1"
+	apisv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+	versioned "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+	internalinterfaces "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1alpha1"
 )
 
 // BackendPolicyInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/apis/v1alpha1/gateway.go
+++ b/pkg/client/informers/externalversions/apis/v1alpha1/gateway.go
@@ -26,10 +26,10 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
-	apisv1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
-	versioned "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
-	internalinterfaces "sigs.k8s.io/service-apis/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "sigs.k8s.io/service-apis/pkg/client/listers/apis/v1alpha1"
+	apisv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+	versioned "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+	internalinterfaces "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1alpha1"
 )
 
 // GatewayInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/apis/v1alpha1/gatewayclass.go
+++ b/pkg/client/informers/externalversions/apis/v1alpha1/gatewayclass.go
@@ -26,10 +26,10 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
-	apisv1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
-	versioned "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
-	internalinterfaces "sigs.k8s.io/service-apis/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "sigs.k8s.io/service-apis/pkg/client/listers/apis/v1alpha1"
+	apisv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+	versioned "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+	internalinterfaces "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1alpha1"
 )
 
 // GatewayClassInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/apis/v1alpha1/httproute.go
+++ b/pkg/client/informers/externalversions/apis/v1alpha1/httproute.go
@@ -26,10 +26,10 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
-	apisv1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
-	versioned "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
-	internalinterfaces "sigs.k8s.io/service-apis/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "sigs.k8s.io/service-apis/pkg/client/listers/apis/v1alpha1"
+	apisv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+	versioned "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+	internalinterfaces "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1alpha1"
 )
 
 // HTTPRouteInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/apis/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/apis/v1alpha1/interface.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	internalinterfaces "sigs.k8s.io/service-apis/pkg/client/informers/externalversions/internalinterfaces"
+	internalinterfaces "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/pkg/client/informers/externalversions/apis/v1alpha1/tcproute.go
+++ b/pkg/client/informers/externalversions/apis/v1alpha1/tcproute.go
@@ -26,10 +26,10 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
-	apisv1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
-	versioned "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
-	internalinterfaces "sigs.k8s.io/service-apis/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "sigs.k8s.io/service-apis/pkg/client/listers/apis/v1alpha1"
+	apisv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+	versioned "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+	internalinterfaces "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1alpha1"
 )
 
 // TCPRouteInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/apis/v1alpha1/tlsroute.go
+++ b/pkg/client/informers/externalversions/apis/v1alpha1/tlsroute.go
@@ -26,10 +26,10 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
-	apisv1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
-	versioned "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
-	internalinterfaces "sigs.k8s.io/service-apis/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "sigs.k8s.io/service-apis/pkg/client/listers/apis/v1alpha1"
+	apisv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+	versioned "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+	internalinterfaces "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1alpha1"
 )
 
 // TLSRouteInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/apis/v1alpha1/udproute.go
+++ b/pkg/client/informers/externalversions/apis/v1alpha1/udproute.go
@@ -26,10 +26,10 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
-	apisv1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
-	versioned "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
-	internalinterfaces "sigs.k8s.io/service-apis/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "sigs.k8s.io/service-apis/pkg/client/listers/apis/v1alpha1"
+	apisv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+	versioned "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+	internalinterfaces "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1alpha1"
 )
 
 // UDPRouteInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -27,9 +27,9 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
-	versioned "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
-	apis "sigs.k8s.io/service-apis/pkg/client/informers/externalversions/apis"
-	internalinterfaces "sigs.k8s.io/service-apis/pkg/client/informers/externalversions/internalinterfaces"
+	versioned "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+	apis "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/apis"
+	internalinterfaces "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 // SharedInformerOption defines the functional option type for SharedInformerFactory.

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -23,7 +23,7 @@ import (
 
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // GenericInformer is type of SharedIndexInformer which will locate and delegate to other

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -24,7 +24,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
-	versioned "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
+	versioned "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 )
 
 // NewInformerFunc takes versioned.Interface and time.Duration to return a SharedIndexInformer.

--- a/pkg/client/listers/apis/v1alpha1/backendpolicy.go
+++ b/pkg/client/listers/apis/v1alpha1/backendpolicy.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // BackendPolicyLister helps list BackendPolicies.

--- a/pkg/client/listers/apis/v1alpha1/gateway.go
+++ b/pkg/client/listers/apis/v1alpha1/gateway.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // GatewayLister helps list Gateways.

--- a/pkg/client/listers/apis/v1alpha1/gatewayclass.go
+++ b/pkg/client/listers/apis/v1alpha1/gatewayclass.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // GatewayClassLister helps list GatewayClasses.

--- a/pkg/client/listers/apis/v1alpha1/httproute.go
+++ b/pkg/client/listers/apis/v1alpha1/httproute.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // HTTPRouteLister helps list HTTPRoutes.

--- a/pkg/client/listers/apis/v1alpha1/tcproute.go
+++ b/pkg/client/listers/apis/v1alpha1/tcproute.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // TCPRouteLister helps list TCPRoutes.

--- a/pkg/client/listers/apis/v1alpha1/tlsroute.go
+++ b/pkg/client/listers/apis/v1alpha1/tlsroute.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // TLSRouteLister helps list TLSRoutes.

--- a/pkg/client/listers/apis/v1alpha1/udproute.go
+++ b/pkg/client/listers/apis/v1alpha1/udproute.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	v1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
+	v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // UDPRouteLister helps list UDPRoutes.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
As discussed in #536, Gateway API more clearly represents this project now.

**Which issue(s) this PR fixes**:
Fixes #536

**Does this PR introduce a user-facing change?**:
```release-note
Renames Service APIs to Gateway API
```