### PR TITLE
Document that ParentRefs require ReferencePolicy.

### DIFF
--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -52,6 +52,11 @@ type ParentRef struct {
 	// Namespace is the namespace of the referent. When unspecified (or empty
 	// string), this refers to the local namespace of the Route.
 	//
+	// Note that when a namespace is specified, a ReferencePolicy object
+	// is required in the referent namespace to allow that namespace's
+	// owner to accept the reference. See the ReferencePolicy documentation
+	// for details.
+	//
 	// Support: Core
 	//
 	// +optional

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -144,7 +144,11 @@ spec:
                     namespace:
                       description: "Namespace is the namespace of the referent. When
                         unspecified (or empty string), this refers to the local namespace
-                        of the Route. \n Support: Core"
+                        of the Route. \n Note that when a namespace is specified,
+                        a ReferencePolicy object is required in the referent namespace
+                        to allow that namespace's owner to accept the reference. See
+                        the ReferencePolicy documentation for details. \n Support:
+                        Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -1370,7 +1374,11 @@ spec:
                         namespace:
                           description: "Namespace is the namespace of the referent.
                             When unspecified (or empty string), this refers to the
-                            local namespace of the Route. \n Support: Core"
+                            local namespace of the Route. \n Note that when a namespace
+                            is specified, a ReferencePolicy object is required in
+                            the referent namespace to allow that namespace's owner
+                            to accept the reference. See the ReferencePolicy documentation
+                            for details. \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -96,7 +96,11 @@ spec:
                     namespace:
                       description: "Namespace is the namespace of the referent. When
                         unspecified (or empty string), this refers to the local namespace
-                        of the Route. \n Support: Core"
+                        of the Route. \n Note that when a namespace is specified,
+                        a ReferencePolicy object is required in the referent namespace
+                        to allow that namespace's owner to accept the reference. See
+                        the ReferencePolicy documentation for details. \n Support:
+                        Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -378,7 +382,11 @@ spec:
                         namespace:
                           description: "Namespace is the namespace of the referent.
                             When unspecified (or empty string), this refers to the
-                            local namespace of the Route. \n Support: Core"
+                            local namespace of the Route. \n Note that when a namespace
+                            is specified, a ReferencePolicy object is required in
+                            the referent namespace to allow that namespace's owner
+                            to accept the reference. See the ReferencePolicy documentation
+                            for details. \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -142,7 +142,11 @@ spec:
                     namespace:
                       description: "Namespace is the namespace of the referent. When
                         unspecified (or empty string), this refers to the local namespace
-                        of the Route. \n Support: Core"
+                        of the Route. \n Note that when a namespace is specified,
+                        a ReferencePolicy object is required in the referent namespace
+                        to allow that namespace's owner to accept the reference. See
+                        the ReferencePolicy documentation for details. \n Support:
+                        Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -427,7 +431,11 @@ spec:
                         namespace:
                           description: "Namespace is the namespace of the referent.
                             When unspecified (or empty string), this refers to the
-                            local namespace of the Route. \n Support: Core"
+                            local namespace of the Route. \n Note that when a namespace
+                            is specified, a ReferencePolicy object is required in
+                            the referent namespace to allow that namespace's owner
+                            to accept the reference. See the ReferencePolicy documentation
+                            for details. \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -96,7 +96,11 @@ spec:
                     namespace:
                       description: "Namespace is the namespace of the referent. When
                         unspecified (or empty string), this refers to the local namespace
-                        of the Route. \n Support: Core"
+                        of the Route. \n Note that when a namespace is specified,
+                        a ReferencePolicy object is required in the referent namespace
+                        to allow that namespace's owner to accept the reference. See
+                        the ReferencePolicy documentation for details. \n Support:
+                        Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -378,7 +382,11 @@ spec:
                         namespace:
                           description: "Namespace is the namespace of the referent.
                             When unspecified (or empty string), this refers to the
-                            local namespace of the Route. \n Support: Core"
+                            local namespace of the Route. \n Note that when a namespace
+                            is specified, a ReferencePolicy object is required in
+                            the referent namespace to allow that namespace's owner
+                            to accept the reference. See the ReferencePolicy documentation
+                            for details. \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/config/crd/stable/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_httproutes.yaml
@@ -144,7 +144,11 @@ spec:
                     namespace:
                       description: "Namespace is the namespace of the referent. When
                         unspecified (or empty string), this refers to the local namespace
-                        of the Route. \n Support: Core"
+                        of the Route. \n Note that when a namespace is specified,
+                        a ReferencePolicy object is required in the referent namespace
+                        to allow that namespace's owner to accept the reference. See
+                        the ReferencePolicy documentation for details. \n Support:
+                        Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -1231,7 +1235,11 @@ spec:
                         namespace:
                           description: "Namespace is the namespace of the referent.
                             When unspecified (or empty string), this refers to the
-                            local namespace of the Route. \n Support: Core"
+                            local namespace of the Route. \n Note that when a namespace
+                            is specified, a ReferencePolicy object is required in
+                            the referent namespace to allow that namespace's owner
+                            to accept the reference. See the ReferencePolicy documentation
+                            for details. \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/config/crd/stable/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_tcproutes.yaml
@@ -96,7 +96,11 @@ spec:
                     namespace:
                       description: "Namespace is the namespace of the referent. When
                         unspecified (or empty string), this refers to the local namespace
-                        of the Route. \n Support: Core"
+                        of the Route. \n Note that when a namespace is specified,
+                        a ReferencePolicy object is required in the referent namespace
+                        to allow that namespace's owner to accept the reference. See
+                        the ReferencePolicy documentation for details. \n Support:
+                        Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -378,7 +382,11 @@ spec:
                         namespace:
                           description: "Namespace is the namespace of the referent.
                             When unspecified (or empty string), this refers to the
-                            local namespace of the Route. \n Support: Core"
+                            local namespace of the Route. \n Note that when a namespace
+                            is specified, a ReferencePolicy object is required in
+                            the referent namespace to allow that namespace's owner
+                            to accept the reference. See the ReferencePolicy documentation
+                            for details. \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/config/crd/stable/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_tlsroutes.yaml
@@ -142,7 +142,11 @@ spec:
                     namespace:
                       description: "Namespace is the namespace of the referent. When
                         unspecified (or empty string), this refers to the local namespace
-                        of the Route. \n Support: Core"
+                        of the Route. \n Note that when a namespace is specified,
+                        a ReferencePolicy object is required in the referent namespace
+                        to allow that namespace's owner to accept the reference. See
+                        the ReferencePolicy documentation for details. \n Support:
+                        Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -427,7 +431,11 @@ spec:
                         namespace:
                           description: "Namespace is the namespace of the referent.
                             When unspecified (or empty string), this refers to the
-                            local namespace of the Route. \n Support: Core"
+                            local namespace of the Route. \n Note that when a namespace
+                            is specified, a ReferencePolicy object is required in
+                            the referent namespace to allow that namespace's owner
+                            to accept the reference. See the ReferencePolicy documentation
+                            for details. \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/config/crd/stable/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_udproutes.yaml
@@ -96,7 +96,11 @@ spec:
                     namespace:
                       description: "Namespace is the namespace of the referent. When
                         unspecified (or empty string), this refers to the local namespace
-                        of the Route. \n Support: Core"
+                        of the Route. \n Note that when a namespace is specified,
+                        a ReferencePolicy object is required in the referent namespace
+                        to allow that namespace's owner to accept the reference. See
+                        the ReferencePolicy documentation for details. \n Support:
+                        Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -378,7 +382,11 @@ spec:
                         namespace:
                           description: "Namespace is the namespace of the referent.
                             When unspecified (or empty string), this refers to the
-                            local namespace of the Route. \n Support: Core"
+                            local namespace of the Route. \n Note that when a namespace
+                            is specified, a ReferencePolicy object is required in
+                            the referent namespace to allow that namespace's owner
+                            to accept the reference. See the ReferencePolicy documentation
+                            for details. \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$


### PR DESCRIPTION

**What type of PR is this?**

/kind bug
/kind api-change

**What this PR does / why we need it**:

Consistent use of ReferencePolicy across the API makes it more
predictable and easier to reason about. Document that ParentRef
references that cross namespaces are required to obey ReferencePolicy
restrictions. I believe that this was always the intention, though
the documentation text was overlooked.

**Which issue(s) this PR fixes**:

Fixes #973.

**Does this PR introduce a user-facing change?**:
```release-note
Controller implementations must enforce ReferencePolicy polocies when
attaching routes to gateways in different namespaces.
```
