### PR TITLE
httproute: drop ImplementationSpecific match types

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -211,7 +211,6 @@ type HTTPRouteRule struct {
 // * "Exact"
 // * "Prefix"
 // * "RegularExpression"
-// * "ImplementationSpecific"
 //
 // Prefix and Exact paths must be syntactically valid:
 //
@@ -220,15 +219,14 @@ type HTTPRouteRule struct {
 // - For prefix paths, a trailing '/' character in the Path is ignored,
 // e.g. /abc and /abc/ specify the same match.
 //
-// +kubebuilder:validation:Enum=Exact;Prefix;RegularExpression;ImplementationSpecific
+// +kubebuilder:validation:Enum=Exact;Prefix;RegularExpression
 type PathMatchType string
 
 // PathMatchType constants.
 const (
-	PathMatchExact                  PathMatchType = "Exact"
-	PathMatchPrefix                 PathMatchType = "Prefix"
-	PathMatchRegularExpression      PathMatchType = "RegularExpression"
-	PathMatchImplementationSpecific PathMatchType = "ImplementationSpecific"
+	PathMatchExact             PathMatchType = "Exact"
+	PathMatchPrefix            PathMatchType = "Prefix"
+	PathMatchRegularExpression PathMatchType = "RegularExpression"
 )
 
 // HTTPPathMatch describes how to select a HTTP route by matching the HTTP request path.
@@ -237,7 +235,7 @@ type HTTPPathMatch struct {
 	//
 	// Support: Core (Exact, Prefix)
 	//
-	// Support: Custom (RegularExpression, ImplementationSpecific)
+	// Support: Custom (RegularExpression)
 	//
 	// Since RegularExpression PathType has custom conformance, implementations
 	// can support POSIX, PCRE or any other dialects of regular expressions.
@@ -261,16 +259,14 @@ type HTTPPathMatch struct {
 //
 // * "Exact"
 // * "RegularExpression"
-// * "ImplementationSpecific"
 //
-// +kubebuilder:validation:Enum=Exact;RegularExpression;ImplementationSpecific
+// +kubebuilder:validation:Enum=Exact;RegularExpression
 type HeaderMatchType string
 
 // HeaderMatchType constants.
 const (
-	HeaderMatchExact                  HeaderMatchType = "Exact"
-	HeaderMatchRegularExpression      HeaderMatchType = "RegularExpression"
-	HeaderMatchImplementationSpecific HeaderMatchType = "ImplementationSpecific"
+	HeaderMatchExact             HeaderMatchType = "Exact"
+	HeaderMatchRegularExpression HeaderMatchType = "RegularExpression"
 )
 
 // HTTPHeaderName is the name of an HTTP header.
@@ -298,7 +294,7 @@ type HTTPHeaderMatch struct {
 	//
 	// Support: Core (Exact)
 	//
-	// Support: Custom (RegularExpression, ImplementationSpecific)
+	// Support: Custom (RegularExpression)
 	//
 	// Since RegularExpression PathType has custom conformance, implementations
 	// can support POSIX, PCRE or any other dialects of regular expressions.
@@ -337,16 +333,14 @@ type HTTPHeaderMatch struct {
 //
 // * "Exact"
 // * "RegularExpression"
-// * "ImplementationSpecific"
 //
-// +kubebuilder:validation:Enum=Exact;RegularExpression;ImplementationSpecific
+// +kubebuilder:validation:Enum=Exact;RegularExpression
 type QueryParamMatchType string
 
 // QueryParamMatchType constants.
 const (
-	QueryParamMatchExact                  QueryParamMatchType = "Exact"
-	QueryParamMatchRegularExpression      QueryParamMatchType = "RegularExpression"
-	QueryParamMatchImplementationSpecific QueryParamMatchType = "ImplementationSpecific"
+	QueryParamMatchExact             QueryParamMatchType = "Exact"
+	QueryParamMatchRegularExpression QueryParamMatchType = "RegularExpression"
 )
 
 // HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
@@ -356,7 +350,7 @@ type HTTPQueryParamMatch struct {
 	//
 	// Support: Extended (Exact)
 	//
-	// Support: Custom (RegularExpression, ImplementationSpecific)
+	// Support: Custom (RegularExpression)
 	//
 	// Since RegularExpression QueryParamMatchType has custom conformance,
 	// implementations can support POSIX, PCRE or any other dialects of regular

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
@@ -964,16 +964,15 @@ spec:
                                   default: Exact
                                   description: "Type specifies how to match against
                                     the value of the header. \n Support: Core (Exact)
-                                    \n Support: Custom (RegularExpression, ImplementationSpecific)
-                                    \n Since RegularExpression PathType has custom
-                                    conformance, implementations can support POSIX,
-                                    PCRE or any other dialects of regular expressions.
-                                    Please read the implementation's documentation
-                                    to determine the supported dialect."
+                                    \n Support: Custom (RegularExpression) \n Since
+                                    RegularExpression PathType has custom conformance,
+                                    implementations can support POSIX, PCRE or any
+                                    other dialects of regular expressions. Please
+                                    read the implementation's documentation to determine
+                                    the supported dialect."
                                   enum:
                                   - Exact
                                   - RegularExpression
-                                  - ImplementationSpecific
                                   type: string
                                 value:
                                   description: Value is the value of HTTP Header to
@@ -1017,8 +1016,8 @@ spec:
                                 default: Prefix
                                 description: "Type specifies how to match against
                                   the path Value. \n Support: Core (Exact, Prefix)
-                                  \n Support: Custom (RegularExpression, ImplementationSpecific)
-                                  \n Since RegularExpression PathType has custom conformance,
+                                  \n Support: Custom (RegularExpression) \n Since
+                                  RegularExpression PathType has custom conformance,
                                   implementations can support POSIX, PCRE or any other
                                   dialects of regular expressions. Please read the
                                   implementation's documentation to determine the
@@ -1027,7 +1026,6 @@ spec:
                                 - Exact
                                 - Prefix
                                 - RegularExpression
-                                - ImplementationSpecific
                                 type: string
                               value:
                                 default: /
@@ -1055,16 +1053,15 @@ spec:
                                   default: Exact
                                   description: "Type specifies how to match against
                                     the value of the query parameter. \n Support:
-                                    Extended (Exact) \n Support: Custom (RegularExpression,
-                                    ImplementationSpecific) \n Since RegularExpression
-                                    QueryParamMatchType has custom conformance, implementations
-                                    can support POSIX, PCRE or any other dialects
-                                    of regular expressions. Please read the implementation's
-                                    documentation to determine the supported dialect."
+                                    Extended (Exact) \n Support: Custom (RegularExpression)
+                                    \n Since RegularExpression QueryParamMatchType
+                                    has custom conformance, implementations can support
+                                    POSIX, PCRE or any other dialects of regular expressions.
+                                    Please read the implementation's documentation
+                                    to determine the supported dialect."
                                   enum:
                                   - Exact
                                   - RegularExpression
-                                  - ImplementationSpecific
                                   type: string
                                 value:
                                   description: Value is the value of HTTP query param


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind api-change

**What this PR does / why we need it**:
ImplementationSpecific is trappy match type: it provides an escape hatch
to do more but it doesn't take into account that multiple
implementation-specific match types could be possible. Use-cases exist
in this area but we have not thought through them deeply.
Being conservative and dropping this feature in v1alpha2 to avoid any potential
breaking change in the future. We may revisit this in the future as we gain a
better understanding.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #832

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
ImplementationSpecific match types in HTTPRoute's path, query, and header matches have been removed.
```
