### PR TITLE
feat: support to configure multiple certificates on GatewayTLSConfig

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -273,11 +273,11 @@ type GatewayTLSConfig struct {
 	//
 	// - Terminate: The TLS session between the downstream client
 	//   and the Gateway is terminated at the Gateway. This mode requires
-	//   certificateRef to be set.
+	//   certificateRefs to be set and contain at least one element.
 	// - Passthrough: The TLS session is NOT terminated by the Gateway. This
 	//   implies that the Gateway can't decipher the TLS stream except for
 	//   the ClientHello message of the TLS protocol.
-	//   CertificateRef field is ignored in this mode.
+	//   CertificateRefs field is ignored in this mode.
 	//
 	// Support: Core
 	//
@@ -285,10 +285,14 @@ type GatewayTLSConfig struct {
 	// +kubebuilder:default=Terminate
 	Mode *TLSModeType `json:"mode,omitempty"`
 
-	// CertificateRef is a reference to a Kubernetes object that contains a TLS
-	// certificate and private key. This certificate is used to establish a TLS
-	// handshake for requests that match the hostname of the associated
-	// listener.
+	// CertificateRefs contains a series of references to Kubernetes objects that
+	// contains TLS certificates and private keys. These certificates are used to
+	// establish a TLS handshake for requests that match the hostname of the
+	// associated listener.
+	//
+	// A single CertificateRef to a Kubernetes Secret has "Core" support.
+	// Implementations MAY choose to support attaching multiple certificates to
+	// a Listener, but this behavior is implementation-specific.
 	//
 	// References to a resource in different namespace are invalid UNLESS there
 	// is a ReferencePolicy in the target namespace that allows the certificate
@@ -296,18 +300,19 @@ type GatewayTLSConfig struct {
 	// "ResolvedRefs" condition MUST be set to False for this listener with the
 	// "InvalidCertificateRef" reason.
 	//
-	// This field is required when mode is set to "Terminate" (default) and
-	// optional otherwise.
+	// This field is required to have at least one element when the mode is set
+	// to "Terminate" (default) and is optional otherwise.
 	//
-	// CertificateRef can reference a standard Kubernetes resource, i.e. Secret,
-	// or an implementation-specific custom resource.
+	// CertificateRefs can reference to standard Kubernetes resources, i.e.
+	// Secret, or implementation-specific custom resources.
 	//
-	// Support: Core (Kubernetes Secrets)
+	// Support: Core - A single reference to a Kubernetes Secret
 	//
-	// Support: Implementation-specific (Other resource types)
+	// Support: Implementation-specific (More than one reference or other resource types)
 	//
 	// +optional
-	CertificateRef *SecretObjectReference `json:"certificateRef,omitempty"`
+	// +kubebuilder:validation:MaxItems=64
+	CertificateRefs []*SecretObjectReference `json:"certificateRefs,omitempty"`
 
 	// Options are a list of key/value pairs to give extended options
 	// to the provider.
@@ -770,7 +775,7 @@ const (
 	ListenerReasonResolvedRefs ListenerConditionReason = "ResolvedRefs"
 
 	// This reason is used with the "ResolvedRefs" condition when the
-	// Listener has a TLS configuration with a TLS CertificateRef
+	// Listener has a TLS configuration with at least one TLS CertificateRef
 	// that is invalid or cannot be resolved.
 	ListenerReasonInvalidCertificateRef ListenerConditionReason = "InvalidCertificateRef"
 

--- a/apis/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/v1alpha2/zz_generated.deepcopy.go
@@ -389,10 +389,16 @@ func (in *GatewayTLSConfig) DeepCopyInto(out *GatewayTLSConfig) {
 		*out = new(TLSModeType)
 		**out = **in
 	}
-	if in.CertificateRef != nil {
-		in, out := &in.CertificateRef, &out.CertificateRef
-		*out = new(SecretObjectReference)
-		(*in).DeepCopyInto(*out)
+	if in.CertificateRefs != nil {
+		in, out := &in.CertificateRefs, &out.CertificateRefs
+		*out = make([]*SecretObjectReference, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(SecretObjectReference)
+				(*in).DeepCopyInto(*out)
+			}
+		}
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
@@ -314,72 +314,82 @@ spec:
                         MUST use the longest matching SNI out of all available certificates
                         for any TLS handshake. \n Support: Core"
                       properties:
-                        certificateRef:
-                          description: "CertificateRef is a reference to a Kubernetes
-                            object that contains a TLS certificate and private key.
-                            This certificate is used to establish a TLS handshake
-                            for requests that match the hostname of the associated
-                            listener. \n References to a resource in different namespace
-                            are invalid UNLESS there is a ReferencePolicy in the target
+                        certificateRefs:
+                          description: "CertificateRefs contains a series of references
+                            to Kubernetes objects that contains TLS certificates and
+                            private keys. These certificates are used to establish
+                            a TLS handshake for requests that match the hostname of
+                            the associated listener. \n A single CertificateRef to
+                            a Kubernetes Secret has \"Core\" support. Implementations
+                            MAY choose to support attaching multiple certificates
+                            to a Listener, but this behavior is implementation-specific.
+                            \n References to a resource in different namespace are
+                            invalid UNLESS there is a ReferencePolicy in the target
                             namespace that allows the certificate to be attached.
                             If a ReferencePolicy does not allow this reference, the
                             \"ResolvedRefs\" condition MUST be set to False for this
                             listener with the \"InvalidCertificateRef\" reason. \n
-                            This field is required when mode is set to \"Terminate\"
-                            (default) and optional otherwise. \n CertificateRef can
-                            reference a standard Kubernetes resource, i.e. Secret,
-                            or an implementation-specific custom resource. \n Support:
-                            Core (Kubernetes Secrets) \n Support: Implementation-specific
-                            (Other resource types)"
-                          properties:
-                            group:
-                              default: ""
-                              description: Group is the group of the referent. For
-                                example, "networking.k8s.io". When unspecified (empty
-                                string), core API group is inferred.
-                              maxLength: 253
-                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                              type: string
-                            kind:
-                              default: Secret
-                              description: Kind is kind of the referent. For example
-                                "HTTPRoute" or "Service".
-                              maxLength: 63
-                              minLength: 1
-                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                              type: string
-                            name:
-                              description: Name is the name of the referent.
-                              maxLength: 253
-                              minLength: 1
-                              type: string
-                            namespace:
-                              description: "Namespace is the namespace of the backend.
-                                When unspecified, the local namespace is inferred.
-                                \n Note that when a namespace is specified, a ReferencePolicy
-                                object is required in the referent namespace to allow
-                                that namespace's owner to accept the reference. See
-                                the ReferencePolicy documentation for details. \n
-                                Support: Core"
-                              maxLength: 63
-                              minLength: 1
-                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                              type: string
-                          required:
-                          - name
-                          type: object
+                            This field is required to have at least one element when
+                            the mode is set to \"Terminate\" (default) and is optional
+                            otherwise. \n CertificateRefs can reference to standard
+                            Kubernetes resources, i.e. Secret, or implementation-specific
+                            custom resources. \n Support: Core - A single reference
+                            to a Kubernetes Secret \n Support: Implementation-specific
+                            (More than one reference or other resource types)"
+                          items:
+                            description: SecretObjectReference identifies an API object
+                              including its namespace, defaulting to Secret.
+                            properties:
+                              group:
+                                default: ""
+                                description: Group is the group of the referent. For
+                                  example, "networking.k8s.io". When unspecified (empty
+                                  string), core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Secret
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: "Namespace is the namespace of the backend.
+                                  When unspecified, the local namespace is inferred.
+                                  \n Note that when a namespace is specified, a ReferencePolicy
+                                  object is required in the referent namespace to
+                                  allow that namespace's owner to accept the reference.
+                                  See the ReferencePolicy documentation for details.
+                                  \n Support: Core"
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          maxItems: 64
+                          type: array
                         mode:
                           default: Terminate
                           description: "Mode defines the TLS behavior for the TLS
                             session initiated by the client. There are two possible
                             modes: \n - Terminate: The TLS session between the downstream
                             client   and the Gateway is terminated at the Gateway.
-                            This mode requires   certificateRef to be set. - Passthrough:
-                            The TLS session is NOT terminated by the Gateway. This
-                            \  implies that the Gateway can't decipher the TLS stream
-                            except for   the ClientHello message of the TLS protocol.
-                            \  CertificateRef field is ignored in this mode. \n Support:
-                            Core"
+                            This mode requires   certificateRefs to be set and contain
+                            at least one element. - Passthrough: The TLS session is
+                            NOT terminated by the Gateway. This   implies that the
+                            Gateway can't decipher the TLS stream except for   the
+                            ClientHello message of the TLS protocol.   CertificateRefs
+                            field is ignored in this mode. \n Support: Core"
                           enum:
                           - Terminate
                           - Passthrough

--- a/examples/v1alpha2/cross-namespace-routing/gateway.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/gateway.yaml
@@ -17,5 +17,5 @@ spec:
           matchLabels:
             shared-gateway-access: "true"
     tls:
-      certificateRef:
-        name: foo-example-com
+      certificateRefs:
+      - name: foo-example-com

--- a/examples/v1alpha2/tls-basic.yaml
+++ b/examples/v1alpha2/tls-basic.yaml
@@ -10,8 +10,8 @@ spec:
     port: 443
     hostname: foo.example.com
     tls:
-      certificateRef:
-        kind: Secret
+      certificateRefs:
+      - kind: Secret
         group: ""
         name: foo-example-com-cert
   - name: bar-https
@@ -19,7 +19,7 @@ spec:
     port: 443
     hostname: bar.example.com
     tls:
-      certificateRef:
-        kind: Secret
+      certificateRefs:
+      - kind: Secret
         group: ""
         name: bar-example-com-cert

--- a/examples/v1alpha2/tls-cert-cross-namespace.yaml
+++ b/examples/v1alpha2/tls-cert-cross-namespace.yaml
@@ -11,8 +11,8 @@ spec:
     port: 443
     hostname: "*.example.com"
     tls:
-      certificateRef:
-        kind: Secret
+      certificateRefs:
+      - kind: Secret
         group: ""
         name: wildcard-example-com-cert
         namespace: gateway-api-example-ns1

--- a/examples/v1alpha2/wildcard-tls-gateway.yaml
+++ b/examples/v1alpha2/wildcard-tls-gateway.yaml
@@ -10,8 +10,8 @@ spec:
     port: 443
     hostname: foo.example.com
     tls:
-      certificateRef:
-        kind: Secret
+      certificateRefs:
+      - kind: Secret
         group: ""
         name: foo-example-com-cert
   - name: wildcard-https
@@ -19,7 +19,7 @@ spec:
     port: 443
     hostname: "*.example.com"
     tls:
-      certificateRef:
-        kind: Secret
+      certificateRefs:
+      - kind: Secret
         group: ""
         name: wildcard-example-com-cert


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

**What this PR does / why we need it**:

This PR uses `CertificateRefs` to instead `CertificateRef` so that multiple certificates can be configured for a Listener. With this feature, we can support things like following items:

* When hostname is empty on the Listener, and Routes attach multiple unique Hostnames
* Providing RSA and EC certs
* Temporarily including new and old certs during an upgrade

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #851 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Use `CertificateRefs` field to instead the `CertificateRef` in `GatewayTLSConfig`.
```
