### PR TITLE
Removing confusing part of ParentRef godoc

### DIFF
--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -27,10 +27,6 @@ import (
 //
 // The API object must be valid in the cluster; the Group and Kind must
 // be registered in the cluster for this reference to be valid.
-//
-// References to objects with invalid Group and Kind are not valid, and must
-// be rejected by the implementation, with appropriate Conditions set
-// on the containing object.
 type ParentReference struct {
 	// Group is the group of the referent.
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -115,10 +115,7 @@ spec:
                     is Gateway. This API may be extended in the future to support
                     additional kinds of parent resources, such as HTTPRoute. \n The
                     API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid. \n
-                    References to objects with invalid Group and Kind are not valid,
-                    and must be rejected by the implementation, with appropriate Conditions
-                    set on the containing object."
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -67,10 +67,7 @@ spec:
                     is Gateway. This API may be extended in the future to support
                     additional kinds of parent resources, such as HTTPRoute. \n The
                     API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid. \n
-                    References to objects with invalid Group and Kind are not valid,
-                    and must be rejected by the implementation, with appropriate Conditions
-                    set on the containing object."
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -113,10 +113,7 @@ spec:
                     is Gateway. This API may be extended in the future to support
                     additional kinds of parent resources, such as HTTPRoute. \n The
                     API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid. \n
-                    References to objects with invalid Group and Kind are not valid,
-                    and must be rejected by the implementation, with appropriate Conditions
-                    set on the containing object."
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -67,10 +67,7 @@ spec:
                     is Gateway. This API may be extended in the future to support
                     additional kinds of parent resources, such as HTTPRoute. \n The
                     API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid. \n
-                    References to objects with invalid Group and Kind are not valid,
-                    and must be rejected by the implementation, with appropriate Conditions
-                    set on the containing object."
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io

--- a/config/crd/stable/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_httproutes.yaml
@@ -115,10 +115,7 @@ spec:
                     is Gateway. This API may be extended in the future to support
                     additional kinds of parent resources, such as HTTPRoute. \n The
                     API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid. \n
-                    References to objects with invalid Group and Kind are not valid,
-                    and must be rejected by the implementation, with appropriate Conditions
-                    set on the containing object."
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io

--- a/config/crd/stable/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_tcproutes.yaml
@@ -67,10 +67,7 @@ spec:
                     is Gateway. This API may be extended in the future to support
                     additional kinds of parent resources, such as HTTPRoute. \n The
                     API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid. \n
-                    References to objects with invalid Group and Kind are not valid,
-                    and must be rejected by the implementation, with appropriate Conditions
-                    set on the containing object."
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io

--- a/config/crd/stable/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_tlsroutes.yaml
@@ -113,10 +113,7 @@ spec:
                     is Gateway. This API may be extended in the future to support
                     additional kinds of parent resources, such as HTTPRoute. \n The
                     API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid. \n
-                    References to objects with invalid Group and Kind are not valid,
-                    and must be rejected by the implementation, with appropriate Conditions
-                    set on the containing object."
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io

--- a/config/crd/stable/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_udproutes.yaml
@@ -67,10 +67,7 @@ spec:
                     is Gateway. This API may be extended in the future to support
                     additional kinds of parent resources, such as HTTPRoute. \n The
                     API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid. \n
-                    References to objects with invalid Group and Kind are not valid,
-                    and must be rejected by the implementation, with appropriate Conditions
-                    set on the containing object."
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This removes a confusing part of the ParentRef doc. The problem was that an invalid ParentRef would mean that no implementation could possibly understand that they were the intended implementor, since the only possible link to an implementation (parentRef) was invalid. I considered leaving in "References to objects with invalid Group and Kind are not valid", but that was really just repeating what was stated in the previous paragraph.

**Which issue(s) this PR fixes**:
Fixes #988

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
