### PR TITLE
Add kind matching helpers to object reference types.

### DIFF
--- a/apis/v1alpha2/object_reference_types.go
+++ b/apis/v1alpha2/object_reference_types.go
@@ -16,6 +16,22 @@ limitations under the License.
 
 package v1alpha2
 
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+func makeGroupKind(g *Group, k *Kind) schema.GroupKind {
+	var gk schema.GroupKind
+
+	if g != nil {
+		gk.Group = string(*g)
+	}
+
+	if k != nil {
+		gk.Kind = string(*k)
+	}
+
+	return gk
+}
+
 // LocalObjectReference identifies an API object within the namespace of the
 // referrer.
 // The API object must be valid in the cluster; the Group and Kind must
@@ -34,6 +50,11 @@ type LocalObjectReference struct {
 
 	// Name is the name of the referent.
 	Name ObjectName `json:"name"`
+}
+
+// HasKind tests whether the reference refers to a resource of the given GroupKind.
+func (l *LocalObjectReference) HasKind(gk schema.GroupKind) bool {
+	return gk == makeGroupKind(&l.Group, &l.Kind)
 }
 
 // SecretObjectReference identifies an API object including its namespace,
@@ -74,6 +95,11 @@ type SecretObjectReference struct {
 	//
 	// +optional
 	Namespace *Namespace `json:"namespace,omitempty"`
+}
+
+// HasKind tests whether the reference refers to a resource of the given GroupKind.
+func (s *SecretObjectReference) HasKind(gk schema.GroupKind) bool {
+	return gk == makeGroupKind(s.Group, s.Kind)
 }
 
 // BackendObjectReference defines how an ObjectReference that is
@@ -128,4 +154,9 @@ type BackendObjectReference struct {
 	//
 	// +optional
 	Port *PortNumber `json:"port,omitempty"`
+}
+
+// HasKind tests whether the reference refers to a resource of the given GroupKind.
+func (r *BackendObjectReference) HasKind(gk schema.GroupKind) bool {
+	return gk == makeGroupKind(r.Group, r.Kind)
 }

--- a/apis/v1alpha2/object_reference_types_test.go
+++ b/apis/v1alpha2/object_reference_types_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestRefKindMatch(t *testing.T) {
+	group := func(s string) *Group {
+		g := Group(s)
+		return &g
+	}
+
+	kind := func(s string) *Kind {
+		k := Kind(s)
+		return &k
+	}
+
+	t.Run("LocalObjectReference", func(t *testing.T) {
+		ref := LocalObjectReference{Group: "foo", Kind: "bar"}
+		assert.True(t, ref.HasKind(schema.GroupKind{Group: "foo", Kind: "bar"}))
+	})
+
+	t.Run("SecretObjectReference", func(t *testing.T) {
+		ref := SecretObjectReference{Group: group("foo"), Kind: kind("bar")}
+		assert.True(t, ref.HasKind(schema.GroupKind{Group: "foo", Kind: "bar"}))
+	})
+
+	t.Run("BackendObjectReference", func(t *testing.T) {
+		ref := BackendObjectReference{Group: group("foo"), Kind: kind("bar")}
+		assert.True(t, ref.HasKind(schema.GroupKind{Group: "foo", Kind: "bar"}))
+	})
+
+	t.Run("nil group matches empty", func(t *testing.T) {
+		ref := BackendObjectReference{Kind: kind("bar")}
+		assert.True(t, ref.HasKind(schema.GroupKind{Group: "", Kind: "bar"}))
+	})
+
+	t.Run("nil has an empty kind", func(t *testing.T) {
+		ref := BackendObjectReference{}
+		assert.True(t, ref.HasKind(schema.GroupKind{Group: "", Kind: ""}))
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind api-change

**What this PR does / why we need it**:

Every controller needs to test whether an object referene matches some
known group and kind, so it's probably convenient if we add a helper
directly to the API package.

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
Added the `HasKind()` member function to object reference types.
```
