### PR TITLE
conformance: add test for listener hostname matching

### DIFF
--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -154,6 +154,52 @@ spec:
             cpu: 10m
 ---
 apiVersion: v1
+kind: Service
+metadata:
+  name: infra-backend-v3
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: infra-backend-v3
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: infra-backend-v3
+  namespace: gateway-conformance-infra
+  labels:
+    app: infra-backend-v3
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: infra-backend-v3
+  template:
+    metadata:
+      labels:
+        app: infra-backend-v3
+    spec:
+      containers:
+      - name: infra-backend-v3
+        image: k8s.gcr.io/ingressconformance/echoserver:v0.0.1
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          requests:
+            cpu: 10m
+---
+apiVersion: v1
 kind: Namespace
 metadata:
   name: gateway-conformance-app-backend

--- a/conformance/tests/httproute-listener-hostname-matching.go
+++ b/conformance/tests/httproute-listener-hostname-matching.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteListenerHostnameMatching)
+}
+
+var HTTPRouteListenerHostnameMatching = suite.ConformanceTest{
+	ShortName:   "HTTPRouteListenerHostnameMatching",
+	Description: "Multiple HTTP listeners with the same port and different hostnames, each with a different HTTPRoute",
+	Manifests:   []string{"tests/httproute-listener-hostname-matching.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+
+		// This test creates an additional Gateway in the gateway-conformance-infra
+		// namespace so we have to wait for it to be ready.
+		kubernetes.NamespacesMustBeReady(t, suite.Client, []string{ns}, 300)
+
+		gwNN := types.NamespacedName{Name: "httproute-listener-hostname-matching", Namespace: ns}
+		routes := []types.NamespacedName{
+			{Namespace: ns, Name: "backend-v1"},
+			{Namespace: ns, Name: "backend-v2"},
+			{Namespace: ns, Name: "backend-v3"},
+		}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routes...)
+
+		testCases := []http.ExpectedResponse{{
+			Request:   http.ExpectedRequest{Host: "bar.com", Path: "/"},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request:   http.ExpectedRequest{Host: "foo.bar.com", Path: "/"},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}, {
+			Request:   http.ExpectedRequest{Host: "baz.bar.com", Path: "/"},
+			Backend:   "infra-backend-v3",
+			Namespace: ns,
+		}, {
+			Request:   http.ExpectedRequest{Host: "boo.bar.com", Path: "/"},
+			Backend:   "infra-backend-v3",
+			Namespace: ns,
+		}, {
+			Request:    http.ExpectedRequest{Host: "too.many.prefixes.bar.com", Path: "/"},
+			StatusCode: 404,
+		}, {
+			Request:    http.ExpectedRequest{Host: "no.matching.host", Path: "/"},
+			StatusCode: 404,
+		}}
+
+		for i := range testCases {
+			// Declare tc here to avoid loop variable
+			// reuse issues across parallel tests.
+			tc := testCases[i]
+			t.Run(testName(tc, i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-listener-hostname-matching.yaml
+++ b/conformance/tests/httproute-listener-hostname-matching.yaml
@@ -1,0 +1,74 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  name: httproute-listener-hostname-matching
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: {GATEWAY_CLASS_NAME}
+  listeners:
+  - name: listener-1
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: bar.com
+  - name: listener-2
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: foo.bar.com
+  - name: listener-3
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: "*.bar.com"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: backend-v1
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: httproute-listener-hostname-matching
+    namespace: gateway-conformance-infra
+    sectionName: listener-1
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: backend-v2
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: httproute-listener-hostname-matching
+    namespace: gateway-conformance-infra
+    sectionName: listener-2
+  rules:
+  - backendRefs:
+    - name: infra-backend-v2
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: backend-v3
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: httproute-listener-hostname-matching
+    namespace: gateway-conformance-infra
+    sectionName: listener-3
+  rules:
+  - backendRefs:
+    - name: infra-backend-v3
+      port: 8080


### PR DESCRIPTION
**What type of PR is this?**
/kind conformance-test

**What this PR does / why we need it**:
Adds a test that verifies that different hostnames
for different HTTP listeners that all use the same
port are matched correctly.

**Which issue(s) this PR fixes**:
Updates #1104.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```

Note, this test also creates a new Gateway, so same question as for https://github.com/kubernetes-sigs/gateway-api/pull/1130#discussion_r861332705. There will be at least one more hostname-related test coming that requires a new Gateway as well.
