### PR TITLE
conformance: add HTTPRoute header matching test

### DIFF
--- a/conformance/tests/httproute-header-matching.go
+++ b/conformance/tests/httproute-header-matching.go
@@ -36,7 +36,7 @@ var HTTPRouteHeaderMatching = suite.ConformanceTest{
 	Manifests:   []string{"tests/httproute-header-matching.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
-		routeNN := types.NamespacedName{Name: "matching", Namespace: ns}
+		routeNN := types.NamespacedName{Name: "header-matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN)
 
@@ -54,6 +54,9 @@ var HTTPRouteHeaderMatching = suite.ConformanceTest{
 			Namespace: ns,
 		}, {
 			Request:    http.ExpectedRequest{Path: "/", Headers: map[string]string{"Color": "orange"}},
+			StatusCode: 404,
+		}, {
+			Request:    http.ExpectedRequest{Path: "/", Headers: map[string]string{"Some-Other-Header": "one"}},
 			StatusCode: 404,
 		}, {
 			Request:   http.ExpectedRequest{Path: "/", Headers: map[string]string{"Color": "blue"}},

--- a/conformance/tests/httproute-header-matching.go
+++ b/conformance/tests/httproute-header-matching.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteHeaderMatching)
+}
+
+var HTTPRouteHeaderMatching = suite.ConformanceTest{
+	ShortName:   "HTTPRouteHeaderMatching",
+	Description: "A single HTTPRoute with header matching for different backends",
+	Manifests:   []string{"tests/httproute-header-matching.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Name: "matching", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN)
+
+		testCases := []http.ExpectedResponse{{
+			Request:   http.ExpectedRequest{Path: "/", Headers: map[string]string{"Version": "one"}},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request:   http.ExpectedRequest{Path: "/", Headers: map[string]string{"Version": "two"}},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}, {
+			Request:   http.ExpectedRequest{Path: "/", Headers: map[string]string{"Version": "two", "Color": "orange"}},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request:    http.ExpectedRequest{Path: "/", Headers: map[string]string{"Color": "orange"}},
+			StatusCode: 404,
+		}, {
+			Request:   http.ExpectedRequest{Path: "/", Headers: map[string]string{"Color": "blue"}},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request:   http.ExpectedRequest{Path: "/", Headers: map[string]string{"Color": "green"}},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request:   http.ExpectedRequest{Path: "/", Headers: map[string]string{"Color": "red"}},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}, {
+			Request:   http.ExpectedRequest{Path: "/", Headers: map[string]string{"Color": "yellow"}},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}, {
+			Request:    http.ExpectedRequest{Path: "/", Headers: map[string]string{"Color": "purple"}},
+			StatusCode: 404,
+		}}
+
+		for i := range testCases {
+			// Declare tc here to avoid loop variable
+			// reuse issues across parallel tests.
+			tc := testCases[i]
+			t.Run(testName(tc, i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-header-matching.yaml
+++ b/conformance/tests/httproute-header-matching.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:
-  name: matching
+  name: header-matching
   namespace: gateway-conformance-infra
 spec:
   parentRefs:

--- a/conformance/tests/httproute-header-matching.yaml
+++ b/conformance/tests/httproute-header-matching.yaml
@@ -1,0 +1,57 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: matching
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  # Matches "version: one"
+  - matches:
+    - headers:
+      - name: version
+        value: one
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  # Matches "version: two"
+  - matches:
+    - headers:
+      - name: version
+        value: two
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080
+  # Matches "version: two" AND "color: orange"
+  - matches:
+    - headers:
+      - name: version
+        value: two
+      - name: color
+        value: orange
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  # Matches "color: blue" OR "color: green"
+  - matches:
+    - headers:
+      - name: color
+        value: blue
+    - headers:
+      - name: color
+        value: green
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  # Matches "color: red" OR "color: yellow"
+  - matches:
+    - headers:
+      - name: color
+        value: red
+    - headers:
+      - name: color
+        value: yellow
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080


### PR DESCRIPTION
**What type of PR is this?**
/ kind conformance-test

**What this PR does / why we need it**:
Add tests for various combinations of header
matches on HTTPRoutes.

**Which issue(s) this PR fixes**:
Updates #1102.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
