### PR TITLE
conformance: do not delay successes

### DIFF
--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -147,9 +147,9 @@ func WaitForConsistency(t *testing.T, r roundtripper.RoundTripper, req roundtrip
 			return false
 		}
 
-		t.Logf("Request passed, ready!")
 		return true
 	})
+	t.Logf("Request passed")
 
 	return cReq, cRes
 }

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -23,8 +23,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
 )
 
@@ -91,40 +89,67 @@ func MakeRequestAndExpectEventuallyConsistentResponse(t *testing.T, r roundtripp
 	ExpectResponse(t, cReq, cRes, expected)
 }
 
+// awaitConvergence runs the given function until it returns 'true' `threshold` times in a row.
+// Each failed attempt has a 1s delay; succesful attempts have no delay.
+func awaitConvergence(t *testing.T, threshold int, fn func() bool) {
+	successes := 0
+	attempts := 0
+	to := time.After(maxTimeToConsistency)
+	delay := time.Second
+	for {
+		select {
+		case <-to:
+			t.Fatalf("timeout while waiting after %d attempts", attempts)
+		default:
+		}
+
+		completed := fn()
+		attempts++
+		if completed {
+			successes++
+			if successes >= threshold {
+				return
+			}
+			// Skip delay if we have a success
+			continue
+		}
+
+		successes = 0
+		select {
+		// Capture the overall timeout
+		case <-to:
+			t.Fatalf("timeout while waiting after %d attempts, %d/%d sucessess", attempts, successes, threshold)
+			// And the per-try delay
+		case <-time.After(delay):
+		}
+	}
+}
+
 // WaitForConsistency repeats the provided request until it completes with a response having
 // the expected status code consistently. The provided threshold determines how many times in
 // a row this must occur to be considered "consistent".
 func WaitForConsistency(t *testing.T, r roundtripper.RoundTripper, req roundtripper.Request, expected ExpectedResponse, threshold int) (*roundtripper.CapturedRequest, *roundtripper.CapturedResponse) {
 	var (
-		cReq         *roundtripper.CapturedRequest
-		cRes         *roundtripper.CapturedResponse
-		err          error
-		numSuccesses int
+		cReq *roundtripper.CapturedRequest
+		cRes *roundtripper.CapturedResponse
+		err  error
 	)
 
-	require.Eventually(t, func() bool {
+	awaitConvergence(t, threshold, func() bool {
 		cReq, cRes, err = r.CaptureRoundTrip(req)
 		if err != nil {
-			numSuccesses = 0
 			t.Logf("Request failed, not ready yet: %v", err.Error())
 			return false
 		}
 
 		if cRes.StatusCode != expected.StatusCode {
-			numSuccesses = 0
 			t.Logf("Expected response to have status %d but got %d, not ready yet", expected.StatusCode, cRes.StatusCode)
 			return false
 		}
 
-		numSuccesses++
-		if numSuccesses < threshold {
-			t.Logf("Request has passed %d times in a row of the desired %d, not ready yet", numSuccesses, threshold)
-			return false
-		}
-
-		t.Logf("Request has passed %d times in a row of the desired %d, ready!", numSuccesses, threshold)
+		t.Logf("Request passed, ready!")
 		return true
-	}, maxTimeToConsistency, 1*time.Second, "error making request, never got expected status")
+	})
 
 	return cReq, cRes
 }


### PR DESCRIPTION
Currently WaitForConsistency requires 3 requests to succeed in a row,
and waits 1s between requests. This means each tests takes a minimum of
3s even in success. This is ok for now, but as we scale up may be quite
slow.

Instead, change the convergence logic so that we only delay on failures


**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
