### PR TITLE
Add a "cleanup-base-resources" conformance flag, and a way to use it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ TOP := $(dir $(firstword $(MAKEFILE_LIST)))
 # ROOT is the root of the mkdocs tree.
 ROOT := $(abspath $(TOP))
 
+# Command-line flags passed to "go test" for the conformance
+# test. These are passed after the "-args" flag.
+CONFORMANCE_FLAGS ?=
+
 all: generate vet fmt verify test
 
 # Run generators for protos, Deepcopy funcs, CRDs, and docs.
@@ -82,7 +86,7 @@ test:
 # Run conformance tests against controller implementation
 .PHONY: conformance
 conformance:
-	go test -v ./conformance/...
+	go test -v ./conformance/... -args ${CONFORMANCE_FLAGS}
 
 # Install CRD's and example resources to a pre-existing cluster.
 .PHONY: install

--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -18,21 +18,17 @@ limitations under the License.
 package conformance_test
 
 import (
-	"flag"
 	"testing"
 
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/conformance/tests"
+	"sigs.k8s.io/gateway-api/conformance/utils/flags"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
-
-var gatewayClassName = flag.String("gateway-class", "gateway-conformance", "Name of GatewayClass to use for tests")
-var showDebug = flag.Bool("debug", false, "Whether to print debug logs")
-var cleanupBaseResources = flag.Bool("cleanup-base-resources", true, "Whether to cleanup base test resources after the run")
 
 func TestConformance(t *testing.T) {
 	cfg, err := config.GetConfig()
@@ -45,13 +41,13 @@ func TestConformance(t *testing.T) {
 	}
 	v1alpha2.AddToScheme(client.Scheme())
 
-	t.Logf("Running conformance tests with %s GatewayClass", *gatewayClassName)
+	t.Logf("Running conformance tests with %s GatewayClass", *flags.GatewayClassName)
 
 	cSuite := suite.New(suite.Options{
 		Client:               client,
-		GatewayClassName:     *gatewayClassName,
-		Debug:                *showDebug,
-		CleanupBaseResources: *cleanupBaseResources,
+		GatewayClassName:     *flags.GatewayClassName,
+		Debug:                *flags.ShowDebug,
+		CleanupBaseResources: *flags.CleanupBaseResources,
 	})
 	cSuite.Setup(t)
 	cSuite.Run(t, tests.ConformanceTests)

--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -32,7 +32,7 @@ import (
 
 var gatewayClassName = flag.String("gateway-class", "gateway-conformance", "Name of GatewayClass to use for tests")
 var showDebug = flag.Bool("debug", false, "Whether to print debug logs")
-var shouldCleanup = flag.Bool("cleanup", true, "Whether to cleanup base resources")
+var cleanupBaseResources = flag.Bool("cleanup-base-resources", true, "Whether to cleanup base test resources after the run")
 
 func TestConformance(t *testing.T) {
 	cfg, err := config.GetConfig()
@@ -48,10 +48,10 @@ func TestConformance(t *testing.T) {
 	t.Logf("Running conformance tests with %s GatewayClass", *gatewayClassName)
 
 	cSuite := suite.New(suite.Options{
-		Client:           client,
-		GatewayClassName: *gatewayClassName,
-		Debug:            *showDebug,
-		Cleanup:          *shouldCleanup,
+		Client:               client,
+		GatewayClassName:     *gatewayClassName,
+		Debug:                *showDebug,
+		CleanupBaseResources: *cleanupBaseResources,
 	})
 	cSuite.Setup(t)
 	cSuite.Run(t, tests.ConformanceTests)

--- a/conformance/utils/flags/flags.go
+++ b/conformance/utils/flags/flags.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// flags contains command-line flag definitions for the conformance
+// tests. They're in this package so they can be shared among the
+// various suites that are all run by the same Makefile invocation.
+package flags
+
+import (
+	"flag"
+)
+
+var (
+	GatewayClassName     = flag.String("gateway-class", "gateway-conformance", "Name of GatewayClass to use for tests")
+	ShowDebug            = flag.Bool("debug", false, "Whether to print debug logs")
+	CleanupBaseResources = flag.Bool("cleanup-base-resources", true, "Whether to cleanup base test resources after the run")
+)

--- a/conformance/utils/kubernetes/apply_test.go
+++ b/conformance/utils/kubernetes/apply_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubernetes
 
 import (
+	"flag"
 	"strings"
 	"testing"
 
@@ -25,6 +26,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+var (
+	// These aren't used by this test but since this test is run using
+	// the same invocation as the conformance test it needs to parse the
+	// same set of flags.
+	_ = flag.String("gateway-class", "", "unused")
+	_ = flag.Bool("debug", false, "unused")
+	_ = flag.Bool("cleanup-base-resources", true, "unused")
 )
 
 func TestPrepareResources(t *testing.T) {

--- a/conformance/utils/kubernetes/apply_test.go
+++ b/conformance/utils/kubernetes/apply_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubernetes
 
 import (
-	"flag"
 	"strings"
 	"testing"
 
@@ -26,15 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
-)
-
-var (
-	// These aren't used by this test but since this test is run using
-	// the same invocation as the conformance test it needs to parse the
-	// same set of flags.
-	_ = flag.String("gateway-class", "", "unused")
-	_ = flag.Bool("debug", false, "unused")
-	_ = flag.Bool("cleanup-base-resources", true, "unused")
+	_ "sigs.k8s.io/gateway-api/conformance/utils/flags"
 )
 
 func TestPrepareResources(t *testing.T) {

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -44,7 +44,6 @@ type Options struct {
 	Client           client.Client
 	GatewayClassName string
 	Debug            bool
-	Cleanup          bool
 	RoundTripper     roundtripper.RoundTripper
 	BaseManifests    string
 	NamespaceLabels  map[string]string
@@ -55,6 +54,10 @@ type Options struct {
 	// four ValidUniqueListenerPorts.
 	// If empty or nil, ports are not modified.
 	ValidUniqueListenerPorts []v1alpha2.PortNumber
+
+	// CleanupBaseResources indicates whether or not the base test
+	// resources such as Gateways should be cleaned up after the run.
+	CleanupBaseResources bool
 }
 
 // New returns a new ConformanceTestSuite.
@@ -69,7 +72,7 @@ func New(s Options) *ConformanceTestSuite {
 		RoundTripper:     roundTripper,
 		GatewayClassName: s.GatewayClassName,
 		Debug:            s.Debug,
-		Cleanup:          s.Cleanup,
+		Cleanup:          s.CleanupBaseResources,
 		BaseManifests:    s.BaseManifests,
 		Applier: kubernetes.Applier{
 			NamespaceLabels:          s.NamespaceLabels,


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
There was a flag called "cleanup" but that wasn't specific enough[1],
so this "cleanup-base-resources" flag does the same thing but leaves
room for other flags that will clean up other things.

This commit adds a Make variable called CONFORMANCE_FLAGS which
provides a way to pass that flag (or any other) into the conformance
tests. For example, if I wanted to override the test GatewayClass
and *not* clean up the base resources, this would be the invocation:

 $ make conformance CONFORMANCE_FLAGS="-cleanup-base-resources=false -gateway-class=acndev-http4"

[1] https://github.com/kubernetes-sigs/gateway-api/pull/1078

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
This commit adds a Make variable called CONFORMANCE_FLAGS which provides a way to pass that flag (or any other) into the conformance tests. For example, if I wanted to override the test GatewayClass and *not* clean up the base resources, this would be the invocation:

 $ make conformance CONFORMANCE_FLAGS="-cleanup-base-resources=false -gateway-class=acndev-http4"
```
