### PR TITLE
Invert apiVersion and kind in docs

### DIFF
--- a/examples/v1alpha1/backendpolicy.yaml
+++ b/examples/v1alpha1/backendpolicy.yaml
@@ -1,5 +1,5 @@
-kind: BackendPolicy
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: BackendPolicy
 metadata:
   name: my-app
 spec:

--- a/examples/v1alpha1/basic-http.yaml
+++ b/examples/v1alpha1/basic-http.yaml
@@ -1,5 +1,5 @@
-kind: GatewayClass
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: GatewayClass
 metadata:
   name: acme-lb
 spec:
@@ -9,8 +9,8 @@ spec:
     group: acme.io
     kind: Parameters
 ---
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: my-gateway
 spec:
@@ -26,8 +26,8 @@ spec:
       namespaces:
         from: "Same"
 ---
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: http-app-1
   labels:

--- a/examples/v1alpha1/basic-tcp.yaml
+++ b/examples/v1alpha1/basic-tcp.yaml
@@ -1,5 +1,5 @@
-kind: GatewayClass
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: GatewayClass
 metadata:
   name: acme-lb
 spec:
@@ -9,8 +9,8 @@ spec:
     group: acme.io
     kind: Parameters
 ---
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: my-tcp-gateway
 spec:
@@ -31,8 +31,8 @@ spec:
         matchLabels:
           "app": "bar"
 ---
-kind: TCPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: TCPRoute
 metadata:
   name: tcp-app-1
   labels:
@@ -43,8 +43,8 @@ spec:
     - serviceName: my-foo-service
       port: 6000
 ---
-kind: TCPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: TCPRoute
 metadata:
   name: tcp-app-2
   namespace: default

--- a/examples/v1alpha1/basic-udp.yaml
+++ b/examples/v1alpha1/basic-udp.yaml
@@ -1,5 +1,5 @@
-kind: GatewayClass
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: GatewayClass
 metadata:
   name: acme-lb
 spec:
@@ -9,8 +9,8 @@ spec:
     group: acme.io
     kind: Parameters
 ---
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: my-gateway
 spec:
@@ -26,8 +26,8 @@ spec:
       namespaces:
         from: "All"
 ---
-kind: UDPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: UDPRoute
 metadata:
   name: udp-app-1
   labels:

--- a/examples/v1alpha1/cross-namespace-routing/gateway.yaml
+++ b/examples/v1alpha1/cross-namespace-routing/gateway.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: shared-gateway
   namespace: infra-ns

--- a/examples/v1alpha1/cross-namespace-routing/site-route.yaml
+++ b/examples/v1alpha1/cross-namespace-routing/site-route.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: home
   namespace: site-ns
@@ -14,8 +14,8 @@ spec:
     - serviceName: home
       port: 8080
 ---
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: login
   namespace: site-ns

--- a/examples/v1alpha1/cross-namespace-routing/store-route.yaml
+++ b/examples/v1alpha1/cross-namespace-routing/store-route.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: store
   namespace: store-ns

--- a/examples/v1alpha1/default-match-http.yaml
+++ b/examples/v1alpha1/default-match-http.yaml
@@ -1,5 +1,5 @@
-kind: GatewayClass
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: GatewayClass
 metadata:
   name: default-match-example
 spec:
@@ -7,8 +7,8 @@ spec:
 
 ---
 
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: default-match-gw
 spec:
@@ -30,8 +30,8 @@ spec:
 # specified, CRD defaults adds a default prefix match on the path "/". This
 # matches every HTTP request and ensures that route rules always have at
 # least one valid match.
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: default-match-route
   labels:

--- a/examples/v1alpha1/http-filter.yaml
+++ b/examples/v1alpha1/http-filter.yaml
@@ -1,5 +1,5 @@
-kind: GatewayClass
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: GatewayClass
 metadata:
   name: filter-lb
 spec: 
@@ -9,8 +9,8 @@ spec:
     group: acme.io
     kind: Parameters
 ---
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: my-filter-gateway
 spec:
@@ -26,8 +26,8 @@ spec:
         namespaces:
           from: "All"
 ---
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: http-filter-1
   labels:

--- a/examples/v1alpha1/http-routing/bar-httproute.yaml
+++ b/examples/v1alpha1/http-routing/bar-httproute.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: bar-route
   labels:

--- a/examples/v1alpha1/http-routing/foo-httproute.yaml
+++ b/examples/v1alpha1/http-routing/foo-httproute.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: foo-route
   labels:

--- a/examples/v1alpha1/http-routing/gateway.yaml
+++ b/examples/v1alpha1/http-routing/gateway.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: prod-web
 spec:

--- a/examples/v1alpha1/http-trafficsplit.yaml
+++ b/examples/v1alpha1/http-trafficsplit.yaml
@@ -1,5 +1,5 @@
-kind: GatewayClass
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: GatewayClass
 metadata:
   name: trafficsplit-lb
 spec: 
@@ -9,8 +9,8 @@ spec:
     group: acme.io
     kind: Parameters
 ---
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: my-trafficsplit-gateway
 spec:
@@ -27,8 +27,8 @@ spec:
           from: "Selector"
           selector: {}
 ---
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: http-trafficsplit-1
   labels:

--- a/examples/v1alpha1/multiple-tcp.yaml
+++ b/examples/v1alpha1/multiple-tcp.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: gateway
 spec:

--- a/examples/v1alpha1/routes-in-multiple-namespaces.yaml
+++ b/examples/v1alpha1/routes-in-multiple-namespaces.yaml
@@ -1,5 +1,5 @@
-kind: GatewayClass
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: GatewayClass
 metadata:
   name: acme-lb
 spec:
@@ -9,8 +9,8 @@ spec:
     group: acme.io
     kind: Parameters
 ---
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: multi-ns-gateway
 spec:
@@ -26,13 +26,13 @@ spec:
       namespaces:
         from: "All"
 ---
-kind: Namespace
 apiVersion: v1
+kind: Namespace
 metadata:
   name: gateway-api-example-ns1
 ---
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: http-app-1
   namespace: gateway-api-example-ns1
@@ -63,13 +63,13 @@ spec:
     - serviceName: my-foo-service2
       port: 8080
 ---
-kind: Namespace
 apiVersion: v1
+kind: Namespace
 metadata:
   name: gateway-api-example-ns2
 ---
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: http-app-2
   namespace: gateway-api-example-ns2

--- a/examples/v1alpha1/simple-gateway/gateway.yaml
+++ b/examples/v1alpha1/simple-gateway/gateway.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: prod-web
 spec:

--- a/examples/v1alpha1/simple-gateway/httproute.yaml
+++ b/examples/v1alpha1/simple-gateway/httproute.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: foo
   labels:

--- a/examples/v1alpha1/single-http.yaml
+++ b/examples/v1alpha1/single-http.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: gateway
 spec:

--- a/examples/v1alpha1/tls-basic.yaml
+++ b/examples/v1alpha1/tls-basic.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: tls-basic
 spec:

--- a/examples/v1alpha1/tls-cert-in-route.yaml
+++ b/examples/v1alpha1/tls-cert-in-route.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: cert-in-route-gateway
 spec:
@@ -22,8 +22,8 @@ spec:
     routes:
       kind: HTTPRoute
 ---
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: http-app-1
 spec:
@@ -43,8 +43,8 @@ spec:
     - serviceName: my-service
       port: 8080
 ---
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: http-app-2
 spec:

--- a/examples/v1alpha1/traffic-splitting/simple-split.yaml
+++ b/examples/v1alpha1/traffic-splitting/simple-split.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: simple-split
 spec:

--- a/examples/v1alpha1/traffic-splitting/traffic-split-1.yaml
+++ b/examples/v1alpha1/traffic-splitting/traffic-split-1.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: foo-route
   labels:

--- a/examples/v1alpha1/traffic-splitting/traffic-split-2.yaml
+++ b/examples/v1alpha1/traffic-splitting/traffic-split-2.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: foo-route
   labels:

--- a/examples/v1alpha1/traffic-splitting/traffic-split-3.yaml
+++ b/examples/v1alpha1/traffic-splitting/traffic-split-3.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: foo-route
   labels:

--- a/examples/v1alpha1/upstream-tls.yaml
+++ b/examples/v1alpha1/upstream-tls.yaml
@@ -1,5 +1,5 @@
-kind: BackendPolicy
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: BackendPolicy
 metadata:
   name: my-app
   annotations:
@@ -30,8 +30,8 @@ spec:
   selector:
     app: my-service
 ---
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: my-service-route
 spec:

--- a/examples/v1alpha1/wildcard-http.yaml
+++ b/examples/v1alpha1/wildcard-http.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: gateway
 spec:

--- a/examples/v1alpha1/wildcard-https.yaml
+++ b/examples/v1alpha1/wildcard-https.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: gateway
 spec:

--- a/examples/v1alpha1/wildcard-tls-gateway.yaml
+++ b/examples/v1alpha1/wildcard-tls-gateway.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
 metadata:
   name: wildcard-tls-gateway
 spec:

--- a/examples/v1alpha2/0-namespaces.yaml
+++ b/examples/v1alpha2/0-namespaces.yaml
@@ -1,11 +1,11 @@
 # These namespaces can be used for examples without recreating them each time.
 ---
-kind: Namespace
 apiVersion: v1
+kind: Namespace
 metadata:
   name: gateway-api-example-ns1
 ---
-kind: Namespace
 apiVersion: v1
+kind: Namespace
 metadata:
   name: gateway-api-example-ns2

--- a/examples/v1alpha2/basic-http.yaml
+++ b/examples/v1alpha2/basic-http.yaml
@@ -1,5 +1,5 @@
-kind: GatewayClass
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: GatewayClass
 metadata:
   name: acme-lb
 spec:
@@ -9,8 +9,8 @@ spec:
     group: acme.io
     kind: Parameters
 ---
-kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
 metadata:
   name: my-gateway
 spec:
@@ -20,8 +20,8 @@ spec:
     protocol: HTTP
     port: 80
 ---
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: http-app-1
 spec:

--- a/examples/v1alpha2/default-match-http.yaml
+++ b/examples/v1alpha2/default-match-http.yaml
@@ -1,12 +1,12 @@
-kind: GatewayClass
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: GatewayClass
 metadata:
   name: default-match-example
 spec:
   controller: acme.io/gateway-controller
 ---
-kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
 metadata:
   name: default-match-gw
 spec:
@@ -20,8 +20,8 @@ spec:
 # specified, CRD defaults adds a default prefix match on the path "/". This
 # matches every HTTP request and ensures that route rules always have at
 # least one valid match.
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: default-match-route
   labels:

--- a/examples/v1alpha2/http-redirect.yaml
+++ b/examples/v1alpha2/http-redirect.yaml
@@ -1,5 +1,5 @@
-kind: GatewayClass
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: GatewayClass
 metadata:
   name: filter-lb
 spec:
@@ -9,13 +9,13 @@ spec:
     group: acme.io
     kind: Parameters
 ---
-kind: Namespace
 apiVersion: v1
+kind: Namespace
 metadata:
   name: gateway-api-example-ns1
 ---
-kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
 metadata:
   name: my-filter-gateway
   namespace: gateway-api-example-ns1
@@ -29,8 +29,8 @@ spec:
       protocol: HTTPS
       port: 443
 ---
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: http-filter-1
   namespace: gateway-api-example-ns1
@@ -46,8 +46,8 @@ spec:
         requestRedirect:
           protocol: HTTPS
 ---
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: http-filter-2
   namespace: gateway-api-example-ns1

--- a/examples/v1alpha2/http-routing/bar-httproute.yaml
+++ b/examples/v1alpha2/http-routing/bar-httproute.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: bar-route
 spec:

--- a/examples/v1alpha2/http-routing/foo-httproute.yaml
+++ b/examples/v1alpha2/http-routing/foo-httproute.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: foo-route
 spec:

--- a/examples/v1alpha2/http-routing/gateway.yaml
+++ b/examples/v1alpha2/http-routing/gateway.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
 metadata:
   name: example-gateway
 spec:
@@ -9,8 +9,8 @@ spec:
     protocol: HTTP
     port: 80
 ---
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: example-route
 spec:

--- a/examples/v1alpha2/tls-basic.yaml
+++ b/examples/v1alpha2/tls-basic.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
 metadata:
   name: tls-basic
 spec:

--- a/examples/v1alpha2/tls-cert-cross-namespace.yaml
+++ b/examples/v1alpha2/tls-cert-cross-namespace.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
 metadata:
   name: cross-namespace-tls-gateway
   namespace: gateway-api-example-ns1
@@ -17,8 +17,8 @@ spec:
         name: wildcard-example-com-cert
         namespace: gateway-api-example-ns1
 ---
-kind: ReferencePolicy
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: ReferencePolicy
 metadata:
   name: allow-ns1-gateways-to-ref-secrets
   namespace: gateway-api-example-ns2

--- a/examples/v1alpha2/traffic-split-1.yaml
+++ b/examples/v1alpha2/traffic-split-1.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: foo-route
 spec:

--- a/examples/v1alpha2/wildcard-tls-gateway.yaml
+++ b/examples/v1alpha2/wildcard-tls-gateway.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
 metadata:
   name: wildcard-tls-gateway
 spec:

--- a/hack/invalid-examples/gateway/duplicate-listeners.yaml
+++ b/hack/invalid-examples/gateway/duplicate-listeners.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
 metadata:
   name: duplicate-listeners
 spec:

--- a/hack/invalid-examples/gateway/invalid-listener-name.yaml
+++ b/hack/invalid-examples/gateway/invalid-listener-name.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
 metadata:
   name: invalid-listener-name
 spec:

--- a/hack/invalid-examples/gateway/invalid-listener-port.yaml
+++ b/hack/invalid-examples/gateway/invalid-listener-port.yaml
@@ -1,5 +1,5 @@
-kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
 metadata:
   name: invalid-listener-port
 spec:

--- a/hack/invalid-examples/gatewayclass/invalid-controller.yaml
+++ b/hack/invalid-examples/gatewayclass/invalid-controller.yaml
@@ -1,5 +1,5 @@
-kind: GatewayClass
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: GatewayClass
 metadata:
   name: invalid-controller
 spec:

--- a/hack/invalid-examples/httproute/duplicate-header-match.yaml
+++ b/hack/invalid-examples/httproute/duplicate-header-match.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: duplicate-header-match
 spec:

--- a/hack/invalid-examples/httproute/duplicate-query-match.yaml
+++ b/hack/invalid-examples/httproute/duplicate-query-match.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: duplicate-query-match
 spec:

--- a/hack/invalid-examples/httproute/invalid-backend-group.yaml
+++ b/hack/invalid-examples/httproute/invalid-backend-group.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: invalid-backend-group
 spec:

--- a/hack/invalid-examples/httproute/invalid-backend-kind.yaml
+++ b/hack/invalid-examples/httproute/invalid-backend-kind.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: invalid-backend-kind
 spec:

--- a/hack/invalid-examples/httproute/invalid-backend-port.yaml
+++ b/hack/invalid-examples/httproute/invalid-backend-port.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: invalid-backend-port
 spec:

--- a/hack/invalid-examples/httproute/invalid-header-name.yaml
+++ b/hack/invalid-examples/httproute/invalid-header-name.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: invalid-header-name
 spec:

--- a/hack/invalid-examples/httproute/invalid-hostname.yaml
+++ b/hack/invalid-examples/httproute/invalid-hostname.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: invalid-hostname
 spec:

--- a/hack/invalid-examples/httproute/invalid-method.yaml
+++ b/hack/invalid-examples/httproute/invalid-method.yaml
@@ -1,5 +1,5 @@
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: invalid-method
 spec:

--- a/hack/invalid-examples/referencepolicy/missing-from.yaml
+++ b/hack/invalid-examples/referencepolicy/missing-from.yaml
@@ -1,5 +1,5 @@
-kind: ReferencePolicy
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: ReferencePolicy
 metadata:
   name: missing-from
 spec:

--- a/hack/invalid-examples/referencepolicy/missing-to.yaml
+++ b/hack/invalid-examples/referencepolicy/missing-to.yaml
@@ -1,5 +1,5 @@
-kind: ReferencePolicy
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: ReferencePolicy
 metadata:
   name: missing-to
 spec:

--- a/hack/invalid-examples/tlsroute/invalid-hostname.yaml
+++ b/hack/invalid-examples/tlsroute/invalid-hostname.yaml
@@ -1,5 +1,5 @@
-kind: TLSRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
 metadata:
   name: invalid-hostname
 spec:

--- a/site-src/geps/gep-713.md
+++ b/site-src/geps/gep-713.md
@@ -277,8 +277,8 @@ to external services. To accomplish this, implementations can choose to support
 a refernce to a virtual resource type:
 
 ```yaml
-kind: RetryPolicy
 apiVersion: networking.acme.io/v1alpha1
+kind: RetryPolicy
 metadata:
   name: foo
 spec:
@@ -388,8 +388,8 @@ to the following concepts on these resources:
 * Service.Ports.Name
 
 ```yaml
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: http-app-1
   labels:
@@ -407,8 +407,8 @@ spec:
     - serviceName: my-service1
       port: 8080
 ---
-kind: RetryPolicy
 apiVersion: networking.acme.io/v1alpha2
+kind: RetryPolicy
 metadata:
   name: foo
 spec:

--- a/site-src/geps/gep-718.md
+++ b/site-src/geps/gep-718.md
@@ -272,8 +272,8 @@ backendRefs:
 For completeness, here is an example of HTTPRoute:
 
 ```yaml
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
 metadata:
   name: bar-route
   labels:

--- a/site-src/v1alpha1/api-types/gatewayclass.md
+++ b/site-src/v1alpha1/api-types/gatewayclass.md
@@ -56,8 +56,8 @@ spec:
     kind: Config
     name: internet-gateway-config
 ---
-kind: Config
 apiVersion: acme.io/v1alpha1
+kind: Config
 metadata:
   name: internet-gateway-config
 spec:

--- a/site-src/v1alpha1/api-types/httproute.md
+++ b/site-src/v1alpha1/api-types/httproute.md
@@ -28,8 +28,8 @@ namespace.
 
 The following example allows Gateways from namespace "httproute-ns-example":
 ```yaml
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: httproute-example
   namespace: httproute-ns-example
@@ -66,8 +66,8 @@ rules and filters (optional).
 The following example defines hostname "my.example.com" and allows Gateways
 from the same namespace as HTTPRoute "httproute-example":
 ```yaml
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: httproute-example
 spec:
@@ -113,8 +113,8 @@ independent, i.e. this rule will be matched if any single match is satisfied.
 
 Take the following matches configuration as an example:
 ```yaml
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 ...
 matches:
   - path:
@@ -209,8 +209,8 @@ update the entry as appropriate when the route is modified.
 The following example indicates HTTPRoute "http-example" has been admitted by
 Gateway "gw-example" in namespace "gw-example-ns":
 ```yaml
-kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: http-example
 ...

--- a/site-src/v1alpha2/api-types/gatewayclass.md
+++ b/site-src/v1alpha2/api-types/gatewayclass.md
@@ -56,8 +56,8 @@ spec:
     kind: Config
     name: internet-gateway-config
 ---
-kind: Config
 apiVersion: acme.io/v1alpha1
+kind: Config
 metadata:
   name: internet-gateway-config
 spec:

--- a/site-src/v1alpha2/api-types/httproute.md
+++ b/site-src/v1alpha2/api-types/httproute.md
@@ -27,8 +27,8 @@ here for implementations to support other types of parent resources.
 
 The following example shows how a Route would attach to the `acme-lb` Gateway:
 ```yaml
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: httproute-example
 spec:
@@ -56,8 +56,8 @@ rules and filters (optional).
 
 The following example defines hostname "my.example.com":
 ```yaml
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: httproute-example
 spec:
@@ -78,8 +78,8 @@ independent, i.e. this rule will be matched if any single match is satisfied.
 
 Take the following matches configuration as an example:
 ```yaml
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha1
+kind: HTTPRoute
 ...
 matches:
   - path:
@@ -170,8 +170,8 @@ appropriate when the route is modified.
 The following example indicates HTTPRoute "http-example" has been admitted by
 Gateway "gw-example" in namespace "gw-example-ns":
 ```yaml
-kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1alpha1
+kind: HTTPRoute
 metadata:
   name: http-example
 ...

--- a/site-src/v1alpha2/references/policy-attachment.md
+++ b/site-src/v1alpha2/references/policy-attachment.md
@@ -199,8 +199,8 @@ policies to requests to external services. To accomplish this, implementations
 can choose to support a refernce to a virtual resource type:
 
 ```yaml
-kind: RetryPolicy
 apiVersion: networking.acme.io/v1alpha1
+kind: RetryPolicy
 metadata:
   name: foo
 spec:


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/810

Done with intellij find+replace on regex `kind: (.*)\napiVersion: (.*)`
to `apiVersion: $1\nkind: $2`
