### PR TITLE
Adding hostname address type

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -502,7 +502,7 @@ type GatewayAddress struct {
 // should raise the "Detached" listener status condition on
 // the Gateway with the "UnsupportedAddress" reason.
 //
-// +kubebuilder:validation:Enum=IPAddress;NamedAddress
+// +kubebuilder:validation:Enum=IPAddress;Hostname;NamedAddress
 type AddressType string
 
 const (
@@ -514,12 +514,19 @@ const (
 	// Support: Extended
 	IPAddressType AddressType = "IPAddress"
 
-	// An opaque identifier that represents a specific IP address. The
-	// interpretation of the name is dependent on the controller. For
-	// example, a "NamedAddress" might be a cloud-dependent identifier
-	// for a static or elastic IP.
+	// A Hostname represents a DNS based ingress point. This is similar to the
+	// corresponding hostname field in Kubernetes load balancer status. For
+	// example, this concept may be used for cloud load balancers where a DNS
+	// name is used to expose a load balancer.
 	//
-	// Support: Implementation-specific
+	// Support: Extended
+	HostnameAddressType AddressType = "Hostname"
+
+	// A NamedAddress provides a way to reference a specific IP address by name.
+	// For example, this may be a name or other unique identifier that refers
+	// to a resource on a cloud provider such as a static IP.
+	//
+	// Support: Implementation-Specific
 	NamedAddressType AddressType = "NamedAddress"
 )
 

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -732,6 +732,7 @@ spec:
                       description: "Type of the address. \n Support: Extended"
                       enum:
                       - IPAddress
+                      - Hostname
                       - NamedAddress
                       type: string
                     value:
@@ -1123,6 +1124,7 @@ spec:
                       description: "Type of the address. \n Support: Extended"
                       enum:
                       - IPAddress
+                      - Hostname
                       - NamedAddress
                       type: string
                     value:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind api-change

**What this PR does / why we need it**:
This corresponds with the hostname field in the [upstream LoadBalancerStatus struct](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/types.go#L3547-L3550).


**Does this PR introduce a user-facing change?**:
```release-note
Gateway status now supports a new Hostname address type
```
