### PR TITLE
Documenting v1alpha1 deprecation, additional v1alpha1 cleanup

### DIFF
--- a/site-src/concepts/api-overview.md
+++ b/site-src/concepts/api-overview.md
@@ -18,9 +18,9 @@ section in the Security model for details.
 ## Resource model
 
 !!! note
-    As of v1alpha2, resources are in the `gateway.networking.k8s.io` API group as
-    Custom Resource Definitions (CRDs). Unqualified resource names below will implicitly
-    be in this API group. Prior to v1alpha1, the API group was `networking.x-k8s.io`.
+    Gateway API resources are in the `gateway.networking.k8s.io` API group as
+    Custom Resource Definitions (CRDs). Unqualified resource names below will
+    implicitly be in this API group.
 
 There are three main types of objects in our resource model:
 

--- a/site-src/faq.md
+++ b/site-src/faq.md
@@ -54,12 +54,10 @@
    A: Gateway API releases are tags of the [Github repository][1].
    The [Github releases][2] page shows all the releases.
 
-* **Q: How should I think about the alpha release?<br>**
-  A: The `v1alpha1` release will be the first Gateway API release. As
-  various projects begin implementing the API, and operators start using
-  it, the working group will collect feedback and issues, which will
-  guide what revisions are needed for the next release. It is possible
-  that the next release will contain breaking changes.
+* **Q: How should I think about alpha API versions?<br>**
+  A: Similar to upstream Kubernetes, alpha API versions indicate that resources
+  are still experimental in nature and may either be removed or changed in
+  breaking ways in future releases of Gateway API.
 
 * **Q: Which Kubernetes versions are supported?<br>**
   A: Generally, we support Kubernetes 1.16+, but certain features like 

--- a/site-src/v1alpha1/api-types/gateway.md
+++ b/site-src/v1alpha1/api-types/gateway.md
@@ -1,5 +1,11 @@
 # Gateway
 
+!!! warning "v1alpha1 has been deprecated"
+
+    Please upgrade to v1alpha2, v1alpha1 will be removed from Gateway API
+    in an upcoming release.
+
+
 A `Gateway` is 1:1 with the life cycle of the configuration of infrastructure.
 When a user creates a `Gateway`, some load balancing infrastructure is
 provisioned or configured (see below for details) by the `GatewayClass`

--- a/site-src/v1alpha1/api-types/gatewayclass.md
+++ b/site-src/v1alpha1/api-types/gatewayclass.md
@@ -1,5 +1,10 @@
 # GatewayClass
 
+!!! warning "v1alpha1 has been deprecated"
+
+    Please upgrade to v1alpha2, v1alpha1 will be removed from Gateway API
+    in an upcoming release.
+
 [GatewayClass][gatewayclass] is cluster-scoped resource defined by the
 infrastructure provider. This resource represents a class of Gateways that can
 be instantiated.

--- a/site-src/v1alpha1/api-types/httproute.md
+++ b/site-src/v1alpha1/api-types/httproute.md
@@ -1,5 +1,10 @@
 # HTTPRoute
 
+!!! warning "v1alpha1 has been deprecated"
+
+    Please upgrade to v1alpha2, v1alpha1 will be removed from Gateway API
+    in an upcoming release.
+
 [HTTPRoute][httproute] is a Gateway API type for specifying routing behavior
 of HTTP requests from a Gateway listener to an API object, i.e. Service.
 

--- a/site-src/v1alpha1/guides/getting-started.md
+++ b/site-src/v1alpha1/guides/getting-started.md
@@ -1,5 +1,9 @@
 # Getting started with Gateway APIs
 
+!!! warning "v1alpha1 has been deprecated"
+
+    Please upgrade to v1alpha2, v1alpha1 will be removed from Gateway API
+    in an upcoming release.
 
 **1.**  **[Install a Gateway controller](#installing-a-gateway-controller)**
  _OR_  **[install the Gateway API CRDs manually](#installing-gateway-api-crds-manually)**

--- a/site-src/v1alpha1/guides/http-routing.md
+++ b/site-src/v1alpha1/guides/http-routing.md
@@ -1,5 +1,10 @@
 # HTTP routing
 
+!!! warning "v1alpha1 has been deprecated"
+
+    Please upgrade to v1alpha2, v1alpha1 will be removed from Gateway API
+    in an upcoming release.
+
 The [HTTPRoute resource](/v1alpha1/api-types/httproute) allows you to match on HTTP
 traffic and direct it to Kubernetes backends. This guide shows how the HTTPRoute
 matches traffic on host, header, and path fields and forwards it to different

--- a/site-src/v1alpha1/guides/multiple-ns.md
+++ b/site-src/v1alpha1/guides/multiple-ns.md
@@ -1,5 +1,10 @@
 # Cross-Namespace routing
 
+!!! warning "v1alpha1 has been deprecated"
+
+    Please upgrade to v1alpha2, v1alpha1 will be removed from Gateway API
+    in an upcoming release.
+
 The Gateway API has core support for cross Namespace routing. This is useful
 when more than one user or team is sharing the underlying networking infrastructure,
 yet control and configuration must be segmented to minimize access and fault

--- a/site-src/v1alpha1/guides/simple-gateway.md
+++ b/site-src/v1alpha1/guides/simple-gateway.md
@@ -1,5 +1,10 @@
 # Deploying a simple Gateway
 
+!!! warning "v1alpha1 has been deprecated"
+
+    Please upgrade to v1alpha2, v1alpha1 will be removed from Gateway API
+    in an upcoming release.
+
 The simplest possible deployment is a Gateway and Route resource which are
 deployed together by the same owner. This represents a similar kind of model
 used for Ingress. In this guide, a Gateway and HTTPRoute are deployed which

--- a/site-src/v1alpha1/guides/tcp.md
+++ b/site-src/v1alpha1/guides/tcp.md
@@ -1,3 +1,8 @@
+!!! warning "v1alpha1 has been deprecated"
+
+    Please upgrade to v1alpha2, v1alpha1 will be removed from Gateway API
+    in an upcoming release.
+
 Gateway API is designed to work with multiple protocols.
 [TCPRoute](/v1alpha1/references/spec/#networking.x-k8s.io/v1alpha1.TCPRoute) is one such route which
 allows for managing TCP traffic.

--- a/site-src/v1alpha1/guides/tls.md
+++ b/site-src/v1alpha1/guides/tls.md
@@ -1,5 +1,10 @@
 # TLS details
 
+!!! warning "v1alpha1 has been deprecated"
+
+    Please upgrade to v1alpha2, v1alpha1 will be removed from Gateway API
+    in an upcoming release.
+
 Gateway API allow for a variety of ways to configure TLS. This document lays
 out various TLS settings and gives general guidelines on how to use them
 effectively.

--- a/site-src/v1alpha1/guides/traffic-splitting.md
+++ b/site-src/v1alpha1/guides/traffic-splitting.md
@@ -1,5 +1,10 @@
 # HTTP traffic splitting
 
+!!! warning "v1alpha1 has been deprecated"
+
+    Please upgrade to v1alpha2, v1alpha1 will be removed from Gateway API
+    in an upcoming release.
+
 The [HTTPRoute resource](/v1alpha1/api-types/httproute) allows you to specify weights to shift
 traffic between different backends. This is useful for splitting traffic during
 rollouts, canarying changes, or for emergencies. The HTTPRoute

--- a/site-src/v1alpha1/references/spec.md
+++ b/site-src/v1alpha1/references/spec.md
@@ -1,3 +1,8 @@
 # API Specification
 
+!!! warning "v1alpha1 has been deprecated"
+
+    Please upgrade to v1alpha2, v1alpha1 will be removed from Gateway API
+    in an upcoming release.
+
 REPLACE_WITH_GENERATED_CONTENT

--- a/site-src/v1alpha2/api-types/httproute.md
+++ b/site-src/v1alpha2/api-types/httproute.md
@@ -27,7 +27,7 @@ here for implementations to support other types of parent resources.
 
 The following example shows how a Route would attach to the `acme-lb` Gateway:
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1alpha1
+apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:
   name: httproute-example
@@ -56,7 +56,7 @@ rules and filters (optional).
 
 The following example defines hostname "my.example.com":
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1alpha1
+apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:
   name: httproute-example
@@ -78,7 +78,7 @@ independent, i.e. this rule will be matched if any single match is satisfied.
 
 Take the following matches configuration as an example:
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1alpha1
+apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 ...
 matches:
@@ -170,7 +170,7 @@ appropriate when the route is modified.
 The following example indicates HTTPRoute "http-example" has been accepted by
 Gateway "gw-example" in namespace "gw-example-ns":
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1alpha1
+apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:
   name: http-example


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
This documents that v1alpha1 has formally been deprecated and will be removed in an upcoming release. It also cleans up/fixes some older references to v1alpha1.

**Which issue(s) this PR fixes**:
Fixes #906

**Does this PR introduce a user-facing change?**:
```release-note
v1alpha1 has been deprecated and will be removed in a future release of the API.
```
