### PR TITLE
Updating k8s references docs links to go to 1.23 instead of 1.18

### DIFF
--- a/hack/api-docs/config.json
+++ b/hack/api-docs/config.json
@@ -13,7 +13,7 @@
         },
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
             "typeMatchPrefix": "^github\\.com/knative/pkg/apis/duck/",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind documentation

**What this PR does / why we need it**:
This updates our k8s reference docs links to go to 1.23 instead of 1.18.

**Which issue(s) this PR fixes**:
Fixes #1032

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
