### PR TITLE
clarify core support of secret reference

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -321,7 +321,7 @@ type GatewayTLSConfig struct {
 	// CertificateRefs can reference to standard Kubernetes resources, i.e.
 	// Secret, or implementation-specific custom resources.
 	//
-	// Support: Core - A single reference to a Kubernetes Secret
+	// Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
 	//
 	// Support: Implementation-specific (More than one reference or other resource types)
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -337,8 +337,9 @@ spec:
                             otherwise. \n CertificateRefs can reference to standard
                             Kubernetes resources, i.e. Secret, or implementation-specific
                             custom resources. \n Support: Core - A single reference
-                            to a Kubernetes Secret \n Support: Implementation-specific
-                            (More than one reference or other resource types)"
+                            to a Kubernetes Secret of type kubernetes.io/tls \n Support:
+                            Implementation-specific (More than one reference or other
+                            resource types)"
                           items:
                             description: "SecretObjectReference identifies an API
                               object including its namespace, defaulting to Secret.

--- a/config/crd/stable/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_gateways.yaml
@@ -337,8 +337,9 @@ spec:
                             otherwise. \n CertificateRefs can reference to standard
                             Kubernetes resources, i.e. Secret, or implementation-specific
                             custom resources. \n Support: Core - A single reference
-                            to a Kubernetes Secret \n Support: Implementation-specific
-                            (More than one reference or other resource types)"
+                            to a Kubernetes Secret of type kubernetes.io/tls \n Support:
+                            Implementation-specific (More than one reference or other
+                            resource types)"
                           items:
                             description: "SecretObjectReference identifies an API
                               object including its namespace, defaulting to Secret.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR clarifies implementation of core support of Secret reference.

**Which issue(s) this PR fixes**:
https://github.com/kubernetes-sigs/gateway-api/discussions/1059

**Does this PR introduce a user-facing change?**:
I think it does not.
```release-note
NONE
```