### PR TITLE
Clarifying TLS Spec on HTTPRoute, Moving to Extended Support

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -113,21 +113,26 @@ type HTTPRouteSpec struct {
 
 	// TLS defines the TLS certificate to use for Hostnames defined in this
 	// Route. This configuration only takes effect if the AllowRouteOverride
-	// field is set to true in the associated Gateway resource.
+	// field is set to true in the associated Gateway Listener.
 	//
-	// Collisions can happen if multiple HTTPRoutes define a TLS certificate
-	// for the same hostname. In such a case, conflict resolution guiding
-	// principles apply, specifically, if hostnames are same and two different
-	// certificates are specified then the certificate in the
-	// oldest resource wins.
+	// Attaching a TLS certificate to HTTPRoutes provides a way for HTTPRoute
+	// owners to effectively populate certificates on Gateway Listeners. Note
+	// that only one certificate may be attached to a Gateway Listener for a
+	// specified hostname. It is not possible to use different certificates for
+	// different HTTPRoutes for the same hostname on the same Gateway Listener.
 	//
-	// Please note that HTTP Route-selection takes place after the
-	// TLS Handshake (ClientHello). Due to this, TLS certificate defined
-	// here will take precedence even if the request has the potential to
-	// match multiple routes (in case multiple HTTPRoutes share the same
-	// hostname).
+	// If multiple HTTPRoutes define a TLS certificate for the same hostname and
+	// are bound to the same Gateway Listener, precedence MUST be determined in
+	// order of the following criteria, continuing on ties:
 	//
-	// Support: Core
+	// * The oldest Route based on creation timestamp. For example, a Route with
+	//   a creation timestamp of "2021-07-28 01:02:03" is given precedence over
+	//   a Route with a creation timestamp of "2021-07-28 01:02:04".
+	// * The Route appearing first in alphabetical order by
+	//   "<namespace>/<name>". For example, foo/bar is given precedence over
+	//   foo/baz.
+	//
+	// Support: Extended
 	//
 	// +optional
 	TLS *RouteTLSConfig `json:"tls,omitempty"`

--- a/config/crd/bases/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/bases/gateway.networking.k8s.io_httproutes.yaml
@@ -988,15 +988,21 @@ spec:
                 description: "TLS defines the TLS certificate to use for Hostnames
                   defined in this Route. This configuration only takes effect if the
                   AllowRouteOverride field is set to true in the associated Gateway
-                  resource. \n Collisions can happen if multiple HTTPRoutes define
-                  a TLS certificate for the same hostname. In such a case, conflict
-                  resolution guiding principles apply, specifically, if hostnames
-                  are same and two different certificates are specified then the certificate
-                  in the oldest resource wins. \n Please note that HTTP Route-selection
-                  takes place after the TLS Handshake (ClientHello). Due to this,
-                  TLS certificate defined here will take precedence even if the request
-                  has the potential to match multiple routes (in case multiple HTTPRoutes
-                  share the same hostname). \n Support: Core"
+                  Listener. \n Attaching a TLS certificate to HTTPRoutes provides
+                  a way for HTTPRoute owners to effectively populate certificates
+                  on Gateway Listeners. Note that only one certificate may be attached
+                  to a Gateway Listener for a specified hostname. It is not possible
+                  to use different certificates for different HTTPRoutes for the same
+                  hostname on the same Gateway Listener. \n If multiple HTTPRoutes
+                  define a TLS certificate for the same hostname and are bound to
+                  the same Gateway Listener, precedence MUST be determined in order
+                  of the following criteria, continuing on ties: \n * The oldest Route
+                  based on creation timestamp. For example, a Route with   a creation
+                  timestamp of \"2021-07-28 01:02:03\" is given precedence over   a
+                  Route with a creation timestamp of \"2021-07-28 01:02:04\". * The
+                  Route appearing first in alphabetical order by   \"<namespace>/<name>\".
+                  For example, foo/bar is given precedence over   foo/baz. \n Support:
+                  Extended"
                 properties:
                   certificateRef:
                     description: "CertificateRef is a reference to a Kubernetes object


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
This PR clarifies the TLS spec on HTTPRoute and moves it to extended support. This has been one of the more confusing  parts of the API, and it seemed like an update to the spec around it could help. I think there are at least some implementations that have reservations around supporting this feature, so I'm also proposing dropping the support level to "Extended" here.

**Does this PR introduce a user-facing change?**:
```release-note
Usage of TLS Certificates in HTTPRoutes has been clarified, support level has changed from "Core" to "Extended".
```
