### PR TITLE
Add validation for Kubernetes object name fields and ProtocolType

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -245,9 +245,19 @@ type Listener struct {
 // protocols. Any protocol defined by implementations will fall under custom
 // conformance.
 //
-// +kubebuilder:validation:MinLength:=1
-// +kubebuilder:validation:MinLength:=255
-// +kubebuilder:validation:Pattern:=`^[a-zA-Z0-9]([A-Z-a-z0-9\/]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Z-a-z0-9\/]*[A-Za-z0-9])?)*$`
+// Valid values include:
+//
+// * "HTTP" - Core support
+// * "example.com/bar" - Implementation-specific support
+//
+// Invalid values include:
+//
+// * "example.com" - must include path if domain is used
+// * "foo.example.com" - must include path if domain is used
+//
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=255
+// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9]([-a-zSA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$`
 type ProtocolType string
 
 const (

--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -63,10 +63,7 @@ type GatewayList struct {
 type GatewaySpec struct {
 	// GatewayClassName used for this Gateway. This is the name of a
 	// GatewayClass resource.
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	GatewayClassName string `json:"gatewayClassName"`
+	GatewayClassName ObjectName `json:"gatewayClassName"`
 
 	// Listeners associated with this Gateway. Listeners define
 	// logical endpoints that are bound on this Gateway's addresses.
@@ -247,6 +244,10 @@ type Listener struct {
 // `mycompany.com/my-custom-protocol`. Un-prefixed names are reserved for core
 // protocols. Any protocol defined by implementations will fall under custom
 // conformance.
+//
+// +kubebuilder:validation:MinLength:=1
+// +kubebuilder:validation:MinLength:=255
+// +kubebuilder:validation:Pattern:=`^[a-zA-Z0-9]([A-Z-a-z0-9\/]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Z-a-z0-9\/]*[A-Za-z0-9])?)*$`
 type ProtocolType string
 
 const (

--- a/apis/v1alpha2/object_reference_types.go
+++ b/apis/v1alpha2/object_reference_types.go
@@ -18,6 +18,12 @@ package v1alpha2
 
 // LocalObjectReference identifies an API object within the namespace of the
 // referrer.
+// The API object must be valid in the cluster; the Group and Kind must
+// be registered in the cluster for this reference to be valid.
+//
+// References to objects with invalid Group and Kind are not valid, and must
+// be rejected by the implementation, with appropriate Conditions set
+// on the containing object.
 type LocalObjectReference struct {
 	// Group is the group of the referent. For example, "networking.k8s.io".
 	// When unspecified (empty string), core API group is inferred.
@@ -30,7 +36,15 @@ type LocalObjectReference struct {
 	Name ObjectName `json:"name"`
 }
 
-// SecretObjectReference identifies an API object including its namespace, defaulting to Secret.
+// SecretObjectReference identifies an API object including its namespace,
+// defaulting to Secret.
+//
+// The API object must be valid in the cluster; the Group and Kind must
+// be registered in the cluster for this reference to be valid.
+//
+// References to objects with invalid Group and Kind are not valid, and must
+// be rejected by the implementation, with appropriate Conditions set
+// on the containing object.
 type SecretObjectReference struct {
 	// Group is the group of the referent. For example, "networking.k8s.io".
 	// When unspecified (empty string), core API group is inferred.
@@ -70,6 +84,13 @@ type SecretObjectReference struct {
 // is required in the referent namespace to allow that namespace's
 // owner to accept the reference. See the ReferencePolicy documentation
 // for details.
+//
+// The API object must be valid in the cluster; the Group and Kind must
+// be registered in the cluster for this reference to be valid.
+//
+// References to objects with invalid Group and Kind are not valid, and must
+// be rejected by the implementation, with appropriate Conditions set
+// on the containing object.
 type BackendObjectReference struct {
 	// Group is the group of the referent. For example, "networking.k8s.io".
 	// When unspecified (empty string), core API group is inferred.

--- a/apis/v1alpha2/object_reference_types.go
+++ b/apis/v1alpha2/object_reference_types.go
@@ -27,10 +27,7 @@ type LocalObjectReference struct {
 	Kind Kind `json:"kind"`
 
 	// Name is the name of the referent.
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Name string `json:"name"`
+	Name ObjectName `json:"name"`
 }
 
 // SecretObjectReference identifies an API object including its namespace, defaulting to Secret.
@@ -49,10 +46,7 @@ type SecretObjectReference struct {
 	Kind *Kind `json:"kind"`
 
 	// Name is the name of the referent.
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Name string `json:"name"`
+	Name ObjectName `json:"name"`
 
 	// Namespace is the namespace of the backend. When unspecified, the local
 	// namespace is inferred.
@@ -91,10 +85,7 @@ type BackendObjectReference struct {
 	Kind *Kind `json:"kind,omitempty"`
 
 	// Name is the name of the referent.
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Name string `json:"name"`
+	Name ObjectName `json:"name"`
 
 	// Namespace is the namespace of the backend. When unspecified, the local
 	// namespace is inferred.

--- a/apis/v1alpha2/policy_types.go
+++ b/apis/v1alpha2/policy_types.go
@@ -29,10 +29,7 @@ type PolicyTargetReference struct {
 	Kind Kind `json:"kind"`
 
 	// Name is the name of the target resource.
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Name string `json:"name"`
+	Name ObjectName `json:"name"`
 
 	// Namespace is the namespace of the referent. When unspecified, the local
 	// namespace is inferred. Even when policy targets a resource in a different

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -53,10 +53,7 @@ type ParentRef struct {
 	// Name is the name of the referent.
 	//
 	// Support: Core
-	//
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	Name string `json:"name"`
+	Name ObjectName `json:"name"`
 
 	// SectionName is the name of a section within the target resource. In the
 	// following resources, SectionName is interpreted as the following:
@@ -283,6 +280,17 @@ type Group string
 // +kubebuilder:validation:MaxLength=63
 // +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
 type Kind string
+
+// ObjectName refers to a Kubernetes object name.
+// Object names can have a variety of forms, including RFC1123 subdomains,
+// RFC 1123 labels, or RFC 1035 labels.
+// Therefore the validation for this type is set to the least restritive out of
+// those options, the RFC1123 subdomain.
+//
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern=`^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+type ObjectName string
 
 // Namespace refers to a Kubernetes namespace. It must be a RFC 1123 label.
 //

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -24,6 +24,13 @@ import (
 // a parent of this resource (usually a route). The only kind of parent resource
 // with "Core" support is Gateway. This API may be extended in the future to
 // support additional kinds of parent resources, such as HTTPRoute.
+//
+// The API object must be valid in the cluster; the Group and Kind must
+// be registered in the cluster for this reference to be valid.
+//
+// References to objects with invalid Group and Kind are not valid, and must
+// be rejected by the implementation, with appropriate Conditions set
+// on the containing object.
 type ParentRef struct {
 	// Group is the group of the referent.
 	//
@@ -281,15 +288,12 @@ type Group string
 // +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
 type Kind string
 
-// ObjectName refers to a Kubernetes object name.
+// ObjectName refers to the name of a Kubernetes object.
 // Object names can have a variety of forms, including RFC1123 subdomains,
 // RFC 1123 labels, or RFC 1035 labels.
-// Therefore the validation for this type is set to the least restritive out of
-// those options, the RFC1123 subdomain.
 //
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 type ObjectName string
 
 // Namespace refers to a Kubernetes namespace. It must be a RFC 1123 label.

--- a/apis/v1alpha2/validation/httproute_test.go
+++ b/apis/v1alpha2/validation/httproute_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 func TestValidateHTTPRoute(t *testing.T) {
-	testService := "test-service"
-	specialService := "special-service"
+	testService := gatewayv1a2.ObjectName("test-service")
+	specialService := gatewayv1a2.ObjectName("special-service")
 	tests := []struct {
 		name     string
 		rules    []gatewayv1a2.HTTPRouteRule

--- a/apis/v1alpha2/validation/httproute_test.go
+++ b/apis/v1alpha2/validation/httproute_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilpointer "k8s.io/utils/pointer"
 
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	pkgutils "sigs.k8s.io/gateway-api/pkg/util"
 )
@@ -299,8 +300,8 @@ func TestValidateHTTPRoute(t *testing.T) {
 }
 
 func TestValidateHTTPBackendUniqueFilters(t *testing.T) {
-	var testService = "testService"
-	var specialService = "specialService"
+	var testService v1alpha2.ObjectName = "testService"
+	var specialService v1alpha2.ObjectName = "specialService"
 	tests := []struct {
 		name     string
 		hRoute   gatewayv1a2.HTTPRoute

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
@@ -100,7 +100,6 @@ spec:
                   of a GatewayClass resource.
                 maxLength: 253
                 minLength: 1
-                pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
               listeners:
                 description: "Listeners associated with this Gateway. Listeners define
@@ -304,8 +303,9 @@ spec:
                     protocol:
                       description: "Protocol specifies the network protocol this listener
                         expects to receive. \n Support: Core"
-                      minLength: 255
-                      pattern: ^[a-zA-Z0-9]([A-Z-a-z0-9\/]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Z-a-z0-9\/]*[A-Za-z0-9])?)*$
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[a-zA-Z0-9]([-a-zSA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
                       type: string
                     tls:
                       description: "TLS is the TLS configuration for the Listener.
@@ -340,8 +340,14 @@ spec:
                             to a Kubernetes Secret \n Support: Implementation-specific
                             (More than one reference or other resource types)"
                           items:
-                            description: SecretObjectReference identifies an API object
-                              including its namespace, defaulting to Secret.
+                            description: "SecretObjectReference identifies an API
+                              object including its namespace, defaulting to Secret.
+                              \n The API object must be valid in the cluster; the
+                              Group and Kind must be registered in the cluster for
+                              this reference to be valid. \n References to objects
+                              with invalid Group and Kind are not valid, and must
+                              be rejected by the implementation, with appropriate
+                              Conditions set on the containing object."
                             properties:
                               group:
                                 default: ""
@@ -363,7 +369,6 @@ spec:
                                 description: Name is the name of the referent.
                                 maxLength: 253
                                 minLength: 1
-                                pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               namespace:
                                 description: "Namespace is the namespace of the backend.

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
@@ -100,6 +100,7 @@ spec:
                   of a GatewayClass resource.
                 maxLength: 253
                 minLength: 1
+                pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
               listeners:
                 description: "Listeners associated with this Gateway. Listeners define
@@ -303,6 +304,8 @@ spec:
                     protocol:
                       description: "Protocol specifies the network protocol this listener
                         expects to receive. \n Support: Core"
+                      minLength: 255
+                      pattern: ^[a-zA-Z0-9]([A-Z-a-z0-9\/]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Z-a-z0-9\/]*[A-Za-z0-9])?)*$
                       type: string
                     tls:
                       description: "TLS is the TLS configuration for the Listener.
@@ -360,6 +363,7 @@ spec:
                                 description: Name is the name of the referent.
                                 maxLength: 253
                                 minLength: 1
+                                pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               namespace:
                                 description: "Namespace is the namespace of the backend.

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
@@ -109,11 +109,16 @@ spec:
                   is the case, the list of routes attached to those resources should
                   also be merged."
                 items:
-                  description: ParentRef identifies an API object (usually a Gateway)
+                  description: "ParentRef identifies an API object (usually a Gateway)
                     that can be considered a parent of this resource (usually a route).
-                    The only kind of parent resource with "Core" support is Gateway.
+                    The only kind of parent resource with \"Core\" support is Gateway.
                     This API may be extended in the future to support additional kinds
-                    of parent resources, such as HTTPRoute.
+                    of parent resources, such as HTTPRoute. \n The API object must
+                    be valid in the cluster; the Group and Kind must be registered
+                    in the cluster for this reference to be valid. \n References to
+                    objects with invalid Group and Kind are not valid, and must be
+                    rejected by the implementation, with appropriate Conditions set
+                    on the containing object."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -135,7 +140,6 @@ spec:
                         Core"
                       maxLength: 253
                       minLength: 1
-                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     namespace:
                       description: "Namespace is the namespace of the referent. When
@@ -239,7 +243,6 @@ spec:
                                       description: Name is the name of the referent.
                                       maxLength: 253
                                       minLength: 1
-                                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                   required:
                                   - group
@@ -403,7 +406,6 @@ spec:
                                           description: Name is the name of the referent.
                                           maxLength: 253
                                           minLength: 1
-                                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         namespace:
                                           description: "Namespace is the namespace
@@ -534,7 +536,6 @@ spec:
                             description: Name is the name of the referent.
                             maxLength: 253
                             minLength: 1
-                            pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           namespace:
                             description: "Namespace is the namespace of the backend.
@@ -629,7 +630,6 @@ spec:
                                 description: Name is the name of the referent.
                                 maxLength: 253
                                 minLength: 1
-                                pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                             required:
                             - group
@@ -782,7 +782,6 @@ spec:
                                     description: Name is the name of the referent.
                                     maxLength: 253
                                     minLength: 1
-                                    pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                     type: string
                                   namespace:
                                     description: "Namespace is the namespace of the
@@ -1228,7 +1227,6 @@ spec:
                             Core"
                           maxLength: 253
                           minLength: 1
-                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         namespace:
                           description: "Namespace is the namespace of the referent.

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
@@ -135,6 +135,7 @@ spec:
                         Core"
                       maxLength: 253
                       minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     namespace:
                       description: "Namespace is the namespace of the referent. When
@@ -238,6 +239,7 @@ spec:
                                       description: Name is the name of the referent.
                                       maxLength: 253
                                       minLength: 1
+                                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                   required:
                                   - group
@@ -401,6 +403,7 @@ spec:
                                           description: Name is the name of the referent.
                                           maxLength: 253
                                           minLength: 1
+                                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         namespace:
                                           description: "Namespace is the namespace
@@ -531,6 +534,7 @@ spec:
                             description: Name is the name of the referent.
                             maxLength: 253
                             minLength: 1
+                            pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           namespace:
                             description: "Namespace is the namespace of the backend.
@@ -625,6 +629,7 @@ spec:
                                 description: Name is the name of the referent.
                                 maxLength: 253
                                 minLength: 1
+                                pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                             required:
                             - group
@@ -777,6 +782,7 @@ spec:
                                     description: Name is the name of the referent.
                                     maxLength: 253
                                     minLength: 1
+                                    pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                     type: string
                                   namespace:
                                     description: "Namespace is the namespace of the
@@ -1222,6 +1228,7 @@ spec:
                             Core"
                           maxLength: 253
                           minLength: 1
+                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         namespace:
                           description: "Namespace is the namespace of the referent.

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_tcproutes.yaml
@@ -61,11 +61,16 @@ spec:
                   is the case, the list of routes attached to those resources should
                   also be merged."
                 items:
-                  description: ParentRef identifies an API object (usually a Gateway)
+                  description: "ParentRef identifies an API object (usually a Gateway)
                     that can be considered a parent of this resource (usually a route).
-                    The only kind of parent resource with "Core" support is Gateway.
+                    The only kind of parent resource with \"Core\" support is Gateway.
                     This API may be extended in the future to support additional kinds
-                    of parent resources, such as HTTPRoute.
+                    of parent resources, such as HTTPRoute. \n The API object must
+                    be valid in the cluster; the Group and Kind must be registered
+                    in the cluster for this reference to be valid. \n References to
+                    objects with invalid Group and Kind are not valid, and must be
+                    rejected by the implementation, with appropriate Conditions set
+                    on the containing object."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -87,7 +92,6 @@ spec:
                         Core"
                       maxLength: 253
                       minLength: 1
-                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     namespace:
                       description: "Namespace is the namespace of the referent. When
@@ -166,7 +170,6 @@ spec:
                             description: Name is the name of the referent.
                             maxLength: 253
                             minLength: 1
-                            pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           namespace:
                             description: "Namespace is the namespace of the backend.
@@ -371,7 +374,6 @@ spec:
                             Core"
                           maxLength: 253
                           minLength: 1
-                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         namespace:
                           description: "Namespace is the namespace of the referent.

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_tcproutes.yaml
@@ -87,6 +87,7 @@ spec:
                         Core"
                       maxLength: 253
                       minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     namespace:
                       description: "Namespace is the namespace of the referent. When
@@ -165,6 +166,7 @@ spec:
                             description: Name is the name of the referent.
                             maxLength: 253
                             minLength: 1
+                            pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           namespace:
                             description: "Namespace is the namespace of the backend.
@@ -369,6 +371,7 @@ spec:
                             Core"
                           maxLength: 253
                           minLength: 1
+                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         namespace:
                           description: "Namespace is the namespace of the referent.

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_tlsroutes.yaml
@@ -107,11 +107,16 @@ spec:
                   is the case, the list of routes attached to those resources should
                   also be merged."
                 items:
-                  description: ParentRef identifies an API object (usually a Gateway)
+                  description: "ParentRef identifies an API object (usually a Gateway)
                     that can be considered a parent of this resource (usually a route).
-                    The only kind of parent resource with "Core" support is Gateway.
+                    The only kind of parent resource with \"Core\" support is Gateway.
                     This API may be extended in the future to support additional kinds
-                    of parent resources, such as HTTPRoute.
+                    of parent resources, such as HTTPRoute. \n The API object must
+                    be valid in the cluster; the Group and Kind must be registered
+                    in the cluster for this reference to be valid. \n References to
+                    objects with invalid Group and Kind are not valid, and must be
+                    rejected by the implementation, with appropriate Conditions set
+                    on the containing object."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -133,7 +138,6 @@ spec:
                         Core"
                       maxLength: 253
                       minLength: 1
-                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     namespace:
                       description: "Namespace is the namespace of the referent. When
@@ -215,7 +219,6 @@ spec:
                             description: Name is the name of the referent.
                             maxLength: 253
                             minLength: 1
-                            pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           namespace:
                             description: "Namespace is the namespace of the backend.
@@ -420,7 +423,6 @@ spec:
                             Core"
                           maxLength: 253
                           minLength: 1
-                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         namespace:
                           description: "Namespace is the namespace of the referent.

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_tlsroutes.yaml
@@ -133,6 +133,7 @@ spec:
                         Core"
                       maxLength: 253
                       minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     namespace:
                       description: "Namespace is the namespace of the referent. When
@@ -214,6 +215,7 @@ spec:
                             description: Name is the name of the referent.
                             maxLength: 253
                             minLength: 1
+                            pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           namespace:
                             description: "Namespace is the namespace of the backend.
@@ -418,6 +420,7 @@ spec:
                             Core"
                           maxLength: 253
                           minLength: 1
+                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         namespace:
                           description: "Namespace is the namespace of the referent.

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_udproutes.yaml
@@ -61,11 +61,16 @@ spec:
                   is the case, the list of routes attached to those resources should
                   also be merged."
                 items:
-                  description: ParentRef identifies an API object (usually a Gateway)
+                  description: "ParentRef identifies an API object (usually a Gateway)
                     that can be considered a parent of this resource (usually a route).
-                    The only kind of parent resource with "Core" support is Gateway.
+                    The only kind of parent resource with \"Core\" support is Gateway.
                     This API may be extended in the future to support additional kinds
-                    of parent resources, such as HTTPRoute.
+                    of parent resources, such as HTTPRoute. \n The API object must
+                    be valid in the cluster; the Group and Kind must be registered
+                    in the cluster for this reference to be valid. \n References to
+                    objects with invalid Group and Kind are not valid, and must be
+                    rejected by the implementation, with appropriate Conditions set
+                    on the containing object."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -87,7 +92,6 @@ spec:
                         Core"
                       maxLength: 253
                       minLength: 1
-                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     namespace:
                       description: "Namespace is the namespace of the referent. When
@@ -166,7 +170,6 @@ spec:
                             description: Name is the name of the referent.
                             maxLength: 253
                             minLength: 1
-                            pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           namespace:
                             description: "Namespace is the namespace of the backend.
@@ -371,7 +374,6 @@ spec:
                             Core"
                           maxLength: 253
                           minLength: 1
-                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         namespace:
                           description: "Namespace is the namespace of the referent.

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_udproutes.yaml
@@ -87,6 +87,7 @@ spec:
                         Core"
                       maxLength: 253
                       minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     namespace:
                       description: "Namespace is the namespace of the referent. When
@@ -165,6 +166,7 @@ spec:
                             description: Name is the name of the referent.
                             maxLength: 253
                             minLength: 1
+                            pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           namespace:
                             description: "Namespace is the namespace of the backend.
@@ -369,6 +371,7 @@ spec:
                             Core"
                           maxLength: 253
                           minLength: 1
+                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                         namespace:
                           description: "Namespace is the namespace of the referent.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

**What this PR does / why we need it**:

This PR ensures that there are no required fields that allow empty values, and that all required fields have consistent validation.

It does this by introducing a new string type alias, ObjectName, for Kubernetes object names, and by ensuring that the Listener ProtocolType has validation.

On the plus side, that was all the required types that could be zero I could find. The Port number field already has validation to ensure it's between 1 and 65535.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #867 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Validation for Kubernetes object names has been updated
Listener ProtocolType now has validation
```
