### PR TITLE
conformance: add option to annotate Namespaces

### DIFF
--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -37,10 +37,14 @@ import (
 	"sigs.k8s.io/gateway-api/conformance"
 )
 
+type Applier struct {
+	NamespaceAnnotations map[string]string
+}
+
 // MustApplyWithCleanup creates or updates Kubernetes resources defined with the
 // provided YAML file and registers a cleanup function for resources it created.
 // Note that this does not remove resources that already existed in the cluster.
-func MustApplyWithCleanup(t *testing.T, c client.Client, location string, gcName string, cleanup bool) {
+func (a Applier) MustApplyWithCleanup(t *testing.T, c client.Client, location string, gcName string, cleanup bool) {
 	data, err := getContentsFromPathOrURL(location)
 	require.NoError(t, err)
 
@@ -61,6 +65,22 @@ func MustApplyWithCleanup(t *testing.T, c client.Client, location string, gcName
 		if uObj.GetKind() == "Gateway" {
 			err = unstructured.SetNestedField(uObj.Object, gcName, "spec", "gatewayClassName")
 			require.NoErrorf(t, err, "error setting `spec.gatewayClassName` on %s Gateway resource", uObj.GetName())
+		}
+
+		if uObj.GetKind() == "Namespace" && uObj.GetObjectKind().GroupVersionKind().Group == "" {
+			annotations, _, err := unstructured.NestedMap(uObj.Object, "metadata", "annotations")
+			require.NoErrorf(t, err, "error getting annotations on Namespace %s", uObj.GetName())
+
+			if annotations == nil {
+				annotations = map[string]interface{}{}
+			}
+
+			for k, v := range a.NamespaceAnnotations {
+				annotations[k] = v
+			}
+
+			err = unstructured.SetNestedMap(uObj.Object, annotations, "metadata", "annotations")
+			require.NoErrorf(t, err, "error setting annotations on Namespace %s", uObj.GetName())
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the option to annotate Namespaces created by the conformance tests.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
