### PR TITLE
Additional Conformance Tests covering HTTPRoute and Gateway

### DIFF
--- a/conformance/tests/httproute-cross-namespace.go
+++ b/conformance/tests/httproute-cross-namespace.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteCrossNamespace)
+}
+
+var HTTPRouteCrossNamespace = suite.ConformanceTest{
+	ShortName:   "HTTPRouteCrossNamespace",
+	Description: "A single HTTPRoute in the gateway-conformance-web-backend namespace should attach to Gateway in another namespace",
+	Manifests:   []string{"cross-namespace.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		routeNN := types.NamespacedName{Name: "cross-namespace", Namespace: "gateway-conformance-web-backend"}
+		gwNN := types.NamespacedName{Name: "backend-namespaces", Namespace: "gateway-conformance-infra"}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN)
+
+		t.Run("Simple HTTP request should reach web-backend", func(t *testing.T) {
+			t.Logf("Making request to http://%s", gwAddr)
+			cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(roundtripper.Request{
+				URL:      url.URL{Scheme: "http", Host: gwAddr},
+				Protocol: "HTTP",
+			})
+
+			require.NoErrorf(t, err, "error making request")
+
+			http.ExpectResponse(t, cReq, cRes, http.ExpectedResponse{
+				Request: http.ExpectedRequest{
+					Method: "GET",
+					Path:   "/",
+				},
+				StatusCode: 200,
+				Backend:    "web-backend",
+				Namespace:  "gateway-conformance-web-backend",
+			})
+		})
+	},
+}

--- a/conformance/tests/httproute-cross-namespace.yaml
+++ b/conformance/tests/httproute-cross-namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: cross-namespace
+  namespace: gateway-conformance-web-backend
+spec:
+  parentRefs:
+  - name: backend-namespaces
+    namespace: gateway-conformance-infra
+  rules:
+  - backendRefs:
+    - name: web-backend
+      port: 8080

--- a/conformance/tests/httproute-invalid-cross-namespace.go
+++ b/conformance/tests/httproute-invalid-cross-namespace.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteInvalidCrossNamespace)
+}
+
+var HTTPRouteInvalidCrossNamespace = suite.ConformanceTest{
+	ShortName:   "HTTPRouteInvalidCrossNamespace",
+	Description: "A single HTTPRoute in the gateway-conformance-web-backend namespace should fail to attach to a Gateway in another namespace that it is not allowed to",
+	Manifests:   []string{"invalid-cross-namespace.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		routeName := types.NamespacedName{Name: "invalid-cross-namespace", Namespace: "gateway-conformance-web-backend"}
+		gwName := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
+
+		// TODO: Determine if this is actually what we want. It is likely
+		// preferable to have status set with some kind of warning/error message
+		// but that is also unlikely to be universally achievable.
+		t.Run("Route should not have Parents set in status", func(t *testing.T) {
+			parents := []v1alpha2.RouteParentStatus{}
+			kubernetes.HTTPRouteMustHaveParents(t, suite.Client, routeName, parents, true, 60)
+		})
+
+		t.Run("Gateway should have 0 Routes attached", func(t *testing.T) {
+			gw := &v1alpha2.Gateway{}
+			err := suite.Client.Get(context.TODO(), gwName, gw)
+			require.NoError(t, err, "error fetching Gateway")
+			// There are two valid ways to represent this:
+			// 1. No listeners in status
+			// 2. One listener in status with 0 attached routes
+			if len(gw.Status.Listeners) == 0 {
+				// No listeners in status.
+			} else if len(gw.Status.Listeners) == 1 {
+				require.Equal(t, int32(0), gw.Status.Listeners[0].AttachedRoutes)
+			} else {
+				t.Errorf("Expected no more than 1 listener in status, got %d", len(gw.Status.Listeners))
+			}
+		})
+	},
+}

--- a/conformance/tests/httproute-invalid-cross-namespace.yaml
+++ b/conformance/tests/httproute-invalid-cross-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: invalid-cross-namespace
+  namespace: gateway-conformance-web-backend
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: web-backend
+      port: 8080

--- a/conformance/tests/httproute-matching-across-routes.go
+++ b/conformance/tests/httproute-matching-across-routes.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteMatchingAcrossRoutes)
+}
+
+var HTTPRouteMatchingAcrossRoutes = suite.ConformanceTest{
+	ShortName:   "HTTPRouteMatchingAcrossRoutes",
+	Description: "Two HTTPRoutes with path matching for different backends",
+	Manifests:   []string{"matching-across-routes.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeNN1 := types.NamespacedName{Name: "matching-part1", Namespace: ns}
+		routeNN2 := types.NamespacedName{Name: "matching-part2", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN1, routeNN2)
+
+		testCases := []http.ExpectedResponse{{
+			Request: http.ExpectedRequest{
+				Host: "example.com",
+				Path: "/",
+			},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request: http.ExpectedRequest{
+				Host: "example.com",
+				Path: "/example",
+			},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request: http.ExpectedRequest{
+				Host: "example.net",
+				Path: "/example",
+			},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request: http.ExpectedRequest{
+				Host:    "example.com",
+				Path:    "/example",
+				Headers: map[string]string{"Version": "one"},
+			},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request: http.ExpectedRequest{
+				Host: "example.com",
+				Path: "/v2",
+			},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}, {
+			Request: http.ExpectedRequest{
+				// v2 matches are limited to *.com
+				Host: "example.net",
+				Path: "/v2",
+			},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request: http.ExpectedRequest{
+				Host: "example.com",
+				Path: "/v2/example",
+			},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}, {
+			Request: http.ExpectedRequest{
+				Host:    "example.com",
+				Path:    "/",
+				Headers: map[string]string{"Version": "two"},
+			},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}}
+
+		for i, tc := range testCases {
+			t.Run(testName(tc, i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectResponse(t, suite.RoundTripper, gwAddr, tc)
+			})
+		}
+	},
+}
+
+func testName(tc http.ExpectedResponse, i int) string {
+	headerStr := ""
+	if tc.Request.Headers != nil {
+		headerStr = " with headers"
+	}
+
+	return fmt.Sprintf("%d request to %s%s%s should go to %s", i, tc.Request.Host, tc.Request.Path, headerStr, tc.Backend)
+}

--- a/conformance/tests/httproute-matching-across-routes.yaml
+++ b/conformance/tests/httproute-matching-across-routes.yaml
@@ -1,0 +1,44 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: matching-part1
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  hostnames:
+  - example.com
+  - example.net
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    - headers:
+      - name: version
+        value: one
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: matching-part2
+  namespace: gateway-conformance-infra
+spec:
+  hostnames:
+  - "*.com"
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /v2
+    - headers:
+      - name: version
+        value: two
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080

--- a/conformance/tests/httproute-matching.go
+++ b/conformance/tests/httproute-matching.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteMatching)
+}
+
+var HTTPRouteMatching = suite.ConformanceTest{
+	ShortName:   "HTTPRouteMatching",
+	Description: "A single HTTPRoute with path and header matching for different backends",
+	Manifests:   []string{"matching.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Name: "matching", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN)
+
+		testCases := []http.ExpectedResponse{{
+			Request:   http.ExpectedRequest{Path: "/"},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request:   http.ExpectedRequest{Path: "/example"},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request:   http.ExpectedRequest{Path: "/", Headers: map[string]string{"Version": "one"}},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request:   http.ExpectedRequest{Path: "/v2"},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}, {
+			Request:   http.ExpectedRequest{Path: "/v2/example"},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}, {
+			Request:   http.ExpectedRequest{Path: "/", Headers: map[string]string{"Version": "two"}},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}}
+
+		for i, tc := range testCases {
+			t.Run(testName(tc, i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectResponse(t, suite.RoundTripper, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-matching.yaml
+++ b/conformance/tests/httproute-matching.yaml
@@ -1,0 +1,29 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: matching
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    - headers:
+      - name: version
+        value: one
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /v2
+    - headers:
+      - name: version
+        value: two
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As suggested by @hbagdi, this is a follow up PR to add the remaining conformance tests that were initially part of #969. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
