### PR TITLE
Duplicate the kustomization.yaml for the stable and experimental folders

### DIFF
--- a/config/crd/experimental/kustomization.yaml
+++ b/config/crd/experimental/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- gateway.networking.k8s.io_gatewayclasses.yaml
+- gateway.networking.k8s.io_gateways.yaml
+- gateway.networking.k8s.io_httproutes.yaml
+- gateway.networking.k8s.io_referencepolicies.yaml
+- gateway.networking.k8s.io_tcproutes.yaml
+- gateway.networking.k8s.io_tlsroutes.yaml
+- gateway.networking.k8s.io_udproutes.yaml

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,8 +1,0 @@
-resources:
-- stable/gateway.networking.k8s.io_gatewayclasses.yaml
-- stable/gateway.networking.k8s.io_gateways.yaml
-- stable/gateway.networking.k8s.io_httproutes.yaml
-- stable/gateway.networking.k8s.io_referencepolicies.yaml
-- stable/gateway.networking.k8s.io_tcproutes.yaml
-- stable/gateway.networking.k8s.io_tlsroutes.yaml
-- stable/gateway.networking.k8s.io_udproutes.yaml

--- a/config/crd/stable/kustomization.yaml
+++ b/config/crd/stable/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- gateway.networking.k8s.io_gatewayclasses.yaml
+- gateway.networking.k8s.io_gateways.yaml
+- gateway.networking.k8s.io_httproutes.yaml
+- gateway.networking.k8s.io_referencepolicies.yaml
+- gateway.networking.k8s.io_tcproutes.yaml
+- gateway.networking.k8s.io_tlsroutes.yaml
+- gateway.networking.k8s.io_udproutes.yaml


### PR DESCRIPTION
**What type of PR is this?**
kind/feature

**What this PR does / why we need it**:
This PR moves the kustomization.yaml in the config/crd folder to the experimental/ and stable/ subfolders. This will allow the user the install either the stable or experimental CRDs based on their need instead of locking the user to only the stable CRDs.

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
Allow the user to install either the stable or experimental set of CRDs.
```
