### PR TITLE
Adding TLS options validation as final sig-network review follow up

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -340,7 +340,7 @@ type GatewayTLSConfig struct {
 	//
 	// +optional
 	// +kubebuilder:validation:MaxProperties=16
-	Options map[string]string `json:"options,omitempty"`
+	Options map[AnnotationKey]AnnotationValue `json:"options,omitempty"`
 }
 
 // TLSModeType type defines how a Gateway handles TLS sessions.

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -352,3 +352,34 @@ type SectionName string
 // +kubebuilder:validation:MaxLength=253
 // +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`
 type GatewayController string
+
+// AnnotationKey is the key of an annotation in Gateway API. This is used for
+// validation of maps such as TLS options. This matches the Kubernetes
+// "qualified name" validation that is used for annotations and other common
+// values.
+//
+// Valid values include:
+//
+// * example
+// * example.com
+// * example.com/path
+// * example.com/path.html
+//
+// Invalid values include:
+//
+// * example~ - "~" is an invalid character
+// * example.com. - can not start or end with "."
+//
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern=`^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]/?)*$`
+type AnnotationKey string
+
+// AnnotationValue is the value of an annotation in Gateway API. This is used
+// for validation of maps such as TLS options. This roughly matches Kubernetes
+// annotation validation, although the length validation in that case is based
+// on the entire size of the annotations struct.
+//
+// +kubebuilder:validation:MinLength=0
+// +kubebuilder:validation:MaxLength=4096
+type AnnotationValue string

--- a/apis/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/v1alpha2/zz_generated.deepcopy.go
@@ -402,7 +402,7 @@ func (in *GatewayTLSConfig) DeepCopyInto(out *GatewayTLSConfig) {
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
-		*out = make(map[string]string, len(*in))
+		*out = make(map[AnnotationKey]AnnotationValue, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
@@ -405,6 +405,14 @@ spec:
                           type: string
                         options:
                           additionalProperties:
+                            description: AnnotationValue is the value of an annotation
+                              in Gateway API. This is used for validation of maps
+                              such as TLS options. This roughly matches Kubernetes
+                              annotation validation, although the length validation
+                              in that case is based on the entire size of the annotations
+                              struct.
+                            maxLength: 4096
+                            minLength: 0
                             type: string
                           description: "Options are a list of key/value pairs to give
                             extended options to the provider. \n There variation among


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind api-change

**What this PR does / why we need it**:
I found a comment from @khenidak that I'd missed from the original sig-network review suggesting more thorough validation here. This adds generic "AnnotationKey" and "AnnotationValue" types in hopes that they'll be useful for more than just TLS options in the future.

**Does this PR introduce a user-facing change?**:
```release-note
* TLS options keys are now subject to the same validation as Kubernetes annotations.
* TLS options values now have a max length of 1024 characters.
```
