### PR TITLE
Add conformance test for HTTPRoute exact path matching

### DIFF
--- a/conformance/tests/httproute-exact-path-matching.go
+++ b/conformance/tests/httproute-exact-path-matching.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPExactPathMatching)
+}
+
+var HTTPExactPathMatching = suite.ConformanceTest{
+	ShortName:   "HTTPExactPathMatching",
+	Description: "A single HTTPRoute with exact path matching for different backends",
+	Manifests:   []string{"tests/httproute-exact-path-matching.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Name: "exact-matching", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				Request:   http.ExpectedRequest{Path: "/one"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			}, {
+				Request:   http.ExpectedRequest{Path: "/two"},
+				Backend:   "infra-backend-v2",
+				Namespace: ns,
+			}, {
+				Request:    http.ExpectedRequest{Path: "/"},
+				StatusCode: 404,
+			}, {
+				Request:    http.ExpectedRequest{Path: "/one/example"},
+				StatusCode: 404,
+			}, {
+				Request:    http.ExpectedRequest{Path: "/two/"},
+				StatusCode: 404,
+			},
+		}
+
+		for i := range testCases {
+			// Declare tc here to avoid loop variable
+			// reuse issues across parallel tests.
+			tc := testCases[i]
+			t.Run(testName(tc, i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-exact-path-matching.yaml
+++ b/conformance/tests/httproute-exact-path-matching.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: exact-matching
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /one
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - matches:
+    - path:
+        type: Exact
+        value: /two
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080


### PR DESCRIPTION
**What type of PR is this?**
/ kind conformance-test

**What this PR does / why we need it**:
Add tests for matching exact path for HTTPRoutes.

**Which issue(s) this PR fixes**:
Updates https://github.com/kubernetes-sigs/gateway-api/issues/1102.

**Does this PR introduce a user-facing change?**:
```
NONE

```
