### PR TITLE
Fixing BackendRef docs for ResolvedRefs condition

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -737,7 +737,7 @@ type HTTPBackendRef struct {
 	//
 	// If there is a cross-namespace reference to an *existing* object
 	// that is not covered by a ReferencePolicy, the controller must ensure the
-	// "ResolvedRefs"  condition on the Route is set to `status: true`,
+	// "ResolvedRefs"  condition on the Route is set to `status: False`,
 	// with the "RefNotPermitted" reason and not configure this backend in the
 	// underlying implementation.
 	//


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind documentation

**What this PR does / why we need it**:
Fixes a mistake in BackendRef docs that suggested ResolvedRefs should be set to "True" when it really should have been "False".

**Does this PR introduce a user-facing change?**:
```release-note
Clarifies that ResolvedRefs should be set to "False" when a ReferencePolicy does not exist to allow a cross-namespace reference.
```
