### PR TITLE
conformance: fixes for invalid reference policy test

### DIFF
--- a/conformance/tests/httproute-invalid-reference-policy.go
+++ b/conformance/tests/httproute-invalid-reference-policy.go
@@ -46,9 +46,6 @@ var HTTPRouteInvalidReferencePolicy = suite.ConformanceTest{
 		ns := v1alpha2.Namespace(gwNN.Namespace)
 		gwKind := v1alpha2.Kind("Gateway")
 
-		// TODO(mikemorris): Add check for Accepted condition once
-		// https://github.com/kubernetes-sigs/gateway-api/issues/1112
-		// has been resolved
 		t.Run("Route status should have a route parent status with a ResolvedRefs condition with status False and reason RefNotPermitted", func(t *testing.T) {
 			parents := []v1alpha2.RouteParentStatus{{
 				ParentRef: v1alpha2.ParentReference{
@@ -90,6 +87,10 @@ var HTTPRouteInvalidReferencePolicy = suite.ConformanceTest{
 		// 	kubernetes.GatewayStatusMustHaveListeners(t, s.Client, gwNN, listeners, 60)
 		// })
 
+		// TODO(mikemorris): Add routeNN to the end of the arguments below
+		// to add check for Accepted condition once
+		// https://github.com/kubernetes-sigs/gateway-api/issues/1112
+		// has been resolved
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, s.Client, s.ControllerName, gwNN)
 
 		// TODO(mikemorris): Add check for HTTP requests successfully reaching

--- a/conformance/tests/httproute-invalid-reference-policy.go
+++ b/conformance/tests/httproute-invalid-reference-policy.go
@@ -68,12 +68,12 @@ var HTTPRouteInvalidReferencePolicy = suite.ConformanceTest{
 			kubernetes.HTTPRouteMustHaveParents(t, s.Client, routeNN, parents, false, 60)
 		})
 
-		// TODO(mikemorris): Un-skip check for Listener ResolvedRefs
+		// TODO(mikemorris): Un-comment check for Listener ResolvedRefs
 		// RefNotPermitted condition and/or add check for attached
 		// routes and any expected Listener conditions once
 		// https://github.com/kubernetes-sigs/gateway-api/issues/1112
 		// has been resolved
-		// t.Skip("Gateway listener should have a ResolvedRefs condition with status False and reason RefNotPermitted", func(t *testing.T) {
+		// t.Run("Gateway listener should have a ResolvedRefs condition with status False and reason RefNotPermitted", func(t *testing.T) {
 		// 	listeners := []v1alpha2.ListenerStatus{{
 		// 		Name: v1alpha2.SectionName("http"),
 		// 		SupportedKinds: []v1alpha2.RouteGroupKind{{
@@ -90,7 +90,7 @@ var HTTPRouteInvalidReferencePolicy = suite.ConformanceTest{
 		// 	kubernetes.GatewayStatusMustHaveListeners(t, s.Client, gwNN, listeners, 60)
 		// })
 
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, s.Client, s.ControllerName, gwNN, routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, s.Client, s.ControllerName, gwNN)
 
 		// TODO(mikemorris): Add check for HTTP requests successfully reaching
 		// app-backend-v1 at path "/" if it is determined that a Route with at

--- a/conformance/tests/httproute-invalid-reference-policy.yaml
+++ b/conformance/tests/httproute-invalid-reference-policy.yaml
@@ -24,7 +24,8 @@ spec:
   rules:
   - matches:
     - path:
-      value: "/v2"
+        type: PathPrefix
+        value: "/v2"
     backendRefs:
     - name: app-backend-v2
       namespace: gateway-conformance-app-backend


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/area conformance

**What this PR does / why we need it**:
#1167 commented out a call to `t.Skip(...)`, however that `t.Skip(...)` call had been written in a misleading way; it was skipping _the rest_ of the test, not just the function passed to t.Skip(...) as an arg. So after commenting it out, the rest of the test now executes and uncovers a couple small issues with the test:

- fixes path prefix match YAML indentation
- removes check for HTTPRoute to be Accepted pending #1112

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
