### PR TITLE
Add master label to the most recent image build

### DIFF
--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -45,8 +45,8 @@ then
 fi
 
 
-# We tag the image with :latest for the most recent PR merge.
-LATEST=true
+# We tag the image with :latest for the most recent PR merge to master.
+LATEST=false
 
 VERSION_TAG=$GIT_TAG
 
@@ -62,10 +62,12 @@ then
 
     # We want the binary version to show up correctly too.
     BINARY_VERSION="${BASE_REF}"
-
-    # If we're on a semver baseref, then we don't want to tag the image with :latest
-    LATEST=false
+else
+    # If our base ref == "master" then we will tag :latest.
+    LATEST=true
 fi
+
+
 
 # First, build the image, with the version info passed in.
 # Note that an image will *always* be built tagged with the GIT_TAG, so we know when it was built.

--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -45,7 +45,8 @@ then
 fi
 
 
-LATEST=false
+# We tag the image with :latest for the most recent PR merge.
+LATEST=true
 
 VERSION_TAG=$GIT_TAG
 
@@ -58,15 +59,12 @@ if [[ "${BASE_REF}" != "master" ]]
 then
     # Since we know this is built from a tag or release branch, we can set the VERSION_TAG
     VERSION_TAG="${BASE_REF}"
+
     # We want the binary version to show up correctly too.
     BINARY_VERSION="${BASE_REF}"
-    # Use some bash magic to check if the semver does not end with -sometext, that
-    # would indicate a prerelease version. If this is not a prerelease, then we want to set
-    # the `latest` tag too.
-    if [[ ! "${BASE_REF}" =~ -(.+)$ ]];
-    then
-    LATEST=true
-    fi
+
+    # If we're on a semver baseref, then we don't want to tag the image with :latest
+    LATEST=false
 fi
 
 # First, build the image, with the version info passed in.
@@ -83,10 +81,6 @@ if [[ $VERSION_TAG != $GIT_TAG ]]
 then
     docker tag ${REGISTRY}/admission-server:${GIT_TAG} ${REGISTRY}/admission-server:${VERSION_TAG}
     docker push ${REGISTRY}/admission-server:${VERSION_TAG}
-else
-# Otherwise, we're on master and we should update the master image here too.
-    docker tag ${REGISTRY}/admission-server:${GIT_TAG} ${REGISTRY}/admission-server:master
-    docker push ${REGISTRY}/admission-server:master
 fi
 
 if [[ $LATEST == true ]]

--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -77,10 +77,16 @@ docker build --build-arg COMMIT=${BINARY_VERSION} --build-arg TAG=${VERSION_TAG}
 docker push ${REGISTRY}/admission-server:${GIT_TAG}
 
 # Then, we add extra tags if required.
+# If the version tag and the git tag aren't the same, we're on a release branch, so
+# we need to push the release tag.
 if [[ $VERSION_TAG != $GIT_TAG ]]
 then
     docker tag ${REGISTRY}/admission-server:${GIT_TAG} ${REGISTRY}/admission-server:${VERSION_TAG}
     docker push ${REGISTRY}/admission-server:${VERSION_TAG}
+else
+# Otherwise, we're on master and we should update the master image here too.
+    docker tag ${REGISTRY}/admission-server:${GIT_TAG} ${REGISTRY}/admission-server:master
+    docker push ${REGISTRY}/admission-server:master
 fi
 
 if [[ $LATEST == true ]]


### PR DESCRIPTION
Signed-off-by: Nick Young <ynick@vmware.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
As I started working on #1017, I realized that we'll need to have a way to refer to "whatever image is the latest master" for our living-dangerously users, so I propose we also add a `master` label, which will go on anything that doesn't get a semver label.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Updates #1017

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
