### PR TITLE
feat: allow URL overrides for conformance test manifests

### DIFF
--- a/conformance/tests/httproute-simple-same-namespace.go
+++ b/conformance/tests/httproute-simple-same-namespace.go
@@ -37,7 +37,7 @@ func init() {
 var HTTPRouteSimpleSameNamespace = suite.ConformanceTest{
 	ShortName:   "HTTPRouteSimpleSameNamespace",
 	Description: "A single HTTPRoute in the gateway-conformance-infra namespace attaches to a Gateway in the same namespace",
-	Manifests:   []string{"httproute-simple-same-namespace.yaml"},
+	Manifests:   []string{"tests/httproute-simple-same-namespace.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := v1alpha2.Namespace("gateway-conformance-infra")
 		routeNN := types.NamespacedName{Name: "gateway-conformance-infra-test", Namespace: string(ns)}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The conformance tests include some hard-coded file paths for testing manifests. This patch makes it possible to override them with your own file paths and additionally enables URL support so that Golang projects can more easily run the test suite by using the [Golang Package](https://pkg.go.dev/sigs.k8s.io/gateway-api).