### PR TITLE
Fix broken links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
       - Implementations: references/implementations.md
   - Contributing:
       - Developer guide: contributing/devguide.md
+      - Gateway Enhancement Proposal: contributing/gep.md
       - Enhancement requests: contributing/enhancement-requests.md
       - Community: contributing/community.md
   - FAQ: faq.md

--- a/site-src/contributing/enhancement-requests.md
+++ b/site-src/contributing/enhancement-requests.md
@@ -19,7 +19,7 @@ enhancement into the project.
    (GEP)][gep]
 
 [issue]: https://github.com/kubernetes-sigs/gateway-api/issues/new/choose
-[gep]: /contributing/gep.md
+[gep]: /contributing/gep
 
 ## What is Considered an Enhancement?
 


### PR DESCRIPTION
Looks like the suggested change didn't get into the commit

/kind cleanup
/kind documentation

```release-note
NONE
```
