### PR TITLE
0.4 Cherry Pick: Migrate kube-webhook-certgen to k8s.gcr.io/ingress-nginx:v1.1.1

### DIFF
--- a/deploy/certificate_config.yaml
+++ b/deploy/certificate_config.yaml
@@ -96,7 +96,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: docker.io/jettech/kube-webhook-certgen:v1.5.0
+          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -130,7 +130,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: docker.io/jettech/kube-webhook-certgen:v1.5.0
+          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1
           imagePullPolicy: IfNotPresent
           args:
             - patch


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This fixes #1125 by cherry picking #991 into release-0.4. (We'll also need a corresponding 0.4 release, but I think we have enough commits backed up to justify a 0.4.3 release.

**Which issue(s) this PR fixes**:
Fixes #1125

**Does this PR introduce a user-facing change?**:
```release-note
Webhook deployment config now uses ingress nginx image for kube-webhook-certgen
```
