### PR TITLE
Adding notes referring to previous project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Kubernetes Gateway API
 
-The Gateway API is a part of the [SIG Network][sn], and this repository
-contains the specification and Custom Resource Definitions (CRDs).
+The Gateway API is a part of the [SIG Network][sn], and this repository contains
+the specification and Custom Resource Definitions (CRDs).
+
+*Note: This project was previously named "Service APIs" until being renamed to
+"Gateway API" in February 2021.*
 
 ## Documentation
 

--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -5,6 +5,9 @@ community. The project's goal is to evolve service networking APIs within the
 Kubernetes ecosystem. Gateway API provide interfaces to expose Kubernetes
 applications - Services, Ingress, and more.
 
+*Note: This project was previously named "Service APIs" until being renamed to
+"Gateway API" in February 2021.*
+
 ### What is the goal of Gateway API?
 
 Gateway API aims to improve service networking by providing expressive,

--- a/docs/index.html
+++ b/docs/index.html
@@ -656,6 +656,8 @@
 community. The project's goal is to evolve service networking APIs within the
 Kubernetes ecosystem. Gateway API provide interfaces to expose Kubernetes
 applications - Services, Ingress, and more.</p>
+<p><em>Note: This project was previously named "Service APIs" until being renamed to
+"Gateway API" in February 2021.</em></p>
 <h3 id="what-is-the-goal-of-gateway-api">What is the goal of Gateway API?</h3>
 <p>Gateway API aims to improve service networking by providing expressive,
 extensible, role-oriented interfaces that are implemented by many vendors and


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
@hbagdi suggested this in https://github.com/kubernetes-sigs/gateway-api/pull/541 and I just realized I forgot to actually update that PR. This should make it a bit clearer that this is actually the project that used to be known as "Service APIs" for anyone that might be confused.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @hbagdi 