### PR TITLE
Avoid creating obsolete gateway-api namespace

### DIFF
--- a/deploy/certificate_config.yaml
+++ b/deploy/certificate_config.yaml
@@ -1,9 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: gateway-api
-  labels:
-    name: gateway-api
+  name: gateway-system
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Small issue in #1051 - both manifests create the required namespace and we only renamed gateway-api to gateway-system in one of them.

Before:

```
namespace/gateway-system created
validatingwebhookconfiguration.admissionregistration.k8s.io/gateway-api-admission created
service/gateway-api-admission-server created
deployment.apps/gateway-api-admission-server created
namespace/gateway-api created
```

after:

```
namespace/gateway-system created
validatingwebhookconfiguration.admissionregistration.k8s.io/gateway-api-admission created
service/gateway-api-admission-server created
deployment.apps/gateway-api-admission-server created
namespace/gateway-system unchanged
```

/kind cleanup