### PR TITLE
minor conformance test fixes

### DIFF
--- a/conformance/tests/httproute-matching-across-routes.go
+++ b/conformance/tests/httproute-matching-across-routes.go
@@ -103,7 +103,10 @@ var HTTPRouteMatchingAcrossRoutes = suite.ConformanceTest{
 			Namespace: ns,
 		}}
 
-		for i, tc := range testCases {
+		for i := range testCases {
+			// Declare tc here to avoid loop variable
+			// reuse issues across parallel tests.
+			tc := testCases[i]
 			t.Run(testName(tc, i), func(t *testing.T) {
 				t.Parallel()
 				http.MakeRequestAndExpectResponse(t, suite.RoundTripper, gwAddr, tc)

--- a/conformance/tests/httproute-matching-across-routes.go
+++ b/conformance/tests/httproute-matching-across-routes.go
@@ -80,7 +80,7 @@ var HTTPRouteMatchingAcrossRoutes = suite.ConformanceTest{
 			Namespace: ns,
 		}, {
 			Request: http.ExpectedRequest{
-				// v2 matches are limited to *.com
+				// v2 matches are limited to example.com
 				Host: "example.net",
 				Path: "/v2",
 			},

--- a/conformance/tests/httproute-matching-across-routes.yaml
+++ b/conformance/tests/httproute-matching-across-routes.yaml
@@ -28,7 +28,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   hostnames:
-  - "*.com"
+  - example.com
   parentRefs:
   - name: same-namespace
   rules:

--- a/conformance/tests/httproute-matching.go
+++ b/conformance/tests/httproute-matching.go
@@ -66,7 +66,10 @@ var HTTPRouteMatching = suite.ConformanceTest{
 			Namespace: ns,
 		}}
 
-		for i, tc := range testCases {
+		for i := range testCases {
+			// Declare tc here to avoid loop variable
+			// reuse issues across parallel tests.
+			tc := testCases[i]
 			t.Run(testName(tc, i), func(t *testing.T) {
 				t.Parallel()
 				http.MakeRequestAndExpectResponse(t, suite.RoundTripper, gwAddr, tc)

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -91,7 +91,8 @@ func NamespacesMustBeReady(t *testing.T, c client.Client, namespaces []string, s
 				t.Errorf("Error listing Pods: %v", err)
 			}
 			for _, pod := range podList.Items {
-				if !findPodConditionInList(t, pod.Status.Conditions, "Ready", "True") {
+				if !findPodConditionInList(t, pod.Status.Conditions, "Ready", "True") &&
+					pod.Status.Phase != v1.PodSucceeded {
 					t.Logf("%s/%s Pod not ready yet", ns, pod.Name)
 					return false, nil
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**What this PR does / why we need it**:
- allows Succeeded pods to exist in conformance test namespaces
- fixes loop variable bug in parallel conformance tests
- fixes HTTPRoute hostname in the "matching across routes" conformance test

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
