### PR TITLE
Updating changelog for v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- [v0.4.1](#v041)
 - [v0.4.0](#v040)
 - [v0.4.0-rc2](#v040-rc2)
 - [v0.4.0-rc1](#v040-rc1)
@@ -10,6 +11,21 @@
 - [v0.1.0](#v010)
 - [v0.1.0-rc2](#v010-rc2)
 - [v0.1.0-rc1](#v010-rc1)
+
+## v0.4.1
+
+API version: v1alpha2
+
+This release contains minor bug fixes for v1alpha2.
+
+### Bug Fixes
+
+* ControllerName now prints correctly in kubectl output for GatewayClass
+  [#909](https://github.com/kubernetes-sigs/gateway-api/pull/909)
+* Namespace can no longer be left unspecified in ReferencePolicy
+  [#964](https://github.com/kubernetes-sigs/gateway-api/pull/964)
+* Wildcard characters can no longer be used in redirect Hostname values
+  [#956](https://github.com/kubernetes-sigs/gateway-api/pull/956)
 
 ## v0.4.0
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This updates the changelog to include v0.4.1. Approving this PR means that you approve the release of this bundle version  of the API at this commit. 

For this to merge, #909 and #964 will first have to be cherry picked back to the release-0.4 branch. When that is complete, this PR will be rebased. Finally, immediately post release, this changelog PR will have to be cherry-picked to master.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/hold