### PR TITLE
Remove RouteTLSConfig requirement for gateway TLS passthrough.

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -147,9 +147,6 @@ type RouteTLSConfig struct {
 	// handshake for requests that match the hostname of the associated HTTPRoute.
 	// The referenced object MUST reside in the same namespace as HTTPRoute.
 	//
-	// This field is required when the TLS configuration mode of the associated
-	// Gateway listener is set to "Passthrough".
-	//
 	// CertificateRef can reference a standard Kubernetes resource, i.e. Secret,
 	// or an implementation-specific custom resource.
 	//

--- a/config/crd/bases/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/bases/gateway.networking.k8s.io_httproutes.yaml
@@ -1010,9 +1010,7 @@ spec:
                       that contains a TLS certificate and private key. This certificate
                       is used to establish a TLS handshake for requests that match
                       the hostname of the associated HTTPRoute. The referenced object
-                      MUST reside in the same namespace as HTTPRoute. \n This field
-                      is required when the TLS configuration mode of the associated
-                      Gateway listener is set to \"Passthrough\". \n CertificateRef
+                      MUST reside in the same namespace as HTTPRoute. \n CertificateRef
                       can reference a standard Kubernetes resource, i.e. Secret, or
                       an implementation-specific custom resource. \n Support: Core
                       (Kubernetes Secrets) \n Support: Implementation-specific (Other


### PR DESCRIPTION
TLS passthrough never terminates TLS sessions, so it doesn't make
sense for TLS certificates to be required in this configuration.

/kind bug
