### PR TITLE
Clarify direction for backend weights

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -701,8 +701,8 @@ type HTTPRouteForwardTo struct {
 	// percentage and the sum of weights does not need to equal 100.
 	//
 	// If only one backend is specified and it has a weight greater than 0, 100%
-	// of the traffic is forwarded to that backend. If weight is set to 0, no
-	// traffic should be forwarded for this entry. If unspecified, weight
+	// of the traffic is forwarded to that backend. If weight is set to 0,
+	// traffic must not be forwarded for this entry. If unspecified, weight
 	// defaults to 1.
 	//
 	// Support: Core

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -1528,7 +1528,7 @@ spec:
                               and the sum of weights does not need to equal 100. \n
                               If only one backend is specified and it has a weight
                               greater than 0, 100% of the traffic is forwarded to
-                              that backend. If weight is set to 0, no traffic should
+                              that backend. If weight is set to 0, traffic must not
                               be forwarded for this entry. If unspecified, weight
                               defaults to 1. \n Support: Core"
                             format: int32


### PR DESCRIPTION
Signed-off-by: Nick Young <ynick@vmware.com>

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
A small update to clarify the behavior of HTTPRoute backends when they are all have weights of 0.

Fixes #596 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
