### PR TITLE
Fix rendering issue of namespace/name in gep-713

### DIFF
--- a/site-src/geps/gep-713.md
+++ b/site-src/geps/gep-713.md
@@ -292,7 +292,7 @@ ties:
 * The oldest Policy based on creation timestamp. For example, a Policy with a
   creation timestamp of "2021-07-15 01:02:03" is given precedence over a Policy
   with a creation timestamp of "2021-07-15 01:02:04".
-* The Policy appearing first in alphabetical order by "<namespace>/<name>". For
+* The Policy appearing first in alphabetical order by `<namespace>/<name>`. For
   example, foo/bar is given precedence over foo/baz.
 
 For a better user experience, a validating webhook can be implemented to prevent


### PR DESCRIPTION
namespace/name currently just renders to "/"

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
