### PR TITLE
api: remove ListenerReasonUnsupportedExtension

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -689,7 +689,6 @@ const (
 	// Possible reasons for this condition to be true are:
 	//
 	// * "PortUnavailable"
-	// * "UnsupportedExtension"
 	// * "UnsupportedProtocol"
 	// * "UnsupportedAddress"
 	//
@@ -709,12 +708,6 @@ const (
 	// * The port is already in use.
 	// * The port is not supported by the implementation.
 	ListenerReasonPortUnavailable ListenerConditionReason = "PortUnavailable"
-
-	// This reason is used with the "Detached" condition when the
-	// controller detects that an implementation-specific Listener
-	// extension is being requested, but is not able to support
-	// the extension.
-	ListenerReasonUnsupportedExtension ListenerConditionReason = "UnsupportedExtension"
 
 	// This reason is used with the "Detached" condition when the
 	// Listener could not be attached to be Gateway because its


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup
/kind documentation
/kind api-change
/kind deprecation

**What this PR does / why we need it**:
This appears to be an artifact of the v1alpha1 configuration style where a listener selects routes directly. If I understand correctly, this is a reference to the `ExtensionRef` field on [`HTTPRouteRule`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRouteRule) (and other xRouteRule objects), which are the only other uses of the term `Extension` currently in the spec codebase.

`UnsupportedExtension` should likely become a RouteConditionReason instead, but I'm not quite sure with which RouteConditionType it should be used.

The intended behavior now is a bit unclear (it's an edge case not currently described in #1112). While rejecting a route entirely because of a single unsupported filter on one rule might have a large blast radius, I'm thinking through a few possible scenarios and potential impact/mitigation and wondering if that might actually be okay (and might even be desirable if using `ExtensionRef` to implement something like JWT auth):
- Moving from one Gateway API implementation to another - some degree of breaking change is likely expected here and would hopefully be discovered in a test environment and mitigated manually.
- Upgrading a Gateway API implementation to a new version which drops support for an old filter - this seems like something that should be clearly identified by the implementation as a breaking change in a changelog or mitigated safely through a deprecation process.
- Attempting to add a new filter to an existing route rule and making a typo - this feels like the most likely common operator risk, could we perhaps suggest implementations add custom webhook validation for this field to prevent accepting invalid `ExtensionRef` configurations that cause an attached route to become detached?

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Refs #1077, https://github.com/kubernetes-sigs/gateway-api/discussions/935#discussioncomment-1695833

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
removes the UnsupportedExtension ListenerConditionReason intended for a route selection model that has changed in the v1alpha2 API
```
