### PR TITLE
Adding details to Conformance GEP

### DIFF
--- a/site-src/geps/gep-917.md
+++ b/site-src/geps/gep-917.md
@@ -1,21 +1,21 @@
-# GEP-917: Gateway API conformance principles
+# GEP-917: Gateway API Conformance Testing
 
 * Issue: [#917](https://github.com/kubernetes-sigs/gateway-api/issues/917)
 * Status: Provisional
 
 ## TLDR
 
-This GEP outlines the reasons for and principles by which the Gateway API will
-design its conformance and testing regime.
+This GEP outlines the principles and overarching structure that Gateway API
+conformance tests will be built with.
 
 ## Goals
 
 - Record why we are doing conformance and what we hope to achieve with it
 - Record the success criteria for the conformance process and associated artifacts
+- Provide a set of guidelines for conformance test structure
 
 ## Non-Goals
 
-- Designing the conformance process at anything more than a very basic level
 - Designing the conformance testing framework or implementation
 - Designing the process for implementations to prove they are conformant
 
@@ -76,9 +76,7 @@ profiles it claims.
 
 ## Proposal
 
-### Conformance profiles principles
-
-#### Basics
+### Conformance Profiles
 
 The Gateway API project defines conformance purely in terms of what resources an
 implementation supports.
@@ -117,7 +115,7 @@ supports, the conformance is composable, and orthogonal for each object type.
 For example, it's valid to only support HTTPRoute and not TCPRoute, or TLSRoute
 and not HTTPRoute.
 
-#### Interaction with existing support levels
+### Interaction with existing support levels
 
 Conformance definitions will ensure that an implementation can provide all the
 features currently marked as "Core" support in the API documentation.
@@ -126,23 +124,47 @@ Fields marked "Extended" support will eventually have conformance tests that
 lock in the behavior of that feature, and there will be a mechanism for implementations
 to tell the testing framework what extended fields they support.
 
-#### Testing framework
+## Testing framework
 
-The Gateway API project will provide a set of tests and harness to run them, such
-that an implementation may point the test harness at a GatewayClass or individual
-Gateway managed by that implementation and have the testing framework deliver a
-report on if it meets the conformance standard. The report must be
-machine-parsable.
+Conformance tests will initially be structured as a CLI that runs on existing
+Kubernetes clusters. This may be expanded to include a testing library that can
+be imported by implementations. This tool will output test results in a
+structured format that can be used to generate reports. Where possible it will
+share code with the existing ingress-controller-conformance test suite.
 
-There is a _lot_ of work to prepare this framework and introduce the initial
-round of tests, let alone to have complete test coverage. Having a minimal set
-of tests is a requirment for the API to graduate to `v1beta1` API stability level.
-(As per our upstream KEP). It's acceptable to begin with a small set and expand
-outward while the project is in beta, but having a full set of conformance tests
-that cover most of the API scope should be a requirement for declaring the API
-stable.
+### Test Definitions
 
-#### Certification process
+Each set of tests will be built around a set of YAML manifests representing
+Gateway API resources. The tests will focus on how they expect a given
+controller to process those resources, configured via GatewayClass name. For
+example, tests may check to ensure that a controller correctly populates status,
+or that a request is appropriately routed to the desired backend with any
+relevant modifications.
+
+Each test definition will include the following:
+
+* Name
+* Description
+* Support Level
+
+In the future, this will be expanded to include:
+
+* Docs URL
+* Function to determine feature enablement
+
+### Prepopulated Gateways
+
+Some implementations of Gateway API support prepopulated or unmanaged `Gateway`
+resources that refer to an underlying server that was created by other means
+(e.g. `Helm`) rather than provisioning and managing the server according to the
+`Gateway` resource. To ensure that our conformance tests can adequately cover
+these implementations, Gateways and any accompanying infrastructure may be
+preloaded into the cluster in which conformance tests will run. Importantly,
+Routes, ReferencePolicies, Services, or other resources used by the test MUST
+NOT be prepopulated. This approach will require a `--prepopulated-gateways` flag
+to be set, this will also be represented in the resulting conformance report.
+
+## Certification process
 
 The Gateway API project will provide a process by which an implementation may
 submit the results of a run of the conformance test suite to a centralized,
@@ -153,14 +175,37 @@ Ideally, this process should be handled using similar methods to upstream
 Kubernetes, while also learning what we can from what the upstream conformance
 efforts wish they could improve.
 
+## Alternatives Considered
 
-## Alternatives
+### Tests Derived from Gateways
 
-There's no real alternative to having some form of conformance testing.
+It could be possible to write a testing framework that could derive the tests
+to run from Gateways that were present in a given cluster. For example, if a
+Gateway was present with an HTTP listener, it would run all tests that were
+possible with that type of listener.
+
+This approach could be especially helpful for implementations that do not yet
+support provisioning arbitrary Gateways. With the current proposal, these
+implementations would have to prepopulate a predefined set of Gateways for
+testing.
+
+Unfortunately, this approach also comes with some significant downsides:
+
+1. Implementations would still have to prepopulate Gateways.
+1. There are many possible inputs and outputs.
+1. We would need to test the testing framework to ensure that the correct tests
+   were being run with a given input.
+1. The testing framework logic could become complicated if we wanted to avoid
+   repeating tests that had already been run with other listeners.
+1. It may be more difficult to debug these tests if anything went wrong.
+1. Tests would need to be smart enough to recognize the side effects of any
+   tests that had previously run. For example, multiple tests using the same
+   Gateway could result in different status conditions depending on the order
+   and/or combination that ran.
 
 
 ## References
 
-[Gateway API Conformance Ideas](https://docs.google.com/document/d/18iECeKMp1OewSGISskv6Chfmjo9u2U0_iUH0jhPdKOk/edit#)
-[Gateway API Conformance Requirements](https://docs.google.com/document/d/1QL-MpIVzqxe32Y2BZ_dYOB8zNsF9c4pnKEIB9ZLt118/edit)
-
+* [Gateway API Conformance Ideas](https://docs.google.com/document/d/18iECeKMp1OewSGISskv6Chfmjo9u2U0_iUH0jhPdKOk/edit#)
+* [Gateway API Conformance Requirements](https://docs.google.com/document/d/1QL-MpIVzqxe32Y2BZ_dYOB8zNsF9c4pnKEIB9ZLt118/edit)
+* [Gateway API Conformance Details](https://docs.google.com/document/d/1QL-MpIVzqxe32Y2BZ_dYOB8zNsF9c4pnKEIB9ZLt118/edit)


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/kind gep

**What this PR does / why we need it**:
This is an addition to GEP #917 that provides a general structure for how we can define conformance tests. Although this could have potentially been a separate GEP, it felt sufficiently small to just bundle with the existing conformance GEP. Happy to split this out if it's easier though.

This is largely a follow up to the [earlier doc](https://docs.google.com/document/d/1QL-MpIVzqxe32Y2BZ_dYOB8zNsF9c4pnKEIB9ZLt118/edit), but it also adds a section to discuss how this could work with prepopulated Gateways. Open to other approaches here, this just seemed like it may be the simplest starting point.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
