### PR TITLE
Clarifying how conflicting matches should be resolved in non-HTTP Routes

### DIFF
--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -142,9 +142,8 @@ type RouteTLSConfig struct {
 // conditions, optionally executing additional processing steps, and forwarding
 // the request to an API object.
 type HTTPRouteRule struct {
-	// Matches define conditions used for matching the rule against
-	// incoming HTTP requests.
-	// Each match is independent, i.e. this rule will be matched
+	// Matches define conditions used for matching the rule against incoming
+	// HTTP requests. Each match is independent, i.e. this rule will be matched
 	// if **any** one of the matches is satisfied.
 	//
 	// For example, take the following matches configuration:
@@ -174,22 +173,27 @@ type HTTPRouteRule struct {
 	// HTTP request.
 	//
 	//
-	// A client request may match multiple HTTP route rules. Matching precedence
-	// MUST be determined in order of the following criteria, continuing on ties:
+	// Each client request MUST map to a maximum of one route rule. If a request
+	// matches multiple rules, matching precedence MUST be determined in order
+	// of the following criteria, continuing on ties:
 	//
 	// * The longest matching hostname.
 	// * The longest matching path.
 	// * The largest number of header matches.
 	//
-	// If ties still exist across multiple Routes:
+	// If ties still exist across multiple Routes, matching precedence MUST be
+	// determined in order of the following criteria, continuing on ties:
+	//
 	// * The oldest Route based on creation timestamp. For example, a Route with
 	//   a creation timestamp of "2020-09-08 01:02:03" is given precedence over
 	//   a Route with a creation timestamp of "2020-09-08 01:02:04".
-	// * The Route appearing first in alphabetical order (namespace/name) for
-	//   example, foo/bar is given precedence over foo/baz.
+	// * The Route appearing first in alphabetical order by
+	//   "<namespace>/<name>". For example, foo/bar is given precedence over
+	//   foo/baz.
 	//
-	// If ties still exist within the Route that has been given precedence:
-	// * The first matching rule meeting the above criteria.
+	// If ties still exist within the Route that has been given precedence,
+	// matching precedence MUST be granted to the first matching rule meeting
+	// the above criteria.
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=8

--- a/apis/v1alpha1/tcproute_types.go
+++ b/apis/v1alpha1/tcproute_types.go
@@ -60,11 +60,32 @@ type TCPRouteStatus struct {
 
 // TCPRouteRule is the configuration for a given rule.
 type TCPRouteRule struct {
-	// Matches define conditions used for matching the rule against
-	// incoming TCP connections. Each match is independent, i.e. this
-	// rule will be matched if **any** one of the matches is satisfied.
-	// If unspecified, all requests from the associated gateway TCP
-	// listener will match.
+	// Matches define conditions used for matching the rule against incoming TCP
+	// connections. Each match is independent, i.e. this rule will be matched if
+	// **any** one of the matches is satisfied. If unspecified (i.e. empty),
+	// this Rule will match all requests for the associated Listener.
+	//
+	// Each client request MUST map to a maximum of one route rule. If a request
+	// matches multiple rules, matching precedence MUST be determined in order
+	// of the following criteria, continuing on ties:
+	//
+	// * The most specific match specified by ExtensionRef. Each implementation
+	//   that supports ExtensionRef may have different ways of determining the
+	//   specificity of the referenced extension.
+	//
+	// If ties still exist across multiple Routes, matching precedence MUST be
+	// determined in order of the following criteria, continuing on ties:
+	//
+	// * The oldest Route based on creation timestamp. For example, a Route with
+	//   a creation timestamp of "2020-09-08 01:02:03" is given precedence over
+	//   a Route with a creation timestamp of "2020-09-08 01:02:04".
+	// * The Route appearing first in alphabetical order by
+	//   "<namespace>/<name>". For example, foo/bar is given precedence over
+	//   foo/baz.
+	//
+	// If ties still exist within the Route that has been given precedence,
+	// matching precedence MUST be granted to the first matching rule meeting
+	// the above criteria.
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=8

--- a/apis/v1alpha1/tlsroute_types.go
+++ b/apis/v1alpha1/tlsroute_types.go
@@ -65,11 +65,35 @@ type TLSRouteStatus struct {
 
 // TLSRouteRule is the configuration for a given rule.
 type TLSRouteRule struct {
-	// Matches define conditions used for matching the rule against an
-	// incoming TLS handshake. Each match is independent, i.e. this
-	// rule will be matched if **any** one of the matches is satisfied.
-	// If unspecified, all requests from the associated gateway TLS
-	// listener will match.
+	// Matches define conditions used for matching the rule against incoming TLS
+	// connections. Each match is independent, i.e. this rule will be matched if
+	// **any** one of the matches is satisfied. If unspecified (i.e. empty),
+	// this Rule will match all requests for the associated Listener.
+	//
+	// Each client request MUST map to a maximum of one route rule. If a request
+	// matches multiple rules, matching precedence MUST be determined in order
+	// of the following criteria, continuing on ties:
+	//
+	// * The longest matching SNI.
+	// * The longest matching precise SNI (without a wildcard). This means that
+	//   "b.example.com" should be given precedence over "*.example.com".
+	// * The most specific match specified by ExtensionRef. Each implementation
+	//   that supports ExtensionRef may have different ways of determining the
+	//   specificity of the referenced extension.
+	//
+	// If ties still exist across multiple Routes, matching precedence MUST be
+	// determined in order of the following criteria, continuing on ties:
+	//
+	// * The oldest Route based on creation timestamp. For example, a Route with
+	//   a creation timestamp of "2020-09-08 01:02:03" is given precedence over
+	//   a Route with a creation timestamp of "2020-09-08 01:02:04".
+	// * The Route appearing first in alphabetical order by
+	//   "<namespace>/<name>". For example, foo/bar is given precedence over
+	//   foo/baz.
+	//
+	// If ties still exist within the Route that has been given precedence,
+	// matching precedence MUST be granted to the first matching rule meeting
+	// the above criteria.
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=8

--- a/apis/v1alpha1/udproute_types.go
+++ b/apis/v1alpha1/udproute_types.go
@@ -60,11 +60,32 @@ type UDPRouteStatus struct {
 
 // UDPRouteRule is the configuration for a given rule.
 type UDPRouteRule struct {
-	// Matches define conditions used for matching the rule against
-	// incoming UDP connections. Each match is independent, i.e. this
-	// rule will be matched if **any** one of the matches is satisfied.
-	// If unspecified, all requests from the associated gateway UDP
-	// listener will match.
+	// Matches define conditions used for matching the rule against incoming UDP
+	// connections. Each match is independent, i.e. this rule will be matched if
+	// **any** one of the matches is satisfied. If unspecified (i.e. empty),
+	// this Rule will match all requests for the associated Listener.
+	//
+	// Each client request MUST map to a maximum of one route rule. If a request
+	// matches multiple rules, matching precedence MUST be determined in order
+	// of the following criteria, continuing on ties:
+	//
+	// * The most specific match specified by ExtensionRef. Each implementation
+	//   that supports ExtensionRef may have different ways of determining the
+	//   specificity of the referenced extension.
+	//
+	// If ties still exist across multiple Routes, matching precedence MUST be
+	// determined in order of the following criteria, continuing on ties:
+	//
+	// * The oldest Route based on creation timestamp. For example, a Route with
+	//   a creation timestamp of "2020-09-08 01:02:03" is given precedence over
+	//   a Route with a creation timestamp of "2020-09-08 01:02:04".
+	// * The Route appearing first in alphabetical order by
+	//   "<namespace>/<name>". For example, foo/bar is given precedence over
+	//   foo/baz.
+	//
+	// If ties still exist within the Route that has been given precedence,
+	// matching precedence MUST be granted to the first matching rule meeting
+	// the above criteria.
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=8

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -609,19 +609,22 @@ spec:
                         how to specify multiple match conditions that should be ANDed
                         together. \n If no matches are specified, the default is a
                         prefix path match on \"/\", which has the effect of matching
-                        every HTTP request. \n A client request may match multiple
-                        HTTP route rules. Matching precedence MUST be determined in
-                        order of the following criteria, continuing on ties: \n *
-                        The longest matching hostname. * The longest matching path.
-                        * The largest number of header matches. \n If ties still exist
-                        across multiple Routes: * The oldest Route based on creation
+                        every HTTP request. \n Each client request MUST map to a maximum
+                        of one route rule. If a request matches multiple rules, matching
+                        precedence MUST be determined in order of the following criteria,
+                        continuing on ties: \n * The longest matching hostname. *
+                        The longest matching path. * The largest number of header
+                        matches. \n If ties still exist across multiple Routes, matching
+                        precedence MUST be determined in order of the following criteria,
+                        continuing on ties: \n * The oldest Route based on creation
                         timestamp. For example, a Route with   a creation timestamp
                         of \"2020-09-08 01:02:03\" is given precedence over   a Route
                         with a creation timestamp of \"2020-09-08 01:02:04\". * The
-                        Route appearing first in alphabetical order (namespace/name)
-                        for   example, foo/bar is given precedence over foo/baz. \n
-                        If ties still exist within the Route that has been given precedence:
-                        * The first matching rule meeting the above criteria."
+                        Route appearing first in alphabetical order by   \"<namespace>/<name>\".
+                        For example, foo/bar is given precedence over   foo/baz. \n
+                        If ties still exist within the Route that has been given precedence,
+                        matching precedence MUST be granted to the first matching
+                        rule meeting the above criteria."
                       items:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given action. Multiple match types are

--- a/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
@@ -184,11 +184,28 @@ spec:
                       minItems: 1
                       type: array
                     matches:
-                      description: Matches define conditions used for matching the
+                      description: "Matches define conditions used for matching the
                         rule against incoming TCP connections. Each match is independent,
                         i.e. this rule will be matched if **any** one of the matches
-                        is satisfied. If unspecified, all requests from the associated
-                        gateway TCP listener will match.
+                        is satisfied. If unspecified (i.e. empty), this Rule will
+                        match all requests for the associated Listener. \n Each client
+                        request MUST map to a maximum of one route rule. If a request
+                        matches multiple rules, matching precedence MUST be determined
+                        in order of the following criteria, continuing on ties: \n
+                        * The most specific match specified by ExtensionRef. Each
+                        implementation   that supports ExtensionRef may have different
+                        ways of determining the   specificity of the referenced extension.
+                        \n If ties still exist across multiple Routes, matching precedence
+                        MUST be determined in order of the following criteria, continuing
+                        on ties: \n * The oldest Route based on creation timestamp.
+                        For example, a Route with   a creation timestamp of \"2020-09-08
+                        01:02:03\" is given precedence over   a Route with a creation
+                        timestamp of \"2020-09-08 01:02:04\". * The Route appearing
+                        first in alphabetical order by   \"<namespace>/<name>\". For
+                        example, foo/bar is given precedence over   foo/baz. \n If
+                        ties still exist within the Route that has been given precedence,
+                        matching precedence MUST be granted to the first matching
+                        rule meeting the above criteria."
                       items:
                         description: TCPRouteMatch defines the predicate used to match
                           connections to a given action.

--- a/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
@@ -188,11 +188,31 @@ spec:
                       minItems: 1
                       type: array
                     matches:
-                      description: Matches define conditions used for matching the
-                        rule against an incoming TLS handshake. Each match is independent,
+                      description: "Matches define conditions used for matching the
+                        rule against incoming TLS connections. Each match is independent,
                         i.e. this rule will be matched if **any** one of the matches
-                        is satisfied. If unspecified, all requests from the associated
-                        gateway TLS listener will match.
+                        is satisfied. If unspecified (i.e. empty), this Rule will
+                        match all requests for the associated Listener. \n Each client
+                        request MUST map to a maximum of one route rule. If a request
+                        matches multiple rules, matching precedence MUST be determined
+                        in order of the following criteria, continuing on ties: \n
+                        * The longest matching SNI. * The longest matching precise
+                        SNI (without a wildcard). This means that   \"b.example.com\"
+                        should be given precedence over \"*.example.com\". * The most
+                        specific match specified by ExtensionRef. Each implementation
+                        \  that supports ExtensionRef may have different ways of determining
+                        the   specificity of the referenced extension. \n If ties
+                        still exist across multiple Routes, matching precedence MUST
+                        be determined in order of the following criteria, continuing
+                        on ties: \n * The oldest Route based on creation timestamp.
+                        For example, a Route with   a creation timestamp of \"2020-09-08
+                        01:02:03\" is given precedence over   a Route with a creation
+                        timestamp of \"2020-09-08 01:02:04\". * The Route appearing
+                        first in alphabetical order by   \"<namespace>/<name>\". For
+                        example, foo/bar is given precedence over   foo/baz. \n If
+                        ties still exist within the Route that has been given precedence,
+                        matching precedence MUST be granted to the first matching
+                        rule meeting the above criteria."
                       items:
                         description: TLSRouteMatch defines the predicate used to match
                           connections to a given action.

--- a/config/crd/bases/networking.x-k8s.io_udproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_udproutes.yaml
@@ -185,11 +185,28 @@ spec:
                       minItems: 1
                       type: array
                     matches:
-                      description: Matches define conditions used for matching the
+                      description: "Matches define conditions used for matching the
                         rule against incoming UDP connections. Each match is independent,
                         i.e. this rule will be matched if **any** one of the matches
-                        is satisfied. If unspecified, all requests from the associated
-                        gateway UDP listener will match.
+                        is satisfied. If unspecified (i.e. empty), this Rule will
+                        match all requests for the associated Listener. \n Each client
+                        request MUST map to a maximum of one route rule. If a request
+                        matches multiple rules, matching precedence MUST be determined
+                        in order of the following criteria, continuing on ties: \n
+                        * The most specific match specified by ExtensionRef. Each
+                        implementation   that supports ExtensionRef may have different
+                        ways of determining the   specificity of the referenced extension.
+                        \n If ties still exist across multiple Routes, matching precedence
+                        MUST be determined in order of the following criteria, continuing
+                        on ties: \n * The oldest Route based on creation timestamp.
+                        For example, a Route with   a creation timestamp of \"2020-09-08
+                        01:02:03\" is given precedence over   a Route with a creation
+                        timestamp of \"2020-09-08 01:02:04\". * The Route appearing
+                        first in alphabetical order by   \"<namespace>/<name>\". For
+                        example, foo/bar is given precedence over   foo/baz. \n If
+                        ties still exist within the Route that has been given precedence,
+                        matching precedence MUST be granted to the first matching
+                        rule meeting the above criteria."
                       items:
                         description: UDPRouteMatch defines the predicate used to match
                           packets to a given action.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
This is a follow up from https://github.com/kubernetes-sigs/gateway-api/pull/620. It takes the conflict resolution guidance we added to HTTPRoute and applies it to the other route types.

**Does this PR introduce a user-facing change?**:
```release-note
Clarifies how conflicting matches should be resolved in non-HTTP routes
```

/cc @hbagdi @youngnick 
