### PR TITLE
Fixing a couple typos related to v1alpha2 release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@ The following changes have been made since v0.3.0:
   GEP added in [#749](https://github.com/kubernetes-sigs/gateway-api/pull/749).
   Implemented in [#768](https://github.com/kubernetes-sigs/gateway-api/pull/768).
 
-  [GEP-851](https://github.com/kubernetes-sigs/gateway-api/blob/master/site-src/geps/gep-851.md),
+  [GEP-851](https://github.com/kubernetes-sigs/gateway-api/blob/master/site-src/geps/gep-851.md)
   was a follow up on this change that allowed multiple Certificate Refs per
   Gateway Listener. This was implemented in
   [#852](https://github.com/kubernetes-sigs/gateway-api/pull/852).

--- a/site-src/blog/2021/introducing-v1alpha2.md
+++ b/site-src/blog/2021/introducing-v1alpha2.md
@@ -106,9 +106,9 @@ There are a lot of changes in v1alpha2 that we haven't covered here. For the
 full changelog, refer to our [v0.4.0 release
 notes](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.4.0). 
 
-Many of our [implementations]((/implementations)) are planning to release
-support for the v1alpha2 API in the coming weeks. We'll update our documentation
-as v1alpha2 implementations become available.
+Many of our [implementations](/implementations) are planning to release support
+for the v1alpha2 API in the coming weeks. We'll update our documentation as
+v1alpha2 implementations become available.
 
 We still have lots more to work on. Some of our next items to discuss include:
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Fixes a couple small typos, one of them was pointed out in an earlier review by @jpeach.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
