### PR TITLE
Use correct namespace for the example of cross namespace certificate references

### DIFF
--- a/examples/v1alpha2/tls-cert-cross-namespace.yaml
+++ b/examples/v1alpha2/tls-cert-cross-namespace.yaml
@@ -15,7 +15,7 @@ spec:
       - kind: Secret
         group: ""
         name: wildcard-example-com-cert
-        namespace: gateway-api-example-ns1
+        namespace: gateway-api-example-ns2
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: ReferencePolicy


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind documentation

**What this PR does / why we need it**:

The gateway in the docs [cross namespace certificate references](https://gateway-api.sigs.k8s.io/v1alpha2/guides/tls/#cross-namespace-certificate-references) uses a same namespace `gateway-api-example-ns1` between gateway and secret as:

```yaml
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: Gateway
metadata:
  name: cross-namespace-tls-gateway
  namespace: gateway-api-example-ns1
spec:
  gatewayClassName: acme-lb
  listeners:
  - name: https
    protocol: HTTPS
    port: 443
    hostname: "*.example.com"
    tls:
      certificateRefs:
      - kind: Secret
        group: ""
        name: wildcard-example-com-cert
        namespace: gateway-api-example-ns1
```

so it does not "cross" the namespace. This patch fixes it.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
