### PR TITLE
Fixing accidental escaping of namespace/name in docs

### DIFF
--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -188,7 +188,7 @@ type HTTPRouteRule struct {
 	//   a creation timestamp of "2020-09-08 01:02:03" is given precedence over
 	//   a Route with a creation timestamp of "2020-09-08 01:02:04".
 	// * The Route appearing first in alphabetical order by
-	//   "<namespace>/<name>". For example, foo/bar is given precedence over
+	//   "{namespace}/{name}". For example, foo/bar is given precedence over
 	//   foo/baz.
 	//
 	// If ties still exist within the Route that has been given precedence,

--- a/apis/v1alpha1/tcproute_types.go
+++ b/apis/v1alpha1/tcproute_types.go
@@ -80,7 +80,7 @@ type TCPRouteRule struct {
 	//   a creation timestamp of "2020-09-08 01:02:03" is given precedence over
 	//   a Route with a creation timestamp of "2020-09-08 01:02:04".
 	// * The Route appearing first in alphabetical order by
-	//   "<namespace>/<name>". For example, foo/bar is given precedence over
+	//   "{namespace}/{name}". For example, foo/bar is given precedence over
 	//   foo/baz.
 	//
 	// If ties still exist within the Route that has been given precedence,

--- a/apis/v1alpha1/tlsroute_types.go
+++ b/apis/v1alpha1/tlsroute_types.go
@@ -88,7 +88,7 @@ type TLSRouteRule struct {
 	//   a creation timestamp of "2020-09-08 01:02:03" is given precedence over
 	//   a Route with a creation timestamp of "2020-09-08 01:02:04".
 	// * The Route appearing first in alphabetical order by
-	//   "<namespace>/<name>". For example, foo/bar is given precedence over
+	//   "{namespace}/{name}". For example, foo/bar is given precedence over
 	//   foo/baz.
 	//
 	// If ties still exist within the Route that has been given precedence,

--- a/apis/v1alpha1/udproute_types.go
+++ b/apis/v1alpha1/udproute_types.go
@@ -80,7 +80,7 @@ type UDPRouteRule struct {
 	//   a creation timestamp of "2020-09-08 01:02:03" is given precedence over
 	//   a Route with a creation timestamp of "2020-09-08 01:02:04".
 	// * The Route appearing first in alphabetical order by
-	//   "<namespace>/<name>". For example, foo/bar is given precedence over
+	//   "{namespace}/{name}". For example, foo/bar is given precedence over
 	//   foo/baz.
 	//
 	// If ties still exist within the Route that has been given precedence,

--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -152,7 +152,7 @@ type HTTPRouteRule struct {
 	//
 	// * The oldest Route based on creation timestamp.
 	// * The Route appearing first in alphabetical order by
-	//   "<namespace>/<name>".
+	//   "{namespace}/{name}".
 	//
 	// If ties still exist within the Route that has been given precedence,
 	// matching precedence MUST be granted to the first matching rule meeting

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -1054,7 +1054,7 @@ spec:
                         Routes, matching precedence MUST be determined in order of
                         the following criteria, continuing on ties: \n * The oldest
                         Route based on creation timestamp. * The Route appearing first
-                        in alphabetical order by   \"<namespace>/<name>\". \n If ties
+                        in alphabetical order by   \"{namespace}/{name}\". \n If ties
                         still exist within the Route that has been given precedence,
                         matching precedence MUST be granted to the first matching
                         rule meeting the above criteria."

--- a/config/crd/stable/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_httproutes.yaml
@@ -915,7 +915,7 @@ spec:
                         Routes, matching precedence MUST be determined in order of
                         the following criteria, continuing on ties: \n * The oldest
                         Route based on creation timestamp. * The Route appearing first
-                        in alphabetical order by   \"<namespace>/<name>\". \n If ties
+                        in alphabetical order by   \"{namespace}/{name}\". \n If ties
                         still exist within the Route that has been given precedence,
                         matching precedence MUST be granted to the first matching
                         rule meeting the above criteria."

--- a/site-src/geps/gep-713.md
+++ b/site-src/geps/gep-713.md
@@ -292,7 +292,7 @@ ties:
 * The oldest Policy based on creation timestamp. For example, a Policy with a
   creation timestamp of "2021-07-15 01:02:03" is given precedence over a Policy
   with a creation timestamp of "2021-07-15 01:02:04".
-* The Policy appearing first in alphabetical order by `<namespace>/<name>`. For
+* The Policy appearing first in alphabetical order by `{namespace}/{name}`. For
   example, foo/bar is given precedence over foo/baz.
 
 For a better user experience, a validating webhook can be implemented to prevent

--- a/site-src/v1alpha2/references/policy-attachment.md
+++ b/site-src/v1alpha2/references/policy-attachment.md
@@ -222,7 +222,7 @@ ties:
 * The oldest Policy based on creation timestamp. For example, a Policy with a
   creation timestamp of "2021-07-15 01:02:03" is given precedence over a Policy
   with a creation timestamp of "2021-07-15 01:02:04".
-* The Policy appearing first in alphabetical order by "<namespace>/<name>". For
+* The Policy appearing first in alphabetical order by "{namespace}/{name}". For
   example, foo/bar is given precedence over foo/baz.
 
 ### Kubectl Plugin


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
This fixes the bug found by @howardjohn in #979

**Which issue(s) this PR fixes**:
Fixes #979

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
