### PR TITLE
Allow the user to tell the conformance tests leave config in place

### DIFF
--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -116,7 +116,7 @@ func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) {
 	}
 	for _, manifestLocation := range test.Manifests {
 		t.Logf("Applying %s", manifestLocation)
-		kubernetes.MustApplyWithCleanup(t, suite.Client, manifestLocation, suite.GatewayClassName, true)
+		kubernetes.MustApplyWithCleanup(t, suite.Client, manifestLocation, suite.GatewayClassName, suite.Cleanup)
 	}
 
 	test.Test(t, suite)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
With this small change you can run the conformance tests and leave the configuration in place at the end of the run:

` $ go test ./conformance/conformance_test.go --gateway-class={your-gw-class} --cleanup=false`

This is helpful when a test fails because you can then explore what went wrong.

**Does this PR introduce a user-facing change?**:
```release-note
To run the conformance tests and leave the configuration in place at the end of the run:
 $ go test ./conformance/conformance_test.go --gateway-class={your-gw-class} --cleanup=false
```
