### PR TITLE
Add caching to golangci-lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ Session.vim
 .*.timestamp
 /site
 admission
+
+/cache

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -24,7 +24,8 @@ readonly KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 cd "${KUBE_ROOT}"
 
 # See configuration file in ${KUBE_ROOT}/.golangci.yml.
+mkdir -p cache
 
-docker run --rm -v $(pwd):/app -w /app "golangci/golangci-lint:$VERSION" golangci-lint run
+docker run --rm -v $(pwd)/cache:/cache -v $(pwd):/app -e GOLANGCI_LINT_CACHE=/cache -w /app "golangci/golangci-lint:$VERSION" golangci-lint run
 
 # ex: ts=2 sw=2 et filetype=sh


### PR DESCRIPTION
This commit adds a cache dir for golangci-lint runs.

Probably will not impact Prow CI times, but should make
running the linting locally a bit faster (my testing shows
around 40 percent faster, but results may vary).

Signed-off-by: Nick Young <ynick@vmware.com>

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #607

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
