### PR TITLE
Marking v1alpha2 CRDs as approved

### DIFF
--- a/config/crd/v1alpha2/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: unapproved
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io
 spec:

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_gateways.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: unapproved
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io
 spec:

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_httproutes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: unapproved
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io
 spec:

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_referencepolicies.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_referencepolicies.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: unapproved
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
   creationTimestamp: null
   name: referencepolicies.gateway.networking.k8s.io
 spec:

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_tcproutes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: unapproved
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
   creationTimestamp: null
   name: tcproutes.gateway.networking.k8s.io
 spec:

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_tlsroutes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: unapproved
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
   creationTimestamp: null
   name: tlsroutes.gateway.networking.k8s.io
 spec:

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_udproutes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: unapproved
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
   creationTimestamp: null
   name: udproutes.gateway.networking.k8s.io
 spec:

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -59,8 +59,7 @@ go run sigs.k8s.io/controller-tools/cmd/controller-gen \
         output:crd:artifacts:config=config/crd/v1alpha2 \
         paths=./apis/v1alpha2
 
-# TODO(robscott): Change this once v1alpha2 has received formal API approval.
-sed -i -e 's/controller\-gen\.kubebuilder\.io\/version\:\ v0\.6\.2/api\-approved\.kubernetes\.io\:\ unapproved/g' config/crd/v1alpha2/gateway.networking.k8s.io*
+sed -i -e 's|controller-gen.kubebuilder.io/version: v0.6.2|api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891|g' config/crd/v1alpha2/gateway.networking.k8s.io*
 
 for VERSION in v1alpha1 v1alpha2
 do


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This updates the `api-approved.kubernetes.io` annotation on our v1alpha2 CRDs to indicate that they have been formally approved. This follows the guidelines in https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2337-k8s.io-group-protection.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```