### PR TITLE
Updating HTTP status code documentation to use 404 instead of 503

### DIFF
--- a/apis/v1alpha2/tlsroute_types.go
+++ b/apis/v1alpha2/tlsroute_types.go
@@ -105,7 +105,7 @@ type TLSRouteRule struct {
 	// a Service with no endpoints), the rule performs no forwarding; if no
 	// filters are specified that would result in a response being sent, the
 	// underlying implementation must actively reject request attempts to this
-	// backend, by rejecting the connection or returning a 503 status code.
+	// backend, by rejecting the connection or returning a 404 status code.
 	// Request rejections must respect weight; if an invalid backend is
 	// requested to have 80% of requests, then 80% of requests must be rejected
 	// instead.

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -213,15 +213,23 @@ spec:
                     and forwarding the request to an API object (backendRefs).
                   properties:
                     backendRefs:
-                      description: "If unspecified or invalid (refers to a non-existent
-                        resource or a Service with no endpoints), the rule performs
-                        no forwarding. If there are also no filters specified that
-                        would result in a response being sent, a HTTP 503 status code
-                        is returned. 503 responses must be sent so that the overall
-                        weight is respected; if an invalid backend is requested to
-                        have 80% of requests, then 80% of requests must get a 503
-                        instead. \n Support: Core for Kubernetes Service Support:
-                        Custom for any other resource \n Support for weight: Core"
+                      description: "BackendRefs defines the backend(s) where matching
+                        requests should be sent. \n A 404 status code MUST be returned
+                        if there are no BackendRefs or filters specified that would
+                        result in a response being sent. \n A BackendRef is considered
+                        invalid when it refers to: \n * an unknown or unsupported
+                        kind of resource * a resource that does not exist * a resource
+                        in another namespace when the reference has not been   explicitly
+                        allowed by a ReferencePolicy (or equivalent concept). \n When
+                        a BackendRef is invalid, 404 status codes MUST be returned
+                        for requests that would have otherwise been routed to an invalid
+                        backend. If multiple backends are specified, and some are
+                        invalid, the proportion of requests that would otherwise have
+                        been routed to an invalid backend MUST receive a 404 status
+                        code. \n When a BackendRef refers to a Service that has no
+                        ready endpoints, it is recommended to return a 503 status
+                        code. \n Support: Core for Kubernetes Service Support: Custom
+                        for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
                           forward an HTTP request.
@@ -1085,7 +1093,9 @@ spec:
                         in alphabetical order by   \"{namespace}/{name}\". \n If ties
                         still exist within the Route that has been given precedence,
                         matching precedence MUST be granted to the first matching
-                        rule meeting the above criteria."
+                        rule meeting the above criteria. \n When no rules matching
+                        a request have been successfully attached to the parent a
+                        request is coming from, a HTTP 404 status code MUST be returned."
                       items:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given action. Multiple match types are

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -210,7 +210,7 @@ spec:
                         the rule performs no forwarding; if no filters are specified
                         that would result in a response being sent, the underlying
                         implementation must actively reject request attempts to this
-                        backend, by rejecting the connection or returning a 503 status
+                        backend, by rejecting the connection or returning a 404 status
                         code. Request rejections must respect weight; if an invalid
                         backend is requested to have 80% of requests, then 80% of
                         requests must be rejected instead. \n Support: Core for Kubernetes

--- a/config/crd/stable/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_httproutes.yaml
@@ -187,15 +187,23 @@ spec:
                     and forwarding the request to an API object (backendRefs).
                   properties:
                     backendRefs:
-                      description: "If unspecified or invalid (refers to a non-existent
-                        resource or a Service with no endpoints), the rule performs
-                        no forwarding. If there are also no filters specified that
-                        would result in a response being sent, a HTTP 503 status code
-                        is returned. 503 responses must be sent so that the overall
-                        weight is respected; if an invalid backend is requested to
-                        have 80% of requests, then 80% of requests must get a 503
-                        instead. \n Support: Core for Kubernetes Service Support:
-                        Custom for any other resource \n Support for weight: Core"
+                      description: "BackendRefs defines the backend(s) where matching
+                        requests should be sent. \n A 404 status code MUST be returned
+                        if there are no BackendRefs or filters specified that would
+                        result in a response being sent. \n A BackendRef is considered
+                        invalid when it refers to: \n * an unknown or unsupported
+                        kind of resource * a resource that does not exist * a resource
+                        in another namespace when the reference has not been   explicitly
+                        allowed by a ReferencePolicy (or equivalent concept). \n When
+                        a BackendRef is invalid, 404 status codes MUST be returned
+                        for requests that would have otherwise been routed to an invalid
+                        backend. If multiple backends are specified, and some are
+                        invalid, the proportion of requests that would otherwise have
+                        been routed to an invalid backend MUST receive a 404 status
+                        code. \n When a BackendRef refers to a Service that has no
+                        ready endpoints, it is recommended to return a 503 status
+                        code. \n Support: Core for Kubernetes Service Support: Custom
+                        for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
                           forward an HTTP request.
@@ -920,7 +928,9 @@ spec:
                         in alphabetical order by   \"{namespace}/{name}\". \n If ties
                         still exist within the Route that has been given precedence,
                         matching precedence MUST be granted to the first matching
-                        rule meeting the above criteria."
+                        rule meeting the above criteria. \n When no rules matching
+                        a request have been successfully attached to the parent a
+                        request is coming from, a HTTP 404 status code MUST be returned."
                       items:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given action. Multiple match types are

--- a/config/crd/stable/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_tlsroutes.yaml
@@ -184,7 +184,7 @@ spec:
                         the rule performs no forwarding; if no filters are specified
                         that would result in a response being sent, the underlying
                         implementation must actively reject request attempts to this
-                        backend, by rejecting the connection or returning a 503 status
+                        backend, by rejecting the connection or returning a 404 status
                         code. Request rejections must respect weight; if an invalid
                         backend is requested to have 80% of requests, then 80% of
                         requests must be rejected instead. \n Support: Core for Kubernetes

--- a/conformance/tests/httproute-invalid-reference-policy.go
+++ b/conformance/tests/httproute-invalid-reference-policy.go
@@ -103,7 +103,7 @@ var HTTPRouteInvalidReferencePolicy = suite.ConformanceTest{
 					Method: "GET",
 					Path:   "/v2",
 				},
-				StatusCode: 503,
+				StatusCode: 404,
 			})
 		})
 	},

--- a/site-src/v1alpha2/api-types/httproute.md
+++ b/site-src/v1alpha2/api-types/httproute.md
@@ -130,7 +130,7 @@ Specifying a core filter multiple times has unspecified or custom conformance.
 
 BackendRefs defines API objects where matching requests should be sent. If
 unspecified, the rule performs no forwarding. If unspecified and no filters
-are specified that would result in a response being sent, a 503 error code
+are specified that would result in a response being sent, a 404 error code
 is returned.
 
 The following example forwards HTTP requests for prefix `/bar` to service


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/kind api-change
/area conformance

**What this PR does / why we need it**:
As suggested by @michaelbeaumont, this updates our HTTP status code guidance to require 404 status codes and removes any recommendations to return 503 status codes.

**Does this PR introduce a user-facing change?**:
```release-note
HTTP 404 responses should be returned whenever a matching route rule does not exist or a backend reference can not be resolved.
```

Adding a hold for consensus.
/hold