### PR TITLE
Making GatewayClass an optional resource

### DIFF
--- a/apis/v1alpha1/gateway_types.go
+++ b/apis/v1alpha1/gateway_types.go
@@ -63,8 +63,13 @@ type GatewayList struct {
 // webhook, but there are many cases that will require asynchronous
 // signaling via the GatewayStatus block.
 type GatewaySpec struct {
-	// GatewayClassName used for this Gateway. This is the name of a
-	// GatewayClass resource.
+	// GatewayClassName used for this Gateway. This may refer to a GatewayClass
+	// resource by name.
+	//
+	// Implementations may also support using this field to specify a controller
+	// name directly without a corresponding GatewayClass resource. This is
+	// particularly useful for namespace-scoped implementations that may not
+	// have access to the cluster-scoped GatewayClass resource.
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -86,8 +86,12 @@ spec:
                 maxItems: 16
                 type: array
               gatewayClassName:
-                description: GatewayClassName used for this Gateway. This is the name
-                  of a GatewayClass resource.
+                description: "GatewayClassName used for this Gateway. This may refer
+                  to a GatewayClass resource by name. \n Implementations may also
+                  support using this field to specify a controller name directly without
+                  a corresponding GatewayClass resource. This is particularly useful
+                  for namespace-scoped implementations that may not have access to
+                  the cluster-scoped GatewayClass resource."
                 maxLength: 253
                 minLength: 1
                 type: string


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind api-change

**What this PR does / why we need it**:
This has been a popular request for IngressClass as well and would make namespace-scoped implementations of the API possible.

**Which issue(s) this PR fixes**:
Fixes #567

**Does this PR introduce a user-facing change?**:
```release-note
GatewayClass resources are now optional to provide better support for namespace-scoped implementations.
```

/cc @howardjohn @hbagdi @bowei 
/assign @thockin 
