### PR TITLE
Clarifying docs around TLS options

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -328,13 +328,14 @@ type GatewayTLSConfig struct {
 	// +kubebuilder:validation:MaxItems=64
 	CertificateRefs []*SecretObjectReference `json:"certificateRefs,omitempty"`
 
-	// Options are a list of key/value pairs to give extended options
-	// to the provider.
+	// Options are a list of key/value pairs to enable extended TLS
+	// configuration for each implementation. For example, configuring the
+	// minimum TLS version or supported cipher suites.
 	//
-	// There variation among providers as to how ciphersuites are
-	// expressed. If there is a common subset for expressing ciphers
-	// then it will make sense to loft that as a core API
-	// construct.
+	// A set of common keys MAY be defined by the API in the future. To avoid
+	// any ambiguity, implementation-specific definitions MUST use
+	// domain-prefixed names, such as `example.com/my-custom-option`.
+	// Un-prefixed names are reserved for key names defined by Gateway API.
 	//
 	// Support: Implementation-specific
 	//

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
@@ -414,12 +414,14 @@ spec:
                             maxLength: 4096
                             minLength: 0
                             type: string
-                          description: "Options are a list of key/value pairs to give
-                            extended options to the provider. \n There variation among
-                            providers as to how ciphersuites are expressed. If there
-                            is a common subset for expressing ciphers then it will
-                            make sense to loft that as a core API construct. \n Support:
-                            Implementation-specific"
+                          description: "Options are a list of key/value pairs to enable
+                            extended TLS configuration for each implementation. For
+                            example, configuring the minimum TLS version or supported
+                            cipher suites. \n A set of common keys MAY be defined
+                            by the API in the future. To avoid any ambiguity, implementation-specific
+                            definitions MUST use domain-prefixed names, such as `example.com/my-custom-option`.
+                            Un-prefixed names are reserved for key names defined by
+                            Gateway API. \n Support: Implementation-specific"
                           maxProperties: 16
                           type: object
                       type: object


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is a follow up from https://github.com/kubernetes-sigs/gateway-api/discussions/896 and our related discussion at the community meeting. 

**Does this PR introduce a user-facing change?**:
```release-note
Added clarification that implementation-specific TLS options MUST be domain-prefixed.
```

/cc @jpeach @youngnick 