### PR TITLE
Fixing broken link to spec page

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Participation in the Kubernetes community is governed by the
 [cm]: https://gateway-api.sigs.k8s.io/contributing/community
 [slack]: https://kubernetes.slack.com/messages/sig-network-gateway-api
 [getting-started]: https://gateway-api.sigs.k8s.io/guides/getting-started
-[spec]: https://gateway-api.sigs.k8s.io/references/spec
+[spec]: https://gateway-api.sigs.k8s.io/v1alpha2/references/spec
 [concepts]: https://gateway-api.sigs.k8s.io/concepts/api-overview
 [security-model]: https://gateway-api.sigs.k8s.io/concepts/security-model
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Fixes broken link to spec page (404) and now sends to https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/

**Which issue(s) this PR fixes**:
none

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
