### PR TITLE
Fixing outdated examples to use controllerName instead of controller

### DIFF
--- a/site-src/v1alpha2/api-types/gatewayclass.md
+++ b/site-src/v1alpha2/api-types/gatewayclass.md
@@ -12,7 +12,7 @@ kind: GatewayClass
 metadata:
   name: cluster-gateway
 spec:
-  controller: "example.net/gateway-controller"
+  controllerName: "example.net/gateway-controller"
 ```
 
 We expect that one or more `GatewayClasses` will be created by the
@@ -50,7 +50,7 @@ kind: GatewayClass
 metadata:
   name: internet
 spec:
-  controller: "example.net/gateway-controller"
+  controllerName: "example.net/gateway-controller"
   parametersRef:
     group: example.net/v1alpha1
     kind: Config


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
@ruigulala found these outdated examples, this fixes them.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
