### PR TITLE
pkg/admission: validate GatewayClass updates

### DIFF
--- a/deploy/admission_webhook.yaml
+++ b/deploy/admission_webhook.yaml
@@ -16,7 +16,7 @@ webhooks:
       - operations: [ "CREATE" , "UPDATE" ]
         apiGroups: [ "networking.x-k8s.io" ]
         apiVersions: [ "v1alpha1", "v1alpha2" ]
-        resources: [ "httproutes", "gateways" ]
+        resources: [ "gateways", "gatewayclasses", "httproutes" ]
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions:

--- a/pkg/admission/server_test.go
+++ b/pkg/admission/server_test.go
@@ -603,6 +603,262 @@ func TestServeHTTPSubmissions(t *testing.T) {
 				},
 			},
 			{
+				name: "v1a1 GatewayClass create events do not result in an error",
+				reqBody: dedent.Dedent(`{
+						"kind": "AdmissionReview",
+						"apiVersion": "` + apiVersion + `",
+						"request": {
+							"uid": "7313cd05-eddc-4150-b88c-971a0d53b2ab",
+							"resource": {
+								"group": "networking.x-k8s.io",
+								"version": "v1alpha1",
+								"resource": "gatewayclasses"
+							},
+							"object": {
+   								"kind": "GatewayClass",
+   								"apiVersion": "networking.x-k8s.io/v1alpha1",
+   								"metadata": {
+   								   "name": "gateway-class-1"
+   								},
+   								"spec": {
+   								   "controller": "example.com/foo"
+   								}
+							},
+						"operation": "CREATE"
+						}
+					}`),
+				wantRespCode: http.StatusOK,
+				wantSuccessResponse: admission.AdmissionResponse{
+					UID:     "7313cd05-eddc-4150-b88c-971a0d53b2ab",
+					Allowed: true,
+					Result:  &metav1.Status{},
+				},
+			},
+			{
+				name: "update to v1alpha1 GatewayClass parameters field does" +
+					" not result in an error",
+				reqBody: dedent.Dedent(`{
+						"kind": "AdmissionReview",
+						"apiVersion": "` + apiVersion + `",
+						"request": {
+							"uid": "7313cd05-eddc-4150-b88c-971a0d53b2ab",
+							"resource": {
+								"group": "networking.x-k8s.io",
+								"version": "v1alpha1",
+								"resource": "gatewayclasses"
+							},
+							"object": {
+   								"kind": "GatewayClass",
+   								"apiVersion": "networking.x-k8s.io/v1alpha1",
+   								"metadata": {
+   								   "name": "gateway-class-1"
+   								},
+   								"spec": {
+   								   "controller": "example.com/foo"
+   								}
+							},
+							"oldObject": {
+   								"kind": "GatewayClass",
+   								"apiVersion": "networking.x-k8s.io/v1alpha1",
+   								"metadata": {
+   								   "name": "gateway-class-1"
+   								},
+   								"spec": {
+									"controller": "example.com/foo",
+									"parametersRef": {
+										"name": "foo",
+										"namespace": "bar",
+										"scope": "Namespace",
+										"group": "example.com",
+										"kind": "ExampleConfig"
+									}
+   								}
+							},
+						"operation": "UPDATE"
+						}
+					}`),
+				wantRespCode: http.StatusOK,
+				wantSuccessResponse: admission.AdmissionResponse{
+					UID:     "7313cd05-eddc-4150-b88c-971a0d53b2ab",
+					Allowed: true,
+					Result:  &metav1.Status{},
+				},
+			},
+			{
+				name: "update to v1alpha1 GatewayClass controller field" +
+					" results in an error ",
+				reqBody: dedent.Dedent(`{
+						"kind": "AdmissionReview",
+						"apiVersion": "` + apiVersion + `",
+						"request": {
+							"uid": "7313cd05-eddc-4150-b88c-971a0d53b2ab",
+							"resource": {
+								"group": "networking.x-k8s.io",
+								"version": "v1alpha1",
+								"resource": "gatewayclasses"
+							},
+							"object": {
+   								"kind": "GatewayClass",
+   								"apiVersion": "networking.x-k8s.io/v1alpha1",
+   								"metadata": {
+   								   "name": "gateway-class-1"
+   								},
+   								"spec": {
+   								   "controller": "example.com/foo"
+   								}
+							},
+							"oldObject": {
+   								"kind": "GatewayClass",
+   								"apiVersion": "networking.x-k8s.io/v1alpha1",
+   								"metadata": {
+   								   "name": "gateway-class-1"
+   								},
+   								"spec": {
+   								   "controller": "example.com/bar"
+   								}
+							},
+						"operation": "UPDATE"
+						}
+					}`),
+				wantRespCode: http.StatusOK,
+				wantSuccessResponse: admission.AdmissionResponse{
+					UID:     "7313cd05-eddc-4150-b88c-971a0d53b2ab",
+					Allowed: false,
+					Result: &metav1.Status{
+						Code:    400,
+						Message: `spec.controller: Invalid value: "example.com/foo": cannot update an immutable field`,
+					},
+				},
+			},
+			{
+				name: "v1a2 GatewayClass create events do not result in an error",
+				reqBody: dedent.Dedent(`{
+						"kind": "AdmissionReview",
+						"apiVersion": "` + apiVersion + `",
+						"request": {
+							"uid": "7313cd05-eddc-4150-b88c-971a0d53b2ab",
+							"resource": {
+								"group": "networking.x-k8s.io",
+								"version": "v1alpha2",
+								"resource": "gatewayclasses"
+							},
+							"object": {
+   								"kind": "GatewayClass",
+   								"apiVersion": "networking.x-k8s.io/v1alpha2",
+   								"metadata": {
+   								   "name": "gateway-class-1"
+   								},
+   								"spec": {
+   								   "controller": "example.com/foo"
+   								}
+							},
+						"operation": "CREATE"
+						}
+					}`),
+				wantRespCode: http.StatusOK,
+				wantSuccessResponse: admission.AdmissionResponse{
+					UID:     "7313cd05-eddc-4150-b88c-971a0d53b2ab",
+					Allowed: true,
+					Result:  &metav1.Status{},
+				},
+			},
+			{
+				name: "update to v1alpha2 GatewayClass parameters field does" +
+					" not result in an error",
+				reqBody: dedent.Dedent(`{
+						"kind": "AdmissionReview",
+						"apiVersion": "` + apiVersion + `",
+						"request": {
+							"uid": "7313cd05-eddc-4150-b88c-971a0d53b2ab",
+							"resource": {
+								"group": "networking.x-k8s.io",
+								"version": "v1alpha2",
+								"resource": "gatewayclasses"
+							},
+							"object": {
+   								"kind": "GatewayClass",
+   								"apiVersion": "networking.x-k8s.io/v1alpha2",
+   								"metadata": {
+   								   "name": "gateway-class-1"
+   								},
+   								"spec": {
+   								   "controller": "example.com/foo"
+   								}
+							},
+							"oldObject": {
+   								"kind": "GatewayClass",
+   								"apiVersion": "networking.x-k8s.io/v1alpha2",
+   								"metadata": {
+   								   "name": "gateway-class-1"
+   								},
+   								"spec": {
+									"controller": "example.com/foo",
+									"parametersRef": {
+										"name": "foo",
+										"namespace": "bar",
+										"scope": "Namespace",
+										"group": "example.com",
+										"kind": "ExampleConfig"
+									}
+   								}
+							},
+						"operation": "UPDATE"
+						}
+					}`),
+				wantRespCode: http.StatusOK,
+				wantSuccessResponse: admission.AdmissionResponse{
+					UID:     "7313cd05-eddc-4150-b88c-971a0d53b2ab",
+					Allowed: true,
+					Result:  &metav1.Status{},
+				},
+			},
+			{
+				name: "update to v1alpha2 GatewayClass controller field" +
+					" results in an error ",
+				reqBody: dedent.Dedent(`{
+						"kind": "AdmissionReview",
+						"apiVersion": "` + apiVersion + `",
+						"request": {
+							"uid": "7313cd05-eddc-4150-b88c-971a0d53b2ab",
+							"resource": {
+								"group": "networking.x-k8s.io",
+								"version": "v1alpha2",
+								"resource": "gatewayclasses"
+							},
+							"object": {
+   								"kind": "GatewayClass",
+   								"apiVersion": "networking.x-k8s.io/v1alpha2",
+   								"metadata": {
+   								   "name": "gateway-class-1"
+   								},
+   								"spec": {
+   								   "controller": "example.com/foo"
+   								}
+							},
+							"oldObject": {
+   								"kind": "GatewayClass",
+   								"apiVersion": "networking.x-k8s.io/v1alpha2",
+   								"metadata": {
+   								   "name": "gateway-class-1"
+   								},
+   								"spec": {
+   								   "controller": "example.com/bar"
+   								}
+							},
+						"operation": "UPDATE"
+						}
+					}`),
+				wantRespCode: http.StatusOK,
+				wantSuccessResponse: admission.AdmissionResponse{
+					UID:     "7313cd05-eddc-4150-b88c-971a0d53b2ab",
+					Allowed: false,
+					Result: &metav1.Status{
+						Code:    400,
+						Message: `spec.controller: Invalid value: "example.com/foo": cannot update an immutable field`,
+					},
+				},
+			},
+			{
 				name: "unknown resource under networking.x-k8s.io",
 				reqBody: dedent.Dedent(`{
 						"kind": "AdmissionReview",


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
**What this PR does / why we need it**:
This patch introduces validation for updates to GatewayClass resources.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #189

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Immutability of `spec.controller` field in GatewayClass resource is now enforced using the validation webhook.
```

/cc @robscott @stevesloka @jpeach 