### PR TITLE
Cherry pick webhook improvements and bug fixes into release-0.4

### DIFF
--- a/apis/v1alpha2/validation/httproute.go
+++ b/apis/v1alpha2/validation/httproute.go
@@ -46,55 +46,61 @@ func ValidateHTTPRoute(route *gatewayv1a2.HTTPRoute) field.ErrorList {
 // validateHTTPRouteSpec validates that required fields of spec are set according to the
 // HTTPRoute specification.
 func validateHTTPRouteSpec(spec *gatewayv1a2.HTTPRouteSpec, path *field.Path) field.ErrorList {
-	return validateHTTPRouteUniqueFilters(spec.Rules, path.Child("rules"))
+	var errs field.ErrorList
+	for i, rule := range spec.Rules {
+		errs = append(errs, validateHTTPRouteFilters(rule.Filters, path.Child("rules").Index(i))...)
+		for j, backendRef := range rule.BackendRefs {
+			errs = append(errs, validateHTTPRouteFilters(backendRef.Filters, path.Child("rules").Index(i).Child("backendsrefs").Index(j))...)
+		}
+	}
+	errs = append(errs, validateHTTPRouteBackendServicePorts(spec.Rules, path.Child("rules"))...)
+	return errs
 }
 
-// validateHTTPRouteUniqueFilters validates whether each core and extended filter
-// is used at most once in each rule.
-func validateHTTPRouteUniqueFilters(rules []gatewayv1a2.HTTPRouteRule, path *field.Path) field.ErrorList {
+// validateHTTPRouteBackendServicePorts validates that v1.Service backends always have a port.
+func validateHTTPRouteBackendServicePorts(rules []gatewayv1a2.HTTPRouteRule, path *field.Path) field.ErrorList {
 	var errs field.ErrorList
 
 	for i, rule := range rules {
-		counts := map[gatewayv1a2.HTTPRouteFilterType]int{}
-		for _, filter := range rule.Filters {
-			counts[filter.Type]++
-		}
-		// custom filters don't have any validation
-		for _, key := range repeatableHTTPRouteFilters {
-			delete(counts, key)
-		}
-
-		for filterType, count := range counts {
-			if count > 1 {
-				errs = append(errs, field.Invalid(path.Index(i).Child("filters"), filterType, "cannot be used multiple times in the same rule"))
+		path = path.Index(i).Child("backendRefs")
+		for i, ref := range rule.BackendRefs {
+			if ref.BackendObjectReference.Group != nil &&
+				*ref.BackendObjectReference.Group != "" {
+				continue
 			}
-		}
 
-		if errList := validateHTTPBackendUniqueFilters(rule.BackendRefs, path, i); len(errList) > 0 {
-			errs = append(errs, errList...)
+			if ref.BackendObjectReference.Kind != nil &&
+				*ref.BackendObjectReference.Kind != "Service" {
+				continue
+			}
+
+			if ref.BackendObjectReference.Port == nil {
+				errs = append(errs, field.Required(path.Index(i).Child("port"), "missing port for Service reference"))
+			}
 		}
 	}
 
 	return errs
 }
 
-func validateHTTPBackendUniqueFilters(ref []gatewayv1a2.HTTPBackendRef, path *field.Path, i int) field.ErrorList {
+// validateHTTPRouteFilters validates that a list of core and extended filters
+// is used at most once and that the filter type matches its value
+func validateHTTPRouteFilters(filters []gatewayv1a2.HTTPRouteFilter, path *field.Path) field.ErrorList {
 	var errs field.ErrorList
+	counts := map[gatewayv1a2.HTTPRouteFilterType]int{}
 
-	for _, bkr := range ref {
-		counts := map[gatewayv1a2.HTTPRouteFilterType]int{}
-		for _, filter := range bkr.Filters {
-			counts[filter.Type]++
-		}
+	for i, filter := range filters {
+		counts[filter.Type]++
+		validateHTTPRouteFilterTypeMatchesValue(filter, path.Index(i))
+	}
+	// custom filters don't have any validation
+	for _, key := range repeatableHTTPRouteFilters {
+		delete(counts, key)
+	}
 
-		for _, key := range repeatableHTTPRouteFilters {
-			delete(counts, key)
-		}
-
-		for filterType, count := range counts {
-			if count > 1 {
-				errs = append(errs, field.Invalid(path.Index(i).Child("BackendRefs"), filterType, "cannot be used multiple times in the same backend"))
-			}
+	for filterType, count := range counts {
+		if count > 1 {
+			errs = append(errs, field.Invalid(path.Child("filters"), filterType, "cannot be used multiple times in the same rule"))
 		}
 	}
 	return errs
@@ -136,4 +142,35 @@ func validateHTTPPathMatch(path *gatewayv1a2.HTTPPathMatch, fldPath *field.Path)
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("pathType"), *path.Type, pathTypes))
 	}
 	return allErrs
+}
+
+// validateHTTPRouteFilterTypeMatchesValue validates that only the expected fields are
+//// set for the specified filter type.
+func validateHTTPRouteFilterTypeMatchesValue(filter gatewayv1a2.HTTPRouteFilter, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if filter.ExtensionRef != nil && filter.Type != gatewayv1a2.HTTPRouteFilterExtensionRef {
+		errs = append(errs, field.Invalid(path, filter.ExtensionRef, "must be nil if the HTTPRouteFilter.Type is not ExtensionRef"))
+	}
+	if filter.ExtensionRef == nil && filter.Type == gatewayv1a2.HTTPRouteFilterExtensionRef {
+		errs = append(errs, field.Required(path, "filter.ExtensionRef must be specified for ExtensionRef HTTPRouteFilter.Type"))
+	}
+	if filter.RequestHeaderModifier != nil && filter.Type != gatewayv1a2.HTTPRouteFilterRequestHeaderModifier {
+		errs = append(errs, field.Invalid(path, filter.RequestHeaderModifier, "must be nil if the HTTPRouteFilter.Type is not RequestHeaderModifier"))
+	}
+	if filter.RequestHeaderModifier == nil && filter.Type == gatewayv1a2.HTTPRouteFilterRequestHeaderModifier {
+		errs = append(errs, field.Required(path, "filter.RequestHeaderModifier must be specified for RequestHeaderModifier HTTPRouteFilter.Type"))
+	}
+	if filter.RequestMirror != nil && filter.Type != gatewayv1a2.HTTPRouteFilterRequestMirror {
+		errs = append(errs, field.Invalid(path, filter.RequestMirror, "must be nil if the HTTPRouteFilter.Type is not RequestMirror"))
+	}
+	if filter.RequestMirror == nil && filter.Type == gatewayv1a2.HTTPRouteFilterRequestMirror {
+		errs = append(errs, field.Required(path, "filter.RequestMirror must be specified for RequestMirror HTTPRouteFilter.Type"))
+	}
+	if filter.RequestRedirect != nil && filter.Type != gatewayv1a2.HTTPRouteFilterRequestRedirect {
+		errs = append(errs, field.Invalid(path, filter.RequestRedirect, "must be nil if the HTTPRouteFilter.Type is not RequestRedirect"))
+	}
+	if filter.RequestRedirect == nil && filter.Type == gatewayv1a2.HTTPRouteFilterRequestRedirect {
+		errs = append(errs, field.Required(path, "filter.RequestRedirect must be specified for RequestRedirect HTTPRouteFilter.Type"))
+	}
+	return errs
 }

--- a/apis/v1alpha2/validation/httproute_test.go
+++ b/apis/v1alpha2/validation/httproute_test.go
@@ -291,7 +291,10 @@ func TestValidateHTTPRoute(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validateHTTPRouteUniqueFilters(tc.rules, field.NewPath("spec").Child("rules"))
+			var errs field.ErrorList
+			for _, rules := range tc.rules {
+				errs = validateHTTPRouteFilters(rules.Filters, field.NewPath("spec").Child("rules"))
+			}
 			if len(errs) != tc.errCount {
 				t.Errorf("ValidateHTTPRoute() got %v errors, want %v errors", len(errs), tc.errCount)
 			}
@@ -381,10 +384,12 @@ func TestValidateHTTPBackendUniqueFilters(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			for index, rule := range tc.hRoute.Spec.Rules {
-				errs := validateHTTPBackendUniqueFilters(rule.BackendRefs, field.NewPath("spec").Child("rules"), index)
-				if len(errs) != tc.errCount {
-					t.Errorf("ValidateHTTPRoute() got %d errors, want %d errors", len(errs), tc.errCount)
+			for _, rule := range tc.hRoute.Spec.Rules {
+				for _, backendRef := range rule.BackendRefs {
+					errs := validateHTTPRouteFilters(backendRef.Filters, field.NewPath("spec").Child("rules"))
+					if len(errs) != tc.errCount {
+						t.Errorf("ValidateHTTPRoute() got %d errors, want %d errors", len(errs), tc.errCount)
+					}
 				}
 			}
 		})
@@ -427,6 +432,260 @@ func TestValidateHTTPPathMatch(t *testing.T) {
 			errs := validateHTTPPathMatch(tc.path, field.NewPath("spec").Child("rules").Child("matches").Child("path"))
 			if len(errs) != tc.errCount {
 				t.Errorf("TestValidateHTTPPathMatch() got %v errors, want %v errors", len(errs), tc.errCount)
+			}
+		})
+	}
+}
+
+func TestValidateServicePort(t *testing.T) {
+	portPtr := func(n int) *gatewayv1a2.PortNumber {
+		p := gatewayv1a2.PortNumber(n)
+		return &p
+	}
+
+	groupPtr := func(g string) *gatewayv1a2.Group {
+		p := gatewayv1a2.Group(g)
+		return &p
+	}
+
+	kindPtr := func(k string) *gatewayv1a2.Kind {
+		p := gatewayv1a2.Kind(k)
+		return &p
+	}
+
+	tests := []struct {
+		name     string
+		route    *gatewayv1a2.HTTPRoute
+		errCount int
+	}{
+		{
+			name:     "default groupkind with port",
+			errCount: 0,
+			route: &gatewayv1a2.HTTPRoute{
+				Spec: gatewayv1a2.HTTPRouteSpec{
+					Rules: []gatewayv1a2.HTTPRouteRule{{
+						BackendRefs: []gatewayv1a2.HTTPBackendRef{{
+							BackendRef: gatewayv1a2.BackendRef{
+								BackendObjectReference: gatewayv1a2.BackendObjectReference{
+									Name: "backend",
+									Port: portPtr(99),
+								},
+							},
+						}},
+					}},
+				},
+			},
+		}, {
+			name:     "default groupkind with no port",
+			errCount: 1,
+			route: &gatewayv1a2.HTTPRoute{
+				Spec: gatewayv1a2.HTTPRouteSpec{
+					Rules: []gatewayv1a2.HTTPRouteRule{{
+						BackendRefs: []gatewayv1a2.HTTPBackendRef{{
+							BackendRef: gatewayv1a2.BackendRef{
+								BackendObjectReference: gatewayv1a2.BackendObjectReference{
+									Name: "backend",
+								},
+							},
+						}},
+					}},
+				},
+			},
+		}, {
+			name:     "explicit service with port",
+			errCount: 0,
+			route: &gatewayv1a2.HTTPRoute{
+				Spec: gatewayv1a2.HTTPRouteSpec{
+					Rules: []gatewayv1a2.HTTPRouteRule{{
+						BackendRefs: []gatewayv1a2.HTTPBackendRef{{
+							BackendRef: gatewayv1a2.BackendRef{
+								BackendObjectReference: gatewayv1a2.BackendObjectReference{
+									Group: groupPtr(""),
+									Kind:  kindPtr("Service"),
+									Name:  "backend",
+									Port:  portPtr(99),
+								},
+							},
+						}},
+					}},
+				},
+			},
+		}, {
+			name:     "explicit service with no port",
+			errCount: 1,
+			route: &gatewayv1a2.HTTPRoute{
+				Spec: gatewayv1a2.HTTPRouteSpec{
+					Rules: []gatewayv1a2.HTTPRouteRule{{
+						BackendRefs: []gatewayv1a2.HTTPBackendRef{{
+							BackendRef: gatewayv1a2.BackendRef{
+								BackendObjectReference: gatewayv1a2.BackendObjectReference{
+									Group: groupPtr(""),
+									Kind:  kindPtr("Service"),
+									Name:  "backend",
+								},
+							},
+						}},
+					}},
+				},
+			},
+		}, {
+			name:     "explicit ref with no port",
+			errCount: 0,
+			route: &gatewayv1a2.HTTPRoute{
+				Spec: gatewayv1a2.HTTPRouteSpec{
+					Rules: []gatewayv1a2.HTTPRouteRule{{
+						BackendRefs: []gatewayv1a2.HTTPBackendRef{{
+							BackendRef: gatewayv1a2.BackendRef{
+								BackendObjectReference: gatewayv1a2.BackendObjectReference{
+									Group: groupPtr("foo.example.com"),
+									Kind:  kindPtr("Foo"),
+									Name:  "backend",
+								},
+							},
+						}},
+					}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateHTTPRouteBackendServicePorts(tc.route.Spec.Rules, field.NewPath("spec").Child("rules"))
+			if len(errs) != tc.errCount {
+				t.Errorf("got %v errors, want %v errors: %s", len(errs), tc.errCount, errs)
+			}
+		})
+	}
+}
+
+func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
+	tests := []struct {
+		name        string
+		routeFilter gatewayv1a2.HTTPRouteFilter
+		errCount    int
+	}{
+		{
+			name: "valid HTTPRouteFilterRequestHeaderModifier route filter",
+			routeFilter: gatewayv1a2.HTTPRouteFilter{
+				Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{
+					Set:    []gatewayv1a2.HTTPHeader{{Name: "name"}},
+					Add:    []gatewayv1a2.HTTPHeader{{Name: "add"}},
+					Remove: []string{"remove"},
+				},
+			},
+			errCount: 0,
+		},
+		{
+			name: "invalid HTTPRouteFilterRequestHeaderModifier type filter with non-matching field",
+			routeFilter: gatewayv1a2.HTTPRouteFilter{
+				Type:          gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
+				RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{},
+			},
+			errCount: 2,
+		},
+		{
+			name: "invalid HTTPRouteFilterRequestHeaderModifier type filter with empty value field",
+			routeFilter: gatewayv1a2.HTTPRouteFilter{
+				Type: gatewayv1a2.HTTPRouteFilterRequestHeaderModifier,
+			},
+			errCount: 1,
+		},
+		{
+			name: "valid HTTPRouteFilterRequestMirror route filter",
+			routeFilter: gatewayv1a2.HTTPRouteFilter{
+				Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
+				RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{BackendRef: gatewayv1a2.BackendObjectReference{
+					Group:     new(gatewayv1a2.Group),
+					Kind:      new(gatewayv1a2.Kind),
+					Name:      "name",
+					Namespace: new(gatewayv1a2.Namespace),
+					Port:      pkgutils.PortNumberPtr(22),
+				}},
+			},
+			errCount: 0,
+		},
+		{
+			name: "invalid HTTPRouteFilterRequestMirror type filter with non-matching field",
+			routeFilter: gatewayv1a2.HTTPRouteFilter{
+				Type:                  gatewayv1a2.HTTPRouteFilterRequestMirror,
+				RequestHeaderModifier: &gatewayv1a2.HTTPRequestHeaderFilter{},
+			},
+			errCount: 2,
+		},
+		{
+			name: "invalid HTTPRouteFilterRequestMirror type filter with empty value field",
+			routeFilter: gatewayv1a2.HTTPRouteFilter{
+				Type: gatewayv1a2.HTTPRouteFilterRequestMirror,
+			},
+			errCount: 1,
+		},
+		{
+			name: "valid HTTPRouteFilterRequestRedirect route filter",
+			routeFilter: gatewayv1a2.HTTPRouteFilter{
+				Type: gatewayv1a2.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1a2.HTTPRequestRedirectFilter{
+					Scheme:     new(string),
+					Port:       new(gatewayv1a2.PortNumber),
+					StatusCode: new(int),
+				},
+			},
+			errCount: 0,
+		},
+		{
+			name: "invalid HTTPRouteFilterRequestRedirect type filter with non-matching field",
+			routeFilter: gatewayv1a2.HTTPRouteFilter{
+				Type:          gatewayv1a2.HTTPRouteFilterRequestRedirect,
+				RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{},
+			},
+			errCount: 2,
+		},
+		{
+			name: "invalid HTTPRouteFilterRequestRedirect type filter with empty value field",
+			routeFilter: gatewayv1a2.HTTPRouteFilter{
+				Type: gatewayv1a2.HTTPRouteFilterRequestRedirect,
+			},
+			errCount: 1,
+		},
+		{
+			name: "valid HTTPRouteFilterExtensionRef filter",
+			routeFilter: gatewayv1a2.HTTPRouteFilter{
+				Type: gatewayv1a2.HTTPRouteFilterExtensionRef,
+				ExtensionRef: &gatewayv1a2.LocalObjectReference{
+					Group: "group",
+					Kind:  "kind",
+					Name:  "name",
+				},
+			},
+			errCount: 0,
+		},
+		{
+			name: "invalid HTTPRouteFilterExtensionRef type filter with non-matching field",
+			routeFilter: gatewayv1a2.HTTPRouteFilter{
+				Type:          gatewayv1a2.HTTPRouteFilterExtensionRef,
+				RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{},
+			},
+			errCount: 2,
+		},
+		{
+			name: "invalid HTTPRouteFilterExtensionRef type filter with empty value field",
+			routeFilter: gatewayv1a2.HTTPRouteFilter{
+				Type: gatewayv1a2.HTTPRouteFilterExtensionRef,
+			},
+			errCount: 1,
+		},
+		{
+			name:        "empty type filter is valid(caught by CRD validation)",
+			routeFilter: gatewayv1a2.HTTPRouteFilter{},
+			errCount:    0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateHTTPRouteFilterTypeMatchesValue(tc.routeFilter, field.NewPath("spec").Child("rules").Index(0).Child("filters").Index(0))
+			if len(errs) != tc.errCount {
+				t.Errorf("got %v errors, want %v errors: %s", len(errs), tc.errCount, errs)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This cherry picks #946 into release 0.4. This includes a number of webhook improvements, including:

* New validation to ensure that a HTTPRouterFilter Type matches its value
* A fix to ensure that Path match validation actually works (previously the function existed but was not used)

**Does this PR introduce a user-facing change?**:
```release-note
Improvements to HTTPRoute validation in the validating webhook:

* New validation to ensure that a HTTPRouterFilter Type matches its value
* A fix to ensure that Path match validation actually works
```
