### PR TITLE
docs: update kong gateway APIs URL

### DIFF
--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -127,7 +127,7 @@ Kong is actively working on an implementation of the Gateway API in the [Kong Ku
 
 [kong]:https://konghq.com
 [kic]:https://github.com/kong/kubernetes-ingress-controller
-[kong-gw-guide]:https://github.com/Kong/kubernetes-ingress-controller/blob/main/FEATURE_PREVIEW_DOCUMENTATION.md#feature-preview-gateway-apis
+[kong-gw-guide]:https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/using-gateway-api/
 
 ### Traefik
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The location of the documentation for the Kong implementation
of Gateway APIs has changed from the ingress controller
repository to Kong's standard documentation site.