### PR TITLE
api: remove ListenerReasonRouteConflict

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -641,7 +641,6 @@ const (
 	//
 	// * "HostnameConflict"
 	// * "ProtocolConflict"
-	// * "RouteConflict"
 	//
 	// Possible reasons for this condition to be False are:
 	//
@@ -662,13 +661,6 @@ const (
 	// multiple Listeners are specified with the same Listener port
 	// number, but have conflicting protocol specifications.
 	ListenerReasonProtocolConflict ListenerConditionReason = "ProtocolConflict"
-
-	// This reason is used with the "Conflicted" condition when the route
-	// resources selected for this Listener conflict with other
-	// specified properties of the Listener (e.g. Protocol).
-	// For example, a Listener that specifies "UDP" as the protocol
-	// but a route selector that resolves "TCPRoute" objects.
-	ListenerReasonRouteConflict ListenerConditionReason = "RouteConflict"
 
 	// This reason is used with the "Conflicted" condition when the condition
 	// is False.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
/kind documentation
/kind api-change
/kind deprecation

**What this PR does / why we need it**:
This appears to be an artifact of the v1alpha1 configuration style where a listener selects routes directly. In v1alpha2 an unsupported route attempting to attach to a listener should instead be rejected by the gateway, and optionally set an `Accepted` RouteCondition with status `False`.

A somewhat-related mismatch between the Listener's [`AllowedRoutes`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1alpha2.AllowedRoutes) `kinds` field and the supported [`protocol`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.ProtocolType) is explicitly expected to be expressed by the `ResolvedRefs` ListenerCondition setting status `False` with the `InvalidRouteKinds` reason (but could possibly be covered instead by webhook validation for the Core support level ProtocolType values and xRoute kinds?)

**Which issue(s) this PR fixes**:
Refs #1077, https://github.com/kubernetes-sigs/gateway-api/discussions/935#discussioncomment-1695833

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
removes the RouteConflict ListenerConditionReason intended to describe an error state that is no longer possible in the v1alpha2 API
```
