### PR TITLE
Documenting Route attachment for v1alpha2

### DIFF
--- a/site-src/v1alpha2/api-types/gateway.md
+++ b/site-src/v1alpha2/api-types/gateway.md
@@ -12,7 +12,7 @@ The `Gateway` spec defines the following:
 *   `GatewayClassName`- Defines the name of a `GatewayClass` object used by
     this Gateway.
 *   `Listeners`-  Define the hostnames, ports, protocol, termination, TLS
-    settings and which routes should be associated to a listener.
+    settings and which routes can be attached to a listener.
 *   `Addresses`- Define the network addresses requested for this gateway.
 
 If the desired configuration specified in Gateway spec cannot be achieved, the
@@ -39,8 +39,8 @@ desired state represented in `spec`. `GatewayStatus` consists of the following:
 
 - `Addresses`- Lists the IP addresses that have actually been bound to the
   Gateway.
-- `Listeners`- Provide status for each unique listener port defined in `spec`.
-- `Conditions`- Describe the current status conditions of the Gateway.  
+- `Listeners`- Provide status for each unique listener defined in `spec`.
+- `Conditions`- Describe the current status conditions of the Gateway.
 
 Both `Conditions` and `Listeners.conditions` follow the conditions pattern used
 elsewhere in Kubernetes. This is a list that includes a type of condition, the

--- a/site-src/v1alpha2/concepts/security-model.md
+++ b/site-src/v1alpha2/concepts/security-model.md
@@ -96,14 +96,11 @@ configuration](https://github.com/open-policy-agent/gatekeeper-library/pull/24)
 that could be used for this.
 
 ## Route Namespaces
-Gateway API allow Gateways to select Routes across multiple Namespaces.
+Gateway API enables Routes to be attached to Gateways from different Namespaces.
 Although this can be remarkably powerful, this capability needs to be used
-carefully. Gateways include a `RouteNamespaces` field that allows selecting
-multiple namespaces with a label selector. By default, this is limited to Routes
-in the same namespace as the Gateway. Additionally, Routes include a `Gateways`
-field that allows them to restrict which Gateways use them. If the Gateways
-field is not specified (i.e. its empty), then the Route will default to allowing
-selection by Gateways in the same namespace.
+carefully. Gateway Listeners include a `namespaces` field that can allow Routes
+to be attached from additional namespaces. By default, this is limited to Routes
+in the same namespace as the Gateway.
 
 ## Controller Requirements
 To be considered conformant with the Gateway API spec, controllers need to:


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This is a follow up to #754 and provides documentation for GEP #724.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

Deploy Previews:

* https://deploy-preview-762--kubernetes-sigs-gateway-api.netlify.app/v1alpha2/concepts/api-overview/
* https://deploy-preview-762--kubernetes-sigs-gateway-api.netlify.app/v1alpha2/concepts/security-model/