### PR TITLE
Fix markdown list formatting.

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -271,6 +271,7 @@ const (
 type GatewayTLSConfig struct {
 	// Mode defines the TLS behavior for the TLS session initiated by the client.
 	// There are two possible modes:
+	//
 	// - Terminate: The TLS session between the downstream client
 	//   and the Gateway is terminated at the Gateway. This mode requires
 	//   certificateRef to be set.

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
@@ -373,7 +373,7 @@ spec:
                           default: Terminate
                           description: "Mode defines the TLS behavior for the TLS
                             session initiated by the client. There are two possible
-                            modes: - Terminate: The TLS session between the downstream
+                            modes: \n - Terminate: The TLS session between the downstream
                             client   and the Gateway is terminated at the Gateway.
                             This mode requires   certificateRef to be set. - Passthrough:
                             The TLS session is NOT terminated by the Gateway. This


### PR DESCRIPTION
There needs to be a newline separating paragraphs from lists to make
the markdown processor format the list as a list.

/kind cleanup
/kind documentation
