### PR TITLE
Bumping webhook image to v0.4.3

### DIFF
--- a/deploy/admission_webhook.yaml
+++ b/deploy/admission_webhook.yaml
@@ -68,7 +68,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: gcr.io/k8s-staging-gateway-api/admission-server:latest
+          image: gcr.io/k8s-staging-gateway-api/admission-server:v0.4.3
           imagePullPolicy: Always
           args:
             - -logtostderr


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Bumps webhook version to v0.4.3 in preparation for release.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
