### PR TITLE
Adding conflict resolution guidance for equivalent rules within a route

### DIFF
--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -179,12 +179,17 @@ type HTTPRouteRule struct {
 	//
 	// * The longest matching hostname.
 	// * The longest matching path.
-	// * The largest number of header matches
+	// * The largest number of header matches.
+	//
+	// If ties still exist across multiple Routes:
 	// * The oldest Route based on creation timestamp. For example, a Route with
 	//   a creation timestamp of "2020-09-08 01:02:03" is given precedence over
 	//   a Route with a creation timestamp of "2020-09-08 01:02:04".
 	// * The Route appearing first in alphabetical order (namespace/name) for
 	//   example, foo/bar is given precedence over foo/baz.
+	//
+	// If ties still exist within the Route that has been given precedence:
+	// * The first matching rule meeting the above criteria.
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=8

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -613,12 +613,15 @@ spec:
                         HTTP route rules. Matching precedence MUST be determined in
                         order of the following criteria, continuing on ties: \n *
                         The longest matching hostname. * The longest matching path.
-                        * The largest number of header matches * The oldest Route
-                        based on creation timestamp. For example, a Route with   a
-                        creation timestamp of \"2020-09-08 01:02:03\" is given precedence
-                        over   a Route with a creation timestamp of \"2020-09-08 01:02:04\".
-                        * The Route appearing first in alphabetical order (namespace/name)
-                        for   example, foo/bar is given precedence over foo/baz."
+                        * The largest number of header matches. \n If ties still exist
+                        across multiple Routes: * The oldest Route based on creation
+                        timestamp. For example, a Route with   a creation timestamp
+                        of \"2020-09-08 01:02:03\" is given precedence over   a Route
+                        with a creation timestamp of \"2020-09-08 01:02:04\". * The
+                        Route appearing first in alphabetical order (namespace/name)
+                        for   example, foo/bar is given precedence over foo/baz. \n
+                        If ties still exist within the Route that has been given precedence:
+                        * The first matching rule meeting the above criteria."
                       items:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given action. Multiple match types are


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
This adds conflict resolution guidance for equivalent rules within a route.

**Which issue(s) this PR fixes**:
Fixes #613 

**Does this PR introduce a user-facing change?**:
```release-note
Adds conflict resolution guidance for equivalent rules within a route
```

/cc @stevesloka @youngnick @hbagdi 