### PR TITLE
Fix listener allowed kinds documentation.

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -381,7 +381,7 @@ type AllowedRoutes struct {
 	// with the application protocol specified in the Listener's Protocol field.
 	// If an implementation does not support or recognize this resource type, it
 	// MUST set the "ResolvedRefs" condition to False for this Listener with the
-	// "InvalidRoutesRef" reason.
+	// "InvalidRouteKinds" reason.
 	//
 	// Support: Core
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -166,7 +166,7 @@ spec:
                             with the application protocol specified in the Listener's
                             Protocol field. If an implementation does not support
                             or recognize this resource type, it MUST set the \"ResolvedRefs\"
-                            condition to False for this Listener with the \"InvalidRoutesRef\"
+                            condition to False for this Listener with the \"InvalidRouteKinds\"
                             reason. \n Support: Core"
                           items:
                             description: RouteGroupKind indicates the group and kind

--- a/config/crd/stable/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_gateways.yaml
@@ -166,7 +166,7 @@ spec:
                             with the application protocol specified in the Listener's
                             Protocol field. If an implementation does not support
                             or recognize this resource type, it MUST set the \"ResolvedRefs\"
-                            condition to False for this Listener with the \"InvalidRoutesRef\"
+                            condition to False for this Listener with the \"InvalidRouteKinds\"
                             reason. \n Support: Core"
                           items:
                             description: RouteGroupKind indicates the group and kind


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

If the listener allowed kinds are not supported, the reason should be
InvalidRouteKinds, not InvalidRoutesRef.

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
