### PR TITLE
Moving method match to v1alpha2 example

### DIFF
--- a/examples/basic-http.yaml
+++ b/examples/basic-http.yaml
@@ -55,7 +55,6 @@ spec:
       path:
         type: Prefix
         value: /some/thing
-      method: GET
     forwardTo:
     - serviceName: my-service2
       port: 8080

--- a/examples/v1alpha2/basic-http.yaml
+++ b/examples/v1alpha2/basic-http.yaml
@@ -55,6 +55,7 @@ spec:
       path:
         type: Prefix
         value: /some/thing
+      method: GET
     forwardTo:
     - serviceName: my-service2
       port: 8080

--- a/hack/verify-examples-kind.sh
+++ b/hack/verify-examples-kind.sh
@@ -54,6 +54,9 @@ kind create cluster --name "${CLUSTER_NAME}" --kubeconfig "${KUBECONFIG}" || res
 # Install CRDs
 kubectl apply --kubeconfig "${KUBECONFIG}" -f config/crd/bases || res=$?
 
+# Temporary workaround for https://github.com/kubernetes/kubernetes/issues/104090
+sleep 8
+
 # Install all example gateway-api resources.
 kubectl apply --kubeconfig "${KUBECONFIG}" --recursive -f examples || res=$?
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind documentation

**What this PR does / why we need it**:
Missed this when I was reviewing #733 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

Note: I'm starting this PR to see if I can get `verify-examples-kind` to fail, will update to complete this transition and remove hold at that point.

/hold