### PR TITLE
api: add RouteConditionReason to v1alpha2

### DIFF
--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -189,11 +189,11 @@ type RouteConditionType string
 const (
 	// This condition indicates whether the route has been accepted or rejected
 	// by a Gateway, and why.
-	ConditionRouteAccepted RouteConditionType = "Accepted"
+	RouteConditionAccepted RouteConditionType = "Accepted"
 
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the Route.
-	ConditionRouteResolvedRefs RouteConditionType = "ResolvedRefs"
+	RouteConditionResolvedRefs RouteConditionType = "ResolvedRefs"
 )
 
 // RouteParentStatus describes the status of a route with respect to an

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -186,9 +186,20 @@ type BackendRef struct {
 // RouteConditionType is a type of condition for a route.
 type RouteConditionType string
 
+// RouteConditionReason is a reason for a route condition.
+type RouteConditionReason string
+
 const (
 	// This condition indicates whether the route has been accepted or rejected
 	// by a Gateway, and why.
+	//
+	// Possible reasons for this condition to be true are:
+	//
+	// * "Accepted"
+	//
+	// Controllers may raise this condition with other reasons,
+	// but should prefer to use the reasons listed above to improve
+	// interoperability.
 	RouteConditionAccepted RouteConditionType = "Accepted"
 
 	// FIXME: alias for backwards compatibility in v1alpha2, remove in next release
@@ -196,10 +207,36 @@ const (
 
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the Route.
+	//
+	// Possible reasons for this condition to be true are:
+	//
+	// * "ResolvedRefs"
+	//
+	// Possible reasons for this condition to be False are:
+	//
+	// * "RefNotPermitted"
+	//
+	// Controllers may raise this condition with other reasons,
+	// but should prefer to use the reasons listed above to improve
+	// interoperability.
 	RouteConditionResolvedRefs RouteConditionType = "ResolvedRefs"
 
 	// FIXME: alias for backwards compatibility in v1alpha2, remove in next release
 	ConditionRouteResolvedRefs RouteConditionType = RouteConditionResolvedRefs
+
+	// This reason is used with the "Accepted" condition when the Route has been
+	// accepted by the Gateway.
+	RouteReasonAccepted RouteConditionReason = "Accepted"
+
+	// This reason is used with the "ResolvedRefs" condition when the condition
+	// is true.
+	RouteReasonResolvedRefs RouteConditionReason = "ResolvedRefs"
+
+	// This reason is used with the "ResolvedRefs" condition when
+	// one of the Listener's Routes has a BackendRef to an object in
+	// another namespace, where the object in the other namespace does
+	// not have a ReferencePolicy explicitly allowing the reference.
+	RouteReasonRefNotPermitted RouteConditionReason = "RefNotPermitted"
 )
 
 // RouteParentStatus describes the status of a route with respect to an

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -191,9 +191,15 @@ const (
 	// by a Gateway, and why.
 	RouteConditionAccepted RouteConditionType = "Accepted"
 
+	// FIXME: alias for backwards compatibility in v1alpha2, remove in next release
+	ConditionRouteAccepted RouteConditionType = RouteConditionAccepted
+
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the Route.
 	RouteConditionResolvedRefs RouteConditionType = "ResolvedRefs"
+
+	// FIXME: alias for backwards compatibility in v1alpha2, remove in next release
+	ConditionRouteResolvedRefs RouteConditionType = RouteConditionResolvedRefs
 )
 
 // RouteParentStatus describes the status of a route with respect to an

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -202,6 +202,10 @@ const (
 	// interoperability.
 	RouteConditionAccepted RouteConditionType = "Accepted"
 
+	// This reason is used with the "Accepted" condition when the Route has been
+	// accepted by the Gateway.
+	RouteReasonAccepted RouteConditionReason = "Accepted"
+
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the Route.
 	//
@@ -217,10 +221,6 @@ const (
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
 	RouteConditionResolvedRefs RouteConditionType = "ResolvedRefs"
-
-	// This reason is used with the "Accepted" condition when the Route has been
-	// accepted by the Gateway.
-	RouteReasonAccepted RouteConditionReason = "Accepted"
 
 	// This reason is used with the "ResolvedRefs" condition when the condition
 	// is true.

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -213,7 +213,7 @@ const (
 	//
 	// * "ResolvedRefs"
 	//
-	// Possible reasons for this condition to be False are:
+	// Possible reasons for this condition to be false are:
 	//
 	// * "RefNotPermitted"
 	//

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -202,9 +202,6 @@ const (
 	// interoperability.
 	RouteConditionAccepted RouteConditionType = "Accepted"
 
-	// FIXME: alias for backwards compatibility in v1alpha2, remove in next release
-	ConditionRouteAccepted RouteConditionType = RouteConditionAccepted
-
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the Route.
 	//
@@ -220,9 +217,6 @@ const (
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
 	RouteConditionResolvedRefs RouteConditionType = "ResolvedRefs"
-
-	// FIXME: alias for backwards compatibility in v1alpha2, remove in next release
-	ConditionRouteResolvedRefs RouteConditionType = RouteConditionResolvedRefs
 
 	// This reason is used with the "Accepted" condition when the Route has been
 	// accepted by the Gateway.

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -133,7 +133,7 @@ func GatewayAndHTTPRoutesMustBeReady(t *testing.T, c client.Client, controllerNa
 			},
 			ControllerName: v1alpha2.GatewayController(controllerName),
 			Conditions: []metav1.Condition{{
-				Type:   string(v1alpha2.ConditionRouteAccepted),
+				Type:   string(v1alpha2.RouteConditionAccepted),
 				Status: metav1.ConditionTrue,
 			}},
 		}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation
/kind feature
/kind api-change
/kind deprecation

**What this PR does / why we need it**:

Adds a `RouteConditionReason` type with known required reasons and renames two `RouteConditionType` constants. Not sure if the release note formatting would make more sense to split this into two separate PRs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1109, refs #1112

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
adds RouteConditionReason type with RouteReasonAccepted, RouteReasonResolvedRefs and RouteReasonRefNotPermitted constants
```
```release-note
deprecates ConditionRouteAccepted and ConditionRouteResolvedRefs constants, adds RouteConditionAccepted and RouteConditionResolvedRefs constants
```
