### PR TITLE
verify-examples-kind: reverse path order for kind binary

### DIFF
--- a/hack/verify-examples-kind.sh
+++ b/hack/verify-examples-kind.sh
@@ -25,7 +25,7 @@ readonly CLUSTER_NAME="verify-gateway-api"
 
 export KUBECONFIG="${GOPATH}/.kubeconfig"
 export GOFLAGS GO111MODULE GOPATH
-export PATH="${PATH}:${GOPATH}/bin"
+export PATH="${GOPATH}/bin:${PATH}"
 
 # Cleanup logic for cleanup on exit
 CLEANED_UP=false


### PR DESCRIPTION
We're installing kind in a temporary `GOPATH`, let's make sure it gets chosen over any older version installed.

I was hitting an issue with 0.7.0 previously installed earlier in my path.

/kind bug