### PR TITLE
Adding basic version navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,13 +8,15 @@ theme:
   icon:
     repo: fontawesome/brands/git-alt
   features:
+    - navigation.tabs
     - search.highlight
 edit_uri: edit/master/site-src/
 extra_css:
   - css/extra.css
 plugins:
   - search
-  - awesome-pages
+  - awesome-pages:
+      collapse_single_pages: true
   - macros:
       include_dir: examples
 markdown_extensions:
@@ -22,32 +24,20 @@ markdown_extensions:
   - toc:
       permalink: true
 nav:
-  - Introduction: index.md
-  - Concepts:
-      API overview: concepts/api-overview.md
-      Security Model: concepts/security-model.md
-      Implementation Guidelines: concepts/guidelines.md
-  - API Types:
-      GatewayClass: api-types/gatewayclass.md
-      Gateway: api-types/gateway.md
-      HTTPRoute: api-types/httproute.md
-  - Guides:
-    - Getting started: guides/getting-started.md
-    - Simple Gateway: guides/simple-gateway.md
-    - HTTP routing: guides/http-routing.md
-    - HTTP traffic splitting: guides/traffic-splitting.md
-    - Multiple namespaces and routes: guides/multiple-ns.md
-    - TLS: guides/tls.md
-    - TCP routing: guides/tcp.md
-  - References:
-    - API specification: references/spec.md
-    - Releases: references/releases.md
-    - Implementations: references/implementations.md
-  - ... | geps/gep-*.md
-  - Contributing:
-    - Developer guide: contributing/devguide.md
-    - Gateway Enhancement Proposal: contributing/gep.md
-    - Enhancement requests: contributing/enhancement-requests.md
-    - Community: contributing/community.md
-  - FAQ: faq.md
-
+  - v1alpha1:
+    - Introduction: index.md
+    - ... | concepts/*.md
+    - ... | api-types/*.md
+    - ... | guides/*.md
+    - ... | references/*.md
+    - ... | contributing/*.md
+    - FAQ: faq.md
+  - v1alpha2:
+    - Introduction: v1alpha2/index.md
+    - ... | v1alpha2/concepts/*.md
+    - ... | v1alpha2/api-types/*.md
+    - ... | v1alpha2/guides/*.md
+    - ... | v1alpha2/references/*.md
+    - ... | v1alpha2/contributing/*.md
+    - ... | geps/gep-*.md
+    - FAQ: v1alpha2/faq.md

--- a/site-src/api-types/.pages
+++ b/site-src/api-types/.pages
@@ -1,0 +1,1 @@
+title: API Types

--- a/site-src/index.md
+++ b/site-src/index.md
@@ -1,1 +1,114 @@
-v1alpha2/index.md
+## What is the Gateway API?
+
+Gateway API is an open source project managed by the [SIG-NETWORK][sig-network]
+community. It's is a collection of resources that model service networking 
+in Kubernetes. These resources - `GatewayClass`,`Gateway`, `HTTPRoute`, 
+`TCPRoute`, `Service`, etc - aim to evolve Kubernetes service networking through 
+expressive, extensible, and role-oriented interfaces that are implemented by 
+many vendors and have broad industry support. 
+
+*Note: This project was previously named "Service APIs" until being renamed to
+"Gateway API" in February 2021.*
+
+![Gateway API Model](./images/api-model.png)
+
+## Getting started
+
+Whether you are a user interested in using the Gateway API or an implementer 
+interested in conforming to the API, the following resources will help give 
+you the necessary background:
+
+- [API overview](/concepts/api-overview)
+- [User guides](/guides/getting-started)
+- [Gateway controller implementations](/references/implementations)
+- [API reference spec](/references/spec)
+- [Community links](/contributing/community) and [developer guide](/contributing/devguide)
+
+
+## Gateway API concepts
+The following design goals drive the concepts of the Gateway API. These 
+demonstrate how Gateway aims to improve upon current standards like Ingress.
+
+
+- **Role-oriented** - Gateway is composed of API resources which model 
+organizational roles that use and configure Kubernetes service networking. 
+- **Portable** - This isn't an improvement but rather something
+that should stay the same. Just as Ingress is a universal specification with
+[numerous implementations](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/),
+Gateway API is designed to be a portable specification supported by many
+implementations.
+- **Expressive** - Gateway API resources support core functionality for things 
+like header-based matching, traffic weighting, and other capabilities that 
+were only possible in Ingress through custom annotations.
+- **Extensible** - Gateway API allows for custom resources to be linked at 
+various layers of the API. This makes granular customization possible at the
+appropriate places within the API structure.
+
+Some other notable capabilities include:
+
+- **GatewayClasses** - GatewayClasses formalize types of load balancing 
+implementations. These classes make it easy and explicit for users to 
+understand what kind of capabilities are available via the Kubernetes resource 
+model.
+- **Shared Gateways and cross-Namespace support** - They allow the sharing of
+load balancers and VIPs by permitting independent Route resources to bind to
+the same Gateway. This allows teams (even across Namespaces) to share
+infrastructure safely without direct coordination.
+- **Typed Routes and typed backends** - The Gateway API supports typed Route 
+resources and also different types of backends. This allows the API to be 
+flexible in supporting various protocols (like HTTP and gRPC) and
+various backend targets (like Kubernetes Services, storage buckets, or
+functions). 
+
+
+## Why does a role-oriented API matter?
+
+Whether it’s roads, power, data centers, or Kubernetes clusters,
+infrastructure is built to be shared. However, shared infrastructure raises a
+common challenge - how to provide flexibility to users of the infrastructure
+while maintaining control by owners of the infrastructure? 
+
+The Gateway API accomplishes this through a role-oriented design for
+Kubernetes service networking that strikes a balance between distributed
+flexibility and centralized control. It allows shared network infrastructure
+(hardware load balancers, cloud networking, cluster-hosted proxies etc) to be
+used by many different and non-coordinating teams, all bound by the policies
+and constraints set by cluster operators. The following example shows how this
+works in practice.
+
+A cluster operator creates a [Gateway](/api-types/gateway) resource derived from a
+[GatewayClass](/api-types/gatewayclass). This Gateway deploys or configures the
+underlying network resources that it represents. Through [Route binding
+policy](/concepts/api-overview#route-binding) set on the Gateway, the operator
+permits (or denies) specific teams to bind to this Gateway and expose their
+applications through it. Centralized policies [such as
+TLS](/guides/tls#downstream-tls) can be enforced on the Gateway by the cluster
+operator. Meanwhile, the store and site teams run [in their own
+Namespaces](/guides/multiple-ns), but bind their Routes against the same shared
+Gateway, allowing them to independently control their [routing
+logic](/guides/http-routing). This separation of concerns allows the store team to
+manage their own [traffic splitting rollout](/guides/traffic-splitting) while
+leaving centralized policies and control to the cluster operators.
+
+![Gateway API Roles](./images/gateway-roles.png)
+
+This flexibility allows the API to adapt to different vastly different
+organizational models and implementations while remaining a portable and
+standard API.
+
+
+## Who is working on Gateway?
+
+The Gateway API is a
+[SIG-Network](https://github.com/kubernetes/community/tree/master/sig-network)
+project being built to improve and standardize service networking in
+Kubernetes. Current and in-progress implementations include Contour,
+Emissary-Ingress (Abassador API Gateway), Google Kubernetes Engine (GKE), Istio,
+Kong, and Traefik. Check out the [implementations
+reference](references/implementations.md) to see the latest projects &
+products that support Gateway. If you are interested in contributing to or
+building an implementation using the Gateway API then don’t hesitate to [get
+involved!](/contributing/community)
+
+[sig-network]: https://github.com/kubernetes/community/tree/master/sig-network
+

--- a/site-src/v1alpha2/api-types/.pages
+++ b/site-src/v1alpha2/api-types/.pages
@@ -1,0 +1,1 @@
+title: API Types

--- a/site-src/v1alpha2/guides/getting-started.md
+++ b/site-src/v1alpha2/guides/getting-started.md
@@ -1,5 +1,6 @@
 # Getting started with Gateway APIs
 
+!!! danger "This page has not been updated for v1alpha2 yet."
 
 **1.**  **[Install a Gateway controller](#installing-a-gateway-controller)**
  _OR_  **[install the Gateway API CRDs manually](#installing-gateway-api-crds-manually)** 

--- a/site-src/v1alpha2/guides/http-routing.md
+++ b/site-src/v1alpha2/guides/http-routing.md
@@ -1,5 +1,7 @@
 # HTTP routing
 
+!!! danger "This page has not been updated for v1alpha2 yet."
+
 The [HTTPRoute resource](/api-types/httproute) allows you to match on HTTP traffic and
 direct it to Kubernetes backends. This guide shows how the HTTPRoute matches
 traffic on host, header, and path fields and forwards it to different

--- a/site-src/v1alpha2/guides/multiple-ns.md
+++ b/site-src/v1alpha2/guides/multiple-ns.md
@@ -1,5 +1,7 @@
 # Routes in multiple namespaces
 
+!!! danger "This page has not been updated for v1alpha2 yet."
+
 With the Gateway API, a single Gateway can target routes across multiple
 namespaces.
 

--- a/site-src/v1alpha2/guides/simple-gateway.md
+++ b/site-src/v1alpha2/guides/simple-gateway.md
@@ -1,5 +1,7 @@
 # Deploying a simple Gateway
 
+!!! danger "This page has not been updated for v1alpha2 yet."
+
 The simplest possible deployment is a Gateway and Route resource which are
 deployed together by the same owner. This represents a similar kind of model
 used for Ingress. In this guide, a Gateway and HTTPRoute are deployed which

--- a/site-src/v1alpha2/guides/tcp.md
+++ b/site-src/v1alpha2/guides/tcp.md
@@ -1,3 +1,7 @@
+# TCP
+
+!!! danger "This page has not been updated for v1alpha2 yet."
+
 Gateway API is designed to work with multiple protocols.
 [TCPRoute](/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute) is one such route which
 allows for managing TCP traffic.

--- a/site-src/v1alpha2/guides/traffic-splitting.md
+++ b/site-src/v1alpha2/guides/traffic-splitting.md
@@ -1,5 +1,7 @@
 # HTTP traffic splitting
 
+!!! danger "This page has not been updated for v1alpha2 yet."
+
 The [HTTPRoute resource](/api-types/httproute) allows you to specify weights to shift
 traffic between different backends. This is useful for splitting traffic during
 rollouts, canarying changes, or for emergencies. The HTTPRoute

--- a/site-src/v1alpha2/index.md
+++ b/site-src/v1alpha2/index.md
@@ -1,5 +1,7 @@
 ## What is the Gateway API?
 
+!!! danger "This version of the API has not been released yet."
+
 Gateway API is an open source project managed by the [SIG-NETWORK][sig-network]
 community. It's is a collection of resources that model service networking 
 in Kubernetes. These resources - `GatewayClass`,`Gateway`, `HTTPRoute`, 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
With v1alpha2 coming quickly, we need some kind of solution here. This is far from perfect, but it appears to work locally for me. I'm still very interested in a better long term solution for this. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

Note: This is closely related to @hbagdi's earlier PR: https://github.com/kubernetes-sigs/gateway-api/pull/757. 