### PR TITLE
Fix ReferencePolicy docs about empty value in `spec.to.name`

### DIFF
--- a/apis/v1alpha2/referencepolicy_types.go
+++ b/apis/v1alpha2/referencepolicy_types.go
@@ -123,7 +123,7 @@ type ReferencePolicyTo struct {
 	// * Service
 	Kind Kind `json:"kind"`
 
-	// Name is the name of the referent. When unspecified or empty, this policy
+	// Name is the name of the referent. When unspecified, this policy
 	// refers to all resources of the specified Group and Kind in the local
 	// namespace.
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_referencepolicies.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_referencepolicies.yaml
@@ -115,9 +115,9 @@ spec:
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                       type: string
                     name:
-                      description: Name is the name of the referent. When unspecified
-                        or empty, this policy refers to all resources of the specified
-                        Group and Kind in the local namespace.
+                      description: Name is the name of the referent. When unspecified,
+                        this policy refers to all resources of the specified Group
+                        and Kind in the local namespace.
                       maxLength: 253
                       minLength: 1
                       type: string

--- a/config/crd/stable/gateway.networking.k8s.io_referencepolicies.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_referencepolicies.yaml
@@ -115,9 +115,9 @@ spec:
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                       type: string
                     name:
-                      description: Name is the name of the referent. When unspecified
-                        or empty, this policy refers to all resources of the specified
-                        Group and Kind in the local namespace.
+                      description: Name is the name of the referent. When unspecified,
+                        this policy refers to all resources of the specified Group
+                        and Kind in the local namespace.
                       maxLength: 253
                       minLength: 1
                       type: string


### PR DESCRIPTION
Current docs explains about `spec.to.name` as:

```
Name is the name of the referent. When unspecified or empty, this policy
refers to all resources of the specified Group and Kind in the local
namespace.
```

However, the ReferencePolicy with empty value (like below):

```shell
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: ReferencePolicy
metadata:
  name: allow-gateways-to-ref-secrets
  namespace: default
spec:
  from:
  - group: gateway.networking.k8s.io
    kind: Gateway
    namespace: istio-system
  to:
  - group: ""
    kind: Secret
    name: ""
EOF
```

It gets the following error `Invalid value: "": spec.to.name in body should be at least 1 chars long` as:

```
The ReferencePolicy "allow-gateways-to-ref-secrets" is invalid: spec.to.name: Invalid value: "": spec.to.name in body should be at least 1 chars long
```
It should be fine to support only "unspecified" case. So, this patch removes "empty" from docs.

/kind documentation

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
