### PR TITLE
Fixing bug where namespace could be unspecified in ReferencePolicy

### DIFF
--- a/apis/v1alpha2/referencepolicy_types.go
+++ b/apis/v1alpha2/referencepolicy_types.go
@@ -104,7 +104,7 @@ type ReferencePolicyFrom struct {
 	// Namespace is the namespace of the referent.
 	//
 	// Support: Core
-	Namespace Namespace `json:"namespace,omitempty"`
+	Namespace Namespace `json:"namespace"`
 }
 
 // ReferencePolicyTo describes what Kinds are allowed as targets of the

--- a/config/crd/experimental/gateway.networking.k8s.io_referencepolicies.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_referencepolicies.yaml
@@ -86,6 +86,7 @@ spec:
                   required:
                   - group
                   - kind
+                  - namespace
                   type: object
                 maxItems: 16
                 minItems: 1

--- a/config/crd/stable/gateway.networking.k8s.io_referencepolicies.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_referencepolicies.yaml
@@ -86,6 +86,7 @@ spec:
                   required:
                   - group
                   - kind
+                  - namespace
                   type: object
                 maxItems: 16
                 minItems: 1

--- a/hack/invalid-examples/v1alpha2/referencepolicy/missing-ns.yaml
+++ b/hack/invalid-examples/v1alpha2/referencepolicy/missing-ns.yaml
@@ -1,0 +1,11 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: ReferencePolicy
+metadata:
+  name: missing-ns
+spec:
+  to:
+  - group: ""
+    kind: "Service"
+  from:
+  - group: "gateway.networking.k8s.io"
+    kind: "HTTPRoute"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind api-change

**What this PR does / why we need it**:
This fixes a bug where namespace could be unspecified in ReferencePolicy

**Which issue(s) this PR fixes**:
Fixes #962

**Does this PR introduce a user-facing change?**:
```release-note
Namespace can no longer be left unspecified in ReferencePolicy. 
```

#963 needs to merge before this one
/hold for consensus
