### PR TITLE
Adding GEP 726: Path Rewrites and Redirects

### DIFF
--- a/site-src/geps/gep-726.md
+++ b/site-src/geps/gep-726.md
@@ -42,20 +42,20 @@ type HTTPPathModifierType string
 const (
   // This type of modifier indicates that the complete path will be replaced by
   // the path redirect value.
-  AbsoluteHTTPPathRedirect HTTPPathModifierType = "Absolute"
+  AbsoluteHTTPPathModifier HTTPPathModifierType = "Absolute"
 
   // This type of modifier indicates that any prefix path matches will be
   // replaced by the substitution value. For example, a path with a prefix match
-  // of "/foo" and a ReplacePrefixPathMatch substitution of "/bar" will have the
+  // of "/foo" and a ReplacePrefixMatch substitution of "/bar" will have the
   // "/foo" prefix replaced with "/bar" in matching requests.
-  PathMatchHTTPPathRedirect HTTPPathModifierType = "ReplacePrefixPathMatch"
+  PrefixMatchHTTPPathModifier HTTPPathModifierType = "ReplacePrefixMatch"
 )
 
 // HTTPPathModifier defines configuration for path modifiers.
 type HTTPPathModifier struct {
   // Type defines the type of path modifier.
   //
-  // +kubebuilder:validation:Enum=Absolute;ReplacePrefixPathMatch
+  // +kubebuilder:validation:Enum=Absolute;ReplacePrefixMatch
   Type HTTPPathModifierType `json:"type"`
 
   // Substitution defines the HTTP path value to substitute. An empty value ("")
@@ -90,11 +90,12 @@ spec:
         requestRedirect:
           hostname: foo.com
           path:
-            type: ReplacePrefixPathMatch
+            type: ReplacePrefixMatch
             value: /bar
 ```
 
-This would be represented with the following API additions:
+This would be represented with the following API addition to the existing
+HTTPRequestRedirect filter:
 ```go
 // HTTPRequestRedirect defines a filter that redirects a request. At most one of
 // these filters may be used on a Route rule. This may not be used on the same
@@ -114,8 +115,8 @@ type HTTPRequestRedirect struct {
 
 ### Rewrites
 
-A new `RequestRewrite` filter can be added to support rewrites. In the following
-example, a a request to `example.com/foo/abc` would be rewritten to
+A new `URLRewrite` filter can be added to support rewrites. In the following
+example, a request to `example.com/foo/abc` would be rewritten to
 `example.net/bar/abc`.
 
 ```yaml
@@ -132,22 +133,22 @@ spec:
           type: Prefix
           value: /foo
       filters:
-      - type: RequestRewrite
+      - type: URLRewrite
         requestRewrite:
           hostname: example.net
           path:
-            type: ReplacePrefixPathMatch
+            type: ReplacePrefixMatch
             substitution: /bar
 ```
 
 This would be represent with the following API additions:
 ```go
-// HTTPRequestRewrite defines a filter that modifies a request during
-// forwarding. At most one of these filters may be used on a Route rule. This
-// may not be used on the same Route rule as a HTTPRequestRedirect filter.
+// HTTPURLRewrite defines a filter that modifies a request during forwarding.
+// At most one of these filters may be used on a Route rule. This may not be
+// used on the same Route rule as a HTTPRequestRedirect filter.
 //
 // Support: Extended
-type HTTPRequestRewrite struct {
+type HTTPURLRewrite struct {
   // Hostname is the value to be used to replace the Host header value during
   // forwarding.
   //
@@ -165,6 +166,10 @@ type HTTPRequestRewrite struct {
   Path *HTTPPathModifier `json:"path,omitempty"`
 }
 ```
+
+Note: `RequestRewrite` was originally considered as a name for this filter.
+`URLRewrite` was chosen as it more clearly represented the capabilities of the
+filter and would not be confused with header or query param modification.
 
 ## Portability
 
@@ -265,7 +270,7 @@ from the initial implementation.
 ## Alternatives
 
 ### 1. Generic Path Match Replacement
-Instead of the `ReplacePrefixPathMatch` option proposed above, we could have a
+Instead of the `ReplacePrefixMatch` option proposed above, we could have a
 `ReplacePathMatch` option. This would provide significantly more flexibility and
 room for growth than prefix replacement.
 

--- a/site-src/geps/gep-726.md
+++ b/site-src/geps/gep-726.md
@@ -31,6 +31,43 @@ there is significantly more variation in both if and how they are implemented.
 Given the wide support for this concept, it is important to design the API in a
 way that would make it easy to add this capability in the future.
 
+### Path Modifiers
+
+Both redirects and rewrites would share the same `PathModifier` types:
+
+```go
+// HTTPPathModifierType defines the type of path redirect.
+type HTTPPathModifierType string
+
+const (
+  // This type of modifier indicates that the complete path will be replaced by
+  // the path redirect value.
+  AbsoluteHTTPPathRedirect HTTPPathModifierType = "Absolute"
+
+  // This type of modifier indicates that any prefix path matches will be
+  // replaced by the substitution value. For example, a path with a prefix match
+  // of "/foo" and a ReplacePrefixPathMatch substitution of "/bar" will have the
+  // "/foo" prefix replaced with "/bar" in matching requests.
+  PathMatchHTTPPathRedirect HTTPPathModifierType = "ReplacePrefixPathMatch"
+)
+
+// HTTPPathModifier defines configuration for path modifiers.
+type HTTPPathModifier struct {
+  // Type defines the type of path modifier.
+  //
+  // +kubebuilder:validation:Enum=Absolute;ReplacePrefixPathMatch
+  Type HTTPPathModifierType `json:"type"`
+
+  // Substitution defines the HTTP path value to substitute. An empty value ("")
+  // indicates that the portion of the path to be changed should be removed from
+  // the resulting path. For example, a request to "/foo/bar" with a prefix
+  // match of "/foo" would be modified to "/bar".
+  //
+  // +kubebuilder:validation:MaxLength=1024
+  Substitution string `json:"substitution"`
+}
+```
+
 ### Redirects
 
 The existing `RequestRedirect` filter can be expanded to support path redirects.
@@ -70,39 +107,8 @@ type HTTPRequestRedirect struct {
   // Support: Extended
   //
   // +optional
-  Path *HTTPPathRedirect `json:"path,omitempty"`
+  Path *HTTPPathModifier `json:"path,omitempty"`
   // ...
-}
-
-// HTTPPathRedirectType defines the type of path redirect.
-type HTTPPathRedirectType string
-
-const (
-  // This type of redirect indicates that the complete path will be replaced by
-  // the path redirect value.
-  AbsoluteHTTPPathRedirect HTTPPathRedirectType = "Absolute"
-
-  // This type of redirect indicates that any prefix path matches will be
-  // replaced by the substitution value. For example, a path with a prefix match
-  // of "/foo" and a ReplacePrefixPathMatch substitution of "/bar" will have the
-  // "/foo" prefix replaced with "/bar" in matching requests.
-  PathMatchHTTPPathRedirect HTTPPathRedirectType = "ReplacePrefixPathMatch"
-)
-
-// HTTPPathRedirect defines configuration for path redirects.
-type HTTPPathRedirect struct {
-  // Type defines the type of path redirect.
-  //
-  // +kubebuilder:validation:Enum=Absolute;ReplacePrefixPathMatch
-  Type HTTPPathRedirectType `json:"type"`
-
-  // Value defines the HTTP path value to redirect to. An empty value ("")
-  // indicates that the portion of the path to be changed in the redirect should
-  // be removed from the redirect path. For example, a request to "/foo/bar"
-  // with a prefix match of "/foo" would be redirected to "/bar".
-  //
-  // +kubebuilder:validation:MaxLength=1024
-  Substitution string `json:"substitution"`
 }
 ```
 
@@ -156,34 +162,7 @@ type HTTPRequestRewrite struct {
   // Support: Extended
   //
   // +optional
-  Path *HTTPPathRewrite `json:"path,omitempty"`
-}
-
-// HTTPPathRewriteType defines the type of path rewrite.
-type HTTPPathRewriteType string
-
-const (
-  // This type of rewrite indicates that any prefix path matches will be
-  // replaced by the substitution value. For example, a path with a prefix match
-  // of "/foo" and a ReplacePrefixPathMatch substitution of "/bar" will have the
-  // "/foo" prefix replaced with "/bar" in matching requests.
-  PathMatchHTTPPathRedirect HTTPPathRedirectType = "ReplacePrefixPathMatch"
-)
-
-// HTTPPathRewrite defines configuration for path rewrites.
-type HTTPPathRewrite struct {
-  // Type defines the type of path rewrite.
-  //
-  // +kubebuilder:validation:Enum=ReplacePrefixPathMatch
-  Type HTTPPathRewriteType `json:"type"`
-
-  // Substitution defines the HTTP path value to rewrite. An empty value ("")
-  // indicates that the portion of the path to be rewritten should be removed
-  // from the rewritten path. For example, a request to "/foo/bar" with a prefix
-  // match of "/foo" would be rewritten to "/bar".
-  //
-  // +kubebuilder:validation:MaxLength=1024
-  Substitution string `json:"substitution"`
+  Path *HTTPPathModifier `json:"path,omitempty"`
 }
 ```
 
@@ -255,7 +234,7 @@ covered by this proposal:
 
 Both of the following can be represented by adding a new field new types. For
 example, this config would result in a request to `/foo/baz` to be rewritten to
-`/foo/bar`:
+`/bar/baz`:
 
 ```yaml
 filters:

--- a/site-src/geps/gep-726.md
+++ b/site-src/geps/gep-726.md
@@ -1,0 +1,274 @@
+# GEP-726: Add Path Redirects and Rewrites
+
+* Issue: [#726](https://github.com/kubernetes-sigs/gateway-api/issues/726)
+* Status: Implementable
+
+## TLDR
+
+This GEP proposes adding support for path redirects and rewrites in addition to
+host rewrites. This would augment the existing host redirection capabilities.
+
+## Goals
+
+* Implement path redirects.
+* Implement the most portable and simple forms of path rewrites.
+* Describe how more advanced rewrite and redirect and redirect capabilities
+  could be added in the future.
+
+## API
+
+Although many implementations support very advanced rewrite and redirect
+capabilities, the following are the most [portable](#portability) concepts that
+are not already supported by the Gateway API:
+
+* Path redirects
+* Path prefix redirects
+* Path prefix rewrites
+* Host rewrites
+
+Although regular expression based redirects and rewrites are commonly supported,
+there is significantly more variation in both if and how they are implemented.
+Given the wide support for this concept, it is important to design the API in a
+way that would make it easy to add this capability in the future.
+
+### Redirects
+
+The existing `RequestRedirect` filter can be expanded to support path redirects.
+In the following example, a request to `/foo/abc` would be redirected to
+`/bar/abc`.
+
+```yaml
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: http-filter-1
+spec:
+  rules:
+    - matches:
+      - path:
+          type: Prefix
+          value: /foo
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          hostname: foo.com
+          path:
+            type: PathMatch
+            value: /bar
+```
+
+This would be represented with the following API additions:
+```go
+// HTTPRequestRedirect defines a filter that redirects a request. At most one of
+// these filters may be used on a Route rule. This may not be used on the same
+// Route rule as a HTTPRequestRewrite filter.
+type HTTPRequestRedirect struct {
+  // Path defines a path redirect.
+  //
+  // Support: Extended
+  //
+  // +optional
+  Path *HTTPPathRedirect `json:"path,omitempty"`
+  // ...
+}
+
+// HTTPPathRedirectType defines the type of path redirect.
+type HTTPPathRedirectType string
+
+const (
+  // This type of redirect indicates that the complete path will be replaced by
+  // the path redirect value.
+  AbsoluteHTTPPathRedirect HTTPPathRedirectType = "Absolute"
+
+  // This type of redirect indicates that the path match will be replaced by
+  // the path redirect value.
+  PathMatchHTTPPathRedirect HTTPPathRedirectType = "PathMatch"
+)
+
+// HTTPPathRedirect defines configuration for path redirects.
+type HTTPPathRedirect struct {
+  // Type defines the type of path redirect.
+  //
+  // +kubebuilder:validation:Enum=Absolute;PathMatch
+  Type HTTPPathRedirectType `json:"type"`
+
+  // Value defines the HTTP path value to redirect to. An empty value ("")
+  // indicates that the portion of the path to be changed in the redirect should
+  // be removed from the redirect path. For example, a request to "/foo/bar"
+  // with a prefix match of "/foo" would be redirected to "/bar".
+  //
+  // +kubebuilder:validation:MaxLength=1024
+  Value string `json:"value"`
+}
+```
+
+### Rewrites
+
+A new `RequestRewrite` filter can be added to support rewrites. In the following
+example, a a request to `example.com/foo/abc` would be rewritten to
+`example.net/bar/abc`.
+
+```yaml
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: http-filter-1
+spec:
+  hostnames:
+  - example.com
+  rules:
+    - matches:
+      - path:
+          type: Prefix
+          value: /foo
+      filters:
+      - type: RequestRewrite
+        requestRewrite:
+          hostname: example.net
+          path:
+            type: ReplacePathMatch
+            value: /bar
+```
+
+This would be represent with the following API additions:
+```go
+// HTTPRequestRewrite defines a filter that modifies a request during
+// forwarding. At most one of these filters may be used on a Route rule. This
+// may not be used on the same Route rule as a HTTPRequestRedirect filter.
+type HTTPRequestRewrite struct {
+  // Hostname is the value to be used to replace the Host header value during
+  // forwarding.
+  //
+  // Support: Extended
+  //
+  // +optional
+  // +kubebuilder:validation:MaxLength=255
+  Hostname *string `json:"hostname,omitempty"`
+
+  // Path defines a path rewrite.
+  //
+  // Support: Extended
+  //
+  // +optional
+  Path *HTTPPathRewrite `json:"path,omitempty"`
+}
+
+// HTTPPathRewriteType defines the type of path rewrite.
+type HTTPPathRewriteType string
+
+const (
+  // This type of rewrite indicates that the prefix match will be replaced by
+  // the path rewrite value.
+  ReplacePathMatchHTTPPathRewrite HTTPPathRewriteType = "ReplacePathMatch"
+)
+
+// HTTPPathRewrite defines configuration for path rewrites.
+type HTTPPathRewrite struct {
+  // Type defines the type of path rewrite.
+  //
+  // +kubebuilder:validation:Enum=ReplacePathMatch
+  Type HTTPPathRewriteType `json:"type"`
+
+  // Value defines the HTTP path value to rewrite. An empty value ("") indicates
+  // that the portion of the path to be rewritten should be removed from the
+  // rewritten path. For example, a request to "/foo/bar" with a prefix match of
+  // "/foo" would be rewritten to "/bar".
+  //
+  // +kubebuilder:validation:MaxLength=1024
+  Value string `json:"value"`
+}
+```
+
+## Portability
+
+When considering what should be possible in the API, it's worth evaluating what
+common tooling is capable of. This is by no means a complete list, but this
+provides a high level overview of how this is configured across different
+implementations.
+
+Although not all of these implementations directly support prefix rewrites or
+redirects, the ones that don't include regular expression support which can be
+used to implement prefix rewrites and redirects.
+
+Note: This section intentionally excludes the redirect capabilities already
+contained in the API.
+
+### Envoy
+Envoy supports the following relevant capabilities
+([reference](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto)):
+
+* path_redirect (redirect only)
+* prefix_rewrite (redirect and forwarding)
+* regex_rewrite (redirect and forwarding)
+* host_rewrite_literal (forwarding only)
+* strip_query (redirect only)
+
+Note that path rewrite relies on the prefix match for the route, there is not
+a way to differentiate between the prefix used for matching and rewriting.
+
+### Google Cloud
+Google Cloud URL Maps support the following relevant capabilities
+([reference](https://cloud.google.com/compute/docs/reference/rest/v1/urlMaps)):
+
+* pathPrefixRewrite (forwarding only)
+* hostRewrite (forwarding only)
+* pathRedirect (redirect only)
+* prefixRedirect (redirect only)
+* stripQuery (redirect only)
+
+Note that path rewrite relies on the prefix match for the route, there is not
+a way to differentiate between the prefix used for matching and rewriting.
+
+### HAProxy
+HAProxy supports the following relevant capabilities
+([reference](https://cbonte.github.io/haproxy-dconv/2.5/configuration.html)):
+
+* http-request set-path (advanced path rewrite capabilities)
+* http-request replace-path (rewrites entire path)
+* http-request replace-pathq (rewrites entire path + query string)
+* http-request replace-uri (URI rewrite based on input regex)
+* redirect location (advanced redirect capabilities)
+
+### NGINX
+The NGINX rewrite module contains the following relevant capabilities
+([reference](http://nginx.org/en/docs/http/ngx_http_rewrite_module.html)):
+
+* PCRE regex based rewrites
+* Rewrite directive can be used during forwarding or redirects
+* Rewrite directive can affect host, path, or both
+* Rewrite directive can be chained
+
+## Alternatives
+
+### 1. Top Level Rewrite Fields
+Although a small difference, we could restructure how the path rewrites and
+redirects were configured. One example would be adding top level fields in the
+filters for each kind of path rewrite or redirect. That would result in a change
+like this:
+
+**Before:**
+```yaml
+requestRewrite:
+  hostname: foo.com
+  path:
+    type: Prefix
+    value: /bar
+```
+
+**After:**
+```yaml
+requestRewrite:
+  hostname: foo.com
+  pathPrefix: /bar
+```
+
+Although simpler for the initial use cases, it may become more difficult to
+maintain and validate as additional types of rewrites and redirects were added.
+
+
+## References
+
+Issues:
+
+- [#200: Add support for configurable HTTP redirects](https://github.com/kubernetes-sigs/gateway-api/issues/200)
+- [#678: Add support for HTTP rewrites](https://github.com/kubernetes-sigs/gateway-api/issues/678)

--- a/site-src/geps/gep-726.md
+++ b/site-src/geps/gep-726.md
@@ -53,7 +53,7 @@ spec:
         requestRedirect:
           hostname: foo.com
           path:
-            type: PathMatch
+            type: ReplacePrefixPathMatch
             value: /bar
 ```
 
@@ -62,6 +62,8 @@ This would be represented with the following API additions:
 // HTTPRequestRedirect defines a filter that redirects a request. At most one of
 // these filters may be used on a Route rule. This may not be used on the same
 // Route rule as a HTTPRequestRewrite filter.
+//
+// Support: Extended
 type HTTPRequestRedirect struct {
   // Path defines a path redirect.
   //
@@ -80,16 +82,18 @@ const (
   // the path redirect value.
   AbsoluteHTTPPathRedirect HTTPPathRedirectType = "Absolute"
 
-  // This type of redirect indicates that the path match will be replaced by
-  // the path redirect value.
-  PathMatchHTTPPathRedirect HTTPPathRedirectType = "PathMatch"
+  // This type of redirect indicates that any prefix path matches will be
+  // replaced by the substitution value. For example, a path with a prefix match
+  // of "/foo" and a ReplacePrefixPathMatch substitution of "/bar" will have the
+  // "/foo" prefix replaced with "/bar" in matching requests.
+  PathMatchHTTPPathRedirect HTTPPathRedirectType = "ReplacePrefixPathMatch"
 )
 
 // HTTPPathRedirect defines configuration for path redirects.
 type HTTPPathRedirect struct {
   // Type defines the type of path redirect.
   //
-  // +kubebuilder:validation:Enum=Absolute;PathMatch
+  // +kubebuilder:validation:Enum=Absolute;ReplacePrefixPathMatch
   Type HTTPPathRedirectType `json:"type"`
 
   // Value defines the HTTP path value to redirect to. An empty value ("")
@@ -98,7 +102,7 @@ type HTTPPathRedirect struct {
   // with a prefix match of "/foo" would be redirected to "/bar".
   //
   // +kubebuilder:validation:MaxLength=1024
-  Value string `json:"value"`
+  Substitution string `json:"substitution"`
 }
 ```
 
@@ -126,8 +130,8 @@ spec:
         requestRewrite:
           hostname: example.net
           path:
-            type: ReplacePathMatch
-            value: /bar
+            type: ReplacePrefixPathMatch
+            substitution: /bar
 ```
 
 This would be represent with the following API additions:
@@ -135,6 +139,8 @@ This would be represent with the following API additions:
 // HTTPRequestRewrite defines a filter that modifies a request during
 // forwarding. At most one of these filters may be used on a Route rule. This
 // may not be used on the same Route rule as a HTTPRequestRedirect filter.
+//
+// Support: Extended
 type HTTPRequestRewrite struct {
   // Hostname is the value to be used to replace the Host header value during
   // forwarding.
@@ -157,25 +163,27 @@ type HTTPRequestRewrite struct {
 type HTTPPathRewriteType string
 
 const (
-  // This type of rewrite indicates that the prefix match will be replaced by
-  // the path rewrite value.
-  ReplacePathMatchHTTPPathRewrite HTTPPathRewriteType = "ReplacePathMatch"
+  // This type of rewrite indicates that any prefix path matches will be
+  // replaced by the substitution value. For example, a path with a prefix match
+  // of "/foo" and a ReplacePrefixPathMatch substitution of "/bar" will have the
+  // "/foo" prefix replaced with "/bar" in matching requests.
+  PathMatchHTTPPathRedirect HTTPPathRedirectType = "ReplacePrefixPathMatch"
 )
 
 // HTTPPathRewrite defines configuration for path rewrites.
 type HTTPPathRewrite struct {
   // Type defines the type of path rewrite.
   //
-  // +kubebuilder:validation:Enum=ReplacePathMatch
+  // +kubebuilder:validation:Enum=ReplacePrefixPathMatch
   Type HTTPPathRewriteType `json:"type"`
 
-  // Value defines the HTTP path value to rewrite. An empty value ("") indicates
-  // that the portion of the path to be rewritten should be removed from the
-  // rewritten path. For example, a request to "/foo/bar" with a prefix match of
-  // "/foo" would be rewritten to "/bar".
+  // Substitution defines the HTTP path value to rewrite. An empty value ("")
+  // indicates that the portion of the path to be rewritten should be removed
+  // from the rewritten path. For example, a request to "/foo/bar" with a prefix
+  // match of "/foo" would be rewritten to "/bar".
   //
   // +kubebuilder:validation:MaxLength=1024
-  Value string `json:"value"`
+  Substitution string `json:"substitution"`
 }
 ```
 
@@ -238,9 +246,63 @@ The NGINX rewrite module contains the following relevant capabilities
 * Rewrite directive can affect host, path, or both
 * Rewrite directive can be chained
 
+## Future Extension
+There are two relatively common types of path rewrite/redirect that are not
+covered by this proposal:
+
+1. Replace a path prefix separate from the match
+2. Replace with a Regular Expression substitution
+
+Both of the following can be represented by adding a new field new types. For
+example, this config would result in a request to `/foo/baz` to be rewritten to
+`/foo/bar`:
+
+```yaml
+filters:
+- type: RequestRewrite
+  requestRewrite:
+    path:
+      type: ReplacePrefix
+      pattern: /foo
+      substitution: /bar
+```
+
+Similarly, this config would result in a request to `/foo/bar/baz` being
+rewritten to `/foo/other/baz`.
+```yaml
+filters:
+- type: RequestRewrite
+  requestRewrite:
+    path:
+      type: RegularExpression
+      pattern: /foo/(.*)/baz
+      substitution: other
+```
+
+Although both of the above are natural extensions of the API, they are not quite
+as broadly supported. For that reason, this GEP proposes omitting these types
+from the initial implementation.
+
 ## Alternatives
 
-### 1. Top Level Rewrite Fields
+### 1. Generic Path Match Replacement
+Instead of the `ReplacePrefixPathMatch` option proposed above, we could have a
+`ReplacePathMatch` option. This would provide significantly more flexibility and
+room for growth than prefix replacement.
+
+Unfortunately it would be difficult to represent conformance and support levels.
+It also would have limited value. Replacing "Exact" match types would be nearly
+identical to the "Absolute" match type, and replacing "RegularExpression" match
+types would likely not yield the desired result. In most cases, RegEx rewrites
+are implemented separately from RegEx path matching. So a user may want to match
+all paths matching one RegEx, but use a separate RegEx + substitution value for
+rewrites.
+
+It is theoretically possible that future patch match types could be useful as a
+rewrite source, but the common proxies described above seem to be limited to the
+rewrite types described above.
+
+### 2. Top Level Rewrite Fields
 Although a small difference, we could restructure how the path rewrites and
 redirects were configured. One example would be adding top level fields in the
 filters for each kind of path rewrite or redirect. That would result in a change
@@ -252,7 +314,7 @@ requestRewrite:
   hostname: foo.com
   path:
     type: Prefix
-    value: /bar
+    substitution: /bar
 ```
 
 **After:**


### PR DESCRIPTION
**What type of PR is this?**
/kind gep

**What this PR does / why we need it**:
This adds GEP #726, a proposed expansion of redirect capabilities along with new rewrite capabilities. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

Deploy Preview: https://deploy-preview-731--kubernetes-sigs-gateway-api.netlify.app/geps/gep-726/