### PR TITLE
Introduces a Validation Package

### DIFF
--- a/apis/v1alpha1/validation/doc.go
+++ b/apis/v1alpha1/validation/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package validation has functions for validating the correctness of api
+// objects and explaining what's wrong with them when they're not valid.
+package validation // import "sigs.k8s.io/gateway-api/apis/v1alpha1/validation"

--- a/apis/v1alpha1/validation/validation.go
+++ b/apis/v1alpha1/validation/validation.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"net"
+	"strings"
+
+	gatewayv1a1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateGateway validates gw according to the Gateway API specification.
+// For additional details of the Gateway spec, refer to:
+//  https://gateway-api.sigs.k8s.io/spec/#networking.x-k8s.io/v1alpha1.Gateway
+func ValidateGateway(gw *gatewayv1a1.Gateway) field.ErrorList {
+	return validateGatewaySpec(&gw.Spec, field.NewPath("spec"))
+}
+
+// validateGatewaySpec validates whether required fields of spec are set according to the
+// Gateway API specification.
+func validateGatewaySpec(spec *gatewayv1a1.GatewaySpec, path *field.Path) field.ErrorList {
+	// TODO [danehans]: Add additional validation of spec fields.
+	return validateGatewayListeners(spec.Listeners, path.Child("listeners"))
+}
+
+// validateGatewayListeners validates whether required fields of listeners are set according
+// to the Gateway API specification.
+func validateGatewayListeners(listeners []gatewayv1a1.Listener, path *field.Path) field.ErrorList {
+	// TODO [danehans]: Add additional validation of listener fields.
+	return validateListenerHostname(listeners, path)
+}
+
+// validateListenerHostname validates each listener hostname is not an IP address and is one
+// of the following:
+//  - A fully qualified domain name of a network host, as defined by RFC 3986.
+//  - A DNS subdomain as defined by RFC 1123.
+//  - A wildcard DNS subdomain as defined by RFC 1034 (section 4.3.3).
+func validateListenerHostname(listeners []gatewayv1a1.Listener, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	for i, h := range listeners {
+		// When unspecified, “”, or *, all hostnames are matched.
+		if h.Hostname == nil || (*h.Hostname == "" || *h.Hostname == "*") {
+			continue
+		}
+		hostname := string(*h.Hostname)
+		if ip := net.ParseIP(hostname); ip != nil {
+			errs = append(errs, field.Invalid(path.Index(i).Child("hostname"), hostname, "must be a DNS hostname, not an IP address"))
+		}
+		if strings.Contains(hostname, "*") {
+			for _, msg := range validation.IsWildcardDNS1123Subdomain(hostname) {
+				errs = append(errs, field.Invalid(path.Index(i).Child("hostname"), hostname, msg))
+			}
+		} else {
+			for _, msg := range validation.IsDNS1123Subdomain(hostname) {
+				errs = append(errs, field.Invalid(path.Index(i).Child("hostname"), hostname, msg))
+			}
+		}
+	}
+	return errs
+}

--- a/apis/v1alpha1/validation/validation_test.go
+++ b/apis/v1alpha1/validation/validation_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	gatewayv1a1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidateGateway(t *testing.T) {
+	listeners := []gatewayv1a1.Listener{
+		{
+			Hostname: nil,
+		},
+	}
+	baseGateway := gatewayv1a1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: gatewayv1a1.GatewaySpec{
+			GatewayClassName: "foo",
+			Listeners:        listeners,
+		},
+	}
+
+	testCases := map[string]struct {
+		mutate             func(gw *gatewayv1a1.Gateway)
+		expectErrsOnFields []string
+	}{
+		"nil hostname": {
+			mutate:             func(gw *gatewayv1a1.Gateway) {},
+			expectErrsOnFields: []string{},
+		},
+		"empty string hostname": {
+			mutate: func(gw *gatewayv1a1.Gateway) {
+				hostname := gatewayv1a1.Hostname("")
+				gw.Spec.Listeners[0].Hostname = &hostname
+			},
+			expectErrsOnFields: []string{},
+		},
+		"wildcard hostname": {
+			mutate: func(gw *gatewayv1a1.Gateway) {
+				hostname := gatewayv1a1.Hostname("*")
+				gw.Spec.Listeners[0].Hostname = &hostname
+			},
+			expectErrsOnFields: []string{},
+		},
+		"wildcard-prefixed hostname": {
+			mutate: func(gw *gatewayv1a1.Gateway) {
+				hostname := gatewayv1a1.Hostname("*.example.com")
+				gw.Spec.Listeners[0].Hostname = &hostname
+			},
+			expectErrsOnFields: []string{},
+		},
+		"valid dns subdomain": {
+			mutate: func(gw *gatewayv1a1.Gateway) {
+				hostname := gatewayv1a1.Hostname("foo.example.com")
+				gw.Spec.Listeners[0].Hostname = &hostname
+			},
+			expectErrsOnFields: []string{},
+		},
+		// Invalid use cases
+		"IPv4 address hostname": {
+			mutate: func(gw *gatewayv1a1.Gateway) {
+				hostname := gatewayv1a1.Hostname("1.2.3.4")
+				gw.Spec.Listeners[0].Hostname = &hostname
+			},
+			expectErrsOnFields: []string{"spec.listeners[0].hostname"},
+		},
+		"Invalid IPv4 address hostname": {
+			mutate: func(gw *gatewayv1a1.Gateway) {
+				hostname := gatewayv1a1.Hostname("1.2.3..4")
+				gw.Spec.Listeners[0].Hostname = &hostname
+			},
+			expectErrsOnFields: []string{"spec.listeners[0].hostname"},
+		},
+		"IPv4 address with port hostname": {
+			mutate: func(gw *gatewayv1a1.Gateway) {
+				hostname := gatewayv1a1.Hostname("1.2.3.4:8080")
+				gw.Spec.Listeners[0].Hostname = &hostname
+			},
+			expectErrsOnFields: []string{"spec.listeners[0].hostname"},
+		},
+		"IPv6 address hostname": {
+			mutate: func(gw *gatewayv1a1.Gateway) {
+				hostname := gatewayv1a1.Hostname("2001:db8::68")
+				gw.Spec.Listeners[0].Hostname = &hostname
+			},
+			expectErrsOnFields: []string{"spec.listeners[0].hostname", "spec.listeners[0].hostname"},
+		},
+		"IPv6 link-local address hostname": {
+			mutate: func(gw *gatewayv1a1.Gateway) {
+				hostname := gatewayv1a1.Hostname("fe80::/10")
+				gw.Spec.Listeners[0].Hostname = &hostname
+			},
+			expectErrsOnFields: []string{"spec.listeners[0].hostname"},
+		},
+		"dns subdomain with port": {
+			mutate: func(gw *gatewayv1a1.Gateway) {
+				hostname := gatewayv1a1.Hostname("foo.example.com:8080")
+				gw.Spec.Listeners[0].Hostname = &hostname
+			},
+			expectErrsOnFields: []string{"spec.listeners[0].hostname"},
+		},
+		"dns subdomain with invalid wildcard label": {
+			mutate: func(gw *gatewayv1a1.Gateway) {
+				hostname := gatewayv1a1.Hostname("*.*.com")
+				gw.Spec.Listeners[0].Hostname = &hostname
+			},
+			expectErrsOnFields: []string{"spec.listeners[0].hostname"},
+		},
+		"dns subdomain with multiple wildcards": {
+			mutate: func(gw *gatewayv1a1.Gateway) {
+				hostname := gatewayv1a1.Hostname("*.foo.*.com")
+				gw.Spec.Listeners[0].Hostname = &hostname
+			},
+			expectErrsOnFields: []string{"spec.listeners[0].hostname"},
+		},
+		"dns subdomain with wildcard root label": {
+			mutate: func(gw *gatewayv1a1.Gateway) {
+				hostname := gatewayv1a1.Hostname("*.foo.*.com")
+				gw.Spec.Listeners[0].Hostname = &hostname
+			},
+			expectErrsOnFields: []string{"spec.listeners[0].hostname"},
+		},
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			gw := baseGateway.DeepCopy()
+			tc.mutate(gw)
+			errs := ValidateGateway(gw)
+			if len(tc.expectErrsOnFields) != len(errs) {
+				t.Fatalf("Expected %d errors, got %d errors: %v", len(tc.expectErrsOnFields), len(errs), errs)
+			}
+			for i, err := range errs {
+				if err.Field != tc.expectErrsOnFields[i] {
+					t.Errorf("Expected error on field: %s, got: %s", tc.expectErrsOnFields[i], err.Error())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

**What this PR does / why we need it**:
This PR adds a validation package. It's needed so implementors no longer need to create a Gateway API validation package. This approach provides validation consistency across implementations, including the future validating webhook. The package is modeled after the Kubernetes [networking APIs validation package](https://github.com/kubernetes/kubernetes/tree/release-1.19/pkg/apis/networking/validation).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Partially Fixes # https://github.com/kubernetes-sigs/gateway-api/issues/487

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```

/cc @stevesloka @youngnick @jpeach 