### PR TITLE
docs: add ssl passthrough note in FAQ

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -339,8 +339,7 @@ const (
 	// implies that the Gateway can't decipher the TLS stream except for
 	// the ClientHello message of the TLS protocol.
 	//
-	// Note that SSL passthrough is not supported for HTTPRoute. If you're
-	// looking to implement that kind of functionality use TLSRoute.
+	// Note that SSL passthrough is only supported by TLSRoute.
 	TLSModePassthrough TLSModeType = "Passthrough"
 )
 

--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -334,9 +334,13 @@ const (
 	// In this mode, TLS session between the downstream client
 	// and the Gateway is terminated at the Gateway.
 	TLSModeTerminate TLSModeType = "Terminate"
+
 	// In this mode, the TLS session is NOT terminated by the Gateway. This
 	// implies that the Gateway can't decipher the TLS stream except for
 	// the ClientHello message of the TLS protocol.
+	//
+	// Note that SSL passthrough is not supported for HTTPRoute. If you're
+	// looking to implement that kind of functionality use TLSRoute.
 	TLSModePassthrough TLSModeType = "Passthrough"
 )
 

--- a/site-src/faq.md
+++ b/site-src/faq.md
@@ -77,5 +77,4 @@
 [2]: https://github.com/kubernetes-sigs/gateway-api/releases
 [tls]:https://en.wikipedia.org/wiki/Transport_Layer_Security
 [tlsroute]:/concepts/api-overview.md#tlsroute
-[httproute]:/concepts/api-overview.md#httproute
 [tlsguide]:/guides/tls.md

--- a/site-src/faq.md
+++ b/site-src/faq.md
@@ -66,5 +66,18 @@
   AppProtocol depend on Kubernetes 1.18 (opt-in) or 1.19 (on by default). 
   There are not any other exceptions to the 1.16+ guideline right now.
 
+* **Q: Is SSL Passthrough supported?**
+  A: SSL Passthrough (wherein a Gateway routes traffic with the [Transport
+  Layer Security (TLS)][tls] encryption _intact_ to a backend service instead of
+  terminating it) is supported by the [TLSRoute][tlsroute] API. Note that SSL
+  Passthrough is _not_ supported by the [HTTPRoute][routes] API as it is not
+  possible to route based on HTTP metadata without terminating TLS. See the
+  [TLS Guide][tlsguide] for more details about passthrough and other TLS
+  configurations.
+
 [1]: https://github.com/kubernetes-sigs/gateway-api
 [2]: https://github.com/kubernetes-sigs/gateway-api/releases
+[tls]:https://en.wikipedia.org/wiki/Transport_Layer_Security
+[tlsroute]:/concepts/api-overview.md#tlsroute
+[routes]:/concepts/api-overview.md#routes
+[tlsguide]:/guides/tls.md

--- a/site-src/faq.md
+++ b/site-src/faq.md
@@ -69,9 +69,7 @@
 * **Q: Is SSL Passthrough supported?**
   A: SSL Passthrough (wherein a Gateway routes traffic with the [Transport
   Layer Security (TLS)][tls] encryption _intact_ to a backend service instead of
-  terminating it) is supported by the [TLSRoute][tlsroute] API. Note that SSL
-  Passthrough is _not_ supported by the [HTTPRoute][routes] API as it is not
-  possible to route based on HTTP metadata without terminating TLS. See the
+  terminating it) is supported by [TLSRoutes][tlsroute]. See the
   [TLS Guide][tlsguide] for more details about passthrough and other TLS
   configurations.
 
@@ -79,5 +77,5 @@
 [2]: https://github.com/kubernetes-sigs/gateway-api/releases
 [tls]:https://en.wikipedia.org/wiki/Transport_Layer_Security
 [tlsroute]:/concepts/api-overview.md#tlsroute
-[routes]:/concepts/api-overview.md#routes
+[httproute]:/concepts/api-overview.md#httproute
 [tlsguide]:/guides/tls.md


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
The `HTTPRoute` API (specifically) doesn't support SSL Passthrough. An implementer recently [reported](https://github.com/kubernetes-sigs/gateway-api/issues/790) this wasn't clear. There is [documentation on this](https://gateway-api.sigs.k8s.io/v1alpha2/guides/tls/#clientserver-and-tls), but in order to help make this more clear/prominent this patch adds a note about it in the FAQ with links to the relevant docs and guides.

**Which issue(s) this PR fixes**:
Fixes #840

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
