### PR TITLE
Adding HTTPRoute merging documentation

### DIFF
--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -228,6 +228,12 @@ A maximum of 100 Gateways can be represented in this list. If this list is full,
 there may be additional Gateways using this Route that are not included in the
 list.
 
+### Merging
+Multiple HTTPRoutes can be attached to a single Gateway resource. Importantly,
+only one Route rule may match each request. For more information on how conflict
+resolution applies to merging, refer to the [API specification](httprouterule).
+
+
 [httproute]: https://gateway-api.sigs.k8s.io/references/spec/#networking.x-k8s.io/v1alpha1.HTTPRoute
 [gateways]: https://gateway-api.sigs.k8s.io/references/spec/#networking.x-k8s.io/v1alpha1.RouteGateways
 [httprouterule]: https://gateway-api.sigs.k8s.io/references/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteRule

--- a/site-src/guides/http-routing.md
+++ b/site-src/guides/http-routing.md
@@ -1,8 +1,8 @@
 # HTTP routing
 
-The [HTTPRoute resource](/api-types/httproute) allows you to match on HTTP traffic and
-direct it to Kubernetes backends. This guide shows how the HTTPRoute matches
-traffic on host, header, and path fields and forwards it to different
+The [HTTPRoute resource](/api-types/httproute) allows you to match on HTTP
+traffic and direct it to Kubernetes backends. This guide shows how the HTTPRoute
+matches traffic on host, header, and path fields and forwards it to different
 Kubernetes Services.
 
 The following diagram describes a required traffic flow across three different
@@ -18,8 +18,9 @@ to `bar-svc-canary`
 The dotted lines show the Gateway resources deployed to configure this routing
 behavior. There are two HTTPRoute resources that create routing rules on the
 same `prod-web` Gateway. This illustrates how more than one Route can bind to a
-Gateway which allows Routes to merge on a Gateway as
-long as they don't conflict.
+Gateway which allows Routes to merge on a Gateway as long as they don't
+conflict. For more information on Route merging, refer to the [HTTPRoute
+documentation](/api-types/httproute#merging).
 
 The following `prod-web` Gateway is defined from the `acme-lb` GatewayClass.
 `prod-web` listens for HTTP traffic on port 80 and will bind to all Routes in

--- a/site-src/v1alpha2/api-types/gatewayclass.md
+++ b/site-src/v1alpha2/api-types/gatewayclass.md
@@ -135,5 +135,5 @@ acme.io/gateway/v2   // Use version 2
 acme.io/gateway      // Use the default version
 ```
 
-[gatewayclass]: https://gateway-api.sigs.k8s.io/references/spec/#networking.x-k8s.io/v1alpha1.GatewayClass
+[gatewayclass]: https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#networking.x-k8s.io/v1alpha2.GatewayClass
 [ingress-class-api]: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class

--- a/site-src/v1alpha2/api-types/httproute.md
+++ b/site-src/v1alpha2/api-types/httproute.md
@@ -228,12 +228,18 @@ A maximum of 100 Gateways can be represented in this list. If this list is full,
 there may be additional Gateways using this Route that are not included in the
 list.
 
-[httproute]: https://gateway-api.sigs.k8s.io/references/spec/#networking.x-k8s.io/v1alpha1.HTTPRoute
-[gateways]: https://gateway-api.sigs.k8s.io/references/spec/#networking.x-k8s.io/v1alpha1.RouteGateways
-[httprouterule]: https://gateway-api.sigs.k8s.io/references/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteRule
-[hostname]: https://gateway-api.sigs.k8s.io/references/spec/#networking.x-k8s.io/v1alpha1.Hostname
-[tls-config]: https://gateway-api.sigs.k8s.io/references/spec/#networking.x-k8s.io/v1alpha1.RouteTLSConfig
+### Merging
+Multiple HTTPRoutes can be attached to a single Gateway resource. Importantly,
+only one Route rule may match each request. For more information on how conflict
+resolution applies to merging, refer to the [API specification](httprouterule).
+
+
+[httproute]: https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#networking.x-k8s.io/v1alpha2.HTTPRoute
+[gateways]: https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#networking.x-k8s.io/v1alpha2.RouteGateways
+[httprouterule]: https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#networking.x-k8s.io/v1alpha2.HTTPRouteRule
+[hostname]: https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#networking.x-k8s.io/v1alpha2.Hostname
+[tls-config]: https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#networking.x-k8s.io/v1alpha2.RouteTLSConfig
 [rfc-3986]: https://tools.ietf.org/html/rfc3986
-[matches]: https://gateway-api.sigs.k8s.io/references/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteMatch
-[filters]: https://gateway-api.sigs.k8s.io/references/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteFilter
-[forwardto]: https://gateway-api.sigs.k8s.io/references/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteForwardTo
+[matches]: https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#networking.x-k8s.io/v1alpha2.HTTPRouteMatch
+[filters]: https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#networking.x-k8s.io/v1alpha2.HTTPRouteFilter
+[forwardto]: https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#networking.x-k8s.io/v1alpha2.HTTPRouteForwardTo

--- a/site-src/v1alpha2/faq.md
+++ b/site-src/v1alpha2/faq.md
@@ -37,7 +37,7 @@
         control policy. This is an example of matching the object by name.
 
         Gateway API uses this decorator pattern with the
-        [`BackendPolicy`](/references/spec/#networking.x-k8s.io/v1alpha1.BackendPolicy)
+        [`BackendPolicy`](/v1alpha2/references/spec/#networking.x-k8s.io/v1alpha2.BackendPolicy)
         resource, which modifies how a `Gateway` should forward traffic
         to a backend target (commonly a Kubernetes `Service`). This is
         an example of using explicit object references.

--- a/site-src/v1alpha2/guides/http-routing.md
+++ b/site-src/v1alpha2/guides/http-routing.md
@@ -18,8 +18,9 @@ to `bar-svc-canary`
 The dotted lines show the Gateway resources deployed to configure this routing
 behavior. There are two HTTPRoute resources that create routing rules on the
 same `prod-web` Gateway. This illustrates how more than one Route can bind to a
-Gateway which allows Routes to merge on a Gateway as
-long as they don't conflict.
+Gateway which allows Routes to merge on a Gateway as long as they don't
+conflict. For more information on Route merging, refer to the [HTTPRoute
+documentation](/api-types/httproute#merging).
 
 The following `prod-web` Gateway is defined from the `acme-lb` GatewayClass.
 `prod-web` listens for HTTP traffic on port 80 and will bind to all Routes in
@@ -32,7 +33,7 @@ bound to each other by their respective owners.
 ```
 
 An HTTPRoute can match against a [single set of
-hostnames](https://gateway-api.sigs.k8s.io/references/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteSpec).
+hostnames](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#networking.x-k8s.io/v1alpha2.HTTPRouteSpec).
 These hostnames are matched before any other matching within the HTTPRoute takes
 place. Since `foo.example.com` and `bar.example.com` are separate hosts with
 different routing requirements, each is deployed as its own HTTPRoute -

--- a/site-src/v1alpha2/guides/tcp.md
+++ b/site-src/v1alpha2/guides/tcp.md
@@ -1,5 +1,5 @@
 Gateway API is designed to work with multiple protocols.
-[TCPRoute](/references/spec/#networking.x-k8s.io/v1alpha1.TCPRoute) is one such route which
+[TCPRoute](/v1alpha2/references/spec/#networking.x-k8s.io/v1alpha2.TCPRoute) is one such route which
 allows for managing TCP traffic.
 
 In this example, we have one Gateway resource and two TCPRoute resources that

--- a/site-src/v1alpha2/guides/traffic-splitting.md
+++ b/site-src/v1alpha2/guides/traffic-splitting.md
@@ -41,7 +41,7 @@ production user traffic for `foo.example.com`. The following HTTPRoute has no
 recieve 100% of the traffic matched by each of their route rules. A canary
 route rule is used (matching the header `traffic=test`) to send synthetic test
 traffic before splitting any production user traffic to `foo-v2`. [Routing
-precedence](/references/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteRule) ensures that
+precedence](/v1alpha2/references/spec/#networking.x-k8s.io/v1alpha2.HTTPRouteRule) ensures that
 all traffic with the matching host and header (the most specific match) will
 be sent to `foo-v2`.
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/kind cleanup

**What this PR does / why we need it**:
This adds HTTPRoute merging documentation. This also updates some v1alpha1 references to v1alpha2 in the v1alpha2
docs.

**Which issue(s) this PR fixes**:
Fixes #573

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
