### PR TITLE
Add a virtualenv convenience target for mkdocs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,3 +94,15 @@ release-staging: build
 	docker push $(REGISTRY)/admission-server:$(TAG)
 	docker tag $(REGISTRY)/admission-server:$(TAG) $(REGISTRY)/admission-server:latest
 	docker push $(REGISTRY)/admission-server:latest
+
+# Generate a virtualenv install, which is useful for hacking on the
+# docs since it installs mkdocs and all the right dependencies.
+#
+# On Ubuntu, this requires the python3-venv package.
+virtualenv: .venv
+.venv: requirements.txt
+	@echo Creating a virtualenv in $@"... "
+	@python3 -m venv $@ || (rm -rf $@ && exit 1)
+	@echo Installing packages in $@"... "
+	@$@/bin/python3 -m pip install -q -r requirements.txt || (rm -rf $@ && exit 1)
+	@echo To enter the virtualenv type \"source $@/bin/activate\",  to exit type \"deactivate\"

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -157,9 +157,18 @@ def file_extension(filename):
     return os.path.splitext(filename)[1].split(".")[-1].lower()
 
 
-skipped_dirs = ['third_party', '_gopath', '_output', '.git', 'cluster/env.sh',
-                "vendor", "test/e2e/generated/bindata.go", "hack/boilerplate/test",
-                "staging/src/k8s.io/kubectl/pkg/generated/bindata.go"]
+skipped_dirs = [
+    'cluster/env.sh',
+    '.git',
+    '_gopath',
+    'hack/boilerplate/test',
+    '_output',
+    'staging/src/k8s.io/kubectl/pkg/generated/bindata.go',
+    'test/e2e/generated/bindata.go',
+    'third_party',
+    'vendor',
+    '.venv',
+]
 
 # list all the files contain 'DO NOT EDIT', but are not generated
 skipped_ungenerated_files = [

--- a/site-src/v1alpha2/contributing/devguide.md
+++ b/site-src/v1alpha2/contributing/devguide.md
@@ -104,9 +104,25 @@ automatically be deployed with Netlify to [gateway-api.sigs.k8s.io]. If you want
 preview docs changes locally, you can install mkdocs and run:
 
 ```shell
-make docs
+ make docs
 ```
 
+To make it easier to use the right version of [mkdocs], there is a `.venv`
+target to create a Python virtualenv that includes [mkdocs]. To use the
+[mkdocs] live preview server while you edit, you can run [mkdocs] from
+the virtualenv:
+
+```shell
+$ make .venv
+Creating a virtualenv in .venv... OK
+To enter the virtualenv type "source .venv/bin/activate", to exit type "deactivate"
+(.venv) $ source .venv/bin/activate
+(.venv) $ mkdocs serve
+INFO    -  Building documentation...
+...
+```
+
+ [mkdocs]: https://www.mkdocs.org/
 [mkdocs]: https://www.mkdocs.org/
 [Netlify]: https://netlify.com/
 [gateway-api.sigs.k8s.io]: https://gateway-api.sigs.k8s.io


### PR DESCRIPTION
Add a make target to create the virtualenv with mkdocs installed to make
it easier to remember how to get the right tooling. Add an example to
the contribution docs.

/kind documentation
