### PR TITLE
Support eventual consistency in conformance tests

### DIFF
--- a/conformance/tests/httproute-cross-namespace.go
+++ b/conformance/tests/httproute-cross-namespace.go
@@ -40,7 +40,7 @@ var HTTPRouteCrossNamespace = suite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN)
 
 		t.Run("Simple HTTP request should reach web-backend", func(t *testing.T) {
-			http.MakeRequestAndExpectResponse(t, suite.RoundTripper, gwAddr, http.ExpectedResponse{
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, http.ExpectedResponse{
 				Request:    http.ExpectedRequest{Path: "/"},
 				StatusCode: 200,
 				Backend:    "web-backend",

--- a/conformance/tests/httproute-cross-namespace.go
+++ b/conformance/tests/httproute-cross-namespace.go
@@ -17,15 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"net/url"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
-	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 )
 
@@ -43,19 +40,8 @@ var HTTPRouteCrossNamespace = suite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN)
 
 		t.Run("Simple HTTP request should reach web-backend", func(t *testing.T) {
-			t.Logf("Making request to http://%s", gwAddr)
-			cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(roundtripper.Request{
-				URL:      url.URL{Scheme: "http", Host: gwAddr},
-				Protocol: "HTTP",
-			})
-
-			require.NoErrorf(t, err, "error making request")
-
-			http.ExpectResponse(t, cReq, cRes, http.ExpectedResponse{
-				Request: http.ExpectedRequest{
-					Method: "GET",
-					Path:   "/",
-				},
+			http.MakeRequestAndExpectResponse(t, suite.RoundTripper, gwAddr, http.ExpectedResponse{
+				Request:    http.ExpectedRequest{Path: "/"},
 				StatusCode: 200,
 				Backend:    "web-backend",
 				Namespace:  "gateway-conformance-web-backend",

--- a/conformance/tests/httproute-matching-across-routes.go
+++ b/conformance/tests/httproute-matching-across-routes.go
@@ -109,7 +109,7 @@ var HTTPRouteMatchingAcrossRoutes = suite.ConformanceTest{
 			tc := testCases[i]
 			t.Run(testName(tc, i), func(t *testing.T) {
 				t.Parallel()
-				http.MakeRequestAndExpectResponse(t, suite.RoundTripper, gwAddr, tc)
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, tc)
 			})
 		}
 	},

--- a/conformance/tests/httproute-matching.go
+++ b/conformance/tests/httproute-matching.go
@@ -72,7 +72,7 @@ var HTTPRouteMatching = suite.ConformanceTest{
 			tc := testCases[i]
 			t.Run(testName(tc, i), func(t *testing.T) {
 				t.Parallel()
-				http.MakeRequestAndExpectResponse(t, suite.RoundTripper, gwAddr, tc)
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, tc)
 			})
 		}
 	},

--- a/conformance/tests/httproute-simple-same-namespace.go
+++ b/conformance/tests/httproute-simple-same-namespace.go
@@ -17,16 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"net/url"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
-	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 )
 
@@ -45,19 +42,8 @@ var HTTPRouteSimpleSameNamespace = suite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN)
 
 		t.Run("Simple HTTP request should reach infra-backend", func(t *testing.T) {
-			t.Logf("Making request to http://%s", gwAddr)
-			cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(roundtripper.Request{
-				URL:      url.URL{Scheme: "http", Host: gwAddr},
-				Protocol: "HTTP",
-			})
-
-			require.NoErrorf(t, err, "error making request")
-
-			http.ExpectResponse(t, cReq, cRes, http.ExpectedResponse{
-				Request: http.ExpectedRequest{
-					Method: "GET",
-					Path:   "/",
-				},
+			http.MakeRequestAndExpectResponse(t, suite.RoundTripper, gwAddr, http.ExpectedResponse{
+				Request:    http.ExpectedRequest{Path: "/"},
 				StatusCode: 200,
 				Backend:    "infra-backend-v1",
 				Namespace:  "gateway-conformance-infra",

--- a/conformance/tests/httproute-simple-same-namespace.go
+++ b/conformance/tests/httproute-simple-same-namespace.go
@@ -42,7 +42,7 @@ var HTTPRouteSimpleSameNamespace = suite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN)
 
 		t.Run("Simple HTTP request should reach infra-backend", func(t *testing.T) {
-			http.MakeRequestAndExpectResponse(t, suite.RoundTripper, gwAddr, http.ExpectedResponse{
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, http.ExpectedResponse{
 				Request:    http.ExpectedRequest{Path: "/"},
 				StatusCode: 200,
 				Backend:    "infra-backend-v1",

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -85,12 +85,12 @@ func MakeRequestAndExpectResponse(t *testing.T, r roundtripper.RoundTripper, gwA
 
 		cReq, cRes, err = r.CaptureRoundTrip(req)
 		if err != nil {
-			t.Log("request failed, not ready yet")
+			t.Logf("Request failed, not ready yet: %v", err.Error())
 			return false
 		}
 
 		if cRes.StatusCode != expected.StatusCode {
-			t.Log("response missing expected status, not ready yet")
+			t.Logf("Expected response to have status %d but got %d, not ready yet", expected.StatusCode, cRes.StatusCode)
 			return false
 		}
 

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -115,6 +115,7 @@ func WaitForConsistency(t *testing.T, r roundtripper.RoundTripper, req roundtrip
 			return false
 		}
 
+		t.Logf("Request has passed %d times in a row of the desired %d, ready!", numSuccesses, threshold)
 		return true
 	}, maxConsistencyPeriodPerRequest, 1*time.Second, "error making request, never got expected status")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
(best effort ^, is there a better option?)

**What this PR does / why we need it**:
We discussed in the sig meeting recently that "accepted" (or "ready" in the future) can only really indicate that the controller has synced all necessary configuration and that routes will begin working "soon".

In order for the conformance tests to support this, they must accept that HTTP requests to new routes may fail for some period of time but should become eventually consistent.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
