### PR TITLE
Update documentation around hostnames for HTTPRoute and Listener

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -144,18 +144,14 @@ type Listener struct {
 	// matched. This field can be omitted for protocols that don't require
 	// hostname based matching.
 	//
-	// Hostname is the fully qualified domain name of a network host, as defined
-	// by RFC 3986. Note the following deviations from the "host" part of the
-	// URI as defined in the RFC:
-	//
-	// 1. IP literals are not allowed.
-	// 2. The `:` delimiter is not respected because ports are not allowed.
-	//
-	// Hostname can be "precise" which is a domain name without the terminating
-	// dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
-	// domain name prefixed with a single wildcard label (e.g. `*.example.com`).
-	// The wildcard character `*` must appear by itself as the first DNS label
-	// and matches only a single label.
+	// For HTTPRoute objects, there is an interaction with the
+	// `spec.hostnames` array. When both listener and route specify hostnames,
+	// there must be an intersection between the values for a Route to be admitted.
+	// For example, a Gateway with `*.example.com` would admit a Route that included
+	// `foo.example.com` as a hostname, but not a Route that *only* included
+	// `foo.acme.io` as a hostname. A Route that included both `foo.example.com`
+	// and `foo.acme.io` would be admitted, but the `foo.acme.io` hostname would
+	// be silently ignored.
 	//
 	// Support: Core
 	//

--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -70,19 +70,40 @@ type HTTPRouteSpec struct {
 	// HTTPRoute rules. If no hostname is specified, traffic is routed
 	// based on the HTTPRouteRules.
 	//
-	// Hostname can be "precise" which is a domain name without the terminating
-	// dot of a network host (e.g. "foo.example.com") or "wildcard", which is
-	// a domain name prefixed with a single wildcard label (e.g. `*.example.com`).
-	// The wildcard character `*` must appear by itself as the first DNS
-	// label and matches only a single label.
-	// You cannot have a wildcard label by itself (e.g. Host == `*`).
 	// Requests will be matched against the Host field in the following order:
 	//
-	// 1. If Host is precise, the request matches this rule if
-	//    the HTTP Host header is equal to Host.
-	// 2. If Host is a wildcard, then the request matches this rule if
+	// 1. If Hostname is precise, the request matches this rule if
+	//    the HTTP Host header is equal to the Hostname.
+	// 2. If Hostname is a wildcard, then the request matches this rule if
 	//    the HTTP Host header is to equal to the suffix
 	//    (removing the first label) of the wildcard rule.
+	// 3. If Hostname is unspecified, empty, or `*`, then any request will match
+	//    this route.
+	//
+	// If a hostname is specified by the Listener that the HTTPRoute is bound
+	// to, at least one hostname specified here must match the Listener specified
+	// hostname as per the rules above. Other hostnames will not affect processing
+	// of the route in that case.
+	//
+	// If no hostname is specified by the Listener, then that value will be treated
+	// as '*', match any hostname, and so any hostname on this Route will match.
+	//
+	// If all hostnames do not match, then the HTTPRoute is not admitted, and
+	// the implementation must raise an 'Admitted' Condition with a status of
+	// `false` for that Listener.
+	//
+	// Examples:
+	// - A Listener with unspecified, empty, or `*` values for Hostname matches
+	//   any HTTPRoute hostname.
+	// - A HTTPRoute with unspecified, empty, or `*` values for Hostname matches
+	//   any Listener hostname.
+	// - A Listener with `test.foo.com` as the hostname matches *only*
+	//   `test.foo.com` or `*.foo.com`. Any other hostnames present must be ignored.
+	// - A Listener with `*.foo.com` as hostname, all hostnames in the HTTPRoute
+	//   must have any single label where the star is, and the rest of the hostname
+	//   must match exactly. So, `test.foo.com`, `*.foo.com` or `blog.foo.com` match.
+	//   `test.blog.foo.com`, `test.bar.com`, or `bar.com` do not. Hostnames that do
+	//   not match will be ignored.
 	//
 	// Support: Core
 	//

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -245,7 +245,22 @@ type RouteStatus struct {
 	Gateways []RouteGatewayStatus `json:"gateways"`
 }
 
-// Hostname is used to specify a hostname that should be matched.
+// Hostname is the fully qualified domain name of a network host, as defined
+// by RFC 3986. Note the following deviations from the "host" part of the
+// URI as defined in the RFC:
+//
+// 1. IP literals are not allowed.
+// 2. The `:` delimiter is not respected because ports are not allowed.
+//
+// Hostname can be "precise" which is a domain name without the terminating
+// dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+// domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+// The wildcard character `*` must appear by itself as the first DNS label
+// and matches only a single label.
+//
+// Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+// alphanumeric characters or '-', and must start and end with an alphanumeric
+// character. No other punctuation is allowed.
 //
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=253

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -788,17 +788,15 @@ spec:
                         for protocol types that define this concept. When unspecified,
                         \"\", or `*`, all hostnames are matched. This field can be
                         omitted for protocols that don't require hostname based matching.
-                        \n Hostname is the fully qualified domain name of a network
-                        host, as defined by RFC 3986. Note the following deviations
-                        from the \"host\" part of the URI as defined in the RFC: \n
-                        1. IP literals are not allowed. 2. The `:` delimiter is not
-                        respected because ports are not allowed. \n Hostname can be
-                        \"precise\" which is a domain name without the terminating
-                        dot of a network host (e.g. \"foo.example.com\") or \"wildcard\",
-                        which is a domain name prefixed with a single wildcard label
-                        (e.g. `*.example.com`). The wildcard character `*` must appear
-                        by itself as the first DNS label and matches only a single
-                        label. \n Support: Core"
+                        \n For HTTPRoute objects, there is an interaction with the
+                        `spec.hostnames` array. When both listener and route specify
+                        hostnames, there must be an intersection between the values
+                        for a Route to be admitted. For example, a Gateway with `*.example.com`
+                        would admit a Route that included `foo.example.com` as a hostname,
+                        but not a Route that *only* included `foo.acme.io` as a hostname.
+                        A Route that included both `foo.example.com` and `foo.acme.io`
+                        would be admitted, but the `foo.acme.io` hostname would be
+                        silently ignored. \n Support: Core"
                       maxLength: 253
                       minLength: 1
                       type: string

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -1041,21 +1041,47 @@ spec:
                   not allowed. 2. The `:` delimiter is not respected because ports
                   are not allowed. \n Incoming requests are matched against the hostnames
                   before the HTTPRoute rules. If no hostname is specified, traffic
-                  is routed based on the HTTPRouteRules. \n Hostname can be \"precise\"
-                  which is a domain name without the terminating dot of a network
-                  host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
-                  name prefixed with a single wildcard label (e.g. `*.example.com`).
-                  The wildcard character `*` must appear by itself as the first DNS
-                  label and matches only a single label. You cannot have a wildcard
-                  label by itself (e.g. Host == `*`). Requests will be matched against
-                  the Host field in the following order: \n 1. If Host is precise,
-                  the request matches this rule if    the HTTP Host header is equal
-                  to Host. 2. If Host is a wildcard, then the request matches this
-                  rule if    the HTTP Host header is to equal to the suffix    (removing
-                  the first label) of the wildcard rule. \n Support: Core"
+                  is routed based on the HTTPRouteRules. \n Requests will be matched
+                  against the Host field in the following order: \n 1. If Hostname
+                  is precise, the request matches this rule if    the HTTP Host header
+                  is equal to the Hostname. 2. If Hostname is a wildcard, then the
+                  request matches this rule if    the HTTP Host header is to equal
+                  to the suffix    (removing the first label) of the wildcard rule.
+                  3. If Hostname is unspecified, empty, or `*`, then any request will
+                  match    this route. \n If a hostname is specified by the Listener
+                  that the HTTPRoute is bound to, at least one hostname specified
+                  here must match the Listener specified hostname as per the rules
+                  above. Other hostnames will not affect processing of the route in
+                  that case. \n If no hostname is specified by the Listener, then
+                  that value will be treated as '*', match any hostname, and so any
+                  hostname on this Route will match. \n If all hostnames do not match,
+                  then the HTTPRoute is not admitted, and the implementation must
+                  raise an 'Admitted' Condition with a status of `false` for that
+                  Listener. \n Examples: - A Listener with unspecified, empty, or
+                  `*` values for Hostname matches   any HTTPRoute hostname. - A HTTPRoute
+                  with unspecified, empty, or `*` values for Hostname matches   any
+                  Listener hostname. - A Listener with `test.foo.com` as the hostname
+                  matches *only*   `test.foo.com` or `*.foo.com`. Any other hostnames
+                  present must be ignored. - A Listener with `*.foo.com` as hostname,
+                  all hostnames in the HTTPRoute   must have any single label where
+                  the star is, and the rest of the hostname   must match exactly.
+                  So, `test.foo.com`, `*.foo.com` or `blog.foo.com` match.   `test.blog.foo.com`,
+                  `test.bar.com`, or `bar.com` do not. Hostnames that do   not match
+                  will be ignored. \n Support: Core"
                 items:
-                  description: Hostname is used to specify a hostname that should
-                    be matched.
+                  description: "Hostname is the fully qualified domain name of a network
+                    host, as defined by RFC 3986. Note the following deviations from
+                    the \"host\" part of the URI as defined in the RFC: \n 1. IP literals
+                    are not allowed. 2. The `:` delimiter is not respected because
+                    ports are not allowed. \n Hostname can be \"precise\" which is
+                    a domain name without the terminating dot of a network host (e.g.
+                    \"foo.example.com\") or \"wildcard\", which is a domain name prefixed
+                    with a single wildcard label (e.g. `*.example.com`). The wildcard
+                    character `*` must appear by itself as the first DNS label and
+                    matches only a single label. \n Note that as per RFC1035 and RFC1123,
+                    a *label* must consist of lower case alphanumeric characters or
+                    '-', and must start and end with an alphanumeric character. No
+                    other punctuation is allowed."
                   maxLength: 253
                   minLength: 1
                   type: string

--- a/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
@@ -681,8 +681,22 @@ spec:
                               a default backend    for a TLS listener. \n Support:
                               Core"
                             items:
-                              description: Hostname is used to specify a hostname
-                                that should be matched.
+                              description: "Hostname is the fully qualified domain
+                                name of a network host, as defined by RFC 3986. Note
+                                the following deviations from the \"host\" part of
+                                the URI as defined in the RFC: \n 1. IP literals are
+                                not allowed. 2. The `:` delimiter is not respected
+                                because ports are not allowed. \n Hostname can be
+                                \"precise\" which is a domain name without the terminating
+                                dot of a network host (e.g. \"foo.example.com\") or
+                                \"wildcard\", which is a domain name prefixed with
+                                a single wildcard label (e.g. `*.example.com`). The
+                                wildcard character `*` must appear by itself as the
+                                first DNS label and matches only a single label. \n
+                                Note that as per RFC1035 and RFC1123, a *label* must
+                                consist of lower case alphanumeric characters or '-',
+                                and must start and end with an alphanumeric character.
+                                No other punctuation is allowed."
                               maxLength: 253
                               minLength: 1
                               type: string


### PR DESCRIPTION
This commit updates documentation around hostnames to make the
interaction between Gateway Listener `Hostname` and HTTPRoute
`Hostnames` field to be more clear.

Closes #654

Signed-off-by: Nick Young <ynick@vmware.com>

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
/kind documentation


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
