### PR TITLE
Deprecating NoSuchGatewayClass status reason

### DIFF
--- a/apis/v1alpha1/gateway_types.go
+++ b/apis/v1alpha1/gateway_types.go
@@ -596,11 +596,11 @@ const (
 	// been recently created and no controller has reconciled it yet.
 	GatewayReasonNotReconciled GatewayConditionReason = "NotReconciled"
 
-	// This reason is used with the "Scheduled" condition when the Gateway
-	// is not scheduled because there is no controller that recognizes
-	// the GatewayClassName. This reason should only be set by
-	// a controller that has cluster-wide visibility of all the
-	// installed GatewayClasses.
+	// This reason is used with the "Scheduled" condition when the Gateway is
+	// not scheduled because there is no controller that recognizes the
+	// GatewayClassName. This reason has been deprecated and will be removed in
+	// a future release.
+	// +deprecated
 	GatewayReasonNoSuchGatewayClass GatewayConditionReason = "NoSuchGatewayClass"
 
 	// This reason is used with the "Scheduled" condition when the


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind deprecation

**What this PR does / why we need it**:
This deprecates the NoSuchGatewayClass status reason. Although this was a useful concept, it was never clear who would actually set it. Although we could develop an official controller that watched Gateways and GatewayClasses and set this status, I don't think anyone has the capacity to maintain that. Alternatively, we could rely on every Gateway controller to write this status, but that could result in some fairly ugly race conditions.

I initially proposed a [new condition](https://github.com/kubernetes-sigs/gateway-api/pull/630) to replace this, but I don't think that's necessary. After discussing this with @jpeach, it seemed like the existing `ListenerConditionResolvedRefs` and `NotReconciled` conditions were sufficient here.

**Does this PR introduce a user-facing change?**:
```release-note
The NoSuchGatewayClass status reason has been deprecated.
```

/cc @jpeach @hbagdi 