### PR TITLE
API overview fixes

### DIFF
--- a/site-src/concepts/api-overview.md
+++ b/site-src/concepts/api-overview.md
@@ -171,9 +171,9 @@ following mechanisms:
 
 1. **Hostname:** When the `hostname` field on a listener is set, attached Routes
    that specify a `hostnames` field must have at least one overlapping value.
-2. **Namespaces:** The `namespaces` field on a listener can be used to restrict
-   where Routes may be attached from. The `namespaces.from` field supports the
-   following values:
+2. **Namespaces:** The `allowedRoutes.namespaces` field on a listener can be
+   used to restrict where Routes may be attached from. The `namespaces.from`
+   field supports the following values:
     * `SameNamespace` is the default option. Only Routes in the same namespace
       as this Gateway may be attached.
     * `All` will allow Routes from all Namespaces to be attached.
@@ -181,8 +181,8 @@ following mechanisms:
       Namespace label selector may be attached to this Gateway. When `Selector`
       is used, the `namespaces.selector` field must be used to specify label
       selectors. This field is not supported with `All` or `SameNamespace`.
-3. **Kinds:** The `kinds` field on a listener can be used to restrict the kinds
-   of Routes that may be attached.
+3. **Kinds:** The `allowedRoutes.kinds` field on a listener can be used to
+   restrict the kinds of Routes that may be attached.
 
 If none of the above are specified, a Gateway listener will trust Routes
 attached from the same namespace that support the listener protocol.

--- a/site-src/concepts/api-overview.md
+++ b/site-src/concepts/api-overview.md
@@ -190,9 +190,9 @@ attached from the same namespace that support the listener protocol.
 #### Further Gateway - Route attachment examples
 
 The following `my-route` Route wants to attach to the `foo-gateway` in the
-`foo-namespace` and will not attach to any other Gateways. Note that
+`gateway-api-example-ns1` and will not attach to any other Gateways. Note that
 `foo-gateway` is in a different Namespace. The `foo-gateway` must allow
-attachment from HTTPRoutes in the namespace `bar-namespace`.
+attachment from HTTPRoutes in the namespace `gateway-api-example-ns2`.
 
 ```yaml
 {% include 'v1alpha2/http-route-attachment/httproute.yaml' %}

--- a/site-src/concepts/api-overview.md
+++ b/site-src/concepts/api-overview.md
@@ -179,9 +179,8 @@ following mechanisms:
     * `All` will allow Routes from all Namespaces to be attached.
     * `Selector` means that Routes from a subset of Namespaces selected by a
       Namespace label selector may be attached to this Gateway. When `Selector`
-      is used, the `listeners.routes.namespaces.selector` field must be used to
-      specify label selectors. This field is not supported with `All` or
-      `SameNamespace`.
+      is used, the `namespaces.selector` field must be used to specify label
+      selectors. This field is not supported with `All` or `SameNamespace`.
 3. **Kinds:** The `kinds` field on a listener can be used to restrict the kinds
    of Routes that may be attached.
 


### PR DESCRIPTION
A few small fixes:

- **don't specify full namespaces.selector path:** the section describing allowedRoutes.namespaces field confusingly uses the full path for the namespace selector, suggesting it's talking about different sections of the spec.
- **qualify allowedRoutes namespaces and kinds:** without qualification, we're currently suggesting that namespaces and kinds are listener fields, like hostname.
- **fix namespace typos:** the route attachment examples moved from foo-namespace and bar-namespace in commit #792

/kind cleanup
/kind documentation