### PR TITLE
Fix HTTPRoute validation tests.

### DIFF
--- a/apis/v1alpha2/validation/httproute_test.go
+++ b/apis/v1alpha2/validation/httproute_test.go
@@ -34,269 +34,274 @@ func TestValidateHTTPRoute(t *testing.T) {
 		name     string
 		rules    []gatewayv1a2.HTTPRouteRule
 		errCount int
-	}{
-		{
-			name: "valid httpRoute with no filters",
-			rules: []gatewayv1a2.HTTPRouteRule{
-				{
-					Matches: []gatewayv1a2.HTTPRouteMatch{
-						{
-							Path: &gatewayv1a2.HTTPPathMatch{
-								Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
-								Value: utilpointer.String("/"),
-							},
+	}{{
+		name:     "valid httpRoute with no filters",
+		errCount: 0,
+		rules: []gatewayv1a2.HTTPRouteRule{
+			{
+				Matches: []gatewayv1a2.HTTPRouteMatch{
+					{
+						Path: &gatewayv1a2.HTTPPathMatch{
+							Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
+							Value: utilpointer.String("/"),
 						},
 					},
-					BackendRefs: []gatewayv1a2.HTTPBackendRef{
-						{
-							BackendRef: gatewayv1a2.BackendRef{
-								BackendObjectReference: gatewayv1a2.BackendObjectReference{
-									Name: testService,
-									Port: pkgutils.PortNumberPtr(8080),
-								},
-								Weight: utilpointer.Int32(100),
+				},
+				BackendRefs: []gatewayv1a2.HTTPBackendRef{
+					{
+						BackendRef: gatewayv1a2.BackendRef{
+							BackendObjectReference: gatewayv1a2.BackendObjectReference{
+								Name: testService,
+								Port: pkgutils.PortNumberPtr(8080),
+							},
+							Weight: utilpointer.Int32(100),
+						},
+					},
+				},
+			},
+		},
+	}, {
+		name:     "valid httpRoute with 1 filter",
+		errCount: 0,
+		rules: []gatewayv1a2.HTTPRouteRule{
+			{
+				Matches: []gatewayv1a2.HTTPRouteMatch{
+					{
+						Path: &gatewayv1a2.HTTPPathMatch{
+							Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
+							Value: utilpointer.String("/"),
+						},
+					},
+				},
+				Filters: []gatewayv1a2.HTTPRouteFilter{
+					{
+						Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
+							BackendRef: gatewayv1a2.BackendObjectReference{
+								Name: testService,
+								Port: pkgutils.PortNumberPtr(8081),
 							},
 						},
 					},
 				},
 			},
-			errCount: 0,
 		},
-		{
-			name: "valid httpRoute with 1 filter",
-			rules: []gatewayv1a2.HTTPRouteRule{
-				{
-					Matches: []gatewayv1a2.HTTPRouteMatch{
-						{
-							Path: &gatewayv1a2.HTTPPathMatch{
-								Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
-								Value: utilpointer.String("/"),
+	}, {
+		name:     "invalid httpRoute with 2 extended filters",
+		errCount: 1,
+		rules: []gatewayv1a2.HTTPRouteRule{
+			{
+				Matches: []gatewayv1a2.HTTPRouteMatch{
+					{
+						Path: &gatewayv1a2.HTTPPathMatch{
+							Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
+							Value: utilpointer.String("/"),
+						},
+					},
+				},
+				Filters: []gatewayv1a2.HTTPRouteFilter{
+					{
+						Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
+							BackendRef: gatewayv1a2.BackendObjectReference{
+								Name: testService,
+								Port: pkgutils.PortNumberPtr(8080),
 							},
 						},
 					},
-					Filters: []gatewayv1a2.HTTPRouteFilter{
-						{
-							Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
-								BackendRef: gatewayv1a2.BackendObjectReference{
-									Name: testService,
-									Port: pkgutils.PortNumberPtr(8081),
-								},
+					{
+						Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
+							BackendRef: gatewayv1a2.BackendObjectReference{
+								Name: specialService,
+								Port: pkgutils.PortNumberPtr(8080),
 							},
 						},
 					},
 				},
 			},
-			errCount: 0,
 		},
-		{
-			name: "invalid httpRoute with 2 extended filters",
-			rules: []gatewayv1a2.HTTPRouteRule{
-				{
-					Matches: []gatewayv1a2.HTTPRouteMatch{
-						{
-							Path: &gatewayv1a2.HTTPPathMatch{
-								Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
-								Value: utilpointer.String("/"),
-							},
-						},
-					},
-					Filters: []gatewayv1a2.HTTPRouteFilter{
-						{
-							Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
-								BackendRef: gatewayv1a2.BackendObjectReference{
-									Name: testService,
-									Port: pkgutils.PortNumberPtr(8080),
-								},
-							},
-						},
-						{
-							Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
-								BackendRef: gatewayv1a2.BackendObjectReference{
-									Name: specialService,
-									Port: pkgutils.PortNumberPtr(8080),
-								},
-							},
+	}, {
+		name:     "invalid httpRoute with mix of filters and one duplicate",
+		errCount: 1,
+		rules: []gatewayv1a2.HTTPRouteRule{
+			{
+				Matches: []gatewayv1a2.HTTPRouteMatch{
+					{
+						Path: &gatewayv1a2.HTTPPathMatch{
+							Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
+							Value: utilpointer.String("/"),
 						},
 					},
 				},
-			},
-			errCount: 1,
-		},
-		{
-			name: "invalid httpRoute with mix of filters and one duplicate",
-			rules: []gatewayv1a2.HTTPRouteRule{
-				{
-					Matches: []gatewayv1a2.HTTPRouteMatch{
-						{
-							Path: &gatewayv1a2.HTTPPathMatch{
-								Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
-								Value: utilpointer.String("/"),
+				Filters: []gatewayv1a2.HTTPRouteFilter{
+					{
+						Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{
+							Set: []gatewayv1a2.HTTPHeader{
+								{
+									Name:  "special-header",
+									Value: "foo",
+								},
 							},
 						},
 					},
-					Filters: []gatewayv1a2.HTTPRouteFilter{
-						{
-							Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
-							RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{
-								Set: []gatewayv1a2.HTTPHeader{
-									{
-										Name:  "special-header",
-										Value: "foo",
-									},
-								},
+					{
+						Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
+							BackendRef: gatewayv1a2.BackendObjectReference{
+								Name: testService,
+								Port: pkgutils.PortNumberPtr(8080),
 							},
 						},
-						{
-							Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
-								BackendRef: gatewayv1a2.BackendObjectReference{
-									Name: testService,
-									Port: pkgutils.PortNumberPtr(8080),
-								},
-							},
-						},
-						{
-							Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
-							RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{
-								Add: []gatewayv1a2.HTTPHeader{
-									{
-										Name:  "my-header",
-										Value: "bar",
-									},
+					},
+					{
+						Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{
+							Add: []gatewayv1a2.HTTPHeader{
+								{
+									Name:  "my-header",
+									Value: "bar",
 								},
 							},
 						},
 					},
 				},
 			},
-			errCount: 1,
 		},
-		{
-			name: "invalid httpRoute with multiple duplicate filters",
-			rules: []gatewayv1a2.HTTPRouteRule{
-				{
-					Matches: []gatewayv1a2.HTTPRouteMatch{
-						{
-							Path: &gatewayv1a2.HTTPPathMatch{
-								Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
-								Value: utilpointer.String("/"),
+	}, {
+		name:     "invalid httpRoute with multiple duplicate filters",
+		errCount: 2,
+		rules: []gatewayv1a2.HTTPRouteRule{
+			{
+				Matches: []gatewayv1a2.HTTPRouteMatch{
+					{
+						Path: &gatewayv1a2.HTTPPathMatch{
+							Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
+							Value: utilpointer.String("/"),
+						},
+					},
+				},
+				Filters: []gatewayv1a2.HTTPRouteFilter{
+					{
+						Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
+							BackendRef: gatewayv1a2.BackendObjectReference{
+								Name: testService,
+								Port: pkgutils.PortNumberPtr(8080),
 							},
 						},
 					},
-					Filters: []gatewayv1a2.HTTPRouteFilter{
-						{
-							Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
-								BackendRef: gatewayv1a2.BackendObjectReference{
-									Name: testService,
-									Port: pkgutils.PortNumberPtr(8080),
+					{
+						Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{
+							Set: []gatewayv1a2.HTTPHeader{
+								{
+									Name:  "special-header",
+									Value: "foo",
 								},
 							},
 						},
-						{
-							Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
-							RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{
-								Set: []gatewayv1a2.HTTPHeader{
-									{
-										Name:  "special-header",
-										Value: "foo",
-									},
+					},
+					{
+						Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
+							BackendRef: gatewayv1a2.BackendObjectReference{
+								Name: testService,
+								Port: pkgutils.PortNumberPtr(8080),
+							},
+						},
+					},
+					{
+						Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{
+							Add: []gatewayv1a2.HTTPHeader{
+								{
+									Name:  "my-header",
+									Value: "bar",
 								},
 							},
 						},
-						{
-							Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
-								BackendRef: gatewayv1a2.BackendObjectReference{
-									Name: testService,
-									Port: pkgutils.PortNumberPtr(8080),
-								},
-							},
-						},
-						{
-							Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
-							RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{
-								Add: []gatewayv1a2.HTTPHeader{
-									{
-										Name:  "my-header",
-										Value: "bar",
-									},
-								},
-							},
-						},
-						{
-							Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
-								BackendRef: gatewayv1a2.BackendObjectReference{
-									Name: specialService,
-									Port: pkgutils.PortNumberPtr(8080),
-								},
+					},
+					{
+						Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
+							BackendRef: gatewayv1a2.BackendObjectReference{
+								Name: specialService,
+								Port: pkgutils.PortNumberPtr(8080),
 							},
 						},
 					},
 				},
 			},
-			errCount: 2,
 		},
-		{
-			name: "valid httpRoute with duplicate ExtensionRef filters",
-			rules: []gatewayv1a2.HTTPRouteRule{
-				{
-					Matches: []gatewayv1a2.HTTPRouteMatch{
-						{
-							Path: &gatewayv1a2.HTTPPathMatch{
-								Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
-								Value: utilpointer.String("/"),
+	}, {
+		name:     "valid httpRoute with duplicate ExtensionRef filters",
+		errCount: 0,
+		rules: []gatewayv1a2.HTTPRouteRule{
+			{
+				Matches: []gatewayv1a2.HTTPRouteMatch{
+					{
+						Path: &gatewayv1a2.HTTPPathMatch{
+							Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
+							Value: utilpointer.String("/"),
+						},
+					},
+				},
+				Filters: []gatewayv1a2.HTTPRouteFilter{
+					{
+						Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{
+							Set: []gatewayv1a2.HTTPHeader{
+								{
+									Name:  "special-header",
+									Value: "foo",
+								},
 							},
 						},
 					},
-					Filters: []gatewayv1a2.HTTPRouteFilter{
-						{
-							Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
-							RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{
-								Set: []gatewayv1a2.HTTPHeader{
-									{
-										Name:  "special-header",
-										Value: "foo",
-									},
-								},
+					{
+						Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
+							BackendRef: gatewayv1a2.BackendObjectReference{
+								Name: testService,
+								Port: pkgutils.PortNumberPtr(8080),
 							},
 						},
-						{
-							Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
-								BackendRef: gatewayv1a2.BackendObjectReference{
-									Name: testService,
-									Port: pkgutils.PortNumberPtr(8080),
-								},
-							},
+					},
+					{
+						Type: "ExtensionRef",
+						ExtensionRef: &gatewayv1a2.LocalObjectReference{
+							Kind: "Service",
+							Name: "test",
 						},
-						{
-							Type: "ExtensionRef",
+					},
+					{
+						Type: "ExtensionRef",
+						ExtensionRef: &gatewayv1a2.LocalObjectReference{
+							Kind: "Service",
+							Name: "test",
 						},
-						{
-							Type: "ExtensionRef",
-						},
-						{
-							Type: "ExtensionRef",
+					},
+					{
+						Type: "ExtensionRef",
+						ExtensionRef: &gatewayv1a2.LocalObjectReference{
+							Kind: "Service",
+							Name: "test",
 						},
 					},
 				},
 			},
-			errCount: 0,
 		},
-	}
+	}}
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var errs field.ErrorList
-			for _, rules := range tc.rules {
-				errs = validateHTTPRouteFilters(rules.Filters, field.NewPath("spec").Child("rules"))
-			}
+			route := gatewayv1a2.HTTPRoute{Spec: gatewayv1a2.HTTPRouteSpec{Rules: tc.rules}}
+			errs = ValidateHTTPRoute(&route)
 			if len(errs) != tc.errCount {
-				t.Errorf("ValidateHTTPRoute() got %v errors, want %v errors", len(errs), tc.errCount)
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
 			}
 		})
 	}
@@ -307,90 +312,78 @@ func TestValidateHTTPBackendUniqueFilters(t *testing.T) {
 	var specialService v1alpha2.ObjectName = "specialService"
 	tests := []struct {
 		name     string
-		hRoute   gatewayv1a2.HTTPRoute
+		rules    []gatewayv1a2.HTTPRouteRule
 		errCount int
-	}{
-		{
-			name: "valid httpRoute Rules backendref filters",
-			hRoute: gatewayv1a2.HTTPRoute{
-				Spec: gatewayv1a2.HTTPRouteSpec{
-					Rules: []gatewayv1a2.HTTPRouteRule{
+	}{{
+		name:     "valid httpRoute Rules backendref filters",
+		errCount: 0,
+		rules: []gatewayv1a2.HTTPRouteRule{{
+			BackendRefs: []gatewayv1a2.HTTPBackendRef{
+				{
+					BackendRef: gatewayv1a2.BackendRef{
+						BackendObjectReference: gatewayv1a2.BackendObjectReference{
+							Name: testService,
+							Port: pkgutils.PortNumberPtr(8080),
+						},
+						Weight: utilpointer.Int32(100),
+					},
+					Filters: []gatewayv1a2.HTTPRouteFilter{
 						{
-							BackendRefs: []gatewayv1a2.HTTPBackendRef{
-								{
-									BackendRef: gatewayv1a2.BackendRef{
-										BackendObjectReference: gatewayv1a2.BackendObjectReference{
-											Name: testService,
-											Port: pkgutils.PortNumberPtr(8080),
-										},
-										Weight: utilpointer.Int32(100),
-									},
-									Filters: []gatewayv1a2.HTTPRouteFilter{
-										{
-											Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
-											RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
-												BackendRef: gatewayv1a2.BackendObjectReference{
-													Name: testService,
-													Port: pkgutils.PortNumberPtr(8080),
-												},
-											},
-										},
-									},
+							Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
+								BackendRef: gatewayv1a2.BackendObjectReference{
+									Name: testService,
+									Port: pkgutils.PortNumberPtr(8080),
 								},
 							},
 						},
 					},
 				},
 			},
-			errCount: 0,
-		},
-		{
-			name: "invalid httpRoute Rules backendref filters",
-			hRoute: gatewayv1a2.HTTPRoute{
-				Spec: gatewayv1a2.HTTPRouteSpec{
-					Rules: []gatewayv1a2.HTTPRouteRule{
+		}},
+	}, {
+		name:     "invalid httpRoute Rules duplicate mirror filter",
+		errCount: 1,
+		rules: []gatewayv1a2.HTTPRouteRule{{
+			BackendRefs: []gatewayv1a2.HTTPBackendRef{
+				{
+					BackendRef: gatewayv1a2.BackendRef{
+						BackendObjectReference: gatewayv1a2.BackendObjectReference{
+							Name: testService,
+							Port: pkgutils.PortNumberPtr(8080),
+						},
+					},
+					Filters: []gatewayv1a2.HTTPRouteFilter{
 						{
-							BackendRefs: []gatewayv1a2.HTTPBackendRef{
-								{
-									Filters: []gatewayv1a2.HTTPRouteFilter{
-										{
-											Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
-											RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
-												BackendRef: gatewayv1a2.BackendObjectReference{
-													Name: testService,
-													Port: pkgutils.PortNumberPtr(8080),
-												},
-											},
-										},
-										{
-											Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
-											RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
-												BackendRef: gatewayv1a2.BackendObjectReference{
-													Name: specialService,
-													Port: pkgutils.PortNumberPtr(8080),
-												},
-											},
-										},
-									},
+							Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
+								BackendRef: gatewayv1a2.BackendObjectReference{
+									Name: testService,
+									Port: pkgutils.PortNumberPtr(8080),
+								},
+							},
+						},
+						{
+							Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{
+								BackendRef: gatewayv1a2.BackendObjectReference{
+									Name: specialService,
+									Port: pkgutils.PortNumberPtr(8080),
 								},
 							},
 						},
 					},
 				},
 			},
-			errCount: 1,
-		},
-	}
+		}},
+	}}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			for _, rule := range tc.hRoute.Spec.Rules {
-				for _, backendRef := range rule.BackendRefs {
-					errs := validateHTTPRouteFilters(backendRef.Filters, field.NewPath("spec").Child("rules"))
-					if len(errs) != tc.errCount {
-						t.Errorf("ValidateHTTPRoute() got %d errors, want %d errors", len(errs), tc.errCount)
-					}
-				}
+			route := gatewayv1a2.HTTPRoute{Spec: gatewayv1a2.HTTPRouteSpec{Rules: tc.rules}}
+			errs := ValidateHTTPRoute(&route)
+			if len(errs) != tc.errCount {
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
 			}
 		})
 	}
@@ -401,37 +394,50 @@ func TestValidateHTTPPathMatch(t *testing.T) {
 		name     string
 		path     *gatewayv1a2.HTTPPathMatch
 		errCount int
-	}{
-		{
-			name: "invalid httpRoute prefix",
-			path: &gatewayv1a2.HTTPPathMatch{
-				Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
-				Value: utilpointer.String("/."),
-			},
-			errCount: 1,
+	}{{
+		name: "invalid httpRoute prefix",
+		path: &gatewayv1a2.HTTPPathMatch{
+			Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
+			Value: utilpointer.String("/."),
 		},
-		{
-			name: "invalid httpRoute Exact",
-			path: &gatewayv1a2.HTTPPathMatch{
-				Type:  pkgutils.PathMatchTypePtr("Exact"),
-				Value: utilpointer.String("/foo/./bar"),
-			},
-			errCount: 1,
+		errCount: 1,
+	}, {
+		name: "invalid httpRoute Exact",
+		path: &gatewayv1a2.HTTPPathMatch{
+			Type:  pkgutils.PathMatchTypePtr("Exact"),
+			Value: utilpointer.String("/foo/./bar"),
 		},
-		{
-			name: "invalid httpRoute prefix",
-			path: &gatewayv1a2.HTTPPathMatch{
-				Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
-				Value: utilpointer.String("/"),
-			},
-			errCount: 0,
+		errCount: 1,
+	}, {
+		name: "invalid httpRoute prefix",
+		path: &gatewayv1a2.HTTPPathMatch{
+			Type:  pkgutils.PathMatchTypePtr("PathPrefix"),
+			Value: utilpointer.String("/"),
 		},
-	}
+		errCount: 0,
+	}}
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validateHTTPPathMatch(tc.path, field.NewPath("spec").Child("rules").Child("matches").Child("path"))
+			route := gatewayv1a2.HTTPRoute{Spec: gatewayv1a2.HTTPRouteSpec{
+				Rules: []gatewayv1a2.HTTPRouteRule{{
+					Matches: []gatewayv1a2.HTTPRouteMatch{{
+						Path: tc.path,
+					}},
+					BackendRefs: []gatewayv1a2.HTTPBackendRef{{
+						BackendRef: gatewayv1a2.BackendRef{
+							BackendObjectReference: gatewayv1a2.BackendObjectReference{
+								Name: gatewayv1a2.ObjectName("test"),
+								Port: pkgutils.PortNumberPtr(8080),
+							},
+						},
+					}},
+				}},
+			}}
+
+			errs := ValidateHTTPRoute(&route)
 			if len(errs) != tc.errCount {
-				t.Errorf("TestValidateHTTPPathMatch() got %v errors, want %v errors", len(errs), tc.errCount)
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
 			}
 		})
 	}
@@ -455,105 +461,84 @@ func TestValidateServicePort(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		route    *gatewayv1a2.HTTPRoute
+		rules    []gatewayv1a2.HTTPRouteRule
 		errCount int
-	}{
-		{
-			name:     "default groupkind with port",
-			errCount: 0,
-			route: &gatewayv1a2.HTTPRoute{
-				Spec: gatewayv1a2.HTTPRouteSpec{
-					Rules: []gatewayv1a2.HTTPRouteRule{{
-						BackendRefs: []gatewayv1a2.HTTPBackendRef{{
-							BackendRef: gatewayv1a2.BackendRef{
-								BackendObjectReference: gatewayv1a2.BackendObjectReference{
-									Name: "backend",
-									Port: portPtr(99),
-								},
-							},
-						}},
-					}},
+	}{{
+		name:     "default groupkind with port",
+		errCount: 0,
+		rules: []gatewayv1a2.HTTPRouteRule{{
+			BackendRefs: []gatewayv1a2.HTTPBackendRef{{
+				BackendRef: gatewayv1a2.BackendRef{
+					BackendObjectReference: gatewayv1a2.BackendObjectReference{
+						Name: "backend",
+						Port: portPtr(99),
+					},
 				},
-			},
-		}, {
-			name:     "default groupkind with no port",
-			errCount: 1,
-			route: &gatewayv1a2.HTTPRoute{
-				Spec: gatewayv1a2.HTTPRouteSpec{
-					Rules: []gatewayv1a2.HTTPRouteRule{{
-						BackendRefs: []gatewayv1a2.HTTPBackendRef{{
-							BackendRef: gatewayv1a2.BackendRef{
-								BackendObjectReference: gatewayv1a2.BackendObjectReference{
-									Name: "backend",
-								},
-							},
-						}},
-					}},
+			}},
+		}},
+	}, {
+		name:     "default groupkind with no port",
+		errCount: 1,
+		rules: []gatewayv1a2.HTTPRouteRule{{
+			BackendRefs: []gatewayv1a2.HTTPBackendRef{{
+				BackendRef: gatewayv1a2.BackendRef{
+					BackendObjectReference: gatewayv1a2.BackendObjectReference{
+						Name: "backend",
+					},
 				},
-			},
-		}, {
-			name:     "explicit service with port",
-			errCount: 0,
-			route: &gatewayv1a2.HTTPRoute{
-				Spec: gatewayv1a2.HTTPRouteSpec{
-					Rules: []gatewayv1a2.HTTPRouteRule{{
-						BackendRefs: []gatewayv1a2.HTTPBackendRef{{
-							BackendRef: gatewayv1a2.BackendRef{
-								BackendObjectReference: gatewayv1a2.BackendObjectReference{
-									Group: groupPtr(""),
-									Kind:  kindPtr("Service"),
-									Name:  "backend",
-									Port:  portPtr(99),
-								},
-							},
-						}},
-					}},
+			}},
+		}},
+	}, {
+		name:     "explicit service with port",
+		errCount: 0,
+		rules: []gatewayv1a2.HTTPRouteRule{{
+			BackendRefs: []gatewayv1a2.HTTPBackendRef{{
+				BackendRef: gatewayv1a2.BackendRef{
+					BackendObjectReference: gatewayv1a2.BackendObjectReference{
+						Group: groupPtr(""),
+						Kind:  kindPtr("Service"),
+						Name:  "backend",
+						Port:  portPtr(99),
+					},
 				},
-			},
-		}, {
-			name:     "explicit service with no port",
-			errCount: 1,
-			route: &gatewayv1a2.HTTPRoute{
-				Spec: gatewayv1a2.HTTPRouteSpec{
-					Rules: []gatewayv1a2.HTTPRouteRule{{
-						BackendRefs: []gatewayv1a2.HTTPBackendRef{{
-							BackendRef: gatewayv1a2.BackendRef{
-								BackendObjectReference: gatewayv1a2.BackendObjectReference{
-									Group: groupPtr(""),
-									Kind:  kindPtr("Service"),
-									Name:  "backend",
-								},
-							},
-						}},
-					}},
+			}},
+		}},
+	}, {
+		name:     "explicit service with no port",
+		errCount: 1,
+		rules: []gatewayv1a2.HTTPRouteRule{{
+			BackendRefs: []gatewayv1a2.HTTPBackendRef{{
+				BackendRef: gatewayv1a2.BackendRef{
+					BackendObjectReference: gatewayv1a2.BackendObjectReference{
+						Group: groupPtr(""),
+						Kind:  kindPtr("Service"),
+						Name:  "backend",
+					},
 				},
-			},
-		}, {
-			name:     "explicit ref with no port",
-			errCount: 0,
-			route: &gatewayv1a2.HTTPRoute{
-				Spec: gatewayv1a2.HTTPRouteSpec{
-					Rules: []gatewayv1a2.HTTPRouteRule{{
-						BackendRefs: []gatewayv1a2.HTTPBackendRef{{
-							BackendRef: gatewayv1a2.BackendRef{
-								BackendObjectReference: gatewayv1a2.BackendObjectReference{
-									Group: groupPtr("foo.example.com"),
-									Kind:  kindPtr("Foo"),
-									Name:  "backend",
-								},
-							},
-						}},
-					}},
+			}},
+		}},
+	}, {
+		name:     "explicit ref with no port",
+		errCount: 0,
+		rules: []gatewayv1a2.HTTPRouteRule{{
+			BackendRefs: []gatewayv1a2.HTTPBackendRef{{
+				BackendRef: gatewayv1a2.BackendRef{
+					BackendObjectReference: gatewayv1a2.BackendObjectReference{
+						Group: groupPtr("foo.example.com"),
+						Kind:  kindPtr("Foo"),
+						Name:  "backend",
+					},
 				},
-			},
-		},
-	}
+			}},
+		}},
+	}}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validateHTTPRouteBackendServicePorts(tc.route.Spec.Rules, field.NewPath("spec").Child("rules"))
+			route := gatewayv1a2.HTTPRoute{Spec: gatewayv1a2.HTTPRouteSpec{Rules: tc.rules}}
+			errs := ValidateHTTPRoute(&route)
 			if len(errs) != tc.errCount {
-				t.Errorf("got %v errors, want %v errors: %s", len(errs), tc.errCount, errs)
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
 			}
 		})
 	}
@@ -564,156 +549,155 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 		name        string
 		routeFilter gatewayv1a2.HTTPRouteFilter
 		errCount    int
-	}{
-		{
-			name: "valid HTTPRouteFilterRequestHeaderModifier route filter",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{
-				Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
-				RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{
-					Set:    []gatewayv1a2.HTTPHeader{{Name: "name"}},
-					Add:    []gatewayv1a2.HTTPHeader{{Name: "add"}},
-					Remove: []string{"remove"},
-				},
+	}{{
+		name: "valid HTTPRouteFilterRequestHeaderModifier route filter",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{
+			Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
+			RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{
+				Set:    []gatewayv1a2.HTTPHeader{{Name: "name"}},
+				Add:    []gatewayv1a2.HTTPHeader{{Name: "add"}},
+				Remove: []string{"remove"},
 			},
-			errCount: 0,
 		},
-		{
-			name: "invalid HTTPRouteFilterRequestHeaderModifier type filter with non-matching field",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{
-				Type:          gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
-				RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{},
+		errCount: 0,
+	}, {
+		name: "invalid HTTPRouteFilterRequestHeaderModifier type filter with non-matching field",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{
+			Type:          gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
+			RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{},
+		},
+		errCount: 2,
+	}, {
+		name: "invalid HTTPRouteFilterRequestHeaderModifier type filter with empty value field",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{
+			Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
+		},
+		errCount: 1,
+	}, {
+		name: "valid HTTPRouteFilterRequestMirror route filter",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{
+			Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
+			RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{BackendRef: gatewayv1a2.BackendObjectReference{
+				Group:     new(gatewayv1a2.Group),
+				Kind:      new(gatewayv1a2.Kind),
+				Name:      "name",
+				Namespace: new(gatewayv1a2.Namespace),
+				Port:      pkgutils.PortNumberPtr(22),
+			}},
+		},
+		errCount: 0,
+	}, {
+		name: "invalid HTTPRouteFilterRequestMirror type filter with non-matching field",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{
+			Type:                  gatewayv1a2.HTTPRouteFilterRequestMirror,
+			RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{},
+		},
+		errCount: 2,
+	}, {
+		name: "invalid HTTPRouteFilterRequestMirror type filter with empty value field",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{
+			Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
+		},
+		errCount: 1,
+	}, {
+		name: "valid HTTPRouteFilterRequestRedirect route filter",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{
+			Type: gatewayv1a2.HTTPRouteFilterRequestRedirect,
+			RequestRedirect: &gatewayv1a2.HTTPRequestRedirectFilter{
+				Scheme:     new(string),
+				Hostname:   new(gatewayv1a2.Hostname),
+				Path:       &gatewayv1a2.HTTPPathModifier{},
+				Port:       new(gatewayv1a2.PortNumber),
+				StatusCode: new(int),
 			},
-			errCount: 2,
 		},
-		{
-			name: "invalid HTTPRouteFilterRequestHeaderModifier type filter with empty value field",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{
-				Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
+		errCount: 0,
+	}, {
+		name: "invalid HTTPRouteFilterRequestRedirect type filter with non-matching field",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{
+			Type:          gatewayv1a2.HTTPRouteFilterRequestRedirect,
+			RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{},
+		},
+		errCount: 2,
+	}, {
+		name: "invalid HTTPRouteFilterRequestRedirect type filter with empty value field",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{
+			Type: gatewayv1a2.HTTPRouteFilterRequestRedirect,
+		},
+		errCount: 1,
+	}, {
+		name: "valid HTTPRouteFilterExtensionRef filter",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{
+			Type: gatewayv1a2.HTTPRouteFilterExtensionRef,
+			ExtensionRef: &gatewayv1a2.LocalObjectReference{
+				Group: "group",
+				Kind:  "kind",
+				Name:  "name",
 			},
-			errCount: 1,
 		},
-		{
-			name: "valid HTTPRouteFilterRequestMirror route filter",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{
-				Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
-				RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{BackendRef: gatewayv1a2.BackendObjectReference{
-					Group:     new(gatewayv1a2.Group),
-					Kind:      new(gatewayv1a2.Kind),
-					Name:      "name",
-					Namespace: new(gatewayv1a2.Namespace),
-					Port:      pkgutils.PortNumberPtr(22),
-				}},
+		errCount: 0,
+	}, {
+		name: "invalid HTTPRouteFilterExtensionRef type filter with non-matching field",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{
+			Type:          gatewayv1a2.HTTPRouteFilterExtensionRef,
+			RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{},
+		},
+		errCount: 2,
+	}, {
+		name: "invalid HTTPRouteFilterExtensionRef type filter with empty value field",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{
+			Type: gatewayv1a2.HTTPRouteFilterExtensionRef,
+		},
+		errCount: 1,
+	}, {
+		name: "valid HTTPRouteFilterURLRewrite route filter",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{
+			Type: gatewayv1a2.HTTPRouteFilterURLRewrite,
+			URLRewrite: &gatewayv1a2.HTTPURLRewriteFilter{
+				Hostname: new(gatewayv1a2.Hostname),
+				Path:     &gatewayv1a2.HTTPPathModifier{},
 			},
-			errCount: 0,
 		},
-		{
-			name: "invalid HTTPRouteFilterRequestMirror type filter with non-matching field",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{
-				Type:                  gatewayv1a2.HTTPRouteFilterRequestMirror,
-				RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{},
-			},
-			errCount: 2,
+		errCount: 0,
+	}, {
+		name: "invalid HTTPRouteFilterURLRewrite type filter with non-matching field",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{
+			Type:          gatewayv1a2.HTTPRouteFilterURLRewrite,
+			RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{},
 		},
-		{
-			name: "invalid HTTPRouteFilterRequestMirror type filter with empty value field",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{
-				Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
-			},
-			errCount: 1,
+		errCount: 2,
+	}, {
+		name: "invalid HTTPRouteFilterURLRewrite type filter with empty value field",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{
+			Type: gatewayv1a2.HTTPRouteFilterURLRewrite,
 		},
-		{
-			name: "valid HTTPRouteFilterRequestRedirect route filter",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{
-				Type: gatewayv1a2.HTTPRouteFilterRequestRedirect,
-				RequestRedirect: &gatewayv1a2.HTTPRequestRedirectFilter{
-					Scheme:     new(string),
-					Hostname:   new(gatewayv1a2.Hostname),
-					Path:       &gatewayv1a2.HTTPPathModifier{},
-					Port:       new(gatewayv1a2.PortNumber),
-					StatusCode: new(int),
-				},
-			},
-			errCount: 0,
-		},
-		{
-			name: "invalid HTTPRouteFilterRequestRedirect type filter with non-matching field",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{
-				Type:          gatewayv1a2.HTTPRouteFilterRequestRedirect,
-				RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{},
-			},
-			errCount: 2,
-		},
-		{
-			name: "invalid HTTPRouteFilterRequestRedirect type filter with empty value field",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{
-				Type: gatewayv1a2.HTTPRouteFilterRequestRedirect,
-			},
-			errCount: 1,
-		},
-		{
-			name: "valid HTTPRouteFilterExtensionRef filter",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{
-				Type: gatewayv1a2.HTTPRouteFilterExtensionRef,
-				ExtensionRef: &gatewayv1a2.LocalObjectReference{
-					Group: "group",
-					Kind:  "kind",
-					Name:  "name",
-				},
-			},
-			errCount: 0,
-		},
-		{
-			name: "invalid HTTPRouteFilterExtensionRef type filter with non-matching field",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{
-				Type:          gatewayv1a2.HTTPRouteFilterExtensionRef,
-				RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{},
-			},
-			errCount: 2,
-		},
-		{
-			name: "invalid HTTPRouteFilterExtensionRef type filter with empty value field",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{
-				Type: gatewayv1a2.HTTPRouteFilterExtensionRef,
-			},
-			errCount: 1,
-		},
-		{
-			name: "valid HTTPRouteFilterURLRewrite route filter",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{
-				Type: gatewayv1a2.HTTPRouteFilterURLRewrite,
-				URLRewrite: &gatewayv1a2.HTTPURLRewriteFilter{
-					Hostname: new(gatewayv1a2.Hostname),
-					Path:     &gatewayv1a2.HTTPPathModifier{},
-				},
-			},
-			errCount: 0,
-		},
-		{
-			name: "invalid HTTPRouteFilterURLRewrite type filter with non-matching field",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{
-				Type:          gatewayv1a2.HTTPRouteFilterURLRewrite,
-				RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{},
-			},
-			errCount: 2,
-		},
-		{
-			name: "invalid HTTPRouteFilterURLRewrite type filter with empty value field",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{
-				Type: gatewayv1a2.HTTPRouteFilterURLRewrite,
-			},
-			errCount: 1,
-		},
-		{
-			name:        "empty type filter is valid(caught by CRD validation)",
-			routeFilter: gatewayv1a2.HTTPRouteFilter{},
-			errCount:    0,
-		},
-	}
+		errCount: 1,
+	}, {
+		name:        "empty type filter is valid (caught by CRD validation)",
+		routeFilter: gatewayv1a2.HTTPRouteFilter{},
+		errCount:    0,
+	}}
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validateHTTPRouteFilterTypeMatchesValue(tc.routeFilter, field.NewPath("spec").Child("rules").Index(0).Child("filters").Index(0))
+			route := gatewayv1a2.HTTPRoute{
+				Spec: gatewayv1a2.HTTPRouteSpec{
+					Rules: []gatewayv1a2.HTTPRouteRule{{
+						Filters: []gatewayv1a2.HTTPRouteFilter{tc.routeFilter},
+						BackendRefs: []gatewayv1a2.HTTPBackendRef{{
+							BackendRef: gatewayv1a2.BackendRef{
+								BackendObjectReference: gatewayv1a2.BackendObjectReference{
+									Name: gatewayv1a2.ObjectName("test"),
+									Port: pkgutils.PortNumberPtr(8080),
+								},
+							},
+						}},
+					}},
+				},
+			}
+			errs := ValidateHTTPRoute(&route)
 			if len(errs) != tc.errCount {
-				t.Errorf("got %v errors, want %v errors: %s", len(errs), tc.errCount, errs)
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
 			}
 		})
 	}

--- a/pkg/admission/server_test.go
+++ b/pkg/admission/server_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/lithammer/dedent"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	admission "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -199,7 +200,7 @@ func TestServeHTTPSubmissions(t *testing.T) {
    								         "matches": [
    								            {
    								               "path": {
-   								                  "type": "Prefix",
+   								                  "type": "PathPrefix",
    								                  "value": "/bar"
    								               }
    								            }
@@ -263,7 +264,7 @@ func TestServeHTTPSubmissions(t *testing.T) {
    								         "matches": [
    								            {
    								               "path": {
-   								                  "type": "Prefix",
+   								                  "type": "PathPrefix",
    								                  "value": "/bar"
    								               }
    								            }
@@ -467,7 +468,7 @@ func TestServeHTTPSubmissions(t *testing.T) {
 				// send request
 				req, err := http.NewRequest("POST", "", bytes.NewBuffer([]byte(tt.reqBody)))
 				req = req.WithContext(context.Background())
-				assert.Nil(err)
+				require.NoError(t, err)
 				handler.ServeHTTP(res, req)
 
 				// check response assertions
@@ -475,7 +476,7 @@ func TestServeHTTPSubmissions(t *testing.T) {
 				if tt.wantRespCode == http.StatusOK {
 					var review admission.AdmissionReview
 					_, _, err = decoder.Decode(res.Body.Bytes(), nil, &review)
-					assert.Nil(err)
+					require.NoError(t, err)
 					assert.EqualValues(&tt.wantSuccessResponse, review.Response)
 				} else {
 					assert.Equal(res.Body.String(), tt.wantFailureMessage)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

The HTTPRoute validation tests were directly calling internal API
functions to try to pinpoint the set of tests that they expected to
be run. This is a risky pattern, because there's nothing that ensures
that the internal functions are actually wired up to the validation
logic correctly.

This change establishes a new pattern, where each test can set up fixtures
in theor own way (for the sake of brevity), but the test is always driven
by the top-level validation call. This exposed a number of bugs where
the validation functions were not wired up correctly.

In the future, this can be improved by updating the tests to supply
specific expecations on the returned errors rather than just the error
count.

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
