### PR TITLE
Migrate kube-webhook-certgen to k8s.gcr.io/ingress-nginx:v1.1.1

### DIFF
--- a/deploy/certificate_config.yaml
+++ b/deploy/certificate_config.yaml
@@ -96,7 +96,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: docker.io/jettech/kube-webhook-certgen:v1.5.0
+          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -130,7 +130,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: docker.io/jettech/kube-webhook-certgen:v1.5.0
+          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1
           imagePullPolicy: IfNotPresent
           args:
             - patch


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The admission webhook certificate generation fails on k8s v1.22, see jet/kube-webhook-certgen#30.
The jet upstream is no longer supported.
It was forked, moved into kubernetes/ingress-nginx, fixed
and is now published at k8s.gcr.io/ingress-nginx.

See also https://github.com/kubernetes/k8s.io/blob/main/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml

**Which issue(s) this PR fixes**:
Fixes #990 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Fix webhook deployment on k8s v1.22+
```
