### PR TITLE
Fixup the getting-started guide to use the v0.3.0 release.

### DIFF
--- a/site-src/guides/getting-started.md
+++ b/site-src/guides/getting-started.md
@@ -34,7 +34,7 @@ these resources. Installing the CRDs will just allow you to see and apply the
 resources, though they won't do anything.
 
 ```
-kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.2.0" \
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.3.0" \
 | kubectl apply -f -
 ```
 
@@ -48,7 +48,7 @@ these resources.
 
 
 ```
-kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.2.0" \
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.3.0" \
 | kubectl delete -f -
 ```
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Updates the getting-started guide to use the latest v0.3.0 release.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

Signed-off-by: Steve Sloka <slokas@vmware.com>