### PR TITLE
Add a package to ease working with references.

### DIFF
--- a/pkg/reference/ref.go
+++ b/pkg/reference/ref.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reference
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+var (
+	// DefaultParentKind is the default metav1.GroupKind for ParentReferences.
+	DefaultParentKind = metav1.GroupKind{
+		Group: v1alpha2.GroupName,
+		Kind:  "Gateway",
+	}
+
+	// DefaultSecretKind is the default metav1.GroupKind for SecretObjectReferences.
+	DefaultSecretKind = metav1.GroupKind{
+		Group: "",
+		Kind:  "Secret",
+	}
+
+	// DefaultBackendObjectKind is the default metav1.GroupKind for BackendObjectReferences.
+	DefaultBackendObjectKind = metav1.GroupKind{
+		Group: "",
+		Kind:  "Service",
+	}
+)
+
+func referenceKind(gk metav1.GroupKind, g *v1alpha2.Group, k *v1alpha2.Kind) metav1.GroupKind {
+	if g != nil {
+		gk.Group = string(*g)
+	}
+
+	if k != nil {
+		gk.Kind = string(*k)
+	}
+
+	return gk
+}
+
+func referenceNamespace(ns *v1alpha2.Namespace) string {
+	if ns != nil {
+		return string(*ns)
+	}
+
+	return ""
+}
+
+// Ref is an interface that represents a reference to a resource.
+type Ref interface {
+	Name() string
+	Namespace() string
+	Kind() metav1.GroupKind
+}
+
+// Local returns a Ref for the LocalObjectReference ref.
+func Local(ref *v1alpha2.LocalObjectReference) Ref {
+	return &localRef{ref}
+}
+
+type localRef struct {
+	ref *v1alpha2.LocalObjectReference
+}
+
+func (l *localRef) Name() string {
+	return string(l.ref.Name)
+}
+
+func (l *localRef) Namespace() string {
+	return ""
+}
+
+func (l *localRef) Kind() metav1.GroupKind {
+	return metav1.GroupKind{Group: string(l.ref.Group), Kind: string(l.ref.Kind)}
+}
+
+// Parent returns a Ref for the ParentReference ref.
+func Parent(ref *v1alpha2.ParentReference) Ref {
+	return &parentRef{ref}
+}
+
+type parentRef struct {
+	ref *v1alpha2.ParentReference
+}
+
+func (p *parentRef) Name() string {
+	return string(p.ref.Name)
+}
+
+func (p *parentRef) Namespace() string {
+	return referenceNamespace(p.ref.Namespace)
+}
+
+func (p *parentRef) Kind() metav1.GroupKind {
+	return referenceKind(DefaultParentKind, p.ref.Group, p.ref.Kind)
+}
+
+// Secret returns a Ref for the SecretObjectReference ref.
+func Secret(ref *v1alpha2.SecretObjectReference) Ref {
+	return &secretRef{ref}
+}
+
+type secretRef struct {
+	ref *v1alpha2.SecretObjectReference
+}
+
+func (s *secretRef) Name() string {
+	return string(s.ref.Name)
+}
+
+func (s *secretRef) Namespace() string {
+	return referenceNamespace(s.ref.Namespace)
+}
+
+func (s *secretRef) Kind() metav1.GroupKind {
+	return referenceKind(DefaultSecretKind, s.ref.Group, s.ref.Kind)
+}
+
+// Backend returns a Ref for the BackendObjectReference ref.
+func Backend(ref *v1alpha2.BackendObjectReference) Ref {
+	return &backendRef{ref}
+}
+
+type backendRef struct {
+	ref *v1alpha2.BackendObjectReference
+}
+
+func (s *backendRef) Name() string {
+	return string(s.ref.Name)
+}
+
+func (s *backendRef) Namespace() string {
+	return referenceNamespace(s.ref.Namespace)
+}
+
+func (s *backendRef) Kind() metav1.GroupKind {
+	return referenceKind(DefaultBackendObjectKind, s.ref.Group, s.ref.Kind)
+}
+
+// NamespaceOf returns the namespace of the Gateway API object reference
+// given by ref when it is referenced from parent. If ref does not specify
+// a namespace, then the namespace of parent is returned.
+func NamespaceOf(parent metav1.Object, ref Ref) string {
+	if ns := ref.Namespace(); ns != "" {
+		return ns
+	}
+
+	return parent.GetNamespace()
+}
+
+// NamespacedName returns the fully qualified object name of ref when
+// it is referenced by the object parent. If ref does not specify
+// a namespace, then the namespace of parent is used.
+func NamespacedName(parent metav1.Object, ref Ref) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: NamespaceOf(parent, ref),
+		Name:      ref.Name(),
+	}
+}

--- a/pkg/reference/ref_test.go
+++ b/pkg/reference/ref_test.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reference
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestNamespacedRefCreate(t *testing.T) {
+	kind := v1alpha2.Kind("SomeKind")
+	group := v1alpha2.Group("SomeGroup")
+	name := v1alpha2.ObjectName("SomeName")
+	namespace := v1alpha2.Namespace("SomeNamespace")
+
+	check := func(t *testing.T, ref Ref) {
+		kind := metav1.GroupKind{
+			Group: string(group),
+			Kind:  string(kind),
+		}
+
+		assert.Equal(t, string(name), ref.Name())
+		assert.Equal(t, string(namespace), ref.Namespace())
+		assert.Equal(t, kind, ref.Kind())
+	}
+
+	t.Run("secret", func(t *testing.T) {
+		check(t, Secret(&v1alpha2.SecretObjectReference{
+			Group:     &group,
+			Kind:      &kind,
+			Name:      name,
+			Namespace: &namespace,
+		}))
+	})
+
+	t.Run("parent", func(t *testing.T) {
+		check(t, Parent(&v1alpha2.ParentReference{
+			Group:     &group,
+			Kind:      &kind,
+			Name:      name,
+			Namespace: &namespace,
+		}))
+	})
+
+	t.Run("backend", func(t *testing.T) {
+		check(t, Backend(&v1alpha2.BackendObjectReference{
+			Group:     &group,
+			Kind:      &kind,
+			Name:      name,
+			Namespace: &namespace,
+		}))
+	})
+}
+
+func TestRefCreate(t *testing.T) {
+	kind := v1alpha2.Kind("SomeKind")
+	group := v1alpha2.Group("SomeGroup")
+	name := v1alpha2.ObjectName("SomeName")
+
+	check := func(t *testing.T, ref Ref) {
+		kind := metav1.GroupKind{
+			Group: string(group),
+			Kind:  string(kind),
+		}
+
+		assert.Equal(t, string(name), ref.Name())
+		assert.Equal(t, string(""), ref.Namespace())
+		assert.Equal(t, kind, ref.Kind())
+	}
+
+	t.Run("secret", func(t *testing.T) {
+		check(t, Secret(&v1alpha2.SecretObjectReference{
+			Group: &group,
+			Kind:  &kind,
+			Name:  name,
+		}))
+	})
+
+	t.Run("parent", func(t *testing.T) {
+		check(t, Parent(&v1alpha2.ParentReference{
+			Group: &group,
+			Kind:  &kind,
+			Name:  name,
+		}))
+	})
+
+	t.Run("backend", func(t *testing.T) {
+		check(t, Backend(&v1alpha2.BackendObjectReference{
+			Group: &group,
+			Kind:  &kind,
+			Name:  name,
+		}))
+	})
+
+	t.Run("local", func(t *testing.T) {
+		ref := Local(&v1alpha2.LocalObjectReference{
+			Group: group,
+			Kind:  kind,
+			Name:  name,
+		})
+
+		kind := metav1.GroupKind{
+			Group: string(group),
+			Kind:  string(kind),
+		}
+
+		assert.Equal(t, string(name), ref.Name())
+		assert.Equal(t, "", ref.Namespace())
+		assert.Equal(t, kind, ref.Kind())
+	})
+}
+
+func TestNamespacedRefNamespaceOf(t *testing.T) {
+	kind := v1alpha2.Kind("SomeKind")
+	group := v1alpha2.Group("SomeGroup")
+	name := v1alpha2.ObjectName("SomeName")
+	namespace := v1alpha2.Namespace("SomeNamespace")
+
+	parent := &v1alpha2.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "parent",
+			Namespace: "gateway-test",
+		},
+	}
+
+	check := func(t *testing.T, ref Ref) {
+		assert.Equal(t, string(namespace), NamespaceOf(parent, ref))
+	}
+
+	t.Run("secret", func(t *testing.T) {
+		check(t, Secret(&v1alpha2.SecretObjectReference{
+			Group:     &group,
+			Kind:      &kind,
+			Name:      name,
+			Namespace: &namespace,
+		}))
+	})
+
+	t.Run("parent", func(t *testing.T) {
+		check(t, Parent(&v1alpha2.ParentReference{
+			Group:     &group,
+			Kind:      &kind,
+			Name:      name,
+			Namespace: &namespace,
+		}))
+	})
+
+	t.Run("backend", func(t *testing.T) {
+		check(t, Backend(&v1alpha2.BackendObjectReference{
+			Group:     &group,
+			Kind:      &kind,
+			Name:      name,
+			Namespace: &namespace,
+		}))
+	})
+}
+
+func TestRefNamespaceOf(t *testing.T) {
+	kind := v1alpha2.Kind("SomeKind")
+	group := v1alpha2.Group("SomeGroup")
+	name := v1alpha2.ObjectName("SomeName")
+
+	parent := &v1alpha2.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "parent",
+			Namespace: "gateway-test",
+		},
+	}
+
+	check := func(t *testing.T, ref Ref) {
+		assert.Equal(t, "gateway-test", NamespaceOf(parent, ref))
+	}
+
+	t.Run("secret", func(t *testing.T) {
+		check(t, Secret(&v1alpha2.SecretObjectReference{
+			Group: &group,
+			Kind:  &kind,
+			Name:  name,
+		}))
+	})
+
+	t.Run("parent", func(t *testing.T) {
+		check(t, Parent(&v1alpha2.ParentReference{
+			Group: &group,
+			Kind:  &kind,
+			Name:  name,
+		}))
+	})
+
+	t.Run("backend", func(t *testing.T) {
+		check(t, Backend(&v1alpha2.BackendObjectReference{
+			Group: &group,
+			Kind:  &kind,
+			Name:  name,
+		}))
+	})
+}
+
+func TestNamespacedRefNamespacedName(t *testing.T) {
+	kind := v1alpha2.Kind("SomeKind")
+	group := v1alpha2.Group("SomeGroup")
+	name := v1alpha2.ObjectName("SomeName")
+	namespace := v1alpha2.Namespace("SomeNamespace")
+
+	parent := &v1alpha2.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "parent",
+			Namespace: "gateway-test",
+		},
+	}
+
+	check := func(t *testing.T, ref Ref) {
+		n := types.NamespacedName{
+			Namespace: string(namespace),
+			Name:      string(name),
+		}
+		assert.Equal(t, n, NamespacedName(parent, ref))
+	}
+
+	t.Run("secret", func(t *testing.T) {
+		check(t, Secret(&v1alpha2.SecretObjectReference{
+			Group:     &group,
+			Kind:      &kind,
+			Name:      name,
+			Namespace: &namespace,
+		}))
+	})
+
+	t.Run("parent", func(t *testing.T) {
+		check(t, Parent(&v1alpha2.ParentReference{
+			Group:     &group,
+			Kind:      &kind,
+			Name:      name,
+			Namespace: &namespace,
+		}))
+	})
+
+	t.Run("backend", func(t *testing.T) {
+		check(t, Backend(&v1alpha2.BackendObjectReference{
+			Group:     &group,
+			Kind:      &kind,
+			Name:      name,
+			Namespace: &namespace,
+		}))
+	})
+}
+
+func TestRefNamespacedName(t *testing.T) {
+	kind := v1alpha2.Kind("SomeKind")
+	group := v1alpha2.Group("SomeGroup")
+	name := v1alpha2.ObjectName("SomeName")
+
+	parent := &v1alpha2.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "parent",
+			Namespace: "gateway-test",
+		},
+	}
+
+	check := func(t *testing.T, ref Ref) {
+		n := types.NamespacedName{
+			Namespace: "gateway-test",
+			Name:      string(name),
+		}
+		assert.Equal(t, n, NamespacedName(parent, ref))
+	}
+
+	t.Run("secret", func(t *testing.T) {
+		check(t, Secret(&v1alpha2.SecretObjectReference{
+			Group: &group,
+			Kind:  &kind,
+			Name:  name,
+		}))
+	})
+
+	t.Run("parent", func(t *testing.T) {
+		check(t, Parent(&v1alpha2.ParentReference{
+			Group: &group,
+			Kind:  &kind,
+			Name:  name,
+		}))
+	})
+
+	t.Run("backend", func(t *testing.T) {
+		check(t, Backend(&v1alpha2.BackendObjectReference{
+			Group: &group,
+			Kind:  &kind,
+			Name:  name,
+		}))
+	})
+}
+
+func TestRefDefaultKind(t *testing.T) {
+	check := func(group string, kind string, ref Ref) {
+		gk := ref.Kind()
+		assert.Equal(t, group, gk.Group)
+		assert.Equal(t, kind, gk.Kind)
+	}
+
+	check("", "", Local(&v1alpha2.LocalObjectReference{}))
+	check(string(v1alpha2.GroupName), "Gateway", Parent(&v1alpha2.ParentReference{}))
+	check("", "Secret", Secret(&v1alpha2.SecretObjectReference{}))
+	check("", "Service", Backend(&v1alpha2.BackendObjectReference{}))
+
+	grp := v1alpha2.Group("G")
+	check("G", "", Local(&v1alpha2.LocalObjectReference{Group: grp}))
+	check("G", "Gateway", Parent(&v1alpha2.ParentReference{Group: &grp}))
+	check("G", "Secret", Secret(&v1alpha2.SecretObjectReference{Group: &grp}))
+	check("G", "Service", Backend(&v1alpha2.BackendObjectReference{Group: &grp}))
+
+	knd := v1alpha2.Kind("K")
+	check("", "K", Local(&v1alpha2.LocalObjectReference{Kind: knd}))
+	check(string(v1alpha2.GroupName), "K", Parent(&v1alpha2.ParentReference{Kind: &knd}))
+	check("", "K", Secret(&v1alpha2.SecretObjectReference{Kind: &knd}))
+	check("", "K", Backend(&v1alpha2.BackendObjectReference{Kind: &knd}))
+
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind api-change

**What this PR does / why we need it**:

The Gateway API uses a number of types to store references to Kubernetes
objects. Add a small API to make it easier to work with these in a
consistent and type safe way.

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:

```release-note
Added a `reference` package for controller authors.
```
