### PR TITLE
Update image generation process with more consistent naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 # Note that the ?= operator works regardless.
 
 # Enable Go modules.
-GO111MODULE=on
+export GO111MODULE=on
 
 # The registry to push container images to.
 export REGISTRY ?= gcr.io/k8s-staging-gateway-api

--- a/Makefile
+++ b/Makefile
@@ -14,18 +14,31 @@
 
 # We need all the Make variables exported as env vars.
 # Note that the ?= operator works regardless.
-.EXPORT_ALL_VARIABLES:
 
 # Enable Go modules.
 GO111MODULE=on
 
-REGISTRY ?= gcr.io/k8s-staging-gateway-api
+# The registry to push container images to.
+export REGISTRY ?= gcr.io/k8s-staging-gateway-api
 
 # These are overridden by cloudbuild.yaml when run by Prow.
-GIT_TAG ?= dev
-BASE_REF ?= master
 
-COMMIT=$(shell git rev-parse --short HEAD)
+# Prow gives this a value of the form vYYYYMMDD-hash.
+# (It's similar to `git describe` output, and for non-tag
+# builds will give vYYYYMMDD-COMMITS-HASH where COMMITS is the
+# number of commits since the last tag.)
+export GIT_TAG ?= dev
+
+# Prow gives this the reference it's called on.
+# The test-infra config job only allows our cloudbuild to
+# be called on `master` and semver tags, so this will be
+# set to one of those things.
+export BASE_REF ?= master
+
+# The commit hash of the current checkout
+# Used to pass a binary version for master,
+# overridden to semver for tagged versions.
+export COMMIT=$(shell git rev-parse --short HEAD)
 
 DOCKER ?= docker
 # TOP is the current directory where this Makefile lives.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,7 +11,8 @@ steps:
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
-    - TAG=$_GIT_TAG
+    - GIT_TAG=$_GIT_TAG
+    - BASE_REF=$_PULL_BASE_REF
     args:
     - release-staging
 substitutions:

--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -71,20 +71,20 @@ fi
 
 # First, build the image, with the version info passed in.
 # Note that an image will *always* be built tagged with the GIT_TAG, so we know when it was built.
-echo docker build --build-arg COMMIT=${BINARY_VERSION} --build-arg TAG=${VERSION_TAG} \
+docker build --build-arg COMMIT=${BINARY_VERSION} --build-arg TAG=${VERSION_TAG} \
   			-t ${REGISTRY}/admission-server:${GIT_TAG} .
 
-echo docker push ${REGISTRY}/admission-server:${GIT_TAG}
+docker push ${REGISTRY}/admission-server:${GIT_TAG}
 
 # Then, we add extra tags if required.
 if [[ $VERSION_TAG != $GIT_TAG ]]
 then
-	echo docker tag ${REGISTRY}/admission-server:${GIT_TAG} ${REGISTRY}/admission-server:${VERSION_TAG}
-	echo docker push ${REGISTRY}/admission-server:${VERSION_TAG}
+    docker tag ${REGISTRY}/admission-server:${GIT_TAG} ${REGISTRY}/admission-server:${VERSION_TAG}
+    docker push ${REGISTRY}/admission-server:${VERSION_TAG}
 fi
 
 if [[ $LATEST == true ]]
 then
-	echo docker tag ${REGISTRY}/admission-server:${GIT_TAG} ${REGISTRY}/admission-server:latest
-	echo docker push ${REGISTRY}/admission-server:latest
+    docker tag ${REGISTRY}/admission-server:${GIT_TAG} ${REGISTRY}/admission-server:latest
+    docker push ${REGISTRY}/admission-server:latest
 fi

--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is run by cloudbuild, from cloudbuild.yaml, using `make release-staging`.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ -z "${GIT_TAG-}" ]];
+then
+    echo "GIT_TAG env var must be set and nonempty."
+    exit 1
+fi
+
+if [[ -z "${BASE_REF-}" ]];
+then
+    echo "BASE_REF env var must be set and nonempty."
+    exit 1
+fi
+
+if [[ -z "${COMMIT-}" ]];
+then
+    echo "COMMIT env var must be set and nonempty."
+    exit 1
+fi
+
+if [[ -z "${REGISTRY-}" ]];
+then
+    echo "REGISTRY env var must be set and nonempty."
+    exit 1
+fi
+
+
+LATEST=false
+
+VERSION_TAG=$GIT_TAG
+
+BINARY_VERSION=$COMMIT
+
+# $BASE_REF has only two things that it can be set to by cloudbuild and Prow,
+# `master`, or a semver tag.
+# This is controlled by k8s.io/test-infra/config/jobs/image-pushing/k8s-staging-gateway-api.yaml.
+if [[ "${BASE_REF}" != "master" ]]
+then
+    # Since we know this is built from a tag or release branch, we can set the VERSION_TAG
+    VERSION_TAG="${BASE_REF}"
+    # We want the binary version to show up correctly too.
+    BINARY_VERSION="${BASE_REF}"
+    # Use some bash magic to check if the semver does not end with -sometext, that
+    # would indicate a prerelease version. If this is not a prerelease, then we want to set
+    # the `latest` tag too.
+    if [[ ! "${BASE_REF}" =~ -(.+)$ ]];
+    then
+    LATEST=true
+    fi
+fi
+
+# First, build the image, with the version info passed in.
+# Note that an image will *always* be built tagged with the GIT_TAG, so we know when it was built.
+echo docker build --build-arg COMMIT=${BINARY_VERSION} --build-arg TAG=${VERSION_TAG} \
+  			-t ${REGISTRY}/admission-server:${GIT_TAG} .
+
+echo docker push ${REGISTRY}/admission-server:${GIT_TAG}
+
+# Then, we add extra tags if required.
+if [[ $VERSION_TAG != $GIT_TAG ]]
+then
+	echo docker tag ${REGISTRY}/admission-server:${GIT_TAG} ${REGISTRY}/admission-server:${VERSION_TAG}
+	echo docker push ${REGISTRY}/admission-server:${VERSION_TAG}
+fi
+
+if [[ $LATEST == true ]]
+then
+	echo docker tag ${REGISTRY}/admission-server:${GIT_TAG} ${REGISTRY}/admission-server:latest
+	echo docker push ${REGISTRY}/admission-server:latest
+fi


### PR DESCRIPTION
Signed-off-by: Nick Young <ynick@vmware.com>

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adds some tooling around building admission-server images, so that we end up with:
- all images built and pushed are labelled with the standard Prow version string, like `v20220209-v0.4.0-114-g36b4551`.
- Images built for a semver branch or tag are also labelled with the branch or tag name
- Images built for a semver branch or tag that don't have a prerelease marker (like `-rc2`, `-beta1` or similar are labelled `latest`.

This will mean that we can now generate consistent manifest YAML for the admission-server when we release a bundle by tagging a branch with a semver tag, since the images will be available by `v0.4.1` or whatever.

I'll leave changing out the build to a multiarch one (#627) for another PR. Having it in a script should make that easier though.

**Which issue(s) this PR fixes**:
Updates #916 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
