### PR TITLE
Fix typos and clarify parts of HTTPRoute type definitions

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -189,7 +189,7 @@ type HTTPRouteRule struct {
 	// sent.
 
 	// If unspecified or invalid (refers to a non-existent resource or a Service
-	// with no endpoints), the rule performs no forwarding. If that are also no
+	// with no endpoints), the rule performs no forwarding. If there are also no
 	// filters specified that would result in a response being sent, a HTTP 503
 	// status code is returned. 503 responses must be sent so that the overall
 	// weight is respected; if an invalid backend is requested to have 80% of
@@ -288,8 +288,8 @@ const (
 //
 // Invalid values include:
 //
-// * ":method" - ":" is an invalid character. This means that pseudo headers are
-//   not currently supported by this type.
+// * ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+//   headers are not currently supported by this type.
 // * "/invalid" - "/" is an invalid character
 //
 // +kubebuilder:validation:MinLength=1
@@ -306,10 +306,10 @@ type HTTPHeaderMatch struct {
 	//
 	// Support: Custom (RegularExpression)
 	//
-	// Since RegularExpression PathType has custom conformance, implementations
-	// can support POSIX, PCRE or any other dialects of regular expressions.
-	// Please read the implementation's documentation to determine the supported
-	// dialect.
+	// Since RegularExpression HeaderMatchType has custom conformance,
+	// implementations can support POSIX, PCRE or any other dialects of regular
+	// expressions. Please read the implementation's documentation to determine
+	// the supported dialect.
 	//
 	// +optional
 	// +kubebuilder:default=Exact

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
@@ -190,7 +190,7 @@ spec:
                     backendRefs:
                       description: "If unspecified or invalid (refers to a non-existent
                         resource or a Service with no endpoints), the rule performs
-                        no forwarding. If that are also no filters specified that
+                        no forwarding. If there are also no filters specified that
                         would result in a response being sent, a HTTP 503 status code
                         is returned. 503 responses must be sent so that the overall
                         weight is respected; if an invalid backend is requested to
@@ -963,7 +963,7 @@ spec:
                                   description: "Type specifies how to match against
                                     the value of the header. \n Support: Core (Exact)
                                     \n Support: Custom (RegularExpression) \n Since
-                                    RegularExpression PathType has custom conformance,
+                                    RegularExpression HeaderMatchType has custom conformance,
                                     implementations can support POSIX, PCRE or any
                                     other dialects of regular expressions. Please
                                     read the implementation's documentation to determine


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This fixes typos and clarifies parts of HTTPRoute type definitions. These were identified by @danwinship in #861.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
