### PR TITLE
Cleaning up PreciseHostname godocs

### DIFF
--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -320,12 +320,9 @@ type RouteStatus struct {
 // +kubebuilder:validation:Pattern=`^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 type Hostname string
 
-// PreciseHostname is the fully qualified domain name of a network host. This matches
-// the RFC 1123 definition of a hostname with 1 notable exception that
+// PreciseHostname is the fully qualified domain name of a network host. This
+// matches the RFC 1123 definition of a hostname with 1 notable exception that
 // numeric IP addresses are not allowed.
-//
-// PreciseHostname can be "precise" which is a domain name without the terminating
-// dot of a network host (e.g. "foo.example.com").
 //
 // Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
 // alphanumeric characters or '-', and must start and end with an alphanumeric


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Cleans up a confusing part of our godocs for PreciseHostname.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/gateway-api/pull/1086#discussion_r846361750

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
