### PR TITLE
Clarifying the fields that all Route types must include

### DIFF
--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -96,7 +96,7 @@ type ParentRef struct {
 	SectionName *SectionName `json:"sectionName,omitempty"`
 }
 
-// CommonRouteSpec defines the common attributes that all Routes should include
+// CommonRouteSpec defines the common attributes that all Routes MUST include
 // within their spec.
 type CommonRouteSpec struct {
 	// ParentRefs references the resources (usually Gateways) that a Route wants
@@ -220,8 +220,8 @@ type RouteParentStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// RouteStatus defines the observed state that is required across
-// all route types.
+// RouteStatus defines the common attributes that all Routes MUST include within
+// their status.
 type RouteStatus struct {
 	// Parents is a list of parent resources (usually Gateways) that are
 	// associated with the route, and the status of the route with respect to

--- a/site-src/concepts/api-overview.md
+++ b/site-src/concepts/api-overview.md
@@ -260,7 +260,9 @@ Here is a summary of extension points in the API:
 the request/response lifecycle of an HTTP request.
 - **Custom Routes**: If none of the above extensions points suffice for a use
   case, Implementers can chose to create custom Route resources for protocols
-  that are not currently supported in the API.
+  that are not currently supported in the API. Custom Route types need to share
+  the same fields that core Route types do. These are contained within
+  CommonRouteSpec and RouteStatus.
 
 Whenever you are using an extension point without any prior art, please let
 the community know. As we learn more about usage of extension points, we would


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
This clarifies which fields must be included by all Route types. If this is sufficient for now, I can create a follow up tracking issue to track creating more detailed documentation on creating custom Route types.

**Which issue(s) this PR fixes**:
Fixes #874

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
