### PR TITLE
docs: Use v0.4.0-rc1 in "Getting started with Gateway APIs" for v1alpha2

### DIFF
--- a/site-src/v1alpha2/guides/getting-started.md
+++ b/site-src/v1alpha2/guides/getting-started.md
@@ -36,7 +36,7 @@ these resources. Installing the CRDs will just allow you to see and apply the
 resources, though they won't do anything.
 
 ```
-kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.3.0" \
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0-rc1" \
 | kubectl apply -f -
 ```
 
@@ -50,7 +50,7 @@ these resources.
 
 
 ```
-kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.3.0" \
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0-rc1" \
 | kubectl delete -f -
 ```
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind documentation

**What this PR does / why we need it**:

As v0.3.0 CRD does not support v1alpha2, v1alpha2 docs should use
v0.4.0-rc1 CRD.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
