### PR TITLE
Cherry pick CI fixes into release-0.4

### DIFF
--- a/hack/verify-examples-kind.sh
+++ b/hack/verify-examples-kind.sh
@@ -45,7 +45,7 @@ trap cleanup INT TERM
 res=0
 
 # Install kind
-(cd $GOPATH && go get -u sigs.k8s.io/kind) || res=$?
+(cd $GOPATH && go install sigs.k8s.io/kind@v0.12.0) || res=$?
 
 # Create cluster
 KIND_CREATE_ATTEMPTED=true


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
This cherry picks #1064 into release-0.4 to fix CI. This will unblock #1071.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
