### PR TITLE
fix(conformance): manifest filenames and reading from disk

### DIFF
--- a/conformance/tests/httproute-cross-namespace.go
+++ b/conformance/tests/httproute-cross-namespace.go
@@ -36,7 +36,7 @@ func init() {
 var HTTPRouteCrossNamespace = suite.ConformanceTest{
 	ShortName:   "HTTPRouteCrossNamespace",
 	Description: "A single HTTPRoute in the gateway-conformance-web-backend namespace should attach to Gateway in another namespace",
-	Manifests:   []string{"cross-namespace.yaml"},
+	Manifests:   []string{"tests/httproute-cross-namespace.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "cross-namespace", Namespace: "gateway-conformance-web-backend"}
 		gwNN := types.NamespacedName{Name: "backend-namespaces", Namespace: "gateway-conformance-infra"}

--- a/conformance/tests/httproute-invalid-cross-namespace.go
+++ b/conformance/tests/httproute-invalid-cross-namespace.go
@@ -35,7 +35,7 @@ func init() {
 var HTTPRouteInvalidCrossNamespace = suite.ConformanceTest{
 	ShortName:   "HTTPRouteInvalidCrossNamespace",
 	Description: "A single HTTPRoute in the gateway-conformance-web-backend namespace should fail to attach to a Gateway in another namespace that it is not allowed to",
-	Manifests:   []string{"invalid-cross-namespace.yaml"},
+	Manifests:   []string{"tests/httproute-invalid-cross-namespace.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		routeName := types.NamespacedName{Name: "invalid-cross-namespace", Namespace: "gateway-conformance-web-backend"}
 		gwName := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}

--- a/conformance/tests/httproute-matching-across-routes.go
+++ b/conformance/tests/httproute-matching-across-routes.go
@@ -34,7 +34,7 @@ func init() {
 var HTTPRouteMatchingAcrossRoutes = suite.ConformanceTest{
 	ShortName:   "HTTPRouteMatchingAcrossRoutes",
 	Description: "Two HTTPRoutes with path matching for different backends",
-	Manifests:   []string{"matching-across-routes.yaml"},
+	Manifests:   []string{"tests/httproute-matching-across-routes.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN1 := types.NamespacedName{Name: "matching-part1", Namespace: ns}

--- a/conformance/tests/httproute-matching.go
+++ b/conformance/tests/httproute-matching.go
@@ -33,7 +33,7 @@ func init() {
 var HTTPRouteMatching = suite.ConformanceTest{
 	ShortName:   "HTTPRouteMatching",
 	Description: "A single HTTPRoute with path and header matching for different backends",
-	Manifests:   []string{"matching.yaml"},
+	Manifests:   []string{"tests/httproute-matching.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "matching", Namespace: ns}

--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -134,7 +134,7 @@ func getContentsFromPathOrURL(location string) (*bytes.Buffer, error) {
 			return nil, err
 		}
 
-		count, err := manifests.Read(b)
+		count, err := manifests.Write(b)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Makes the conformance tests runnable with the local manifests


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
