### PR TITLE
Adding gateway-api category and age column to CRDs

### DIFF
--- a/apis/v1alpha1/backendpolicy_types.go
+++ b/apis/v1alpha1/backendpolicy_types.go
@@ -22,8 +22,9 @@ import (
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=bp
+// +kubebuilder:resource:categories=gateway-api,shortName=bp
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // BackendPolicy defines policies associated with backends. For the purpose of
 // this API, a backend is defined as any resource that a route can forward

--- a/apis/v1alpha1/gateway_types.go
+++ b/apis/v1alpha1/gateway_types.go
@@ -22,9 +22,10 @@ import (
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=gtw
+// +kubebuilder:resource:categories=gateway-api,shortName=gtw
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Class",type=string,JSONPath=`.spec.gatewayClassName`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // Gateway represents an instantiation of a service-traffic handling
 // infrastructure by binding Listeners to a set of IP addresses.

--- a/apis/v1alpha1/gatewayclass_types.go
+++ b/apis/v1alpha1/gatewayclass_types.go
@@ -23,9 +23,10 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster,shortName=gc
+// +kubebuilder:resource:categories=gateway-api,scope=Cluster,shortName=gc
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Controller",type=string,JSONPath=`.spec.controller`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // GatewayClass describes a class of Gateways available to the user
 // for creating Gateway resources.

--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -22,8 +22,10 @@ import (
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=gateway-api
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Hostnames",type=string,JSONPath=`.spec.hostnames`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // HTTPRoute is the Schema for the HTTPRoute resource.
 type HTTPRoute struct {

--- a/apis/v1alpha1/tcproute_types.go
+++ b/apis/v1alpha1/tcproute_types.go
@@ -22,7 +22,9 @@ import (
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=gateway-api
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // TCPRoute is the Schema for the TCPRoute resource.
 type TCPRoute struct {

--- a/apis/v1alpha1/tlsroute_types.go
+++ b/apis/v1alpha1/tlsroute_types.go
@@ -22,7 +22,9 @@ import (
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=gateway-api
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // The TLSRoute resource is similar to TCPRoute, but can be configured
 // to match against TLS-specific metadata. This allows more flexibility

--- a/apis/v1alpha1/udproute_types.go
+++ b/apis/v1alpha1/udproute_types.go
@@ -22,7 +22,9 @@ import (
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=gateway-api
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // UDPRoute is a resource that specifies how a Gateway should forward UDP traffic.
 type UDPRoute struct {

--- a/config/crd/bases/networking.x-k8s.io_backendpolicies.yaml
+++ b/config/crd/bases/networking.x-k8s.io_backendpolicies.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: networking.x-k8s.io
   names:
+    categories:
+    - gateway-api
     kind: BackendPolicy
     listKind: BackendPolicyList
     plural: backendpolicies
@@ -18,7 +20,11 @@ spec:
     singular: backendpolicy
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: BackendPolicy defines policies associated with backends. For the purpose of this API, a backend is defined as any resource that a route can forward traffic to. A common example of a backend is a Service. Configuration that is implementation specific may be represented with similar implementation specific custom resources.

--- a/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: networking.x-k8s.io
   names:
+    categories:
+    - gateway-api
     kind: GatewayClass
     listKind: GatewayClassList
     plural: gatewayclasses
@@ -22,6 +24,9 @@ spec:
     - jsonPath: .spec.controller
       name: Controller
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: networking.x-k8s.io
   names:
+    categories:
+    - gateway-api
     kind: Gateway
     listKind: GatewayList
     plural: gateways
@@ -22,6 +24,9 @@ spec:
     - jsonPath: .spec.gatewayClassName
       name: Class
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: networking.x-k8s.io
   names:
+    categories:
+    - gateway-api
     kind: HTTPRoute
     listKind: HTTPRouteList
     plural: httproutes
@@ -20,6 +22,9 @@ spec:
     - jsonPath: .spec.hostnames
       name: Hostnames
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
@@ -10,13 +10,19 @@ metadata:
 spec:
   group: networking.x-k8s.io
   names:
+    categories:
+    - gateway-api
     kind: TCPRoute
     listKind: TCPRouteList
     plural: tcproutes
     singular: tcproute
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: TCPRoute is the Schema for the TCPRoute resource.

--- a/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
@@ -10,13 +10,19 @@ metadata:
 spec:
   group: networking.x-k8s.io
   names:
+    categories:
+    - gateway-api
     kind: TLSRoute
     listKind: TLSRouteList
     plural: tlsroutes
     singular: tlsroute
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: "The TLSRoute resource is similar to TCPRoute, but can be configured to match against TLS-specific metadata. This allows more flexibility in matching streams for a given TLS listener. \n If you need to forward traffic to a single target for a TLS listener, you could choose to use a TCPRoute with a TLS listener."

--- a/config/crd/bases/networking.x-k8s.io_udproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_udproutes.yaml
@@ -10,13 +10,19 @@ metadata:
 spec:
   group: networking.x-k8s.io
   names:
+    categories:
+    - gateway-api
     kind: UDPRoute
     listKind: UDPRouteList
     plural: udproutes
     singular: udproute
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: UDPRoute is a resource that specifies how a Gateway should forward UDP traffic.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This adds a gateway-api category to our CRDs as well as a new "age" column for "kubectl get" output.
<img width="901" alt="Screen Shot 2021-03-19 at 3 06 04 PM" src="https://user-images.githubusercontent.com/419322/111846763-b7969a00-88c4-11eb-9d21-7af0059ec168.png">

**Which issue(s) this PR fixes**:
Fixes #589
Also inspired by #588 

**Does this PR introduce a user-facing change?**:
```release-note
* Gateway API CRDs are not part of the "gateway-api" category. Running "kubectl get gateway-api" now returns all Gateway API resources.
* Each Gateway API resource now includes an "Age" column in "kubectl get" output.
```