### PR TITLE
fix: kustomize resource paths

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,8 +1,8 @@
 resources:
-- v1alpha2/gateway.networking.k8s.io_gatewayclasses.yaml
-- v1alpha2/gateway.networking.k8s.io_gateways.yaml
-- v1alpha2/gateway.networking.k8s.io_httproutes.yaml
-- v1alpha2/gateway.networking.k8s.io_referencepolicies.yaml
-- v1alpha2/gateway.networking.k8s.io_tcproutes.yaml
-- v1alpha2/gateway.networking.k8s.io_tlsroutes.yaml
-- v1alpha2/gateway.networking.k8s.io_udproutes.yaml
+- stable/gateway.networking.k8s.io_gatewayclasses.yaml
+- stable/gateway.networking.k8s.io_gateways.yaml
+- stable/gateway.networking.k8s.io_httproutes.yaml
+- stable/gateway.networking.k8s.io_referencepolicies.yaml
+- stable/gateway.networking.k8s.io_tcproutes.yaml
+- stable/gateway.networking.k8s.io_tlsroutes.yaml
+- stable/gateway.networking.k8s.io_udproutes.yaml


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind regression

**What this PR does / why we need it**:

Previously I was able to deploy the Gateway CRDs with the following one-liner in CI:

```console
$ kubectl kustomize https://github.com/kubernetes-sigs/gateway-api/config/crd | kubectl apply -f -
```

With the changes in 0d40986f4f16016a470bfde3a1f445cb9a891e52 this now fails:

```console
$ kubectl kustomize https://github.com/kubernetes-sigs/gateway-api/config/crd | kubectl apply -f -
Error: accumulating resources: accumulation err='accumulating resources from 'v1alpha2/gateway.networking.k8s.io_gatewayclasses.yaml': evalsymlink failure on '/tmp/kustomize-2449990972/config/crd/v1alpha2/gateway.networking.k8s.io_gatewayclasses.yaml' : lstat /tmp/kustomize-2449990972/config/crd/v1alpha2: no such file or directory': evalsymlink failure on '/tmp/kustomize-2449990972/config/crd/v1alpha2/gateway.networking.k8s.io_gatewayclasses.yaml' : lstat /tmp/kustomize-2449990972/config/crd/v1alpha2: no such file or directory
```

This patch updates the kustomize resource list to match the new location of the stable CRDs.