### PR TITLE
Adding anchor links in reference docs

### DIFF
--- a/hack/api-docs/type.tpl
+++ b/hack/api-docs/type.tpl
@@ -3,6 +3,7 @@
 <h3 id="{{ anchorIDForType . }}">
     {{- .Name.Name }}
     {{ if eq .Kind "Alias" }}(<code>{{.Underlying}}</code> alias)</p>{{ end -}}
+    <a class="headerlink" href="#{{ anchorIDForType . }}" title="Permanent link">¶</a>
 </h3>
 {{ with (typeReferences .) }}
     <p>


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This adds anchor links in our reference docs as suggested in #1031

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
