### PR TITLE
Fix broken link in TCPRoute guide

### DIFF
--- a/site-src/tcp.md
+++ b/site-src/tcp.md
@@ -1,5 +1,5 @@
 Gateway API is designed to work with multiple protocols.
-[TCPRoute](spec/#networking.x-k8s.io/v1alpha1.TCPRoute) is one such route which
+[TCPRoute](/spec/#networking.x-k8s.io/v1alpha1.TCPRoute) is one such route which
 allows for managing TCP traffic.
 
 In this example, we have one Gateway resource and two TCPRoute resources that


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://kubernetes-sigs.github.io/gateway-api/devguide/)
   and our community page (https://kubernetes-sigs.github.io/gateway-api/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Use an absolute path for the TCPRoute spec. The current relative path attempts to load `/tcp/spec/#networking.x-k8s.io/v1alpha1.TCPRoute`, but the spec actually lives at `/spec/#networking.x-k8s.io/v1alpha1.TCPRoute`:

https://gateway-api.sigs.k8s.io/tcp/spec/#networking.x-k8s.io/v1alpha1.TCPRoute
https://gateway-api.sigs.k8s.io/spec/#networking.x-k8s.io/v1alpha1.TCPRoute


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
