### PR TITLE
Fix TLS guide with TLSRoute can be terminated

### DIFF
--- a/site-src/guides/tls.md
+++ b/site-src/guides/tls.md
@@ -22,6 +22,7 @@ Depending on the Listener Protocol, different TLS modes and Route types are supp
 Listener Protocol | TLS Mode | Route Type Supported
 --- | --- | ---
 TLS | Passthrough | TLSRoute
+TLS | Terminate | TLSRoute
 TLS | Terminate | TCPRoute
 HTTPS | Terminate | HTTPRoute
 


### PR DESCRIPTION
Previously guide stated that TLSRoutes cannot be terminated on the gateway, however, there is no requirement that the proxy to the backend hop has to be TLS when using TLSRoute. As it's about matching not the traffic protocol.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind documentation

**What this PR does / why we need it**:

Fix TLS guide with info that TLSRoutes can be used with TLS terminated at the gateway

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
No
