### PR TITLE
fix support level for HTTPRequestHeaderFilter

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -606,8 +606,6 @@ type HTTPRequestHeaderFilter struct {
 	//   GET /foo HTTP/1.1
 	//   my-header: bar
 	//
-	// Support: Extended
-	//
 	// +optional
 	Set []HTTPHeader `json:"set,omitempty"`
 
@@ -626,8 +624,6 @@ type HTTPRequestHeaderFilter struct {
 	//   GET /foo HTTP/1.1
 	//   my-header: foo
 	//   my-header: bar
-	//
-	// Support: Extended
 	//
 	// +optional
 	Add []HTTPHeader `json:"add,omitempty"`
@@ -649,8 +645,6 @@ type HTTPRequestHeaderFilter struct {
 	// Output:
 	//   GET /foo HTTP/1.1
 	//   my-header2: bar
-	//
-	// Support: Extended
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=16

--- a/config/crd/bases/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/bases/gateway.networking.k8s.io_httproutes.yaml
@@ -217,7 +217,7 @@ spec:
                                   name. \n Input:   GET /foo HTTP/1.1   my-header:
                                   foo \n Config:   add: {\"my-header\": \"bar\"} \n
                                   Output:   GET /foo HTTP/1.1   my-header: foo   my-header:
-                                  bar \n Support: Extended"
+                                  bar"
                                 items:
                                   description: HTTPHeader represents an HTTP Header
                                     name and value as defined by RFC 7230.
@@ -255,8 +255,7 @@ spec:
                                   \n Input:   GET /foo HTTP/1.1   my-header1: foo
                                   \  my-header2: bar   my-header3: baz \n Config:
                                   \  remove: [\"my-header1\", \"my-header3\"] \n Output:
-                                  \  GET /foo HTTP/1.1   my-header2: bar \n Support:
-                                  Extended"
+                                  \  GET /foo HTTP/1.1   my-header2: bar"
                                 items:
                                   type: string
                                 maxItems: 16
@@ -266,7 +265,7 @@ spec:
                                   given header (name, value) before the action. \n
                                   Input:   GET /foo HTTP/1.1   my-header: foo \n Config:
                                   \  set: {\"my-header\": \"bar\"} \n Output:   GET
-                                  /foo HTTP/1.1   my-header: bar \n Support: Extended"
+                                  /foo HTTP/1.1   my-header: bar"
                                 items:
                                   description: HTTPHeader represents an HTTP Header
                                     name and value as defined by RFC 7230.
@@ -519,7 +518,7 @@ spec:
                                         HTTP/1.1   my-header: foo \n Config:   add:
                                         {\"my-header\": \"bar\"} \n Output:   GET
                                         /foo HTTP/1.1   my-header: foo   my-header:
-                                        bar \n Support: Extended"
+                                        bar"
                                       items:
                                         description: HTTPHeader represents an HTTP
                                           Header name and value as defined by RFC
@@ -561,7 +560,7 @@ spec:
                                         foo   my-header2: bar   my-header3: baz \n
                                         Config:   remove: [\"my-header1\", \"my-header3\"]
                                         \n Output:   GET /foo HTTP/1.1   my-header2:
-                                        bar \n Support: Extended"
+                                        bar"
                                       items:
                                         type: string
                                       maxItems: 16
@@ -572,7 +571,7 @@ spec:
                                         action. \n Input:   GET /foo HTTP/1.1   my-header:
                                         foo \n Config:   set: {\"my-header\": \"bar\"}
                                         \n Output:   GET /foo HTTP/1.1   my-header:
-                                        bar \n Support: Extended"
+                                        bar"
                                       items:
                                         description: HTTPHeader represents an HTTP
                                           Header name and value as defined by RFC


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
**What this PR does / why we need it**:
As noted in #655, a core filter with extended support fields is
confusing and also seems to be incorrect.
This patch drops the extended field from the filter and is a partial fix
for the referenced issue.

HTTPRequestMirroFilter has not been patch as GEP-718 could potentially
simplify that.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Partial fix for #655

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
bugfix: To avoid confusion, fields within HTTPRequestHeaderFilter are no more marked as 'extended'. All fields must be supported by implementations for this core filter.
```
