### PR TITLE
conformance: add hostname intersection test

### DIFF
--- a/conformance/tests/httproute-hostname-intersection.go
+++ b/conformance/tests/httproute-hostname-intersection.go
@@ -93,6 +93,11 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 					Namespace: ns,
 				},
 				http.ExpectedResponse{
+					Request:   http.ExpectedRequest{Host: "foo.bar.wildcard.io", Path: "/s2"},
+					Backend:   "infra-backend-v2",
+					Namespace: ns,
+				},
+				http.ExpectedResponse{
 					Request:    http.ExpectedRequest{Host: "non.matching.com", Path: "/s2"},
 					StatusCode: 404,
 				},
@@ -100,10 +105,7 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 					Request:    http.ExpectedRequest{Host: "wildcard.io", Path: "/s2"},
 					StatusCode: 404,
 				},
-				http.ExpectedResponse{
-					Request:    http.ExpectedRequest{Host: "foo.bar.wildcard.io", Path: "/s2"},
-					StatusCode: 404,
-				},
+
 				http.ExpectedResponse{
 					Request:    http.ExpectedRequest{Host: "very.specific.com", Path: "/s2"},
 					StatusCode: 404,
@@ -152,13 +154,15 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 					Namespace: ns,
 				},
 				http.ExpectedResponse{
+					Request:   http.ExpectedRequest{Host: "foo.bar.anotherwildcard.io", Path: "/s4"},
+					Backend:   "infra-backend-v1",
+					Namespace: ns,
+				},
+				http.ExpectedResponse{
 					Request:    http.ExpectedRequest{Host: "anotherwildcard.io", Path: "/s4"},
 					StatusCode: 404,
 				},
-				http.ExpectedResponse{
-					Request:    http.ExpectedRequest{Host: "too.many.anotherwildcard.io", Path: "/s4"},
-					StatusCode: 404,
-				},
+
 				http.ExpectedResponse{
 					Request:    http.ExpectedRequest{Host: "foo.wildcard.io", Path: "/s4"},
 					StatusCode: 404,
@@ -207,7 +211,7 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 					StatusCode: 404,
 				},
 				{
-					Request:    http.ExpectedRequest{Host: "too.many.prefixes.wildcard.io", Path: "/s5"},
+					Request:    http.ExpectedRequest{Host: "wildcard.io", Path: "/s5"},
 					StatusCode: 404,
 				},
 			}

--- a/conformance/tests/httproute-hostname-intersection.go
+++ b/conformance/tests/httproute-hostname-intersection.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteHostnameIntersection)
+}
+
+var HTTPRouteHostnameIntersection = suite.ConformanceTest{
+	ShortName:   "HTTPRouteHostnameIntersection",
+	Description: "HTTPRoutes should attach to listeners only if they have intersecting hostnames, and should accept requests only for the intersecting hostnames",
+	Manifests:   []string{"tests/httproute-hostname-intersection.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		gwNN := types.NamespacedName{Name: "httproute-hostname-intersection", Namespace: ns}
+
+		// This test creates an additional Gateway in the gateway-conformance-infra
+		// namespace so we have to wait for it to be ready.
+		kubernetes.NamespacesMustBeReady(t, suite.Client, []string{ns}, 300)
+
+		t.Run("HTTPRoutes that do intersect with listener hostnames", func(t *testing.T) {
+			routes := []types.NamespacedName{
+				{Namespace: ns, Name: "specific-host-matches-listener-specific-host"},
+				{Namespace: ns, Name: "specific-host-matches-listener-wildcard-host"},
+				{Namespace: ns, Name: "wildcard-host-matches-listener-specific-host"},
+				{Namespace: ns, Name: "wildcard-host-matches-listener-wildcard-host"},
+			}
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routes...)
+
+			var testCases []http.ExpectedResponse
+
+			// Test cases for HTTPRoute "specific-host-matches-listener-specific-host".
+			testCases = append(testCases,
+				http.ExpectedResponse{
+					Request:   http.ExpectedRequest{Host: "very.specific.com", Path: "/s1"},
+					Backend:   "infra-backend-v1",
+					Namespace: ns,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "non.matching.com", Path: "/s1"},
+					StatusCode: 404,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "foo.nonmatchingwildcard.io", Path: "/s1"},
+					StatusCode: 404,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "foo.wildcard.io", Path: "/s1"},
+					StatusCode: 404,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "very.specific.com", Path: "/non-matching-prefix"},
+					StatusCode: 404,
+				},
+			)
+
+			//  Test cases for HTTPRoute "specific-host-matches-listener-wildcard-host".
+			testCases = append(testCases,
+				http.ExpectedResponse{
+					Request:   http.ExpectedRequest{Host: "foo.wildcard.io", Path: "/s2"},
+					Backend:   "infra-backend-v2",
+					Namespace: ns,
+				},
+				http.ExpectedResponse{
+					Request:   http.ExpectedRequest{Host: "bar.wildcard.io", Path: "/s2"},
+					Backend:   "infra-backend-v2",
+					Namespace: ns,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "non.matching.com", Path: "/s2"},
+					StatusCode: 404,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "wildcard.io", Path: "/s2"},
+					StatusCode: 404,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "foo.bar.wildcard.io", Path: "/s2"},
+					StatusCode: 404,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "very.specific.com", Path: "/s2"},
+					StatusCode: 404,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "foo.wildcard.io", Path: "/non-matching-prefix"},
+					StatusCode: 404,
+				},
+			)
+
+			//  Test cases for HTTPRoute "wildcard-host-matches-listener-specific-host".
+			testCases = append(testCases,
+				http.ExpectedResponse{
+					Request:   http.ExpectedRequest{Host: "very.specific.com", Path: "/s3"},
+					Backend:   "infra-backend-v3",
+					Namespace: ns,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "non.matching.com", Path: "/s3"},
+					StatusCode: 404,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "foo.specific.com", Path: "/s3"},
+					StatusCode: 404,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "foo.wildcard.io", Path: "/s3"},
+					StatusCode: 404,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "very.specific.com", Path: "/non-matching-prefix"},
+					StatusCode: 404,
+				},
+			)
+
+			//  Test cases for HTTPRoute "wildcard-host-matches-listener-wildcard-host".
+			testCases = append(testCases,
+				http.ExpectedResponse{
+					Request:   http.ExpectedRequest{Host: "foo.anotherwildcard.io", Path: "/s4"},
+					Backend:   "infra-backend-v1",
+					Namespace: ns,
+				},
+				http.ExpectedResponse{
+					Request:   http.ExpectedRequest{Host: "bar.anotherwildcard.io", Path: "/s4"},
+					Backend:   "infra-backend-v1",
+					Namespace: ns,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "anotherwildcard.io", Path: "/s4"},
+					StatusCode: 404,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "too.many.anotherwildcard.io", Path: "/s4"},
+					StatusCode: 404,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "foo.wildcard.io", Path: "/s4"},
+					StatusCode: 404,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "very.specific.com", Path: "/s4"},
+					StatusCode: 404,
+				},
+				http.ExpectedResponse{
+					Request:    http.ExpectedRequest{Host: "foo.anotherwildcard.io", Path: "/non-matching-prefix"},
+					StatusCode: 404,
+				},
+			)
+
+			for i := range testCases {
+				// Declare tc here to avoid loop variable
+				// reuse issues across parallel tests.
+				tc := testCases[i]
+				t.Run(testName(tc, i), func(t *testing.T) {
+					t.Parallel()
+					http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, tc)
+				})
+			}
+		})
+
+		t.Run("HTTPRoutes that do not intersect with listener hostnames", func(t *testing.T) {
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN)
+
+			routeName := types.NamespacedName{Namespace: ns, Name: "no-intersecting-hosts"}
+			parents := []v1alpha2.RouteParentStatus{{
+				ParentRef:      parentRefTo(gwNN),
+				ControllerName: v1alpha2.GatewayController(suite.ControllerName),
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(v1alpha2.RouteConditionAccepted),
+						Status: metav1.ConditionFalse,
+					},
+				},
+			}}
+
+			kubernetes.HTTPRouteMustHaveParents(t, suite.Client, routeName, parents, true, 60)
+
+			testCases := []http.ExpectedResponse{
+				{
+					Request:    http.ExpectedRequest{Host: "specific.but.wrong.com", Path: "/s5"},
+					StatusCode: 404,
+				},
+				{
+					Request:    http.ExpectedRequest{Host: "too.many.prefixes.wildcard.io", Path: "/s5"},
+					StatusCode: 404,
+				},
+			}
+
+			for i := range testCases {
+				// Declare tc here to avoid loop variable
+				// reuse issues across parallel tests.
+				tc := testCases[i]
+				t.Run(testName(tc, i), func(t *testing.T) {
+					t.Parallel()
+					http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, tc)
+				})
+			}
+		})
+	},
+}
+
+func parentRefTo(gateway types.NamespacedName) v1alpha2.ParentReference {
+	var (
+		group     = v1alpha2.Group(v1alpha2.GroupName)
+		kind      = v1alpha2.Kind("Gateway")
+		namespace = v1alpha2.Namespace(gateway.Namespace)
+		name      = v1alpha2.ObjectName(gateway.Name)
+	)
+
+	return v1alpha2.ParentReference{
+		Group:     &group,
+		Kind:      &kind,
+		Namespace: &namespace,
+		Name:      name,
+	}
+}

--- a/conformance/tests/httproute-hostname-intersection.yaml
+++ b/conformance/tests/httproute-hostname-intersection.yaml
@@ -62,9 +62,9 @@ spec:
   hostnames:
   - non.matching.com
   - wildcard.io
-  - foo.bar.wildcard.io
   - foo.wildcard.io # matches listener-2's wildcard host
   - bar.wildcard.io # matches listener-2's wildcard host
+  - foo.bar.wildcard.io # matches listener-2's wildcard host
   rules:
   - matches:
     - path:
@@ -126,7 +126,7 @@ spec:
     namespace: gateway-conformance-infra
   hostnames:
   - specific.but.wrong.com
-  - too.many.prefixes.wildcard.io
+  - wildcard.io
   rules:
   - matches:
     - path:

--- a/conformance/tests/httproute-hostname-intersection.yaml
+++ b/conformance/tests/httproute-hostname-intersection.yaml
@@ -1,0 +1,137 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  name: httproute-hostname-intersection
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: {GATEWAY_CLASS_NAME}
+  listeners:
+  - name: listener-1
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: very.specific.com
+  - name: listener-2
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: "*.wildcard.io"
+  - name: listener-3
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: "*.anotherwildcard.io"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: specific-host-matches-listener-specific-host
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: httproute-hostname-intersection
+    namespace: gateway-conformance-infra
+  hostnames:
+  - non.matching.com
+  - "*.nonmatchingwildcard.io"
+  - very.specific.com # matches listener-1's specific host
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /s1
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: specific-host-matches-listener-wildcard-host
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: httproute-hostname-intersection
+    namespace: gateway-conformance-infra
+  hostnames:
+  - non.matching.com
+  - wildcard.io
+  - foo.bar.wildcard.io
+  - foo.wildcard.io # matches listener-2's wildcard host
+  - bar.wildcard.io # matches listener-2's wildcard host
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /s2
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: wildcard-host-matches-listener-specific-host
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: httproute-hostname-intersection
+    namespace: gateway-conformance-infra
+  hostnames:
+  - non.matching.com
+  - "*.specific.com"  # matches listener-1's specific host
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /s3
+    backendRefs:
+    - name: infra-backend-v3
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: wildcard-host-matches-listener-wildcard-host
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: httproute-hostname-intersection
+    namespace: gateway-conformance-infra
+  hostnames:
+  - "*.anotherwildcard.io"  # matches listener-3's wildcard host
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /s4
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: no-intersecting-hosts
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: httproute-hostname-intersection
+    namespace: gateway-conformance-infra
+  hostnames:
+  - specific.but.wrong.com
+  - too.many.prefixes.wildcard.io
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /s5
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080


### PR DESCRIPTION
**What type of PR is this?**
/area conformance

**What this PR does / why we need it**:
Adds a conformance test that validates hostname
intersection between HTTPRoutes and Listeners.

**Which issue(s) this PR fixes**:
Updates #1104 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
