### PR TITLE
Add a success message to verify-boilerplate

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -248,6 +248,8 @@ def main():
         if not file_passes(filename, refs, regexs):
             print(filename, file=sys.stdout)
 
+    print("Verified %d file headers match boilerplate" % (len(filenames),), file=sys.stderr)
+
     return 0
 
 


### PR DESCRIPTION
I fooled myself into thinking this wasn't actually doing anything, so I figure it would be good to add a reassuring success message:

```
$ ./hack/verify-boilerplate.sh
Verified 111 file headers match boilerplate
```

It's arguable this change should go into k/k first, but perhaps a little laziness can be forgiven!

/kind cleanup