### PR TITLE
Clarifying TLS Reencryption Docs

### DIFF
--- a/site-src/concepts/api-overview.md
+++ b/site-src/concepts/api-overview.md
@@ -112,11 +112,16 @@ to allow multiple Routes to share ports on the Listener.
 
 |Object|OSI Layer|Routing Discriminator|TLS Support|Purpose|
 |------|---------|---------------------|-----------|-------|
-|HTTPRoute| Layer 7 | Anything in the HTTP Protocol | Terminated only, can be reencrypted| HTTP and HTTPS Routing|
-|TLSRoute| Somewhere between layer 4 and 7| SNI or other TLS properties| Passthrough or terminated, can be reencrypted if terminated. | Routing of TLS protocols including HTTPS where inspection of the HTTP stream is not required.|
+|HTTPRoute| Layer 7 | Anything in the HTTP Protocol | Terminated only | HTTP and HTTPS Routing|
+|TLSRoute| Somewhere between layer 4 and 7| SNI or other TLS properties| Passthrough or Terminated | Routing of TLS protocols including HTTPS where inspection of the HTTP stream is not required.|
 |TCPRoute| Layer 4| destination port | Passthrough or Terminated | Allows for forwarding of a TCP stream from the Listener to the Backends |
 |UDPRoute| Layer 4| destination port | None | Allows for forwarding of a UDP stream from the Listener to the Backends. |
 
+Note that traffic routed via HTTPRoute and TCPRoute can be encrypted between the
+Gateway and backend (commonly referred to as reencryption). It is not possible
+to configure that with existing Gateway API resources, but implementations may
+provide custom configuration for this until there is a standardized approach
+defined by Gateway API.
 
 ### Attaching Routes to Gateways
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This fixes a confusing part of our documentation that describes reencryption as being possible without clarifying that it is not currently configurable with the API. If/when this merges, I'll create a follow up issue to track the feature request/GEP for configuring reencryption.

**Which issue(s) this PR fixes**:
Fixes #968

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
