### PR TITLE
Mention BackendObjectReference.Kind default in docstring

### DIFF
--- a/apis/v1alpha2/object_reference_types.go
+++ b/apis/v1alpha2/object_reference_types.go
@@ -100,6 +100,7 @@ type BackendObjectReference struct {
 	Group *Group `json:"group,omitempty"`
 
 	// Kind is kind of the referent. For example "HTTPRoute" or "Service".
+	// Defaults to "Service" when not specified.
 	//
 	// +optional
 	// +kubebuilder:default=Service

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -426,6 +426,7 @@ spec:
                                           default: Service
                                           description: Kind is kind of the referent.
                                             For example "HTTPRoute" or "Service".
+                                            Defaults to "Service" when not specified.
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -626,7 +627,8 @@ spec:
                           kind:
                             default: Service
                             description: Kind is kind of the referent. For example
-                              "HTTPRoute" or "Service".
+                              "HTTPRoute" or "Service". Defaults to "Service" when
+                              not specified.
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -872,7 +874,8 @@ spec:
                                   kind:
                                     default: Service
                                     description: Kind is kind of the referent. For
-                                      example "HTTPRoute" or "Service".
+                                      example "HTTPRoute" or "Service". Defaults to
+                                      "Service" when not specified.
                                     maxLength: 63
                                     minLength: 1
                                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -189,7 +189,8 @@ spec:
                           kind:
                             default: Service
                             description: Kind is kind of the referent. For example
-                              "HTTPRoute" or "Service".
+                              "HTTPRoute" or "Service". Defaults to "Service" when
+                              not specified.
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -238,7 +238,8 @@ spec:
                           kind:
                             default: Service
                             description: Kind is kind of the referent. For example
-                              "HTTPRoute" or "Service".
+                              "HTTPRoute" or "Service". Defaults to "Service" when
+                              not specified.
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -189,7 +189,8 @@ spec:
                           kind:
                             default: Service
                             description: Kind is kind of the referent. For example
-                              "HTTPRoute" or "Service".
+                              "HTTPRoute" or "Service". Defaults to "Service" when
+                              not specified.
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/stable/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_httproutes.yaml
@@ -400,6 +400,7 @@ spec:
                                           default: Service
                                           description: Kind is kind of the referent.
                                             For example "HTTPRoute" or "Service".
+                                            Defaults to "Service" when not specified.
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -529,7 +530,8 @@ spec:
                           kind:
                             default: Service
                             description: Kind is kind of the referent. For example
-                              "HTTPRoute" or "Service".
+                              "HTTPRoute" or "Service". Defaults to "Service" when
+                              not specified.
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -775,7 +777,8 @@ spec:
                                   kind:
                                     default: Service
                                     description: Kind is kind of the referent. For
-                                      example "HTTPRoute" or "Service".
+                                      example "HTTPRoute" or "Service". Defaults to
+                                      "Service" when not specified.
                                     maxLength: 63
                                     minLength: 1
                                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/stable/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_tcproutes.yaml
@@ -163,7 +163,8 @@ spec:
                           kind:
                             default: Service
                             description: Kind is kind of the referent. For example
-                              "HTTPRoute" or "Service".
+                              "HTTPRoute" or "Service". Defaults to "Service" when
+                              not specified.
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/stable/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_tlsroutes.yaml
@@ -212,7 +212,8 @@ spec:
                           kind:
                             default: Service
                             description: Kind is kind of the referent. For example
-                              "HTTPRoute" or "Service".
+                              "HTTPRoute" or "Service". Defaults to "Service" when
+                              not specified.
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/stable/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_udproutes.yaml
@@ -163,7 +163,8 @@ spec:
                           kind:
                             default: Service
                             description: Kind is kind of the referent. For example
-                              "HTTPRoute" or "Service".
+                              "HTTPRoute" or "Service". Defaults to "Service" when
+                              not specified.
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Mention that the BackendObjectReference.Kind default is `Service` in its godoc string. Doc generation pulls in that this is optional, but not the kubebuilder tag that indicates the default, and a BackendObjectReference with an _empty_ Kind doesn't make much sense.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
