### PR TITLE
Change Admitted to Accepted in v1alpha2 docs

### DIFF
--- a/site-src/v1alpha2/api-types/gatewayclass.md
+++ b/site-src/v1alpha2/api-types/gatewayclass.md
@@ -79,12 +79,12 @@ kind: GatewayClass
 ...
 status:
   conditions:
-  - type: Admitted
+  - type: Accepted
     status: False
     ...
 ```
 
-A new `GatewayClass` will start with the `Admitted` condition set to
+A new `GatewayClass` will start with the `Accepted` condition set to
 `False`. At this point the controller has not seen the configuration. Once the
 controller has processed the configuration, the condition will be set to
 `True`:
@@ -94,7 +94,7 @@ kind: GatewayClass
 ...
 status:
   conditions:
-  - type: Admitted
+  - type: Accepted
     status: True
     ...
 ```
@@ -107,7 +107,7 @@ kind: GatewayClass
 ...
 status:
   conditions:
-  - type: Admitted
+  - type: Accepted
     status: False
     Reason: BadFooBar
     Message: "foobar" is an FooBar.

--- a/site-src/v1alpha2/api-types/httproute.md
+++ b/site-src/v1alpha2/api-types/httproute.md
@@ -167,7 +167,7 @@ parentRefs, the controller that manages the Gateway should add an entry to this
 list when the controller first sees the route and should update the entry as
 appropriate when the route is modified.
 
-The following example indicates HTTPRoute "http-example" has been admitted by
+The following example indicates HTTPRoute "http-example" has been accepted by
 Gateway "gw-example" in namespace "gw-example-ns":
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1alpha1
@@ -181,7 +181,7 @@ status:
       name: gw-example
       namespace: gw-example-ns
     conditions:
-    - type: Admitted
+    - type: Accepted
       status: "True"
 ```
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
`Admitted` was changed to `Accepted` for v1alpha2 and some documentation wasn't updated to reflect this.

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
