### PR TITLE
Clarifying that HTTP listeners may be used for Cleartext HTTP/2

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -250,7 +250,10 @@ type Listener struct {
 type ProtocolType string
 
 const (
-	// Accepts cleartext HTTP/1.1 sessions over TCP.
+	// Accepts cleartext HTTP/1.1 sessions over TCP. Implementations MAY also
+	// support HTTP/2 over cleartext. If implementations support HTTP/2 over
+	// cleartext on "HTTP" listeners, that MUST be clearly documented by the
+	// implementation.
 	HTTPProtocolType ProtocolType = "HTTP"
 
 	// Accepts HTTP/1.1 or HTTP/2 sessions over TLS.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Clarifies that HTTP listeners may be used for Cleartext HTTP/2.

**Which issue(s) this PR fixes**:
Fixes #817

**Does this PR introduce a user-facing change?**:
```release-note
HTTP listeners may now be used for Cleartext HTTP/2
```
