### PR TITLE
Revert PR template labels

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,3 @@
----
-labels: 'tide/merge-method-squash'
----
-
 <!--  Thanks for sending a pull request! Here are some tips for you:
 
 1. If this is your first time contributing to Gateway API, please read our


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Reverts PR template labels. It appears that this feature only works for issues. (Example: https://github.com/kubernetes-sigs/gateway-api/pull/692)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @hbagdi 