### PR TITLE
Adding suggested reasons for when conditions are healthy

### DIFF
--- a/apis/v1alpha1/shared_types.go
+++ b/apis/v1alpha1/shared_types.go
@@ -169,10 +169,21 @@ type RouteForwardTo struct {
 // RouteConditionType is a type of condition for a route.
 type RouteConditionType string
 
+// RouteConditionReason is a reason for a route condition.
+type RouteConditionReason string
+
 const (
 	// This condition indicates whether the route has been admitted
-	// or rejected by a Gateway, and why.
+	// or refused by a Gateway.
 	ConditionRouteAdmitted RouteConditionType = "Admitted"
+
+	// This reason is used with the "Admitted" condition when the Route has been
+	// admitted by the Gateway.
+	RouteReasonAdmitted RouteConditionReason = "Admitted"
+
+	// This reason is used with the "Admitted" condition when the Route has been
+	// refused by the Gateway.
+	RouteReasonRefused RouteConditionReason = "Refused"
 )
 
 // RouteGatewayStatus describes the status of a route with respect to an

--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -576,14 +576,18 @@ type GatewayStatus struct {
 // field.
 type GatewayConditionType string
 
-// GatewayConditionReason defines the set of reasons that explain
-// why a particular Gateway condition type has been raised.
+// GatewayConditionReason defines the set of reasons that explain why a
+// particular Gateway condition type has been raised.
 type GatewayConditionReason string
 
 const (
 	// This condition is true when the controller managing the
 	// Gateway has scheduled the Gateway to the underlying network
 	// infrastructure.
+	//
+	// Possible reasons for this condition to be true are:
+	//
+	// * "Scheduled"
 	//
 	// Possible reasons for this condition to be false are:
 	//
@@ -595,6 +599,10 @@ const (
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
 	GatewayConditionScheduled GatewayConditionType = "Scheduled"
+
+	// This reason is used with the "Scheduled" condition when the condition is
+	// true.
+	GatewayReasonScheduled GatewayConditionReason = "Scheduled"
 
 	// This reason is used with the "Scheduled" condition when
 	// been recently created and no controller has reconciled it yet.
@@ -624,6 +632,10 @@ const (
 	// reasons are true, the Gateway controller should prefer the
 	// "ListenersNotValid" reason.
 	//
+	// Possible reasons for this condition to be true are:
+	//
+	// * "Ready"
+	//
 	// Possible reasons for this condition to be false are:
 	//
 	// * "ListenersNotValid"
@@ -634,6 +646,10 @@ const (
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
 	GatewayConditionReady GatewayConditionType = "Ready"
+
+	// This reason is used with the "Ready" condition when the condition is
+	// true.
+	GatewayReasonReady GatewayConditionReason = "Ready"
 
 	// This reason is used with the "Ready" condition when one or
 	// more Listeners have an invalid or unsupported configuration
@@ -698,6 +714,10 @@ const (
 	// * "ProtocolConflict"
 	// * "RouteConflict"
 	//
+	// Possible reasons for this condition to be false are:
+	//
+	// * "NoConflicts"
+	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
@@ -720,6 +740,10 @@ const (
 	// For example, a Listener that specifies "UDP" as the protocol
 	// but a route selector that resolves "TCPRoute" objects.
 	ListenerReasonRouteConflict ListenerConditionReason = "RouteConflict"
+
+	// This reason is used with the "Conflicted" condition when the condition
+	// is false.
+	ListenerReasonNoConflicts ListenerConditionReason = "NoConflicts"
 )
 
 const (
@@ -739,6 +763,10 @@ const (
 	// * "UnsupportedExtension"
 	// * "UnsupportedProtocol"
 	// * "UnsupportedAddress"
+	//
+	// Possible reasons for this condition to be false are:
+	//
+	// * "Attached"
 	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
@@ -764,11 +792,19 @@ const (
 	// the Listener could not be attached to the Gateway because the
 	// requested address is not supported.
 	ListenerReasonUnsupportedAddress ListenerConditionReason = "UnsupportedAddress"
+
+	// This reason is used with the "Detached" condition when the condition is
+	// false.
+	ListenerReasonAttached ListenerConditionReason = "Attached"
 )
 
 const (
 	// This condition indicates whether the controller was able to
 	// resolve all the object references for the Listener.
+	//
+	// Possible reasons for this condition to be true are:
+	//
+	// * "ResolvedRefs"
 	//
 	// Possible reasons for this condition to be false are:
 	//
@@ -780,6 +816,10 @@ const (
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
 	ListenerConditionResolvedRefs ListenerConditionType = "ResolvedRefs"
+
+	// This reason is used with the "ResolvedRefs" condition when the condition
+	// is true.
+	ListenerReasonResolvedRefs ListenerConditionReason = "ResolvedRefs"
 
 	// This reason is used with the "ResolvedRefs" condition
 	// when not all of the routes selected by this Listener could be
@@ -804,6 +844,10 @@ const (
 	// This condition indicates whether the Listener has been
 	// configured on the Gateway.
 	//
+	// Possible reasons for this condition to be true are:
+	//
+	// * "Ready"
+	//
 	// Possible reasons for this condition to be false are:
 	//
 	// * "Invalid"
@@ -813,6 +857,10 @@ const (
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
 	ListenerConditionReady ListenerConditionType = "Ready"
+
+	// This reason is used with the "Ready" condition when the condition is
+	// true.
+	ListenerReasonReady ListenerConditionReason = "Ready"
 
 	// This reason is used with the "Ready" condition when the
 	// Listener is syntactically or semantically invalid.

--- a/apis/v1alpha2/gatewayclass_types.go
+++ b/apis/v1alpha2/gatewayclass_types.go
@@ -132,36 +132,48 @@ type ParametersReference struct {
 // GatewayClassStatus.Conditions field.
 type GatewayClassConditionType string
 
-// GatewayClassConditionReason defines the set of reasons that explain why
-// a particular GatewayClass condition type has been raised.
+// GatewayClassConditionReason defines the set of reasons that explain why a
+// particular GatewayClass condition type has been raised.
 type GatewayClassConditionReason string
 
 const (
-	// This condition indicates whether the GatewayClass has been
-	// admitted by the controller requested in the `spec.controller`
-	// field.
+	// This condition indicates whether the GatewayClass has been admitted by
+	// the controller requested in the `spec.controller` field.
 	//
-	// This condition defaults to False, and MUST be set by a controller when it sees
-	// a GatewayClass using its controller string.
-	// The status of this condition MUST be set to true if the controller will support
-	// provisioning Gateways using this class. Otherwise, this status MUST be set to false.
-	// If the status is set to false, the controller SHOULD set a Message and Reason as an
-	// explanation.
+	// This condition defaults to False, and MUST be set by a controller when it
+	// sees a GatewayClass using its controller string. The status of this
+	// condition MUST be set to true if the controller will support provisioning
+	// Gateways using this class. Otherwise, this status MUST be set to false.
+	// If the status is set to false, the controller SHOULD set a Message and
+	// Reason as an explanation.
+	//
+	// Possible reasons for this condition to be true are:
+	//
+	// * "Admitted"
+	//
+	// Possible reasons for this condition to be false are:
+	//
+	// * "InvalidParameters"
+	// * "Waiting"
 	//
 	// Controllers should prefer to use the values of GatewayClassConditionReason
 	// for the corresponding Reason, where appropriate.
 	GatewayClassConditionStatusAdmitted GatewayClassConditionType = "Admitted"
 
+	// This reason is used with the "Admitted" condition when the condition is
+	// true.
+	GatewayClassReasonAdmitted GatewayClassConditionReason = "Admitted"
+
 	// This reason is used with the "Admitted" condition when the
 	// GatewayClass was not admitted because the parametersRef field
 	// was invalid, with more detail in the message.
-	GatewayClassNotAdmittedInvalidParameters GatewayClassConditionReason = "InvalidParameters"
+	GatewayClassReasonInvalidParameters GatewayClassConditionReason = "InvalidParameters"
 
 	// This reason is used with the "Admitted" condition when the
 	// requested controller has not yet made a decision about whether
 	// to admit the GatewayClass. It is the default Reason on a new
 	// GatewayClass. It indicates
-	GatewayClassNotAdmittedWaiting GatewayClassConditionReason = "Waiting"
+	GatewayClassReasonWaiting GatewayClassConditionReason = "Waiting"
 
 	// GatewayClassFinalizerGatewaysExist should be added as a finalizer to the
 	// GatewayClass whenever there are provisioned Gateways using a GatewayClass.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adds reasons for when conditions are healthy. When the conditions are positive, the healthy reason is identical to the condition name. 

**Does this PR introduce a user-facing change?**:
```release-note
Guidance has been added for condition reasons when they are healthy.
```

Slack thread with a bit more discussion: https://kubernetes.slack.com/archives/CR0H13KGA/p1616184252018300

/cc @jpeach @howardjohn @lelenanam 