### PR TITLE
Clarifying how HTTP and TLS Route status should be populated

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -83,9 +83,10 @@ type HTTPRouteSpec struct {
 	// HTTPRoute specified `test.example.com` and `test.example.net`,
 	// `test.example.net` must not be considered for a match.
 	//
-	// If hostnames do not match with the criteria above, then the HTTPRoute is
-	// not accepted, and the implementation must raise an 'Accepted' Condition
-	// with a status of `False` for the target Listener(s).
+	// If both the Listener and HTTPRoute have specified hostnames, and none
+	// match with the criteria above, then the HTTPRoute is not accepted. The
+	// implementation must raise an 'Accepted' Condition with a status of
+	// `False` in the corresponding RouteParentStatus.
 	//
 	// Support: Core
 	//

--- a/apis/v1alpha2/tlsroute_types.go
+++ b/apis/v1alpha2/tlsroute_types.go
@@ -75,9 +75,10 @@ type TLSRouteSpec struct {
 	// TLSRoute specified `test.example.com` and `test.example.net`,
 	// `test.example.net` must not be considered for a match.
 	//
-	// If all hostnames do not match with the criteria above, then the TLSRoute
-	// is not accepted, and the implementation must raise an 'Accepted'
-	// Condition with a status of `False` for the target Listener(s).
+	// If both the Listener and TLSRoute have specified hostnames, and none
+	// match with the criteria above, then the TLSRoute is not accepted. The
+	// implementation must raise an 'Accepted' Condition with a status of
+	// `False` in the corresponding RouteParentStatus.
 	//
 	// Support: Core
 	//

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
@@ -69,11 +69,11 @@ spec:
                   hostnames, any HTTPRoute hostnames that do not match the Listener
                   hostname MUST be ignored. For example, if a Listener specified `*.example.com`,
                   and the HTTPRoute specified `test.example.com` and `test.example.net`,
-                  `test.example.net` must not be considered for a match. \n If hostnames
-                  do not match with the criteria above, then the HTTPRoute is not
-                  accepted, and the implementation must raise an 'Accepted' Condition
-                  with a status of `False` for the target Listener(s). \n Support:
-                  Core"
+                  `test.example.net` must not be considered for a match. \n If both
+                  the Listener and HTTPRoute have specified hostnames, and none match
+                  with the criteria above, then the HTTPRoute is not accepted. The
+                  implementation must raise an 'Accepted' Condition with a status
+                  of `False` in the corresponding RouteParentStatus. \n Support: Core"
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_tlsroutes.yaml
@@ -67,11 +67,11 @@ spec:
                   hostnames, any TLSRoute hostnames that do not match the Listener
                   hostname MUST be ignored. For example, if a Listener specified `*.example.com`,
                   and the TLSRoute specified `test.example.com` and `test.example.net`,
-                  `test.example.net` must not be considered for a match. \n If all
-                  hostnames do not match with the criteria above, then the TLSRoute
-                  is not accepted, and the implementation must raise an 'Accepted'
-                  Condition with a status of `False` for the target Listener(s). \n
-                  Support: Core"
+                  `test.example.net` must not be considered for a match. \n If both
+                  the Listener and TLSRoute have specified hostnames, and none match
+                  with the criteria above, then the TLSRoute is not accepted. The
+                  implementation must raise an 'Accepted' Condition with a status
+                  of `False` in the corresponding RouteParentStatus. \n Support: Core"
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This fixes the confusing guidance (originally added by me) in HTTP and TLS Routes that suggested that conditions should be populated on Gateway Listeners. I had originally built out conditions that could be populated on Gateway and Listeners, but I'm not sure that's the right approach. I think the simplest and most straightforward answer here is to populate Route status. If Route owners can't attach to a Gateway they want to, they can simply contact the Gateway owner.

**Which issue(s) this PR fixes**:
Fixes #849

**Does this PR introduce a user-facing change?**:
```release-note
Updated guidance on how HTTP and TLS Route status should be populated when hostnames do not match.
```

/cc @youngnick @howardjohn 