### PR TITLE
Introduce wildcardhostname field

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -740,7 +740,7 @@ type HTTPRequestRedirectFilter struct {
 	// Support: Core
 	//
 	// +optional
-	Hostname *Hostname `json:"hostname,omitempty"`
+	Hostname *PreciseHostname `json:"hostname,omitempty"`
 
 	// Path defines parameters used to modify the path of the incoming request.
 	// The modified path is then used to construct the `Location` header. When

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -252,6 +252,24 @@ type RouteStatus struct {
 // +kubebuilder:validation:Pattern=`^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 type Hostname string
 
+// PreciseHostname is the fully qualified domain name of a network host. This matches
+// the RFC 1123 definition of a hostname with 2 notable exceptions:
+//
+// 1. IPs are not allowed.
+// 2. A hostname may not be prefixed with a wildcard label (`*.`).
+//
+// Hostname can be "precise" which is a domain name without the terminating
+// dot of a network host (e.g. "foo.example.com").
+//
+// Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+// alphanumeric characters or '-', and must start and end with an alphanumeric
+// character. No other punctuation is allowed.
+//
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+type PreciseHostname string
+
 // Group refers to a Kubernetes Group. It must either be an empty string or a
 // RFC 1123 subdomain.
 //

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -253,12 +253,10 @@ type RouteStatus struct {
 type Hostname string
 
 // PreciseHostname is the fully qualified domain name of a network host. This matches
-// the RFC 1123 definition of a hostname with 2 notable exceptions:
+// the RFC 1123 definition of a hostname with 1 notable exception that
+// numeric IP addresses are not allowed.
 //
-// 1. IPs are not allowed.
-// 2. A hostname may not be prefixed with a wildcard label (`*.`).
-//
-// Hostname can be "precise" which is a domain name without the terminating
+// PreciseHostname can be "precise" which is a domain name without the terminating
 // dot of a network host (e.g. "foo.example.com").
 //
 // Note that as per RFC1035 and RFC1123, a *label* must consist of lower case

--- a/apis/v1alpha2/validation/httproute_test.go
+++ b/apis/v1alpha2/validation/httproute_test.go
@@ -605,7 +605,7 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 			Type: gatewayv1a2.HTTPRouteFilterRequestRedirect,
 			RequestRedirect: &gatewayv1a2.HTTPRequestRedirectFilter{
 				Scheme:     new(string),
-				Hostname:   new(gatewayv1a2.Hostname),
+				Hostname:   new(gatewayv1a2.PreciseHostname),
 				Path:       &gatewayv1a2.HTTPPathModifier{},
 				Port:       new(gatewayv1a2.PortNumber),
 				StatusCode: new(int),

--- a/apis/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/v1alpha2/zz_generated.deepcopy.go
@@ -593,7 +593,7 @@ func (in *HTTPRequestRedirectFilter) DeepCopyInto(out *HTTPRequestRedirectFilter
 	}
 	if in.Hostname != nil {
 		in, out := &in.Hostname, &out.Hostname
-		*out = new(Hostname)
+		*out = new(PreciseHostname)
 		**out = **in
 	}
 	if in.Path != nil {

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -450,7 +450,7 @@ spec:
                                         of the request is used. \n Support: Core"
                                       maxLength: 253
                                       minLength: 1
-                                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                     path:
                                       description: "Path defines parameters used to
@@ -894,7 +894,7 @@ spec:
                                   \n Support: Core"
                                 maxLength: 253
                                 minLength: 1
-                                pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               path:
                                 description: "Path defines parameters used to modify

--- a/config/crd/stable/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_httproutes.yaml
@@ -450,7 +450,7 @@ spec:
                                         of the request is used. \n Support: Core"
                                       maxLength: 253
                                       minLength: 1
-                                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                     port:
                                       description: "Port is the port to be used in
@@ -823,7 +823,7 @@ spec:
                                   \n Support: Core"
                                 maxLength: 253
                                 minLength: 1
-                                pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               port:
                                 description: "Port is the port to be used in the value

--- a/hack/invalid-examples/v1alpha2/httproute/invalid-httredirect-hostname.yaml
+++ b/hack/invalid-examples/v1alpha2/httproute/invalid-httredirect-hostname.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: invalid-backend-port
+spec:
+  rules:
+  - backendRefs:
+    - name: my-service
+      port: 8080
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: "*.gateway.networking.k8s.io"
+


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change

**What this PR does / why we need it**:

Update the HTTPRequestRedirectFilter.Hostname to use a Hostname type which validates the value cannot
contain wildcard characters. Updates all other references which used Hostname to use WildcardHostname
which does allow for wildcard characters.

Signed-off-by: Steve Sloka <slokas@vmware.com>

**Which issue(s) this PR fixes**:
Fixes #949

**Does this PR introduce a user-facing change?**:
```release-note
Introduced WildcardHostname which allows for wildcard characters in relevant Hostname values. 
```
