### PR TITLE
Adding GEP 851: Allow Multiple Certificate Refs per Gateway Listener

### DIFF
--- a/site-src/geps/gep-851.md
+++ b/site-src/geps/gep-851.md
@@ -1,0 +1,102 @@
+# GEP-851: Allow Multiple Certificate Refs per Gateway Listener
+
+* Issue: [#851](https://github.com/kubernetes-sigs/gateway-api/issues/851)
+* Status: Implementable
+
+## TLDR
+
+Replace `CertificateRef` field with a `CertificateRefs` field in Gateway
+Listeners.
+
+## Goals
+
+* Allow certs to be attached for multiple unique Hostnames for the same
+  Listener. This is most helpful in the following situations:
+  * The hostname on the Listener is empty or unspecified allowing Routes to
+    attach arbitrary hostnames to the Listener with Routes.
+  * The hostname on the Listener is a wildcard and Route owners want to attach
+    multi-level subdomains. For example, `*.example.com` on the Listener and
+    `app.dev.example.com` on a Route.
+* Enable specifying RSA and ECDSA certs on the same Listener.
+* Improve cert upgrades by allowing new and old certs to be attached to the same
+  Listener.
+
+## Non-Goals
+
+* Be too prescriptive about how multiple certificates are handled for a Gateway
+  Listener. Each implementation may handle this slightly differently.
+
+## Introduction
+
+When we removed certificate references from HTTPRoute ([GEP
+746](/geps/gep-746/)) we lost the capability to attach multiple certificates to
+a Listener. This GEP proposes adding that capability back, directly to the
+Gateway Listener this time.
+
+In addition to helping with the self service approach, where app owners may
+attach multiple hostnames (and certs) to a single Listener, this can help with
+other use cases:
+
+* Attaching RSA and ECDSA certs.
+* Attaching both new and old certs during an upgrade.
+
+## API
+
+The `CertificateRef` field in `GatewayTLSConfig` would be replaced with the
+following `CertificateRefs` field:
+
+```go
+    // CertificateRefs contains a series of references to Kubernetes objects that
+    // contains TLS certificates and private keys. These certificates are used to
+    // establish a TLS handshake for requests that match the hostname of the
+    // associated listener.
+    //
+    // When multiple TLS certificates are specified, SNI matching MUST be used
+    // to determine the appropriate certificate to use.
+    //
+    // Implementations SHOULD verify that there is an intersection between the
+    // hostname(s) attached to this Listener and the CN and SAN of each attached
+    // certificate. If there is no intersection, implementations SHOULD NOT
+    // attach the certificate and SHOULD set the ResolvedRefs condition to False
+    // with the "InvalidCertificateRef" reason. Implementations MAY choose to
+    // skip this validation to support certain use cases like self-signed
+    // certificates with missing or invalid CN or SANs. If implementations do
+    // not implement this validation, they MUST clearly document that.
+    //
+    // References to a resource in different namespace are invalid UNLESS there
+    // is a ReferencePolicy in the target namespace that allows the certificate
+    // to be attached. If a ReferencePolicy does not allow this reference, the
+    // "ResolvedRefs" condition MUST be set to False for this listener with the
+    // "InvalidCertificateRef" reason.
+    //
+    // This field is required to have at least one element when the mode is set
+    // to "Terminate" (default) and is optional otherwise.
+    //
+    // CertificateRefs can reference to standard Kubernetes resources, i.e.
+    // Secret, or implementation-specific custom resources.
+    //
+    // Support: Core (Kubernetes Secrets)
+    //
+    // Support: Implementation-specific (Other resource types)
+    //
+    // +optional
+	// +kubebuilder:validation:MaxItems=64
+    CertificateRefs []*SecretObjectReference `json:"certificateRefs,omitempty"`
+```
+
+## Self Service Model
+
+This change helps enable a self service model for TLS certificates. As an
+example, a Gateway may have a listener that does not specify a hostname. Two
+HTTP Routes may be attached, both with different hostnames. This change enables
+attaching different certificates for each of those hostnames to a Gateway
+Listener.
+
+Taking this a step further, it would be possible to build a controller that
+attached these certificates to the Gateway listener. This would enable a self
+service model where application owners do not need direct access to a Gateway to
+attach a certificate.
+
+## Alternatives
+
+N/A

--- a/site-src/geps/gep-851.md
+++ b/site-src/geps/gep-851.md
@@ -10,35 +10,33 @@ Listeners.
 
 ## Goals
 
-* Allow certs to be attached for multiple unique Hostnames for the same
-  Listener. This is most helpful in the following situations:
-  * The hostname on the Listener is empty or unspecified allowing Routes to
-    attach arbitrary hostnames to the Listener with Routes.
-  * The hostname on the Listener is a wildcard and Route owners want to attach
-    multi-level subdomains. For example, `*.example.com` on the Listener and
-    `app.dev.example.com` on a Route.
-* Enable specifying RSA and ECDSA certs on the same Listener.
-* Improve cert upgrades by allowing new and old certs to be attached to the same
-  Listener.
+Provide a path for implementations to support:
+
+* RSA and ECDSA certs on the same Listener.
+* Referencing certificates for different hostnames from the same Listener (maybe
+  as part of a self-service TLS approach).
+* Including new and old certificates as part of renewal process.
+* Certificate pinning: enable implementations that require certain certificates
+  for legacy clients while exposing a "normal" certificate to non-legacy
+  clients.
 
 ## Non-Goals
 
-* Be too prescriptive about how multiple certificates are handled for a Gateway
-  Listener. Each implementation may handle this slightly differently.
+* Define how implementations should support these features. Many implementations
+  have limited control as far as how certs are handled. Some implementations
+  just pass certs directly to the dataplane and rely on that implementation
+  specific behavior to determine which certs are used for a given request. That
+  makes it difficult to define any truly portable handling of multiple
+  certificates.
 
 ## Introduction
 
-When we removed certificate references from HTTPRoute ([GEP
-746](/geps/gep-746/)) we lost the capability to attach multiple certificates to
-a Listener. This GEP proposes adding that capability back, directly to the
-Gateway Listener this time.
-
-In addition to helping with the self service approach, where app owners may
-attach multiple hostnames (and certs) to a single Listener, this can help with
-other use cases:
-
-* Attaching RSA and ECDSA certs.
-* Attaching both new and old certs during an upgrade.
+As described above, there are a number of potential use cases for attaching
+multiple certificates to a Gateway Listener. The most straightforward reason for
+that involves attaching RSA and ECDSA certs. Although this is not a very common
+use case, it is a clearly understood and broadly supported example of why this
+change would be helpful. This change will enable implementations to support
+these more advanced use cases while still providing a portable core.
 
 ## API
 
@@ -51,17 +49,9 @@ following `CertificateRefs` field:
     // establish a TLS handshake for requests that match the hostname of the
     // associated listener.
     //
-    // When multiple TLS certificates are specified, SNI matching MUST be used
-    // to determine the appropriate certificate to use.
-    //
-    // Implementations SHOULD verify that there is an intersection between the
-    // hostname(s) attached to this Listener and the CN and SAN of each attached
-    // certificate. If there is no intersection, implementations SHOULD NOT
-    // attach the certificate and SHOULD set the ResolvedRefs condition to False
-    // with the "InvalidCertificateRef" reason. Implementations MAY choose to
-    // skip this validation to support certain use cases like self-signed
-    // certificates with missing or invalid CN or SANs. If implementations do
-    // not implement this validation, they MUST clearly document that.
+    // A single CertificateRef to a Kubernetes Secret has "Core" support.
+    // Implementations MAY choose to support attaching multiple certificates to
+    // a Listener, but this behavior is implementation-specific.
     //
     // References to a resource in different namespace are invalid UNLESS there
     // is a ReferencePolicy in the target namespace that allows the certificate
@@ -75,27 +65,14 @@ following `CertificateRefs` field:
     // CertificateRefs can reference to standard Kubernetes resources, i.e.
     // Secret, or implementation-specific custom resources.
     //
-    // Support: Core (Kubernetes Secrets)
+    // Support: Core - A single reference to a Kubernetes Secret
     //
-    // Support: Implementation-specific (Other resource types)
+    // Support: Implementation-specific (More than one reference or other resource types)
     //
     // +optional
-	// +kubebuilder:validation:MaxItems=64
+    // +kubebuilder:validation:MaxItems=64
     CertificateRefs []*SecretObjectReference `json:"certificateRefs,omitempty"`
 ```
-
-## Self Service Model
-
-This change helps enable a self service model for TLS certificates. As an
-example, a Gateway may have a listener that does not specify a hostname. Two
-HTTP Routes may be attached, both with different hostnames. This change enables
-attaching different certificates for each of those hostnames to a Gateway
-Listener.
-
-Taking this a step further, it would be possible to build a controller that
-attached these certificates to the Gateway listener. This would enable a self
-service model where application owners do not need direct access to a Gateway to
-attach a certificate.
 
 ## Alternatives
 


### PR DESCRIPTION
**What type of PR is this?**
/kind gep

**What this PR does / why we need it**:
This adds GEP #851: Allow Multiple Certificate Refs per Gateway Listener.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
