### PR TITLE
Tightening validation + adding basic validation tests

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -148,9 +148,7 @@ type Listener struct {
 	// within a Gateway.
 	//
 	// Support: Core
-	//
-	// +kubebuilder:validation:MaxLength=253
-	Name string `json:"name"`
+	Name SectionName `json:"name"`
 
 	// Hostname specifies the virtual hostname to match for protocol types that
 	// define this concept. When unspecified, "", or `*`, all hostnames are
@@ -322,6 +320,7 @@ type GatewayTLSConfig struct {
 	// Support: Implementation-specific
 	//
 	// +optional
+	// +kubebuilder:validation:MaxProperties=16
 	Options map[string]string `json:"options,omitempty"`
 }
 
@@ -414,14 +413,10 @@ type RouteGroupKind struct {
 	//
 	// +optional
 	// +kubebuilder:default=gateway.networking.k8s.io
-	// +kubebuilder:validation:MaxLength=253
-	Group *string `json:"group,omitempty"`
+	Group *Group `json:"group,omitempty"`
 
 	// Kind is the kind of the Route.
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Kind string `json:"kind"`
+	Kind Kind `json:"kind"`
 }
 
 // GatewayAddress describes an address that can be bound to a Gateway.
@@ -622,9 +617,7 @@ type ListenerStatus struct {
 	// Name is the name of the Listener. If the Gateway has more than one
 	// Listener present, each ListenerStatus MUST specify a name. The names of
 	// ListenerStatus objects MUST be unique within a Gateway.
-	//
-	// +kubebuilder:validation:MaxLength=253
-	Name string `json:"name"`
+	Name SectionName `json:"name"`
 
 	// SupportedKinds is the list indicating the Kinds supported by this
 	// listener. When this is not specified on the Listener, this MUST represent

--- a/apis/v1alpha2/gatewayclass_types.go
+++ b/apis/v1alpha2/gatewayclass_types.go
@@ -61,9 +61,7 @@ type GatewayClassSpec struct {
 	// and PATH is a valid HTTP path as defined by RFC 3986.
 	//
 	// Support: Core
-	//
-	// +kubebuilder:validation:MaxLength=253
-	Controller string `json:"controller"`
+	Controller GatewayController `json:"controller"`
 
 	// ParametersRef is a reference to a resource that contains the configuration
 	// parameters corresponding to the GatewayClass. This is optional if the
@@ -83,7 +81,6 @@ type GatewayClassSpec struct {
 
 	// Description helps describe a GatewayClass with more details.
 	//
-	//
 	// +kubebuilder:validation:MaxLength=64
 	// +optional
 	Description *string `json:"description,omitempty"`
@@ -93,15 +90,10 @@ type GatewayClassSpec struct {
 // configuration resource within the cluster.
 type ParametersReference struct {
 	// Group is the group of the referent.
-	//
-	// +kubebuilder:validation:MaxLength=253
-	Group string `json:"group"`
+	Group Group `json:"group"`
 
 	// Kind is kind of the referent.
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Kind string `json:"kind"`
+	Kind Kind `json:"kind"`
 
 	// Name is the name of the referent.
 	//
@@ -111,6 +103,7 @@ type ParametersReference struct {
 
 	// Scope represents if the referent is a Cluster or Namespace scoped resource.
 	// This may be set to "Cluster" or "Namespace".
+	//
 	// +kubebuilder:validation:Enum=Cluster;Namespace
 	// +kubebuilder:default=Cluster
 	// +optional
@@ -120,10 +113,8 @@ type ParametersReference struct {
 	// This field is required when scope is set to "Namespace" and ignored when
 	// scope is set to "Cluster".
 	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
 	// +optional
-	Namespace *string `json:"namespace,omitempty"`
+	Namespace *Namespace `json:"namespace,omitempty"`
 }
 
 // GatewayClassConditionType is the type for status conditions on

--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -262,6 +262,7 @@ type HTTPPathMatch struct {
 	//
 	// +optional
 	// +kubebuilder:default="/"
+	// +kubebuilder:validation:MaxLength=1024
 	Value *string `json:"value,omitempty"`
 }
 
@@ -281,6 +282,24 @@ const (
 	HeaderMatchRegularExpression      HeaderMatchType = "RegularExpression"
 	HeaderMatchImplementationSpecific HeaderMatchType = "ImplementationSpecific"
 )
+
+// HTTPHeaderName is the name of an HTTP header.
+//
+// Valid values include:
+//
+// * "Authorization"
+// * "Set-Cookie"
+//
+// Invalid values include:
+//
+// * ":method" - ":" is an invalid character. This means that pseudo headers are
+//   not currently supported by this type.
+// * "/invalid" - "/" is an invalid character
+//
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=256
+// +kubebuilder:validation:Pattern=`^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$`
+type HTTPHeaderName string
 
 // HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
 // headers.
@@ -314,10 +333,7 @@ type HTTPHeaderMatch struct {
 	// Generally, proxies should follow the guidance from the RFC:
 	// https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
 	// processing a repeated header, with special handling for "Set-Cookie".
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=256
-	Name string `json:"name"`
+	Name HTTPHeaderName `json:"name"`
 
 	// Value is the value of HTTP Header to be matched.
 	//
@@ -423,14 +439,20 @@ type HTTPRouteMatch struct {
 	// ANDed together, meaning, a request must match all the specified headers
 	// to select the route.
 	//
+	// +listType=map
+	// +listMapKey=name
 	// +optional
+	// +kubebuilder:validation:MaxItems=16
 	Headers []HTTPHeaderMatch `json:"headers,omitempty"`
 
 	// QueryParams specifies HTTP query parameter matchers. Multiple match
 	// values are ANDed together, meaning, a request must match all the
 	// specified query parameters to select the route.
 	//
+	// +listType=map
+	// +listMapKey=name
 	// +optional
+	// +kubebuilder:validation:MaxItems=16
 	QueryParams []HTTPQueryParamMatch `json:"queryParams,omitempty"`
 
 	// Method specifies HTTP method matcher.
@@ -574,10 +596,7 @@ type HTTPHeader struct {
 	// entries with an equivalent header name MUST be ignored. Due to the
 	// case-insensitivity of header names, "foo" and "Foo" are considered
 	// equivalent.
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=256
-	Name string `json:"name"`
+	Name HTTPHeaderName `json:"name"`
 
 	// Value is the value of HTTP Header to be matched.
 	//
@@ -604,6 +623,9 @@ type HTTPRequestHeaderFilter struct {
 	//   my-header: bar
 	//
 	// +optional
+	// +listType=map
+	// +listMapKey=name
+	// +kubebuilder:validation:MaxItems=16
 	Set []HTTPHeader `json:"set,omitempty"`
 
 	// Add adds the given header(s) (name, value) to the request
@@ -623,6 +645,9 @@ type HTTPRequestHeaderFilter struct {
 	//   my-header: bar
 	//
 	// +optional
+	// +listType=map
+	// +listMapKey=name
+	// +kubebuilder:validation:MaxItems=16
 	Add []HTTPHeader `json:"add,omitempty"`
 
 	// Remove the given header(s) from the HTTP request before the
@@ -659,6 +684,7 @@ type HTTPRequestRedirect struct {
 	// +optional
 	// +kubebuilder:validation:Enum=HTTP;HTTPS
 	Protocol *string `json:"protocol,omitempty"`
+
 	// Hostname is the hostname to be used in the value of the `Location`
 	// header in the response.
 	// When empty, the hostname of the request is used.
@@ -666,7 +692,8 @@ type HTTPRequestRedirect struct {
 	// Support: Core
 	//
 	// +optional
-	Hostname *string `json:"hostname,omitempty"`
+	Hostname *Hostname `json:"hostname,omitempty"`
+
 	// Port is the port to be used in the value of the `Location`
 	// header in the response.
 	// When empty, port (if specified) of the request is used.
@@ -674,14 +701,15 @@ type HTTPRequestRedirect struct {
 	// Support: Extended
 	//
 	// +optional
-	Port *int `json:"port,omitempty"`
+	Port *PortNumber `json:"port,omitempty"`
+
 	// StatusCode is the HTTP status code to be used in response.
 	//
 	// Support: Core
 	//
 	// +optional
 	// +kubebuilder:default=302
-	// +kubebuilder:validation=301;302
+	// +kubebuilder:validation:Enum=301;302
 	StatusCode *int `json:"statusCode,omitempty"`
 }
 

--- a/apis/v1alpha2/object_reference_types.go
+++ b/apis/v1alpha2/object_reference_types.go
@@ -19,16 +19,12 @@ package v1alpha2
 // LocalObjectReference identifies an API object within the namespace of the
 // referrer.
 type LocalObjectReference struct {
-	// Group is the group of the referent.
-	//
-	// +kubebuilder:validation:MaxLength=253
-	Group string `json:"group"`
+	// Group is the group of the referent. For example, "networking.k8s.io".
+	// When unspecified (empty string), core API group is inferred.
+	Group Group `json:"group"`
 
-	// Kind is kind of the referent.
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Kind string `json:"kind"`
+	// Kind is kind of the referent. For example "HTTPRoute" or "Service".
+	Kind Kind `json:"kind"`
 
 	// Name is the name of the referent.
 	//
@@ -39,21 +35,18 @@ type LocalObjectReference struct {
 
 // ObjectReference identifies an API object including its namespace.
 type ObjectReference struct {
-	// Group is the group of the referent.
+	// Group is the group of the referent. For example, "networking.k8s.io".
 	// When unspecified (empty string), core API group is inferred.
 	//
 	// +optional
 	// +kubebuilder:default=""
-	// +kubebuilder:validation:MaxLength=253
-	Group *string `json:"group"`
+	Group *Group `json:"group"`
 
-	// Kind is kind of the referent.
+	// Kind is kind of the referent. For example "HTTPRoute" or "Service".
 	//
 	// +optional
 	// +kubebuilder:default=Service
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Kind *string `json:"kind"`
+	Kind *Kind `json:"kind"`
 
 	// Name is the name of the referent.
 	//
@@ -71,10 +64,8 @@ type ObjectReference struct {
 	//
 	// Support: Core
 	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
 	// +optional
-	Namespace *string `json:"namespace,omitempty"`
+	Namespace *Namespace `json:"namespace,omitempty"`
 }
 
 // BackendObjectReference defines how an ObjectReference that is
@@ -86,21 +77,18 @@ type ObjectReference struct {
 // owner to accept the reference. See the ReferencePolicy documentation
 // for details.
 type BackendObjectReference struct {
-	// Group is the group of the referent.
+	// Group is the group of the referent. For example, "networking.k8s.io".
 	// When unspecified (empty string), core API group is inferred.
 	//
 	// +optional
 	// +kubebuilder:default=""
-	// +kubebuilder:validation:MaxLength=253
-	Group *string `json:"group,omitempty"`
+	Group *Group `json:"group,omitempty"`
 
-	// Kind is kind of the referent.
+	// Kind is kind of the referent. For example "HTTPRoute" or "Service".
 	//
 	// +optional
 	// +kubebuilder:default=Service
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Kind *string `json:"kind,omitempty"`
+	Kind *Kind `json:"kind,omitempty"`
 
 	// Name is the name of the referent.
 	//
@@ -118,10 +106,8 @@ type BackendObjectReference struct {
 	//
 	// Support: Core
 	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
 	// +optional
-	Namespace *string `json:"namespace,omitempty"`
+	Namespace *Namespace `json:"namespace,omitempty"`
 
 	// Port specifies the destination port number to use for this resource.
 	// Port is required when the referent is a Kubernetes Service.

--- a/apis/v1alpha2/policy_types.go
+++ b/apis/v1alpha2/policy_types.go
@@ -23,16 +23,10 @@ package v1alpha2
 // for Gateway API.
 type PolicyTargetReference struct {
 	// Group is the group of the target resource.
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Group string `json:"group"`
+	Group Group `json:"group"`
 
 	// Kind is kind of the target resource.
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Kind string `json:"kind"`
+	Kind Kind `json:"kind"`
 
 	// Name is the name of the target resource.
 	//
@@ -45,10 +39,8 @@ type PolicyTargetReference struct {
 	// namespace, it MUST only apply to traffic originating from the same
 	// namespace as the policy.
 	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
 	// +optional
-	Namespace *string `json:"namespace,omitempty"`
+	Namespace *Namespace `json:"namespace,omitempty"`
 
 	// ClassName is the name of the class this policy should apply to. When
 	// unspecified, the policy will apply to all classes that support it.

--- a/apis/v1alpha2/referencepolicy_types.go
+++ b/apis/v1alpha2/referencepolicy_types.go
@@ -89,9 +89,7 @@ type ReferencePolicyFrom struct {
 	// When empty, the "core" API group is inferred.
 	//
 	// Support: Core
-	//
-	// +kubebuilder:validation:MaxLength=253
-	Group string `json:"group"`
+	Group Group `json:"group"`
 
 	// Kind is the kind of the referent. Although implementations may support
 	// additional resources, the following Route types are part of the "Core"
@@ -101,18 +99,12 @@ type ReferencePolicyFrom struct {
 	// * TCPRoute
 	// * TLSRoute
 	// * UDPRoute
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Kind string `json:"kind"`
+	Kind Kind `json:"kind"`
 
 	// Namespace is the namespace of the referent.
 	//
 	// Support: Core
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Namespace string `json:"namespace,omitempty"`
+	Namespace Namespace `json:"namespace,omitempty"`
 }
 
 // ReferencePolicyTo describes what Kinds are allowed as targets of the
@@ -122,17 +114,12 @@ type ReferencePolicyTo struct {
 	// When empty, the "core" API group is inferred.
 	//
 	// Support: Core
-	//
-	// +kubebuilder:validation:MaxLength=253
-	Group string `json:"group"`
+	Group Group `json:"group"`
 
 	// Kind is the kind of the referent. Although implementations may support
 	// additional resources, the following types are part of the "Core"
 	// support level for this field:
 	//
 	// * Service
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Kind string `json:"kind"`
+	Kind Kind `json:"kind"`
 }

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -29,22 +29,18 @@ type ParentRef struct {
 	//
 	// Support: Core
 	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:default=gateway.networking.k8s.io
 	// +optional
-	Group *string `json:"group,omitempty"`
+	Group *Group `json:"group,omitempty"`
 
 	// Kind is kind of the referent.
 	//
 	// Support: Core (Gateway)
 	// Support: Custom (Other Resources)
 	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:default=Gateway
 	// +optional
-	Kind *string `json:"kind,omitempty"`
+	Kind *Kind `json:"kind,omitempty"`
 
 	// Namespace is the namespace of the referent. When unspecified (or empty
 	// string), this will either be:
@@ -54,10 +50,8 @@ type ParentRef struct {
 	//
 	// Support: Core
 	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
 	// +optional
-	Namespace *string `json:"namespace,omitempty"`
+	Namespace *Namespace `json:"namespace,omitempty"`
 
 	// Scope represents if this refers to a cluster or namespace scoped
 	// resource. This may be set to "Cluster" or "Namespace".
@@ -98,10 +92,8 @@ type ParentRef struct {
 	//
 	// Support: Core
 	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
 	// +optional
-	SectionName *string `json:"sectionName,omitempty"`
+	SectionName SectionName `json:"sectionName,omitempty"`
 }
 
 // CommonRouteSpec defines the common attributes that all Routes should include
@@ -195,10 +187,7 @@ type RouteParentStatus struct {
 	// The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
 	// valid Kubernetes names
 	// (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Controller string `json:"controller"`
+	Controller GatewayController `json:"controller"`
 
 	// Conditions describes the status of the route with respect to the
 	// Gateway. The "Admitted" condition must always be specified by controllers
@@ -249,4 +238,99 @@ type RouteStatus struct {
 //
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern=`^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 type Hostname string
+
+// Group refers to a Kubernetes Group. It must either be an empty string or a
+// RFC 1123 subdomain.
+//
+// This validation is based off of the corresponding Kubernetes validation:
+// https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/util/validation/validation.go#L208
+//
+// Valid values include:
+//
+// * "" - empty string implies core Kubernetes API group
+// * "networking.k8s.io"
+// * "foo.example.com"
+//
+// Invalid values include:
+//
+// * "example.com/bar" - "/" is an invalid character
+//
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern=`^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+type Group string
+
+// Kind refers to a Kubernetes Kind.
+//
+// Valid values include:
+//
+// * "Service"
+// * "HTTPRoute"
+//
+// Invalid values include:
+//
+// * "invalid/kind" - "/" is an invalid character
+//
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=63
+// +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
+type Kind string
+
+// Namespace refers to a Kubernetes namespace. It must be a RFC 1123 label.
+//
+// This validation is based off of the corresponding Kubernetes validation:
+// https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/util/validation/validation.go#L187
+//
+// This is used for Namespace name validation here:
+// https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/api/validation/generic.go#L63
+//
+// Valid values include:
+//
+// * "example"
+//
+// Invalid values include:
+//
+// * "example.com" - "." is an invalid character
+//
+// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=63
+type Namespace string
+
+// SectionName is the name of a section in a Kubernetes resource. It must be a
+// RFC 1123 subdomain.
+//
+// This validation is based off of the corresponding Kubernetes validation:
+// https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/util/validation/validation.go#L208
+//
+// Valid values include:
+//
+// * "example.com"
+// * "foo.example.com"
+//
+// Invalid values include:
+//
+// * "example.com/bar" - "/" is an invalid character
+//
+// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=253
+type SectionName string
+
+// GatewayController is the name of a Gateway API controller. It must be a
+// domain prefixed path.
+//
+// Valid values include:
+//
+// * "example.com/bar"
+//
+// Invalid values include:
+//
+// * "example.com" - must include path
+// * "foo.example.com" - must include path
+//
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`
+type GatewayController string

--- a/apis/v1alpha2/validation/gatewayclass_test.go
+++ b/apis/v1alpha2/validation/gatewayclass_test.go
@@ -61,12 +61,12 @@ func TestValidateGatewayClassUpdate(t *testing.T) {
 			args: args{
 				oldClass: &gatewayv1a2.GatewayClass{
 					Spec: gatewayv1a2.GatewayClassSpec{
-						Controller: "foo",
+						Controller: "foo.com/gateway",
 					},
 				},
 				newClass: &gatewayv1a2.GatewayClass{
 					Spec: gatewayv1a2.GatewayClassSpec{
-						Controller: "bar",
+						Controller: "bar.com/gateway",
 					},
 				},
 			},
@@ -75,7 +75,7 @@ func TestValidateGatewayClassUpdate(t *testing.T) {
 					Type:     field.ErrorTypeInvalid,
 					Field:    "spec.controller",
 					Detail:   "cannot update an immutable field",
-					BadValue: "bar",
+					BadValue: gatewayv1a2.GatewayController("bar.com/gateway"),
 				},
 			},
 		},

--- a/apis/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/v1alpha2/zz_generated.deepcopy.go
@@ -30,17 +30,17 @@ func (in *BackendObjectReference) DeepCopyInto(out *BackendObjectReference) {
 	*out = *in
 	if in.Group != nil {
 		in, out := &in.Group, &out.Group
-		*out = new(string)
+		*out = new(Group)
 		**out = **in
 	}
 	if in.Kind != nil {
 		in, out := &in.Kind, &out.Kind
-		*out = new(string)
+		*out = new(Kind)
 		**out = **in
 	}
 	if in.Namespace != nil {
 		in, out := &in.Namespace, &out.Namespace
-		*out = new(string)
+		*out = new(Namespace)
 		**out = **in
 	}
 	if in.Port != nil {
@@ -548,12 +548,12 @@ func (in *HTTPRequestRedirect) DeepCopyInto(out *HTTPRequestRedirect) {
 	}
 	if in.Hostname != nil {
 		in, out := &in.Hostname, &out.Hostname
-		*out = new(string)
+		*out = new(Hostname)
 		**out = **in
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(PortNumber)
 		**out = **in
 	}
 	if in.StatusCode != nil {
@@ -897,17 +897,17 @@ func (in *ObjectReference) DeepCopyInto(out *ObjectReference) {
 	*out = *in
 	if in.Group != nil {
 		in, out := &in.Group, &out.Group
-		*out = new(string)
+		*out = new(Group)
 		**out = **in
 	}
 	if in.Kind != nil {
 		in, out := &in.Kind, &out.Kind
-		*out = new(string)
+		*out = new(Kind)
 		**out = **in
 	}
 	if in.Namespace != nil {
 		in, out := &in.Namespace, &out.Namespace
-		*out = new(string)
+		*out = new(Namespace)
 		**out = **in
 	}
 }
@@ -932,7 +932,7 @@ func (in *ParametersReference) DeepCopyInto(out *ParametersReference) {
 	}
 	if in.Namespace != nil {
 		in, out := &in.Namespace, &out.Namespace
-		*out = new(string)
+		*out = new(Namespace)
 		**out = **in
 	}
 }
@@ -952,26 +952,21 @@ func (in *ParentRef) DeepCopyInto(out *ParentRef) {
 	*out = *in
 	if in.Group != nil {
 		in, out := &in.Group, &out.Group
-		*out = new(string)
+		*out = new(Group)
 		**out = **in
 	}
 	if in.Kind != nil {
 		in, out := &in.Kind, &out.Kind
-		*out = new(string)
+		*out = new(Kind)
 		**out = **in
 	}
 	if in.Namespace != nil {
 		in, out := &in.Namespace, &out.Namespace
-		*out = new(string)
+		*out = new(Namespace)
 		**out = **in
 	}
 	if in.Scope != nil {
 		in, out := &in.Scope, &out.Scope
-		*out = new(string)
-		**out = **in
-	}
-	if in.SectionName != nil {
-		in, out := &in.SectionName, &out.SectionName
 		*out = new(string)
 		**out = **in
 	}
@@ -992,7 +987,7 @@ func (in *PolicyTargetReference) DeepCopyInto(out *PolicyTargetReference) {
 	*out = *in
 	if in.Namespace != nil {
 		in, out := &in.Namespace, &out.Namespace
-		*out = new(string)
+		*out = new(Namespace)
 		**out = **in
 	}
 	if in.ClassName != nil {
@@ -1130,7 +1125,7 @@ func (in *RouteGroupKind) DeepCopyInto(out *RouteGroupKind) {
 	*out = *in
 	if in.Group != nil {
 		in, out := &in.Group, &out.Group
-		*out = new(string)
+		*out = new(Group)
 		**out = **in
 	}
 }

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -62,6 +62,8 @@ spec:
                   and PATH is a valid HTTP path as defined by RFC 3986. \n Support:
                   Core"
                 maxLength: 253
+                minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                 type: string
               description:
                 description: Description helps describe a GatewayClass with more details.
@@ -80,11 +82,13 @@ spec:
                   group:
                     description: Group is the group of the referent.
                     maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   kind:
                     description: Kind is kind of the referent.
-                    maxLength: 253
+                    maxLength: 63
                     minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                     type: string
                   name:
                     description: Name is the name of the referent.
@@ -95,8 +99,9 @@ spec:
                     description: Namespace is the namespace of the referent. This
                       field is required when scope is set to "Namespace" and ignored
                       when scope is set to "Cluster".
-                    maxLength: 253
+                    maxLength: 63
                     minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   scope:
                     default: Cluster

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
@@ -145,6 +145,7 @@ spec:
                         silently ignored. \n Support: Core"
                       maxLength: 253
                       minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     name:
                       description: "Name is the name of the Listener. If more than
@@ -152,6 +153,8 @@ spec:
                         The names of Listeners MUST be unique within a Gateway. \n
                         Support: Core"
                       maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     port:
                       description: "Port is the network port. Multiple listeners may
@@ -218,11 +221,13 @@ spec:
                                 default: gateway.networking.k8s.io
                                 description: Group is the group of the Route.
                                 maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               kind:
                                 description: Kind is the kind of the Route.
-                                maxLength: 253
+                                maxLength: 63
                                 minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                                 type: string
                             required:
                             - kind
@@ -332,15 +337,19 @@ spec:
                           properties:
                             group:
                               default: ""
-                              description: Group is the group of the referent. When
-                                unspecified (empty string), core API group is inferred.
+                              description: Group is the group of the referent. For
+                                example, "networking.k8s.io". When unspecified (empty
+                                string), core API group is inferred.
                               maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                               type: string
                             kind:
                               default: Service
-                              description: Kind is kind of the referent.
-                              maxLength: 253
+                              description: Kind is kind of the referent. For example
+                                "HTTPRoute" or "Service".
+                              maxLength: 63
                               minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                               type: string
                             name:
                               description: Name is the name of the referent.
@@ -355,8 +364,9 @@ spec:
                                 that namespace's owner to accept the reference. See
                                 the ReferencePolicy documentation for details. \n
                                 Support: Core"
-                              maxLength: 253
+                              maxLength: 63
                               minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                           required:
                           - name
@@ -386,6 +396,7 @@ spec:
                             is a common subset for expressing ciphers then it will
                             make sense to loft that as a core API construct. \n Support:
                             Implementation-specific"
+                          maxProperties: 16
                           type: object
                       type: object
                   required:
@@ -623,6 +634,8 @@ spec:
                         specify a name. The names of ListenerStatus objects MUST be
                         unique within a Gateway.
                       maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     supportedKinds:
                       description: SupportedKinds is the list indicating the Kinds
@@ -640,11 +653,13 @@ spec:
                             default: gateway.networking.k8s.io
                             description: Group is the group of the Route.
                             maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             description: Kind is the kind of the Route.
-                            maxLength: 253
+                            maxLength: 63
                             minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                             type: string
                         required:
                         - kind

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
@@ -97,6 +97,7 @@ spec:
                     other punctuation is allowed."
                   maxLength: 253
                   minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
                 maxItems: 16
                 type: array
@@ -128,14 +129,15 @@ spec:
                       description: "Group is the group of the referent. \n Support:
                         Core"
                       maxLength: 253
-                      minLength: 1
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
                         (Gateway) Support: Custom (Other Resources)"
-                      maxLength: 253
+                      maxLength: 63
                       minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                       type: string
                     name:
                       description: "Name is the name of the referent. \n Support:
@@ -148,8 +150,9 @@ spec:
                         unspecified (or empty string), this will either be: \n * local
                         namespace of the route when scope is set to Namespace. * no
                         namespace when scope is set to Cluster. \n Support: Core"
-                      maxLength: 253
+                      maxLength: 63
                       minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     scope:
                       default: Namespace
@@ -180,6 +183,7 @@ spec:
                         Support: Core"
                       maxLength: 253
                       minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                   required:
                   - name
@@ -242,12 +246,17 @@ spec:
                                   properties:
                                     group:
                                       description: Group is the group of the referent.
+                                        For example, "networking.k8s.io". When unspecified
+                                        (empty string), core API group is inferred.
                                       maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                     kind:
-                                      description: Kind is kind of the referent.
-                                      maxLength: 253
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
                                       minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                                       type: string
                                     name:
                                       description: Name is the name of the referent.
@@ -292,6 +301,7 @@ spec:
                                               equivalent."
                                             maxLength: 256
                                             minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
@@ -303,7 +313,11 @@ spec:
                                         - name
                                         - value
                                         type: object
+                                      maxItems: 16
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
                                     remove:
                                       description: "Remove the given header(s) from
                                         the HTTP request before the action. The value
@@ -345,6 +359,7 @@ spec:
                                               equivalent."
                                             maxLength: 256
                                             minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
@@ -356,7 +371,11 @@ spec:
                                         - name
                                         - value
                                         type: object
+                                      maxItems: 16
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
                                   type: object
                                 requestMirror:
                                   description: "RequestMirror defines a schema for
@@ -387,15 +406,19 @@ spec:
                                         group:
                                           default: ""
                                           description: Group is the group of the referent.
-                                            When unspecified (empty string), core
-                                            API group is inferred.
+                                            For example, "networking.k8s.io". When
+                                            unspecified (empty string), core API group
+                                            is inferred.
                                           maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
                                           description: Kind is kind of the referent.
-                                          maxLength: 253
+                                            For example "HTTPRoute" or "Service".
+                                          maxLength: 63
                                           minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                                           type: string
                                         name:
                                           description: Name is the name of the referent.
@@ -412,8 +435,9 @@ spec:
                                             the reference. See the ReferencePolicy
                                             documentation for details. \n Support:
                                             Core"
-                                          maxLength: 253
+                                          maxLength: 63
                                           minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
                                           description: Port specifies the destination
@@ -439,12 +463,18 @@ spec:
                                         used in the value of the `Location` header
                                         in the response. When empty, the hostname
                                         of the request is used. \n Support: Core"
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
                                         response. When empty, port (if specified)
                                         of the request is used. \n Support: Extended"
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
                                       type: integer
                                     protocol:
                                       description: "Protocol is the protocol to be
@@ -459,6 +489,9 @@ spec:
                                       default: 302
                                       description: "StatusCode is the HTTP status
                                         code to be used in response. \n Support: Core"
+                                      enum:
+                                      - 301
+                                      - 302
                                       type: integer
                                   type: object
                                 type:
@@ -496,15 +529,19 @@ spec:
                             type: array
                           group:
                             default: ""
-                            description: Group is the group of the referent. When
-                              unspecified (empty string), core API group is inferred.
+                            description: Group is the group of the referent. For example,
+                              "networking.k8s.io". When unspecified (empty string),
+                              core API group is inferred.
                             maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: Kind is kind of the referent.
-                            maxLength: 253
+                            description: Kind is kind of the referent. For example
+                              "HTTPRoute" or "Service".
+                            maxLength: 63
                             minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                             type: string
                           name:
                             description: Name is the name of the referent.
@@ -519,8 +556,9 @@ spec:
                               that namespace's owner to accept the reference. See
                               the ReferencePolicy documentation for details. \n Support:
                               Core"
-                            maxLength: 253
+                            maxLength: 63
                             minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
                             description: Port specifies the destination port number
@@ -588,13 +626,18 @@ spec:
                               filters. \n Support: Implementation-specific"
                             properties:
                               group:
-                                description: Group is the group of the referent.
+                                description: Group is the group of the referent. For
+                                  example, "networking.k8s.io". When unspecified (empty
+                                  string), core API group is inferred.
                                 maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               kind:
-                                description: Kind is kind of the referent.
-                                maxLength: 253
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
                                 minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                                 type: string
                               name:
                                 description: Name is the name of the referent.
@@ -636,6 +679,7 @@ spec:
                                         equivalent."
                                       maxLength: 256
                                       minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: Value is the value of HTTP Header
@@ -647,7 +691,11 @@ spec:
                                   - name
                                   - value
                                   type: object
+                                maxItems: 16
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                               remove:
                                 description: "Remove the given header(s) from the
                                   HTTP request before the action. The value of RemoveHeader
@@ -684,6 +732,7 @@ spec:
                                         equivalent."
                                       maxLength: 256
                                       minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: Value is the value of HTTP Header
@@ -695,7 +744,11 @@ spec:
                                   - name
                                   - value
                                   type: object
+                                maxItems: 16
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                             type: object
                           requestMirror:
                             description: "RequestMirror defines a schema for a filter
@@ -724,15 +777,18 @@ spec:
                                   group:
                                     default: ""
                                     description: Group is the group of the referent.
-                                      When unspecified (empty string), core API group
-                                      is inferred.
+                                      For example, "networking.k8s.io". When unspecified
+                                      (empty string), core API group is inferred.
                                     maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                     type: string
                                   kind:
                                     default: Service
-                                    description: Kind is kind of the referent.
-                                    maxLength: 253
+                                    description: Kind is kind of the referent. For
+                                      example "HTTPRoute" or "Service".
+                                    maxLength: 63
                                     minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                                     type: string
                                   name:
                                     description: Name is the name of the referent.
@@ -747,8 +803,9 @@ spec:
                                       in the referent namespace to allow that namespace's
                                       owner to accept the reference. See the ReferencePolicy
                                       documentation for details. \n Support: Core"
-                                    maxLength: 253
+                                    maxLength: 63
                                     minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   port:
                                     description: Port specifies the destination port
@@ -773,12 +830,18 @@ spec:
                                   in the value of the `Location` header in the response.
                                   When empty, the hostname of the request is used.
                                   \n Support: Core"
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               port:
                                 description: "Port is the port to be used in the value
                                   of the `Location` header in the response. When empty,
                                   port (if specified) of the request is used. \n Support:
                                   Extended"
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
                                 type: integer
                               protocol:
                                 description: "Protocol is the protocol to be used
@@ -793,6 +856,9 @@ spec:
                                 default: 302
                                 description: "StatusCode is the HTTP status code to
                                   be used in response. \n Support: Core"
+                                enum:
+                                - 301
+                                - 302
                                 type: integer
                             type: object
                           type:
@@ -883,13 +949,18 @@ spec:
                               specifically. \n Support: Custom"
                             properties:
                               group:
-                                description: Group is the group of the referent.
+                                description: Group is the group of the referent. For
+                                  example, "networking.k8s.io". When unspecified (empty
+                                  string), core API group is inferred.
                                 maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               kind:
-                                description: Kind is kind of the referent.
-                                maxLength: 253
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
                                 minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                                 type: string
                               name:
                                 description: Name is the name of the referent.
@@ -928,6 +999,7 @@ spec:
                                     handling for \"Set-Cookie\"."
                                   maxLength: 256
                                   minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                   type: string
                                 type:
                                   default: Exact
@@ -954,7 +1026,11 @@ spec:
                               - name
                               - value
                               type: object
+                            maxItems: 16
                             type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           method:
                             description: "Method specifies HTTP method matcher. When
                               specified, this route will be matched only if the request
@@ -997,6 +1073,7 @@ spec:
                               value:
                                 default: /
                                 description: Value of the HTTP path to match against.
+                                maxLength: 1024
                                 type: string
                             type: object
                           queryParams:
@@ -1040,7 +1117,11 @@ spec:
                               - name
                               - value
                               type: object
+                            maxItems: 16
                             type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                         type: object
                       maxItems: 8
                       type: array
@@ -1156,6 +1237,7 @@ spec:
                         and PATH are valid Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)."
                       maxLength: 253
                       minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                       type: string
                     parentRef:
                       description: ParentRef corresponds with a ParentRef in the spec
@@ -1166,14 +1248,15 @@ spec:
                           description: "Group is the group of the referent. \n Support:
                             Core"
                           maxLength: 253
-                          minLength: 1
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
                             Core (Gateway) Support: Custom (Other Resources)"
-                          maxLength: 253
+                          maxLength: 63
                           minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                           type: string
                         name:
                           description: "Name is the name of the referent. \n Support:
@@ -1187,8 +1270,9 @@ spec:
                             \n * local namespace of the route when scope is set to
                             Namespace. * no namespace when scope is set to Cluster.
                             \n Support: Core"
-                          maxLength: 253
+                          maxLength: 63
                           minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         scope:
                           default: Namespace
@@ -1219,6 +1303,7 @@ spec:
                             detached from the Gateway. \n Support: Core"
                           maxLength: 253
                           minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                       required:
                       - name

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_referencepolicies.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_referencepolicies.yaml
@@ -65,20 +65,23 @@ spec:
                       description: "Group is the group of the referent. When empty,
                         the \"core\" API group is inferred. \n Support: Core"
                       maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
                       description: "Kind is the kind of the referent. Although implementations
                         may support additional resources, the following Route types
                         are part of the \"Core\" support level for this field: \n
                         * HTTPRoute * TCPRoute * TLSRoute * UDPRoute"
-                      maxLength: 253
+                      maxLength: 63
                       minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                       type: string
                     namespace:
                       description: "Namespace is the namespace of the referent. \n
                         Support: Core"
-                      maxLength: 253
+                      maxLength: 63
                       minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                   required:
                   - group
@@ -101,13 +104,15 @@ spec:
                       description: "Group is the group of the referent. When empty,
                         the \"core\" API group is inferred. \n Support: Core"
                       maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
                       description: "Kind is the kind of the referent. Although implementations
                         may support additional resources, the following types are
                         part of the \"Core\" support level for this field: \n * Service"
-                      maxLength: 253
+                      maxLength: 63
                       minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                       type: string
                   required:
                   - group

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_tcproutes.yaml
@@ -70,14 +70,15 @@ spec:
                       description: "Group is the group of the referent. \n Support:
                         Core"
                       maxLength: 253
-                      minLength: 1
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
                         (Gateway) Support: Custom (Other Resources)"
-                      maxLength: 253
+                      maxLength: 63
                       minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                       type: string
                     name:
                       description: "Name is the name of the referent. \n Support:
@@ -90,8 +91,9 @@ spec:
                         unspecified (or empty string), this will either be: \n * local
                         namespace of the route when scope is set to Namespace. * no
                         namespace when scope is set to Cluster. \n Support: Core"
-                      maxLength: 253
+                      maxLength: 63
                       minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     scope:
                       default: Namespace
@@ -122,6 +124,7 @@ spec:
                         Support: Core"
                       maxLength: 253
                       minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                   required:
                   - name
@@ -155,15 +158,19 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: Group is the group of the referent. When
-                              unspecified (empty string), core API group is inferred.
+                            description: Group is the group of the referent. For example,
+                              "networking.k8s.io". When unspecified (empty string),
+                              core API group is inferred.
                             maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: Kind is kind of the referent.
-                            maxLength: 253
+                            description: Kind is kind of the referent. For example
+                              "HTTPRoute" or "Service".
+                            maxLength: 63
                             minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                             type: string
                           name:
                             description: Name is the name of the referent.
@@ -178,8 +185,9 @@ spec:
                               that namespace's owner to accept the reference. See
                               the ReferencePolicy documentation for details. \n Support:
                               Core"
-                            maxLength: 253
+                            maxLength: 63
                             minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
                             description: Port specifies the destination port number
@@ -255,13 +263,18 @@ spec:
                               specifically. \n Support: Custom"
                             properties:
                               group:
-                                description: Group is the group of the referent.
+                                description: Group is the group of the referent. For
+                                  example, "networking.k8s.io". When unspecified (empty
+                                  string), core API group is inferred.
                                 maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               kind:
-                                description: Kind is kind of the referent.
-                                maxLength: 253
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
                                 minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                                 type: string
                               name:
                                 description: Name is the name of the referent.
@@ -391,6 +404,7 @@ spec:
                         and PATH are valid Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)."
                       maxLength: 253
                       minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                       type: string
                     parentRef:
                       description: ParentRef corresponds with a ParentRef in the spec
@@ -401,14 +415,15 @@ spec:
                           description: "Group is the group of the referent. \n Support:
                             Core"
                           maxLength: 253
-                          minLength: 1
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
                             Core (Gateway) Support: Custom (Other Resources)"
-                          maxLength: 253
+                          maxLength: 63
                           minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                           type: string
                         name:
                           description: "Name is the name of the referent. \n Support:
@@ -422,8 +437,9 @@ spec:
                             \n * local namespace of the route when scope is set to
                             Namespace. * no namespace when scope is set to Cluster.
                             \n Support: Core"
-                          maxLength: 253
+                          maxLength: 63
                           minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         scope:
                           default: Namespace
@@ -454,6 +470,7 @@ spec:
                             detached from the Gateway. \n Support: Core"
                           maxLength: 253
                           minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                       required:
                       - name

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_tlsroutes.yaml
@@ -79,6 +79,7 @@ spec:
                     other punctuation is allowed."
                   maxLength: 253
                   minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
                 maxItems: 16
                 type: array
@@ -110,14 +111,15 @@ spec:
                       description: "Group is the group of the referent. \n Support:
                         Core"
                       maxLength: 253
-                      minLength: 1
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
                         (Gateway) Support: Custom (Other Resources)"
-                      maxLength: 253
+                      maxLength: 63
                       minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                       type: string
                     name:
                       description: "Name is the name of the referent. \n Support:
@@ -130,8 +132,9 @@ spec:
                         unspecified (or empty string), this will either be: \n * local
                         namespace of the route when scope is set to Namespace. * no
                         namespace when scope is set to Cluster. \n Support: Core"
-                      maxLength: 253
+                      maxLength: 63
                       minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     scope:
                       default: Namespace
@@ -162,6 +165,7 @@ spec:
                         Support: Core"
                       maxLength: 253
                       minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                   required:
                   - name
@@ -196,15 +200,19 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: Group is the group of the referent. When
-                              unspecified (empty string), core API group is inferred.
+                            description: Group is the group of the referent. For example,
+                              "networking.k8s.io". When unspecified (empty string),
+                              core API group is inferred.
                             maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: Kind is kind of the referent.
-                            maxLength: 253
+                            description: Kind is kind of the referent. For example
+                              "HTTPRoute" or "Service".
+                            maxLength: 63
                             minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                             type: string
                           name:
                             description: Name is the name of the referent.
@@ -219,8 +227,9 @@ spec:
                               that namespace's owner to accept the reference. See
                               the ReferencePolicy documentation for details. \n Support:
                               Core"
-                            maxLength: 253
+                            maxLength: 63
                             minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
                             description: Port specifies the destination port number
@@ -299,13 +308,18 @@ spec:
                               specifically. \n Support: Custom"
                             properties:
                               group:
-                                description: Group is the group of the referent.
+                                description: Group is the group of the referent. For
+                                  example, "networking.k8s.io". When unspecified (empty
+                                  string), core API group is inferred.
                                 maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               kind:
-                                description: Kind is kind of the referent.
-                                maxLength: 253
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
                                 minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                                 type: string
                               name:
                                 description: Name is the name of the referent.
@@ -435,6 +449,7 @@ spec:
                         and PATH are valid Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)."
                       maxLength: 253
                       minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                       type: string
                     parentRef:
                       description: ParentRef corresponds with a ParentRef in the spec
@@ -445,14 +460,15 @@ spec:
                           description: "Group is the group of the referent. \n Support:
                             Core"
                           maxLength: 253
-                          minLength: 1
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
                             Core (Gateway) Support: Custom (Other Resources)"
-                          maxLength: 253
+                          maxLength: 63
                           minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                           type: string
                         name:
                           description: "Name is the name of the referent. \n Support:
@@ -466,8 +482,9 @@ spec:
                             \n * local namespace of the route when scope is set to
                             Namespace. * no namespace when scope is set to Cluster.
                             \n Support: Core"
-                          maxLength: 253
+                          maxLength: 63
                           minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         scope:
                           default: Namespace
@@ -498,6 +515,7 @@ spec:
                             detached from the Gateway. \n Support: Core"
                           maxLength: 253
                           minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                       required:
                       - name

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_udproutes.yaml
@@ -71,14 +71,15 @@ spec:
                       description: "Group is the group of the referent. \n Support:
                         Core"
                       maxLength: 253
-                      minLength: 1
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
                         (Gateway) Support: Custom (Other Resources)"
-                      maxLength: 253
+                      maxLength: 63
                       minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                       type: string
                     name:
                       description: "Name is the name of the referent. \n Support:
@@ -91,8 +92,9 @@ spec:
                         unspecified (or empty string), this will either be: \n * local
                         namespace of the route when scope is set to Namespace. * no
                         namespace when scope is set to Cluster. \n Support: Core"
-                      maxLength: 253
+                      maxLength: 63
                       minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     scope:
                       default: Namespace
@@ -123,6 +125,7 @@ spec:
                         Support: Core"
                       maxLength: 253
                       minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                   required:
                   - name
@@ -156,15 +159,19 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: Group is the group of the referent. When
-                              unspecified (empty string), core API group is inferred.
+                            description: Group is the group of the referent. For example,
+                              "networking.k8s.io". When unspecified (empty string),
+                              core API group is inferred.
                             maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: Kind is kind of the referent.
-                            maxLength: 253
+                            description: Kind is kind of the referent. For example
+                              "HTTPRoute" or "Service".
+                            maxLength: 63
                             minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                             type: string
                           name:
                             description: Name is the name of the referent.
@@ -179,8 +186,9 @@ spec:
                               that namespace's owner to accept the reference. See
                               the ReferencePolicy documentation for details. \n Support:
                               Core"
-                            maxLength: 253
+                            maxLength: 63
                             minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
                             description: Port specifies the destination port number
@@ -256,13 +264,18 @@ spec:
                               specifically. \n Support: Custom"
                             properties:
                               group:
-                                description: Group is the group of the referent.
+                                description: Group is the group of the referent. For
+                                  example, "networking.k8s.io". When unspecified (empty
+                                  string), core API group is inferred.
                                 maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               kind:
-                                description: Kind is kind of the referent.
-                                maxLength: 253
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
                                 minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                                 type: string
                               name:
                                 description: Name is the name of the referent.
@@ -392,6 +405,7 @@ spec:
                         and PATH are valid Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)."
                       maxLength: 253
                       minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                       type: string
                     parentRef:
                       description: ParentRef corresponds with a ParentRef in the spec
@@ -402,14 +416,15 @@ spec:
                           description: "Group is the group of the referent. \n Support:
                             Core"
                           maxLength: 253
-                          minLength: 1
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
                             Core (Gateway) Support: Custom (Other Resources)"
-                          maxLength: 253
+                          maxLength: 63
                           minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                           type: string
                         name:
                           description: "Name is the name of the referent. \n Support:
@@ -423,8 +438,9 @@ spec:
                             \n * local namespace of the route when scope is set to
                             Namespace. * no namespace when scope is set to Cluster.
                             \n Support: Core"
-                          maxLength: 253
+                          maxLength: 63
                           minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         scope:
                           default: Namespace
@@ -455,6 +471,7 @@ spec:
                             detached from the Gateway. \n Support: Core"
                           maxLength: 253
                           minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                       required:
                       - name

--- a/hack/invalid-examples/gateway/duplicate-listeners.yaml
+++ b/hack/invalid-examples/gateway/duplicate-listeners.yaml
@@ -1,0 +1,13 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: duplicate-listeners
+spec:
+  gatewayClassName: acme-lb
+  listeners:
+  - name: same
+    protocol: HTTP
+    port: 80
+  - name: same
+    protocol: HTTP
+    port: 443

--- a/hack/invalid-examples/gateway/invalid-listener-name.yaml
+++ b/hack/invalid-examples/gateway/invalid-listener-name.yaml
@@ -1,0 +1,10 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: invalid-listener-name
+spec:
+  gatewayClassName: acme-lb
+  listeners:
+  - name: bad>
+    protocol: HTTP
+    port: 80

--- a/hack/invalid-examples/gateway/invalid-listener-port.yaml
+++ b/hack/invalid-examples/gateway/invalid-listener-port.yaml
@@ -1,0 +1,10 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: invalid-listener-port
+spec:
+  gatewayClassName: acme-lb
+  listeners:
+  - name: foo
+    protocol: HTTP
+    port: 123456789

--- a/hack/invalid-examples/gatewayclass/invalid-controller.yaml
+++ b/hack/invalid-examples/gatewayclass/invalid-controller.yaml
@@ -1,0 +1,6 @@
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: invalid-controller
+spec:
+  controller: example

--- a/hack/invalid-examples/httproute/duplicate-header-match.yaml
+++ b/hack/invalid-examples/httproute/duplicate-header-match.yaml
@@ -1,0 +1,12 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: duplicate-header-match
+spec:
+  rules:
+  - matches:
+    - headers:
+      - name: foo
+        value: bar
+      - name: foo
+        value: bar

--- a/hack/invalid-examples/httproute/duplicate-query-match.yaml
+++ b/hack/invalid-examples/httproute/duplicate-query-match.yaml
@@ -1,0 +1,12 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: duplicate-query-match
+spec:
+  rules:
+  - matches:
+    - queryParams:
+      - name: foo
+        value: bar
+      - name: foo
+        value: bar

--- a/hack/invalid-examples/httproute/invalid-backend-group.yaml
+++ b/hack/invalid-examples/httproute/invalid-backend-group.yaml
@@ -1,0 +1,10 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: invalid-backend-group
+spec:
+  rules:
+  - backendRefs:
+    - group: "*"
+      name: foo
+      port: 80

--- a/hack/invalid-examples/httproute/invalid-backend-kind.yaml
+++ b/hack/invalid-examples/httproute/invalid-backend-kind.yaml
@@ -1,0 +1,10 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: invalid-backend-kind
+spec:
+  rules:
+  - backendRefs:
+    - kind: "*"
+      name: foo
+      port: 80

--- a/hack/invalid-examples/httproute/invalid-backend-port.yaml
+++ b/hack/invalid-examples/httproute/invalid-backend-port.yaml
@@ -1,0 +1,9 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: invalid-backend-port
+spec:
+  rules:
+  - backendRefs:
+    - name: my-service1
+      port: 800080

--- a/hack/invalid-examples/httproute/invalid-header-name.yaml
+++ b/hack/invalid-examples/httproute/invalid-header-name.yaml
@@ -1,0 +1,11 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: invalid-header-name
+spec:
+  rules:
+  - matches:
+    - headers:
+      - type: Exact
+        name: magic/
+        value: foo

--- a/hack/invalid-examples/httproute/invalid-hostname.yaml
+++ b/hack/invalid-examples/httproute/invalid-hostname.yaml
@@ -1,0 +1,10 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: invalid-hostname
+spec:
+  hostnames:
+  - http://a<
+  rules:
+  - backendRefs:
+    - name: foo

--- a/hack/invalid-examples/httproute/invalid-method.yaml
+++ b/hack/invalid-examples/httproute/invalid-method.yaml
@@ -1,0 +1,8 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: invalid-method
+spec:
+  rules:
+  - matches:
+    - method: NOTREAL

--- a/hack/invalid-examples/referencepolicy/missing-from.yaml
+++ b/hack/invalid-examples/referencepolicy/missing-from.yaml
@@ -1,0 +1,8 @@
+kind: ReferencePolicy
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: missing-from
+spec:
+  to:
+  - group: ""
+    kind: "Service"

--- a/hack/invalid-examples/referencepolicy/missing-to.yaml
+++ b/hack/invalid-examples/referencepolicy/missing-to.yaml
@@ -1,0 +1,9 @@
+kind: ReferencePolicy
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: missing-to
+spec:
+  from:
+  - group: ""
+    kind: "Service"
+    namespace: "example"

--- a/hack/invalid-examples/tlsroute/invalid-hostname.yaml
+++ b/hack/invalid-examples/tlsroute/invalid-hostname.yaml
@@ -1,0 +1,10 @@
+kind: TLSRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: invalid-hostname
+spec:
+  hostnames:
+  - http://a<
+  rules:
+  - backendRefs:
+    - name: foo

--- a/hack/verify-examples-kind.sh
+++ b/hack/verify-examples-kind.sh
@@ -66,6 +66,9 @@ do
   kubectl delete --kubeconfig "${KUBECONFIG}" -f config/crd/"${VERSION}" || res=$?
 done
 
+# None of these examples should be successfully configured
+kubectl apply --recursive -f hack/invalid-examples | grep configured && res=2
+
 # Clean up and exit
 cleanup || res=$?
 exit $res


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This adds regex validation and map keys throughout the v1alpha2 API, consolidates shared types, and adds some very simple validation tests. Much of this logic was pulled from [upstream Kubernetes validation](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go).

**Which issue(s) this PR fixes**:
Fixes #767

**Does this PR introduce a user-facing change?**:
```release-note
Many string fields are now validated with regular expressions.
```

/cc @hbagdi @Miciah @bowei 