### PR TITLE
Align path prefix matching with Ingress.

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -214,18 +214,33 @@ type HTTPRouteRule struct {
 //
 // Prefix and Exact paths must be syntactically valid:
 //
-// - Must begin with the '/' character
-// - Must not contain consecutive '/' characters (e.g. /foo///, //).
-// - For prefix paths, a trailing '/' character in the Path is ignored,
-// e.g. /abc and /abc/ specify the same match.
+// - Must begin with the `/` character
+// - Must not contain consecutive `/` characters (e.g. `/foo///`, `//`).
 //
 // +kubebuilder:validation:Enum=Exact;Prefix;RegularExpression
 type PathMatchType string
 
-// PathMatchType constants.
 const (
-	PathMatchExact             PathMatchType = "Exact"
-	PathMatchPrefix            PathMatchType = "Prefix"
+	// Matches based on a URL path prefix split by `/`. Matching is
+	// case sensitive and done on a path element by element basis. A
+	// path element refers to the list of labels in the path split by
+	// the `/` separator. A request is a match for path _p_ if every
+	// _p_ is an element-wise prefix of the request path.
+	//
+	// For example, `/abc`, `/abc/` and `/abc/def` match the prefix
+	// `/abc`, but `/abcd` does not.
+	PathMatchExact PathMatchType = "Exact"
+
+	// Matches the URL path exactly and with case sensitivity.
+	PathMatchPrefix PathMatchType = "Prefix"
+
+	// Matches if the URL path matches the given regular expression with
+	// case sensitivity.
+	//
+	// Since `"RegularExpression"` has custom conformance, implementations
+	// can support POSIX, PCRE, RE2 or any other regular expression dialect.
+	// Please read the implementation's documentation to determine the supported
+	// dialect.
 	PathMatchRegularExpression PathMatchType = "RegularExpression"
 )
 
@@ -236,11 +251,6 @@ type HTTPPathMatch struct {
 	// Support: Core (Exact, Prefix)
 	//
 	// Support: Custom (RegularExpression)
-	//
-	// Since RegularExpression PathType has custom conformance, implementations
-	// can support POSIX, PCRE or any other dialects of regular expressions.
-	// Please read the implementation's documentation to determine the supported
-	// dialect.
 	//
 	// +optional
 	// +kubebuilder:default=Prefix

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
@@ -1020,12 +1020,7 @@ spec:
                                 default: Prefix
                                 description: "Type specifies how to match against
                                   the path Value. \n Support: Core (Exact, Prefix)
-                                  \n Support: Custom (RegularExpression) \n Since
-                                  RegularExpression PathType has custom conformance,
-                                  implementations can support POSIX, PCRE or any other
-                                  dialects of regular expressions. Please read the
-                                  implementation's documentation to determine the
-                                  supported dialect."
+                                  \n Support: Custom (RegularExpression)"
                                 enum:
                                 - Exact
                                 - Prefix


### PR DESCRIPTION
Explicitly align path prefix matching with the Ingress API by specifying
it as an prefix of path elements, not a prefix of bytes.

**What type of PR is this?**
/kind bug
/kind api-change

**Which issue(s) this PR fixes**:
This fixes #866.

**Does this PR introduce a user-facing change?**:
```release-note
Aligned path prefix matching with Ingress by clarifying that it is a prefix of path elements.
```
