### PR TITLE
Fix markdown rendering for GEP 1016

### DIFF
--- a/site-src/geps/gep-1016.md
+++ b/site-src/geps/gep-1016.md
@@ -3,7 +3,7 @@
 * Issue: [#1016](https://github.com/kubernetes-sigs/gateway-api/issues/1016)
 * Status: Implementable
 
-(See definitions in [Kubernetes KEP][kep-status].
+(See definitions in [Kubernetes KEP][kep-status]).
 
 [kep-status]: https://github.com/kubernetes/enhancements/blob/master/keps/NNNN-kep-template/kep.yaml#L9
 
@@ -240,6 +240,7 @@ should raise a "Detached" condition for the affected listener with a reason of
 
 ### Structs
 
+{% raw%}
 ```go
 // +genclient
 // +kubebuilder:object:root=true
@@ -671,6 +672,7 @@ type GRPCRouteFilter struct {
 	ExtensionRef *LocalObjectReference `json:"extensionRef,omitempty"`
 }
 ```
+{% endraw%}
 
 
 

--- a/site-src/geps/gep-1016.md
+++ b/site-src/geps/gep-1016.md
@@ -699,7 +699,8 @@ moment, however, that all of the following may be added at a later date in a
 backward-compatible manner.
 
 Some of these ideas are:
-- Ingtegration with Service Meshes (both sidecar-proxied and proxyless)
+
+- Integration with Service Meshes (both sidecar-proxied and proxyless)
 - Better UX for enabling reflection support
 - gRPC Web support
 - HTTP/JSON transcoding at the gateway


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
It seems `mkdoc` has some issue with the double curly braces used in kubebuilder annotations:

```
INFO     -  [macros] - ERROR # _Macro Syntax Error_                                                       
            _Line 337 in Markdown file:_ **expected token 'end of print statement', got ':'**
            ```python                                                                                                                                                                                               
                    // +kubebuilder:default={{matches: {{method: {{type: "Exact"}}}}}}
            ```                                       
```

This PR marks the markdown section as raw text to ensure proper rendering.

**Which issue(s) this PR fixes**:
None. (Let me know if procedure requires that I create one to document the fix)

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
