### PR TITLE
document multi-value headers as undefined

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -343,11 +343,17 @@ type HTTPHeaderMatch struct {
 	// Name is the name of the HTTP Header to be matched. Name matching MUST be
 	// case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 	//
-	// If multiple entries specify equivalent header names, only the first entry
-	// with an equivalent name MUST be considered for a match. Subsequent
+	// If multiple entries specify equivalent header names, only the first
+	// entry with an equivalent name MUST be considered for a match. Subsequent
 	// entries with an equivalent header name MUST be ignored. Due to the
 	// case-insensitivity of header names, "foo" and "Foo" are considered
 	// equivalent.
+	//
+	// When a header is repeated in an HTTP request, it is
+	// implementation-specific behavior as to how this is represented.
+	// Generally, proxies should follow the guidance from the RFC:
+	// https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+	// processing a repeated header, with special handling for "Set-Cookie".
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256

--- a/config/crd/bases/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/bases/gateway.networking.k8s.io_httproutes.yaml
@@ -872,7 +872,13 @@ spec:
                                     name MUST be considered for a match. Subsequent
                                     entries with an equivalent header name MUST be
                                     ignored. Due to the case-insensitivity of header
-                                    names, \"foo\" and \"Foo\" are considered equivalent."
+                                    names, \"foo\" and \"Foo\" are considered equivalent.
+                                    \n When a header is repeated in an HTTP request,
+                                    it is implementation-specific behavior as to how
+                                    this is represented. Generally, proxies should
+                                    follow the guidance from the RFC: https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2
+                                    regarding processing a repeated header, with special
+                                    handling for \"Set-Cookie\"."
                                   maxLength: 256
                                   minLength: 1
                                   type: string


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Clarifies that matching behavior for multi-value headers is undefined. This seems like a very rare use-case and specifying something that may cause conformance headaches doesn't seem to be worth it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #213

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
