### PR TITLE
Cherrypick #909 and #964 into release-0.4

### DIFF
--- a/apis/v1alpha2/gatewayclass_types.go
+++ b/apis/v1alpha2/gatewayclass_types.go
@@ -26,7 +26,7 @@ import (
 // +kubebuilder:resource:categories=gateway-api,scope=Cluster,shortName=gc
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:printcolumn:name="Controller",type=string,JSONPath=`.spec.controller`
+// +kubebuilder:printcolumn:name="Controller",type=string,JSONPath=`.spec.controllerName`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:printcolumn:name="Description",type=string,JSONPath=`.spec.description`,priority=1
 

--- a/apis/v1alpha2/referencepolicy_types.go
+++ b/apis/v1alpha2/referencepolicy_types.go
@@ -104,7 +104,7 @@ type ReferencePolicyFrom struct {
 	// Namespace is the namespace of the referent.
 	//
 	// Support: Core
-	Namespace Namespace `json:"namespace,omitempty"`
+	Namespace Namespace `json:"namespace"`
 }
 
 // ReferencePolicyTo describes what Kinds are allowed as targets of the

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -21,7 +21,7 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.controller
+    - jsonPath: .spec.controllerName
       name: Controller
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/config/crd/v1alpha2/gateway.networking.k8s.io_referencepolicies.yaml
+++ b/config/crd/v1alpha2/gateway.networking.k8s.io_referencepolicies.yaml
@@ -86,6 +86,7 @@ spec:
                   required:
                   - group
                   - kind
+                  - namespace
                   type: object
                 maxItems: 16
                 minItems: 1

--- a/hack/invalid-examples/v1alpha2/referencepolicy/missing-ns.yaml
+++ b/hack/invalid-examples/v1alpha2/referencepolicy/missing-ns.yaml
@@ -1,0 +1,11 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: ReferencePolicy
+metadata:
+  name: missing-ns
+spec:
+  to:
+  - group: ""
+    kind: "Service"
+  from:
+  - group: "gateway.networking.k8s.io"
+    kind: "HTTPRoute"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This cherry picks #909 and #964 into release 0.4 as a prerequisite for #965 and the release of v0.4.1.

**Does this PR introduce a user-facing change?**:
```release-note
* Fixes a bug where v1alpha2 GatewayClass controller names were not being shown in the output of `kubectl get gatewayclasses`.
* Namespace can no longer be left unspecified in ReferencePolicy. 
```
