### PR TITLE
Update version of golangci-lint as well as remove deprecated linters.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,9 +11,12 @@ linters:
   enable:
   - gofmt
   - goimports
-  - golint
+  - revive
   - govet
   - misspell
+  - exportloopref
+  disable:
+  - scopelint
   disable-all: false
   presets:
   - bugs

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly VERSION="v1.39.0"
+readonly VERSION="v1.43.0"
 readonly KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 cd "${KUBE_ROOT}"

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -25,7 +25,7 @@ import (
 func Test_PortNumberPtr(t *testing.T) {
 	var exportedPort65535 gatewayv1a2.PortNumber = 65535
 	var exportedPort1 gatewayv1a2.PortNumber = 1
-	var exportedPort0 gatewayv1a2.PortNumber = 0
+	var exportedPort0 gatewayv1a2.PortNumber
 	var exportedPort65536 gatewayv1a2.PortNumber = 65536
 
 	portNumberPtrTests := []struct {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

I noticed a few deprecated linter errors, so this fixes up those replacing with valid ones along with one small nit found in the revive linter for a single test. 

**Does this PR introduce a user-facing change?**:

```release-note
none
```
