### PR TITLE
api: add RouteReasonNotAllowedByListeners

### DIFF
--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -193,6 +193,10 @@ const (
 	//
 	// * "Accepted"
 	//
+	// Possible reasons for this condition to be False are:
+	//
+	// * "NotAllowedByListeners"
+	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
@@ -201,6 +205,11 @@ const (
 	// This reason is used with the "Accepted" condition when the Route has been
 	// accepted by the Gateway.
 	RouteReasonAccepted RouteConditionReason = "Accepted"
+
+	// This reason is used with the "Accepted" condition when the route has not
+	// been accepted by a Gateway because the Gateway had no Listener whose
+	// allowedRoutes criteria permit the route
+	RouteReasonNotAllowedByListeners RouteConditionReason = "NotAllowedByListeners"
 
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the Route.

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -196,6 +196,7 @@ const (
 	// Possible reasons for this condition to be False are:
 	//
 	// * "NotAllowedByListeners"
+	// * "NoMatchingListenerHostname"
 	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
@@ -210,6 +211,10 @@ const (
 	// been accepted by a Gateway because the Gateway had no Listener whose
 	// allowedRoutes criteria permit the route
 	RouteReasonNotAllowedByListeners RouteConditionReason = "NotAllowedByListeners"
+
+	// This reason is used with the "Accepted" condition when the Gateway has no
+	// compatible Listeners whose Hostname matches the route
+	RouteReasonNoMatchingListenerHostname RouteConditionReason = "NoMatchingListenerHostname"
 
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the Route.

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -208,7 +208,7 @@ const (
 	RouteReasonAccepted RouteConditionReason = "Accepted"
 
 	// This reason is used with the "Accepted" condition when the route has not
-	// been accepted by a Gateway because the Gateway had no Listener whose
+	// been accepted by a Gateway because the Gateway has no Listener whose
 	// allowedRoutes criteria permit the route
 	RouteReasonNotAllowedByListeners RouteConditionReason = "NotAllowedByListeners"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change

**What this PR does / why we need it**:
Adds two `RouteConditionReason` constants for `RouteConditionAccepted==false`:
- `NotAllowedByListeners` indicates that none of the Gateway's Listeners have an `allowedRoutes` that permits the route.
- `NoMatchingListenerHostname` indicates that none of the Gateway's compatible Listeners have a Hostname that matches one of the route's hostnames (and implicitly that there is no compatible Listener without a Hostname, which would match any route).

**Which issue(s) this PR fixes**:
Related to #1077 

**Does this PR introduce a user-facing change?**:

```release-note
adds RouteReasonNotAllowedByListeners and RouteReasonNoMatchingListenerHostname RouteConditionReason constants
```
