### PR TITLE
conformance: embed manifests in Go binary

### DIFF
--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package conformance
+// conformance_test contains code to run the conformance tests. This is in its own package to avoid circular imports.
+package conformance_test
 
 import (
 	"flag"

--- a/conformance/embed.go
+++ b/conformance/embed.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import "embed"
+
+//go:embed tests/* base/*
+var Manifests embed.FS


### PR DESCRIPTION
This allows importing the suite as a go package and running in
controller repos. This was the same stated purpose as
https://github.com/kubernetes-sigs/gateway-api/pull/1023; we would
prefer not to pull manifests from URL though. Its possible the URL
support is obsolete from this, or we can keep both depending on
feedback.

**What type of PR is this?**
/kind feature
**What this PR does / why we need it**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
