### PR TITLE
docs: update multiple-ns guide for v1alpha2

### DIFF
--- a/examples/v1alpha2/cross-namespace-routing/0-namespaces.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/0-namespaces.yaml
@@ -2,17 +2,24 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: infra-ns
+  labels:
+    shared-gateway-access: "true"
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: site-ns
   labels:
-    environment: development
+    shared-gateway-access: "true"
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: store-ns
   labels:
-    environment: development
+    shared-gateway-access: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: no-external-access

--- a/examples/v1alpha2/cross-namespace-routing/0-namespaces.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/0-namespaces.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: infra-ns
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: site-ns
+  labels:
+    environment: development
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: store-ns
+  labels:
+    environment: development

--- a/examples/v1alpha2/cross-namespace-routing/gateway.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/gateway.yaml
@@ -6,12 +6,16 @@ metadata:
 spec:
   gatewayClassName: shared-gateway-class
   listeners:
-  - name: http
+  - name: https
     hostname: "foo.example.com"
-    protocol: HTTP
-    port: 80
-    routes:
+    protocol: HTTPS
+    port: 443
+    allowedRoutes:
       namespaces:
+        from: Selector
         selector:
           matchLabels:
-            environment: development
+            shared-gateway-access: "true"
+    tls:
+      certificateRef:
+        name: foo-example-com

--- a/examples/v1alpha2/cross-namespace-routing/gateway.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/gateway.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  name: shared-gateway
+  namespace: infra-ns
+spec:
+  gatewayClassName: shared-gateway-class
+  listeners:
+  - name: http
+    hostname: "foo.example.com"
+    protocol: HTTP
+    port: 80
+    routes:
+      namespaces:
+        selector:
+          matchLabels:
+            environment: development

--- a/examples/v1alpha2/cross-namespace-routing/site-route.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/site-route.yaml
@@ -1,0 +1,34 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: home
+  namespace: site-ns
+spec:
+  parentRefs:
+  - name: shared-gateway
+    namespace: infra-ns
+  rules:
+  - backendRefs:
+    - name: home
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: login
+  namespace: site-ns
+spec:
+  parentRefs:
+  - name: shared-gateway
+    namespace: infra-ns
+  rules:
+  - matches:
+    - path:
+        value: /login
+    backendRefs:
+    - name: login-v1
+      port: 8080
+      weight: 90
+    - name: login-v2
+      port: 8080
+      weight: 10

--- a/examples/v1alpha2/cross-namespace-routing/store-route.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/store-route.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: store
+  namespace: store-ns
+spec:
+  parentRefs:
+  - name: shared-gateway
+    namespace: infra-ns
+  rules:
+  - matches:
+    - path:
+        value: /store
+    backendRefs:
+    - name: store
+      port: 8080

--- a/site-src/v1alpha2/guides/multiple-ns.md
+++ b/site-src/v1alpha2/guides/multiple-ns.md
@@ -1,152 +1,137 @@
 # Cross-Namespace routing
 
 The Gateway API has core support for cross Namespace routing. This is useful
-when more than one user or team is sharing the underlying networking infrastructure,
-yet control and configuration must be segmented to minimize access and fault
-domains. Gateways and Routes can be deployed into different Namespaces and bind
-with each other across Namespace boundaries. This allows differing user access
-and roles (RBAC) to be applied to separate Namespaces, effectively controlling
-who has access to different parts of the cluster-wide routing configuration. The
-ability for Routes to bind with Gateways across Namespace boundaries is goverend
-by [_Route binding_](#cross-namespace-route-binding), which
-is explored in this guide. The guide shows how two independent teams can safely
-share the same Gateway from different Namespaces.
+when more than one user or team is sharing the underlying networking
+infrastructure, yet control and configuration must be segmented to minimize
+access and fault domains.
+
+Gateways and Routes can be deployed into different Namespaces and Routes 
+attached to Gateways across Namespace boundaries. This allows differing user access and
+roles (RBAC) to be applied to separate Namespaces, effectively controlling who
+has access to different parts of the cluster-wide routing configuration. The
+ability for Routes to attach to Gateways across Namespace boundaries is governed
+by [_Route Attaching_](#cross-namespace-route-attachment), which
+is explored in this guide which will demonstrate how two independent teams can
+safely share the same Gateway from different Namespaces.
 
 In this guide there are two independent teams, _store_ and _site_, operating
-in the same Kubernetes cluster in the `store-ns` and `site-ns` Namespaces. These are
-their requirements:
+in the same Kubernetes cluster in the `store-ns` and `site-ns` Namespaces. These
+are their requirements:
 
-- The site team has two applications, _home_ and _login_, that are running 
+- The site team has two applications, _home_ and _login_, that are running
 behind `foo.example.com`. They want to isolate access and configuration across
-their apps as much as possible to minimize access and failure domains. 
-They use separate HTTPRoutes for each app, to isolate app routing configurations 
-such as canary rollouts. but share the same load balancer 
+their apps as much as possible to minimize access and failure domains.
+They use separate HTTPRoutes for each app, to isolate app routing configurations
+such as canary rollouts, but share the same load balancer
 IP, port, domain, and TLS certificate.
-- The store team has a single Service called _store_ that they have deployed 
-in the `store-ns` Namespace. 
-- The Foobar Corporation operates behind the `foo.example.com` domain so they 
-would like to host all applications on the same Gateway resource. This is 
-controlled by a central infrastructure team, operating in the `infra-ns` Namespace.
-- Lastly, the security team controls the certificate for `foo.example.com`. 
-By managing this certificate through the single shared Gateway they are able 
+- The store team has a single Service called _store_ that they have deployed
+in the `store-ns` Namespace.
+- The Foobar Corporation operates behind the `foo.example.com` domain so they
+would like to host all applications on the same Gateway resource. This is
+controlled by a central infrastructure team, operating in the `infra-ns`
+Namespace.
+- Lastly, the security team controls the certificate for `foo.example.com`.
+By managing this certificate through the single shared Gateway they are able
 to centrally control security without directly involving application teams.
 
 The logical relationship between the Gateway API resources looks like this:
 
 ![Cross-Namespace routing](../images/cross-namespace-routing.svg)
 
-## Cross-namespace Route binding
+## Cross-namespace Route Attachment
 
-[Route binding](/concepts/api-overview/#route-binding) is an important concept 
-that dictates how Routes and Gateways select each other to apply routing
-configuration to a Gateway. It is especially relevant when there are multiple
-Gateways and multiple Namespaces in a cluster. Gateway and Route binding is
-bidirectional - a binding can only exist if the Gateway owner and Route owner
-owner both agree to the relationship. This bi-directional relationship exists
-for two reasons:
+[Route attachment][attaching] is an important concept that dictates how Routes
+and Gateways select each other to apply routing configuration to a Gateway. It
+is especially relevant when there are multiple Gateways and multiple Namespaces
+in a cluster. Gateway and Route attachment is bidirectional - attachment can
+only succeed if the Gateway owner and Route owner owner both agree to the
+relationship. This bi-directional relationship exists for two reasons:
 
-- Route owners don't want to overexpose their applications and don't want 
+- Route owners don't want to overexpose their applications and don't want
 their apps to be accessible through paths they are not aware of.
-- Gateway owners don't want apps using certain Gateways they should not be 
-using. An internal application shouldn't be exposed through a public Gateway 
+- Gateway owners don't want apps using certain Gateways they should not be
+using. An internal application shouldn't be exposed through a public Gateway
 for example.
 
-
 As a result, Gateways and Routes have independent control to determine which
-resources they permit binding with. It is a handshake between the infra owners
-and the application owners that allows them to be independent actors.
-Route-owners can specify that they will bind with all Gateways in the cluster,
-or only Gateways from a specific Namespace, with a specific label selector, or
-an individual Gateway. Similarly, Gateways provide the same level of control.
-This allows a cluster to be more self-governed, which requires less central
-administration to ensure that Routes are not over-exposed.
+resources will succeed in attaching. It is a handshake between the infra owners
+and the application owners that allows them to be independent actors. Routes
+can only attach to specified gateways and Gateways provide a similar level of
+selection control over which Routes they allow to attach to by trusting
+specific namespaces in which those Routes live and operate. This allows a
+cluster to be more self-governed, which requires less central administration
+to ensure that Routes are not over-exposed.
 
-## Resource Deployment
+## Multi-Namespace Gateways Example
 
-The infrastructure team deploys the `shared-gateway` Gateway into the `infra-ns` 
-Namespace. 
+The infrastructure team deploys the `shared-gateway` Gateway into the `infra-ns`
+Namespace:
 
 ```yaml
-{% include 'v1alpha1/cross-namespace-routing/gateway.yaml' %}
+{% include 'v1alpha2/cross-namespace-routing/gateway.yaml' %}
 ```
 
-A few notes about this Gateway:
+The `http` listener in the above `Gateway` matches traffic for the
+`foo.example.com` domain specifically, this frees `HTTPRoute` resources which
+attach to it from needing to do any matching on the `hostname` which can reduce
+the amount of templating needed for deployment of the underlying application,
+since the `HTTPRoutes` developed for it can be domain agnostic (helpful for
+situations where the domain hosting the application is not static).
 
-- It is matching for the `foo.example.com` domain. This is configured on the 
-Gateway so that each HTTPRoute does not also have to configure hostname matching, 
-since they are all using the same domain. This also allows these HTTPRoute 
-manifests to be reused across production and dev environments where the dev 
-environment might be hosted at `foo.dev.corp.example.com`.
-- The Gateway is configured for HTTPS and references the `foo-example-com` Secret. 
-This allows the certificate to be managed centrally for all applications which 
-are using this Gateway.
-- It allows any Route in the cluster to use this Gateway because `namespaces.from = All`. 
-This is a permissive method of Route selection since the Routes are given 
-full control to select this Gateway. There are more restrictive forms of Route 
-selection that allow selection on a per-Namespace basis, detailed 
-in [Route binding](/concepts/api-overview/#route-binding). The following block
-specifies how this Gateway allows HTTPRoutes from all Namespaces in the 
-cluster to bind to it:
+
+The `routes` section of this `Gateway` is particularly important because it is
+the crux of how multiple namespace support is configured in this example:
 
 ```yaml
-    routes:
-      kind: HTTPRoute
+   routes:
       namespaces:
-        from: "All"
+        selector:
+          matchLabels:
+            environment: development
 ```
 
-Meanwhile, the store team deploys their route for the `store` Service in the 
-`store-ns` Namespace:
+In the above _only_ namespaces labeled as `development` will be able to attach
+their routes to the `Gateway`. The namespaces themselves must be decorated with
+the corresponding labels:
 
 ```yaml
-{% include 'v1alpha1/cross-namespace-routing/store-route.yaml' %}
+{% include 'v1alpha2/cross-namespace-routing/0-namespaces.yaml' %}
 ```
 
-This Route has straightforward routing logic as it just matches for 
-`/store` traffic which it sends to the `store` Service. The following snippet 
-of the [`gateways` field](/v1alpha2/references/spec/#networking.x-k8s.io/v1alpha1.RouteGateways) 
-controls which Gateways this Route can bind to:
+## Route Attachment Examples
+
+The store team deploys their route for the `store` Service in the `store-ns`
+Namespace:
 
 ```yaml
-  gateways:
-    allow: FromList
-    gatewayRefs:
-    - name: shared-gateway
-      namespace: infra
+{% include 'v1alpha2/cross-namespace-routing/store-route.yaml' %}
 ```
 
-`gateways.allow` can be configured for Gateways in the same Namespace as the
-Route (the default), all Gateways, or a list of specific Gateways. In this
-example the store and site teams decide to reference a specific Gateway. This is
-the least permissive choice which ensures that other Gateways in the cluster
-(perhaps created in the future at some point) will not bind with these Routes.
-If cluster administrators have full control over how Gateways are deployed in a
-cluster then a more permissive binding option could be configured on Routes. The
-less permissive the Gateway selection is, the less that application owners need
-to know about which Gateways are deployed. 
+This Route has straightforward routing logic as it just matches for
+`/store` traffic which it sends to the `store` Service.
 
 The site team now deploys Routes for their applications. They deploy two
 HTTPRoutes into the `site-ns` Namespace:
 
-- The `home` HTTPRoute acts as a default routing rule, matching for all traffic 
-to `foo.example.com/*` not matched by an existing routing rule and sending it to 
+- The `home` HTTPRoute acts as a default routing rule, matching for all traffic
+to `foo.example.com/*` not matched by an existing routing rule and sending it to
 the `home` Service.
-- The `login` HTTPRoute  routes traffic for `foo.example.com/login` to 
-`service/login-v1` and `service/login-v2`. It uses weights to granularly 
-control traffic distribution between them. 
+- The `login` HTTPRoute  routes traffic for `foo.example.com/login` to
+`service/login-v1` and `service/login-v2`. It uses weights to granularly
+control traffic distribution between them.
 
-Both of these Routes use the same Gateway binding configuration which specifies
-`gateway/shared-gateway` in the `infra-ns` Namespace as the only Gateway that these
-Routes can bind with.
+Both of these Routes use the same Gateway attachment configuration which
+specifies `gateway/shared-gateway` in the `infra-ns` Namespace as the only
+Gateway that these Routes want to attach to.
 
 ```yaml
-{% include 'v1alpha1/cross-namespace-routing/site-route.yaml' %}
+{% include 'v1alpha2/cross-namespace-routing/site-route.yaml' %}
 ```
 
-After these three Routes are deployed, they will all be bound to the 
+After these three Routes are deployed, they will all be bound to the
 `shared-gateway` Gateway. The Gateway merges its bound Routes into a single flat
 list of routing rules. [Routing
-precedence](/references/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteRule)
+precedence](/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRouteRule)
 between the flat list of routing rules is determined by most specific match and
 conflicts are handled according to [conflict
 resolution](/concepts/guidelines#conflicts). This provides predictable and
@@ -156,3 +141,5 @@ Thanks to cross-Namespace routing, the Foobar Corporation can distribute
 ownership of their infrastructure more evenly, while still retaining centralized
 control. This gives them the best of both worlds, all delivered through
 declarative and open source APIs.
+
+[attaching]:/concepts/api-overview/#attaching-routes-to-gateways


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This updates the `multiple-ns.md` guide for `v1alpha2`.

**Which issue(s) this PR fixes**:

Resolves the 3rd task for https://github.com/kubernetes-sigs/gateway-api/issues/783

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
