### PR TITLE
Replace networking.x-k8s.io with gateway.networking.k8s.io in hack/delete-crds.sh

### DIFF
--- a/hack/delete-crds.sh
+++ b/hack/delete-crds.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 # Delete all CR and CRDs installed by gateway-api.
 
-RESOURCES=$(kubectl api-resources --api-group=networking.x-k8s.io -o name)
+RESOURCES=$(kubectl api-resources --api-group=gateway.networking.k8s.io -o name)
 
 for TYPE in ${RESOURCES}; do
   kubectl delete ${TYPE} --all


### PR DESCRIPTION
This patch replaces `networking.x-k8s.io` with `gateway.networking.k8s.io`
in `hack/delete-crds.sh`.

**What type of PR is this?**

/kind cleanup

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-sigs/gateway-api/issues/930

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
