### PR TITLE
tcp guide: remove section on metadata based tcp matches

### DIFF
--- a/site-src/v1alpha2/guides/tcp.md
+++ b/site-src/v1alpha2/guides/tcp.md
@@ -65,15 +65,6 @@ address patterns. In this way separate `TCPRoute` objects can be responsible
 for routing different traffic on the same `Gateway` listener and can enable
 significant flexibility for pure TCP routing.
 
-## Alternatives: TCP Traffic Routing Using Metadata
-
-While in the above examples we mainly focused on routing by port, it is also
-possible to use metadata to route traffic from the `Gateway` to the underlying
-`TCPRoutes` using `spec.rules[].matches[].extensionRef`.
-
-See the [spec][tcproute] for more details on how to configure alternative logic
-for routing TCP traffic beyond just using ports and selecting `listener` names.
-
 [tcproute]:/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute
 [tcp]:https://datatracker.ietf.org/doc/html/rfc793
 [httproute]:/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRoute


### PR DESCRIPTION
In #808, we documented how the tcp route match extension point can be used for metadata based tcp matching.

Soon after, in #829, this extension point was removed, but the docs remained.

Remove this section to reflect the current state of the API.

/kind cleanup
/kind documentation