### PR TITLE
GEP 735 L4 Traffic Matching

### DIFF
--- a/site-src/geps/gep-735.md
+++ b/site-src/geps/gep-735.md
@@ -52,6 +52,9 @@ type AddressMatch struct {
 	//
 	// For IPAddress the implementor may expect either IPv4 or IPv6.
 	//
+	// Support: Core (IPAddress)
+	// Support: Custom (NamedAddress)
+	//
 	// +optional
 	// +kubebuilder:validation:Enum=IPAddress;NamedAddress
 	// +kubebuilder:default=IPAddress
@@ -61,6 +64,8 @@ type AddressMatch struct {
 	// on the type and support by the controller.
 	//
 	// Examples: `1.2.3.4`, `128::1`, `my-named-address`.
+	//
+	// Support: Core
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
@@ -77,10 +82,14 @@ Using the new `AddressMatch` type matches can be expressed in topical lists on
 type TrafficMatches struct {
 	// SourceAddresses indicates the originating (source) network
 	// addresses which are valid for routing traffic.
+	//
+	// Support: Core
 	SourceAddresses []AddressMatch `json:"sourceAddresses"`
 
 	// DestinationAddresses indicates the destination network addresses
 	// which are valid for routing traffic.
+	//
+	// Support: Core
 	DestinationAddresses []AddressMatch `json:"destinationAddresses"`
 ```
 

--- a/site-src/geps/gep-735.md
+++ b/site-src/geps/gep-735.md
@@ -31,59 +31,57 @@ level of tuning options for L4 traffic routing at a level below the `Gateway`.
 
 The API changes include the following new types:
 
-- `NetworkMatch` to indicate the IP for address matching
+- `AddressMatch` to indicate the IP for address matching
 - `TrafficMatches` to configure matching according to network address
 
 These types enable the address matching required, with some active
 considerations about how to leave these open ended for later expansion.
 
-### NetworkMatch Type
+### AddressMatch Type
 
-A new `NetworkMatch` type provides the targeting mechanism for match inclusion
+A new `AddressMatch` type provides the targeting mechanism for match inclusion
 of a given network address:
 
 ```go
-type NetworkMatch struct {
-	// Address is an IP address which refers to either an IPv4 or IPv6 address.
+type AddressMatch struct {
+	// Type of the address, either IPAddress or NamedAddress.
 	//
-	// Examples: `127.0.0.1`, `::1`
+	// If NamedAddress is used this is a custom and specific value for each
+	// implementation to handle (and add validation for) according to their
+	// own needs.
+	//
+	// For IPAddress the implementor may expect either IPv4 or IPv6.
+	//
+	// +optional
+	// +kubebuilder:validation:Enum=IPAddress;NamedAddress
+	// +kubebuilder:default=IPAddress
+	Type *AddressType `json:"type,omitempty"`
+
+	// Value of the address. The validity of the values will depend
+	// on the type and support by the controller.
+	//
+	// Examples: `1.2.3.4`, `128::1`, `my-named-address`.
 	//
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=45
-	Address string `json:"address"`
+	// +kubebuilder:validation:MaxLength=253
+	Value string `json:"value"`
 }
 ```
-
-The purpose of calling this `NetworkMatch` and wrapping the single `IP` attribute in
-a structure is to enable forward expansion in case later we're interested in
-adding more specificity, such as perhaps the network mask or `/<int>` CIDR to
-allow matching within a network range, instead of a specific IP address:
-
-```go
-type NetworkMatch struct {
-	Address string `json:"address"`
-	Mask    *string `json:"mask"`
-}
-```
-
-However for this iteration the goal is to keep the initial spec simple and to
-the immediate goals so only `Address` is intended for inclusion until further
-requirements develop.
 
 ### TrafficMatches Type
 
-Using the new `NetworkMatch` type matches can be expressed in topical lists on
+Using the new `AddressMatch` type matches can be expressed in topical lists on
 `TCPRoute` and `UDPRoute` using the new `TrafficMatches` type:
 
 ```go
 type TrafficMatches struct {
 	// SourceAddresses indicates the originating (source) network
 	// addresses which are valid for routing traffic.
-	SourceAddresses []NetworkMatch `json:"sourceAddresses"`
+	SourceAddresses []AddressMatch `json:"sourceAddresses"`
 
 	// DestinationAddresses indicates the destination network addresses
 	// which are valid for routing traffic.
-	DestinationAddresses []NetworkMatch `json:"destinationAddresses"`
+	DestinationAddresses []AddressMatch `json:"destinationAddresses"`
 ```
 
 This type becomes an optional field and shared by both `TCPRouteRule` and
@@ -109,10 +107,12 @@ spec:
   rules:
   - matches:
       sourceAddresses:
-      - address: "192.168.1.1"
-      - address: "FE80::0202:B3FF:FE1E:8329"
+      - value: "192.168.1.1"
+      - value: "FE80::0202:B3FF:FE1E:8329"
+      - type: NamedAddress
+        value: "my-custom-name"
       destinationAddresses:
-      - address: "10.96.0.1"
+      - value: "10.96.0.1"
     backendRefs:
     - name: my-service
       port: 8080
@@ -150,6 +150,17 @@ listeners for the Gateway make it much harder to understand the value at this
 stage. We're deferring port matching to focus on address matching for this
 iteration so that we can come back around to it separately once we've gathered
 more use case information.
+
+### CIDR AddressType
+
+When using `AddressType` as a component to `AddressMatch` it was considered to
+add a new type `CIDRAddress` which would allow matching against an entire
+subnet. This sounds good, but given a lack of concrete feedback on an
+immediate need for this in the original issue [#727][issue-727] it was decided
+that this could wait for now and just as easily be added later in a backwards
+compatible manner.
+
+[issue-727]:https://github.com/kubernetes-sigs/gateway-api/issues/727
 
 ## References
 

--- a/site-src/geps/gep-735.md
+++ b/site-src/geps/gep-735.md
@@ -63,6 +63,11 @@ type AddressMatch struct {
 	// Value of the address. The validity of the values will depend
 	// on the type and support by the controller.
 	//
+	// If implementations support proxy-protocol (see:
+	// https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) they
+	// are expected to respect the connection meta-data from proxy-protocol
+	// in the match logic implemented for these address values.
+	//
 	// Examples: `1.2.3.4`, `128::1`, `my-named-address`.
 	//
 	// Support: Core

--- a/site-src/geps/gep-735.md
+++ b/site-src/geps/gep-735.md
@@ -65,7 +65,7 @@ type AddressMatch struct {
 	//
 	// If implementations support proxy-protocol (see:
 	// https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) they
-	// are expected to respect the connection meta-data from proxy-protocol
+	// must respect the connection metadata from proxy-protocol
 	// in the match logic implemented for these address values.
 	//
 	// Examples: `1.2.3.4`, `128::1`, `my-named-address`.

--- a/site-src/geps/gep-735.md
+++ b/site-src/geps/gep-735.md
@@ -1,0 +1,159 @@
+# GEP-735: TCP and UDP addresses matching
+
+* Issue: [#735](https://github.com/kubernetes-sigs/gateway-api/issues/735)
+* Status: Provisional
+
+## TLDR
+
+Spec for matching source and destination addresses on L4 APIs.
+
+## Goals
+
+- add matching rules for address to `TCPRoute`
+- add matching rules for address to `UDPRoute`
+- intentionally avoid type definitions that would make it hard to expand later
+
+## Non-Goals
+
+- define rules for port matching
+
+## Introduction
+
+While `TCPRoute` and `UDPRoute` currently support custom matching extensions,
+there is desire among the community to include some "fundamental" matching
+options in the spec that cover the most common requirements. In this GEP we
+request address matching for these APIs in order to support a standard
+for some of the commonplace setups of gateway implementations. Matching is
+intended to be covered for both _source_ and _destination_ to enable a finer
+level of tuning options for L4 traffic routing at a level below the `Gateway`.
+
+## API
+
+The API changes include the following new types:
+
+- `NetworkMatch` to indicate the IP for address matching
+- `TrafficMatches` to configure matching according to network address
+
+These types enable the address matching required, with some active
+considerations about how to leave these open ended for later expansion.
+
+### NetworkMatch Type
+
+A new `NetworkMatch` type provides the targeting mechanism for match inclusion
+of a given network address:
+
+```go
+type NetworkMatch struct {
+	// Address is an IP address which refers to either an IPv4 or IPv6 address.
+	//
+	// Examples: `127.0.0.1`, `::1`
+	//
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=45
+	Address string `json:"address"`
+}
+```
+
+The purpose of calling this `NetworkMatch` and wrapping the single `IP` attribute in
+a structure is to enable forward expansion in case later we're interested in
+adding more specificity, such as perhaps the network mask or `/<int>` CIDR to
+allow matching within a network range, instead of a specific IP address:
+
+```go
+type NetworkMatch struct {
+	Address string `json:"address"`
+	Mask    *string `json:"mask"`
+}
+```
+
+However for this iteration the goal is to keep the initial spec simple and to
+the immediate goals so only `Address` is intended for inclusion until further
+requirements develop.
+
+### TrafficMatches Type
+
+Using the new `NetworkMatch` type matches can be expressed in topical lists on
+`TCPRoute` and `UDPRoute` using the new `TrafficMatches` type:
+
+```go
+type TrafficMatches struct {
+	// SourceAddresses indicates the originating (source) network
+	// addresses which are valid for routing traffic.
+	SourceAddresses []NetworkMatch `json:"sourceAddresses"`
+
+	// DestinationAddresses indicates the destination network addresses
+	// which are valid for routing traffic.
+	DestinationAddresses []NetworkMatch `json:"destinationAddresses"`
+```
+
+This type becomes an optional field and shared by both `TCPRouteRule` and
+`UDPRouteRule`:
+
+```go
+type TCPRouteRule struct {
+	// Matches add rules for filtering traffic to backends based on addresses.
+	//
+	// +optional
+	Matches *TrafficMatches `json:"matches"`
+}
+```
+
+The above would make the following YAML examples possible:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: matching
+spec:
+  rules:
+  - matches:
+      sourceAddresses:
+      - address: "192.168.1.1"
+      - address: "FE80::0202:B3FF:FE1E:8329"
+      destinationAddresses:
+      - address: "10.96.0.1"
+    backendRefs:
+    - name: my-service
+      port: 8080
+```
+
+## Alternatives
+
+### Pure Gateway Mode
+
+Technically the existing specification supported this kind of matching through
+`Gateway` object `Listeners` and it was considered to simply document that
+further and expand upon it, but in a desire to better support more complex
+setups that are becoming commonplace in the ecosystem (e.g. service mesh) there
+was sufficient cause to add this functionality at the route level.
+
+### Copying NetworkPolicy
+
+After the first draft of this document we consulted the `NetworkPolicy` API to
+determine if there were enough similarities to copy some of the semantics there
+to here. Both the [existing API][k8s-net] and (at the time of writing) the
+[upcoming API][pol-new] were reviewed. Ultimately some influence was taken from
+`NetworkPolicyPort` to define the `PolicyMatch` structure here, but some ideas
+such as binding ports and network addresses together in a single struct did not
+seem necessary as the `RuleAction` present in policy did not seem applicable
+for this work at the time. We may want to revisit this as the new policy work
+merges and matures.
+
+[k8s-net]:https://github.com/kubernetes/kubernetes/blob/1e6f3b5cd68049a3501782af8ff3ddd647d0b408/pkg/apis/networking/types.go#L95
+[pol-new]:https://github.com/kubernetes/enhancements/pull/2522
+
+### Port Matching
+
+While we were able to think of some cases for port matching, the constraints of
+listeners for the Gateway make it much harder to understand the value at this
+stage. We're deferring port matching to focus on address matching for this
+iteration so that we can come back around to it separately once we've gathered
+more use case information.
+
+## References
+
+A related conversation in [#727][issue-727] ultimately instigated these
+new requirements and may be helpful to review.
+
+[issue-727]:https://github.com/kubernetes-sigs/gateway-api/issues/727


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind design
/kind gep
/kind api-change
-->

**What this PR does / why we need it**:

This adds traffic matching to enable more expressive routing for `TCPRoute` and `UDPRoute`.

**Which issue(s) this PR fixes**:

Fixes #735

**Does this PR introduce a user-facing change?**:

```release-note
- TCPRouteRule now includes an optional "matches" field for traffic matching
- UDPRouteRule now includes an optional "matches" field for traffic matching
```