### PR TITLE
Bumping version references to v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Table of Contents
 
+- [v0.4.3](#v043)
+- [v0.4.2](#v042)
+- [v0.4.1](#v041)
 - [v0.4.0](#v040)
 - [v0.4.0-rc2](#v040-rc2)
 - [v0.4.0-rc1](#v040-rc1)
@@ -10,6 +13,45 @@
 - [v0.1.0](#v010)
 - [v0.1.0-rc2](#v010-rc2)
 - [v0.1.0-rc1](#v010-rc1)
+
+## v0.4.3
+
+API version: v1alpha2
+
+This release includes improvements to our webhook, including:
+
+* Migrating kube-webhook-certgen to k8s.gcr.io/ingress-nginx:v1.1.1.
+  [#1126](https://github.com/kubernetes-sigs/gateway-api/pull/1126)
+* New validation to ensure that a HTTPRouterFilter Type matches its value
+  [#1071](https://github.com/kubernetes-sigs/gateway-api/pull/1071)
+* A fix to ensure that Path match validation actually works
+  [#1071](https://github.com/kubernetes-sigs/gateway-api/pull/1071)
+
+## v0.4.2
+
+API version: v1alpha2
+
+This release is intended to verify our webhook image tagging process.
+
+### Bug Fixes
+
+* Update image generation process with more consistent naming
+  [#1034](https://github.com/kubernetes-sigs/gateway-api/pull/1034)
+
+## v0.4.1
+
+API version: v1alpha2
+
+This release contains minor bug fixes for v1alpha2.
+
+### Bug Fixes
+
+* ControllerName now prints correctly in kubectl output for GatewayClass
+  [#909](https://github.com/kubernetes-sigs/gateway-api/pull/909)
+* Namespace can no longer be left unspecified in ReferencePolicy
+  [#964](https://github.com/kubernetes-sigs/gateway-api/pull/964)
+* Wildcard characters can no longer be used in redirect Hostname values
+  [#956](https://github.com/kubernetes-sigs/gateway-api/pull/956)
 
 ## v0.4.0
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ the specification and Custom Resource Definitions (CRDs).
 
 ## Status
 
-The latest supported version is v1alpha2 as released by the [v0.4.2
-release](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.4.2) of
+The latest supported version is v1alpha2 as released by the [v0.4.3
+release](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.4.3) of
 this project. This version of the API is expected to graduate to beta in the
 future with relatively minimal changes.
 

--- a/site-src/v1alpha2/guides/getting-started.md
+++ b/site-src/v1alpha2/guides/getting-started.md
@@ -38,7 +38,7 @@ these resources. Installing the CRDs will just allow you to see and apply the
 resources, but they won't do anything without a controller implementing them.
 
 ```
-kubectl apply -k "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.2"
+kubectl apply -k "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.3"
 ```
 
 ### Install the Webhook
@@ -50,8 +50,8 @@ Until that point, the webhook can be installed with the following kubectl
 commands:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v0.4.2/deploy/admission_webhook.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v0.4.2/deploy/certificate_config.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v0.4.3/deploy/admission_webhook.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v0.4.3/deploy/certificate_config.yaml
 ```
 
 ### Cleanup


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This updates our docs to reference v0.4.3 now that it's been released.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
