### PR TITLE
docs: update getting-started and httproute guides for v1alpha2

### DIFF
--- a/examples/v1alpha2/http-routing/bar-httproute.yaml
+++ b/examples/v1alpha2/http-routing/bar-httproute.yaml
@@ -1,0 +1,20 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: bar-route
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "bar.example.com"
+  rules:
+  - matches:
+    - headers:
+      - type: Exact
+        name: env
+        value: canary
+    backendRefs:
+    - name: bar-svc-canary
+      port: 8080
+    - name: bar-svc
+      port: 8080

--- a/examples/v1alpha2/http-routing/foo-httproute.yaml
+++ b/examples/v1alpha2/http-routing/foo-httproute.yaml
@@ -1,0 +1,17 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: foo-route
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "foo.example.com"
+  rules:
+  - matches:
+    - path:
+        type: Prefix
+        value: /login
+    backendRefs:
+    - name: foo-svc
+      port: 8080

--- a/examples/v1alpha2/http-routing/gateway.yaml
+++ b/examples/v1alpha2/http-routing/gateway.yaml
@@ -1,0 +1,24 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+metadata:
+  name: example-route
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80

--- a/site-src/v1alpha2/guides/getting-started.md
+++ b/site-src/v1alpha2/guides/getting-started.md
@@ -1,10 +1,10 @@
 # Getting started with Gateway APIs
 
 !!! danger
-    This page has not been updated for v1alpha2 yet.
+    This page and some of its sub-pages are not fully updated for v1alpha2 yet.
 
 **1.**  **[Install a Gateway controller](#installing-a-gateway-controller)**
- _OR_  **[install the Gateway API CRDs manually](#installing-gateway-api-crds-manually)** 
+ _OR_  **[install the Gateway API CRDs manually](#installing-gateway-api-crds-manually)**
 
 _THEN_
 
@@ -19,20 +19,20 @@ _THEN_
 
 ## Installing a Gateway controller
 
-There are [multiple projects](/v1alpha2/references/implementations) that support the Gateway
-API. By installing a Gateway controller in your Kubernetes cluster, you can
-try out the guides above. This will demonstrate that the desired routing
+There are [multiple projects](/references/implementations) that support the
+Gateway API. By installing a Gateway controller in your Kubernetes cluster,
+you can try out the guides above. This will demonstrate that the desired routing
 configuration is actually being implemented by your Gateway resources (and the
-network infrastructure that your Gateway resources represent). Note that many 
-of the Gateway controller setups will install and remove the Gateway API CRDs 
+network infrastructure that your Gateway resources represent). Note that many
+of the Gateway controller setups will install and remove the Gateway API CRDs
 for you.
 
 ## Installing Gateway API CRDs manually
 
 The following command will install the Gateway API CRDs. This includes the
-GatewayClass, Gateway, HTTPRoute, TCPRoute, and more. Note that a running 
-Gateway controller in your Kubernetes cluster is required to actually act on 
-these resources. Installing the CRDs will just allow you to see and apply the 
+GatewayClass, Gateway, HTTPRoute, TCPRoute, and more. Note that a running
+Gateway controller in your Kubernetes cluster is required to actually act on
+these resources. Installing the CRDs will just allow you to see and apply the
 resources, though they won't do anything.
 
 ```
@@ -40,11 +40,11 @@ kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.3.0"
 | kubectl apply -f -
 ```
 
-After you're done, you can clean up after yourself by uninstalling the 
-Gateway API CRDs. The following command will remove all GatewayClass, Gateway, 
+After you're done, you can clean up after yourself by uninstalling the
+Gateway API CRDs. The following command will remove all GatewayClass, Gateway,
 and associated resources in your cluster. If these resources are in-use or
-if they were installed by a Gateway controller, then do not uninstall them. 
-This will uninstall the Gateway API CRDs for the entire cluster. Do not do 
+if they were installed by a Gateway controller, then do not uninstall them.
+This will uninstall the Gateway API CRDs for the entire cluster. Do not do
 this if they might be in-use by someone else as this will break anything using
 these resources.
 

--- a/site-src/v1alpha2/guides/http-routing.md
+++ b/site-src/v1alpha2/guides/http-routing.md
@@ -1,9 +1,5 @@
 # HTTP routing
 
-!!! danger
-    This page has not been updated for v1alpha2 yet.
-
-
 The [HTTPRoute resource](/v1alpha2/api-types/httproute) allows you to match on HTTP traffic and
 direct it to Kubernetes backends. This guide shows how the HTTPRoute matches
 traffic on host, header, and path fields and forwards it to different
@@ -26,18 +22,16 @@ Gateway which allows Routes to merge on a Gateway as long as they don't
 conflict. For more information on Route merging, refer to the [HTTPRoute
 documentation](/v1alpha2/api-types/httproute#merging).
 
-The following `prod-web` Gateway is defined from the `acme-lb` GatewayClass.
-`prod-web` listens for HTTP traffic on port 80 and will bind to all Routes in
-the same Namespace that have the matching `gateway: prod-web-gw` label.
-Route labels and Gateway label selectors allow Routes and Gateways to be
-bound to each other by their respective owners.
+In order to receive traffic from a [Gateway][gateway] an `HTTPRoute` resource
+must be configured with `ParentRefs` which reference the parent gateway(s) that it
+should be attached to. The following example shows how the combination
+of `Gateway` and `HTTPRoute` would be configured to serve HTTP traffic:
 
 ```yaml
-{% include 'v1alpha1/http-routing/gateway.yaml' %}
+{% include 'v1alpha2/http-routing/gateway.yaml' %}
 ```
 
-An HTTPRoute can match against a [single set of
-hostnames](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRouteSpec).
+An HTTPRoute can match against a [single set of hostnames][spec].
 These hostnames are matched before any other matching within the HTTPRoute takes
 place. Since `foo.example.com` and `bar.example.com` are separate hosts with
 different routing requirements, each is deployed as its own HTTPRoute -
@@ -50,7 +44,7 @@ forwarded. Traffic to any other paths that do not begin with `/login` will not
 be matched by this Route.
 
 ```yaml
-{% include 'v1alpha1/http-routing/foo-httproute.yaml' %}
+{% include 'v1alpha2/http-routing/foo-httproute.yaml' %}
 ```
 
 Similarly, the `bar-route` HTTPRoute matches traffic for `bar.example.com`. All
@@ -60,6 +54,9 @@ canary` header will be forwarded to `bar-svc-canary` and if the header is
 missing or not `canary` then it'll be forwarded to `bar-svc`.
 
 ```yaml
-{% include 'v1alpha1/http-routing/bar-httproute.yaml' %}
+{% include 'v1alpha2/http-routing/bar-httproute.yaml' %}
 ```
 
+[gateway]:https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRouteSpec
+[spec]:https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRouteSpec
+[svc]:https://kubernetes.io/docs/concepts/services-networking/service/


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This updates the examples in the `HTTPRoute` guide for `v1alpha2`, and does some spacing cleanup for the getting started guide (but that guide did not appear to need any special updating for `v1alpha2`).

**Which issue(s) this PR fixes**:

Resolves the first two tasks in https://github.com/kubernetes-sigs/gateway-api/issues/783