### PR TITLE
Fix release-staging cloudbuild job - hopefully

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,10 @@ export BASE_REF ?= master
 # The commit hash of the current checkout
 # Used to pass a binary version for master,
 # overridden to semver for tagged versions.
-export COMMIT=$(shell git rev-parse --short HEAD)
+# Cloudbuild will set this in the environment to the
+# commit SHA, since the Prow does not seem to check out
+# a git repo.
+export COMMIT ?= $(shell git rev-parse --short HEAD)
 
 DOCKER ?= docker
 # TOP is the current directory where this Makefile lives.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,6 +13,7 @@ steps:
     - DOCKER_CLI_EXPERIMENTAL=enabled
     - GIT_TAG=$_GIT_TAG
     - BASE_REF=$_PULL_BASE_REF
+    - COMMIT=$_PULL_BASE_SHA
     args:
     - release-staging
 substitutions:
@@ -22,3 +23,5 @@ substitutions:
   # _PULL_BASE_REF will contain the ref that was pushed to to trigger this build -
   # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
   _PULL_BASE_REF: 'master'
+  # _PULL_BASE_SHA will contain the Git SHA of the commit that was pushed to trigger this build.
+  _PULL_BASE_SHA: 'abcdef'


### PR DESCRIPTION
Signed-off-by: Nick Young <ynick@vmware.com>

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/kind cleanup

**What this PR does / why we need it**:
Cherry-pick #1043 back to release-0.4 so we can test.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
