### PR TITLE
Updating GEP 696 to consistently reference newer issue

### DIFF
--- a/site-src/geps/gep-696.md
+++ b/site-src/geps/gep-696.md
@@ -1,6 +1,6 @@
-# GEP-684: GEP template
+# GEP-696: GEP template
 
-* Issue URL: https://github.com/kubernetes-sigs/gateway-api/pull/684
+* Issue URL: https://github.com/kubernetes-sigs/gateway-api/issues/696
 * Status: (provisional, implementable, implemented, deferred, rejected, withdrawn, or replaced)
 
 (See definitions in [Kubernetes KEP][kep-status].


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This GEP had a couple references to PR # instead of issue, this fixes that.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
