### PR TITLE
Fix doc as user cannot omit port field in Gateway

### DIFF
--- a/site-src/concepts/api-overview.md
+++ b/site-src/concepts/api-overview.md
@@ -67,7 +67,7 @@ GatewayClass.
 
 As the Gateway spec captures user intent, it may not contain a complete
 specification for all attributes in the spec. For example, the user may omit
-fields such as addresses, ports, TLS settings. This allows the controller
+fields such as addresses, TLS settings. This allows the controller
 managing the GatewayClass to provide these settings for the user, resulting in a
 more portable spec. This behaviour will be made clear using the GatewayClass
 Status object.

--- a/site-src/v1alpha2/concepts/api-overview.md
+++ b/site-src/v1alpha2/concepts/api-overview.md
@@ -67,7 +67,7 @@ GatewayClass.
 
 As the Gateway spec captures user intent, it may not contain a complete
 specification for all attributes in the spec. For example, the user may omit
-fields such as addresses, ports, TLS settings. This allows the controller
+fields such as addresses, TLS settings. This allows the controller
 managing the GatewayClass to provide these settings for the user, resulting in a
 more portable spec. This behaviour will be made clear using the GatewayClass
 Status object.


### PR DESCRIPTION
This patch makes a tiny change to remove `ports` that 
current doc says user can omit it from Gateway. 
Port in Gateway is not optional.

/kind cleanup
/kind documentation

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
