### PR TITLE
implement validation for GatewayClass resource

### DIFF
--- a/apis/v1alpha1/validation/validation.go
+++ b/apis/v1alpha1/validation/validation.go
@@ -122,3 +122,18 @@ func validateHTTPRouteUniqueFilters(rules []gatewayv1a1.HTTPRouteRule, path *fie
 
 	return errs
 }
+
+// ValidateGatewayClassUpdate validates an update to oldClass according to the
+// Gateway API specification. For additional details of the GatewayClass spec, refer to:
+// https://gateway-api.sigs.k8s.io/spec/#networking.x-k8s.io/v1alpha2.GatewayClass
+func ValidateGatewayClassUpdate(oldClass, newClass *gatewayv1a1.GatewayClass) field.ErrorList {
+	if oldClass == nil || newClass == nil {
+		return nil
+	}
+	var errs field.ErrorList
+	if oldClass.Spec.Controller != newClass.Spec.Controller {
+		errs = append(errs, field.Invalid(field.NewPath("spec.controller"), newClass.Spec.Controller,
+			"cannot update an immutable field"))
+	}
+	return errs
+}

--- a/apis/v1alpha1/validation/validation_test.go
+++ b/apis/v1alpha1/validation/validation_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package validation
 
 import (
+	"reflect"
 	"testing"
 
 	gatewayv1a1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilpointer "k8s.io/utils/pointer"
 )
 
@@ -423,4 +425,77 @@ func pathMatchTypePtr(s string) *gatewayv1a1.PathMatchType {
 func portNumberPtr(p int) *gatewayv1a1.PortNumber {
 	result := gatewayv1a1.PortNumber(p)
 	return &result
+}
+
+func TestValidateGatewayClassUpdate(t *testing.T) {
+	type args struct {
+		oldClass *gatewayv1a1.GatewayClass
+		newClass *gatewayv1a1.GatewayClass
+	}
+	tests := []struct {
+		name string
+		args args
+		want field.ErrorList
+	}{
+		{
+			name: "changing parameters reference is allowed",
+			args: args{
+				oldClass: &gatewayv1a1.GatewayClass{
+					Spec: gatewayv1a1.GatewayClassSpec{
+						Controller: "foo",
+					},
+				},
+				newClass: &gatewayv1a1.GatewayClass{
+					Spec: gatewayv1a1.GatewayClassSpec{
+						Controller: "foo",
+						ParametersRef: &gatewayv1a1.ParametersReference{
+							Group: "example.com",
+							Kind:  "GatewayClassConfig",
+							Name:  "foo",
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "changing controller field results in an error",
+			args: args{
+				oldClass: &gatewayv1a1.GatewayClass{
+					Spec: gatewayv1a1.GatewayClassSpec{
+						Controller: "foo",
+					},
+				},
+				newClass: &gatewayv1a1.GatewayClass{
+					Spec: gatewayv1a1.GatewayClassSpec{
+						Controller: "bar",
+					},
+				},
+			},
+			want: field.ErrorList{
+				{
+					Type:     field.ErrorTypeInvalid,
+					Field:    "spec.controller",
+					Detail:   "cannot update an immutable field",
+					BadValue: "bar",
+				},
+			},
+		},
+		{
+			name: "nil input result in no errors",
+			args: args{
+				oldClass: nil,
+				newClass: nil,
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ValidateGatewayClassUpdate(tt.args.oldClass, tt.args.newClass); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ValidateGatewayClassUpdate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/apis/v1alpha2/validation/validation.go
+++ b/apis/v1alpha2/validation/validation.go
@@ -122,3 +122,18 @@ func validateHTTPRouteUniqueFilters(rules []gatewayv1a2.HTTPRouteRule, path *fie
 
 	return errs
 }
+
+// ValidateGatewayClassUpdate validates an update to oldClass according to the
+// Gateway API specification. For additional details of the GatewayClass spec, refer to:
+// https://gateway-api.sigs.k8s.io/spec/#networking.x-k8s.io/v1alpha2.GatewayClass
+func ValidateGatewayClassUpdate(oldClass, newClass *gatewayv1a2.GatewayClass) field.ErrorList {
+	if oldClass == nil || newClass == nil {
+		return nil
+	}
+	var errs field.ErrorList
+	if oldClass.Spec.Controller != newClass.Spec.Controller {
+		errs = append(errs, field.Invalid(field.NewPath("spec.controller"), newClass.Spec.Controller,
+			"cannot update an immutable field"))
+	}
+	return errs
+}


### PR DESCRIPTION
This currently comprises only of an immutability check for
`spec.controller` field. This can expanded in future.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
**What this PR does / why we need it**:
This validation is a pre-requisite for #189. Once this is merged in, we can start enforcing this using a validation webhook.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
