### PR TITLE
Updating meeting times

### DIFF
--- a/site-src/v1alpha2/contributing/community.md
+++ b/site-src/v1alpha2/contributing/community.md
@@ -32,17 +32,12 @@ Gateway API meetings as well as any other SIG-Network meetings.
   scrolling="no">
 </iframe>
 
-Gateway API community meetings happen weekly, alternating between the following
-times. Refer to the calendar above to find the current place in the rotation.
+Gateway API community meetings happen weekly on Mondays at 3pm Pacific Time
+(23:00 UTC):
 
-* **Mondays at 3pm Pacific (11pm UTC)**
-    * [Zoom link](https://zoom.us/j/441530404)
-    * [Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=PT%20%28Pacific%20Time%29)
-    * [Add to your calendar](https://calendar.google.com/event?action=TEMPLATE&tmeid=NXU4OXYyY2pqNzEzYzUwYnVsYmZwdXJzZDlfMjAyMTA1MTBUMjIwMDAwWiA4OGZlMWwzcWZuMmI2cjExazh1bTVhbTc2Y0Bn&tmsrc=88fe1l3qfn2b6r11k8um5am76c%40group.calendar.google.com&scp=ALL)
-* **Tuesdays at 10am Pacific (6pm UTC)**
-    * [Zoom link](https://zoom.us/j/441530404)
-    * [Convert to your timezone](http://www.thetimezoneconverter.com/?t=10:00&tz=PT%20%28Pacific%20Time%29)
-    * [Add to your calendar](https://calendar.google.com/event?action=TEMPLATE&tmeid=NmowbnNxdDRkYjEzNjlrcWRkdXBmczU1bnNfMjAyMTA1MThUMTcwMDAwWiA4OGZlMWwzcWZuMmI2cjExazh1bTVhbTc2Y0Bn&tmsrc=88fe1l3qfn2b6r11k8um5am76c%40group.calendar.google.com&scp=ALL)
+* [Zoom link](https://zoom.us/j/441530404)
+* [Convert to your timezone](http://www.thetimezoneconverter.com/?t=15:00&tz=PT%20%28Pacific%20Time%29)
+* [Add to your calendar](https://calendar.google.com/event?action=TEMPLATE&tmeid=NXU4OXYyY2pqNzEzYzUwYnVsYmZwdXJzZDlfMjAyMTA1MTBUMjIwMDAwWiA4OGZlMWwzcWZuMmI2cjExazh1bTVhbTc2Y0Bn&tmsrc=88fe1l3qfn2b6r11k8um5am76c%40group.calendar.google.com&scp=ALL)
 
 
 ### Meeting Notes and Recordings


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
Updates meeting times based on discussion in our most recent community meeting. Everyone that had been attending the EMEA meeting time was also able to attend the APAC time. (Related thread in Slack: https://kubernetes.slack.com/archives/CR0H13KGA/p1624990383109000).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
