### PR TITLE
conformance: add option to read manifests from disk

### DIFF
--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -134,6 +135,15 @@ func getContentsFromPathOrURL(location string) (*bytes.Buffer, error) {
 			return nil, fmt.Errorf("received %d bytes from %s, expected %d", count, location, resp.ContentLength)
 		}
 		return manifests, nil
+	} else if strings.HasPrefix(location, "file://") {
+		fn := strings.TrimPrefix(location, "file://")
+
+		b, err := ioutil.ReadFile(fn)
+		if err != nil {
+			return nil, fmt.Errorf("error reading manifests from file: %w", err)
+		}
+
+		return bytes.NewBuffer(b), nil
 	}
 	b, err := conformance.Manifests.ReadFile(location)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Adds the ability to run the conformance tests using manifests on disk. Useful for example if the manifests are generated by taking the embedded files and tweaking them.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
