### PR TITLE
Clarifying that wildcard hostname matching is suffix matching

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -172,6 +172,10 @@ type Listener struct {
 	// accepted. For more information, refer to the Route specific Hostnames
 	// documentation.
 	//
+	// Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+	// as a suffix match. That means that a match for `*.example.com` would match
+	// both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+	//
 	// Support: Core
 	//
 	// +optional

--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -74,8 +74,13 @@ type HTTPRouteSpec struct {
 	// * A Listener with `*.example.com` as the hostname matches HTTPRoutes
 	//   that have either not specified any hostnames or have specified at least
 	//   one hostname that matches the Listener hostname. For example,
-	//   `test.example.com` and `*.example.com` would both match. On the other
-	//   hand, `example.com` and `test.example.net` would not match.
+	//   `*.example.com`, `test.example.com`, and `foo.test.example.com` would
+	//   all match. On the other hand, `example.com` and `test.example.net` would
+	//   not match.
+	//
+	// Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+	// as a suffix match. That means that a match for `*.example.com` would match
+	// both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
 	//
 	// If both the Listener and HTTPRoute have specified hostnames, any
 	// HTTPRoute hostnames that do not match the Listener hostname MUST be

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -280,7 +280,11 @@ spec:
                         array. When both listener and route specify hostnames, there
                         MUST be an intersection between the values for a Route to
                         be accepted. For more information, refer to the Route specific
-                        Hostnames documentation. \n Support: Core"
+                        Hostnames documentation. \n Hostnames that are prefixed with
+                        a wildcard label (`*.`) are interpreted as a suffix match.
+                        That means that a match for `*.example.com` would match both
+                        `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+                        \n Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -63,17 +63,21 @@ spec:
                   * A Listener with `*.example.com` as the hostname matches HTTPRoutes
                   \  that have either not specified any hostnames or have specified
                   at least   one hostname that matches the Listener hostname. For
-                  example,   `test.example.com` and `*.example.com` would both match.
-                  On the other   hand, `example.com` and `test.example.net` would
-                  not match. \n If both the Listener and HTTPRoute have specified
-                  hostnames, any HTTPRoute hostnames that do not match the Listener
-                  hostname MUST be ignored. For example, if a Listener specified `*.example.com`,
-                  and the HTTPRoute specified `test.example.com` and `test.example.net`,
-                  `test.example.net` must not be considered for a match. \n If both
-                  the Listener and HTTPRoute have specified hostnames, and none match
-                  with the criteria above, then the HTTPRoute is not accepted. The
-                  implementation must raise an 'Accepted' Condition with a status
-                  of `False` in the corresponding RouteParentStatus. \n Support: Core"
+                  example,   `*.example.com`, `test.example.com`, and `foo.test.example.com`
+                  would   all match. On the other hand, `example.com` and `test.example.net`
+                  would   not match. \n Hostnames that are prefixed with a wildcard
+                  label (`*.`) are interpreted as a suffix match. That means that
+                  a match for `*.example.com` would match both `test.example.com`,
+                  and `foo.test.example.com`, but not `example.com`. \n If both the
+                  Listener and HTTPRoute have specified hostnames, any HTTPRoute hostnames
+                  that do not match the Listener hostname MUST be ignored. For example,
+                  if a Listener specified `*.example.com`, and the HTTPRoute specified
+                  `test.example.com` and `test.example.net`, `test.example.net` must
+                  not be considered for a match. \n If both the Listener and HTTPRoute
+                  have specified hostnames, and none match with the criteria above,
+                  then the HTTPRoute is not accepted. The implementation must raise
+                  an 'Accepted' Condition with a status of `False` in the corresponding
+                  RouteParentStatus. \n Support: Core"
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with

--- a/config/crd/stable/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_gateways.yaml
@@ -280,7 +280,11 @@ spec:
                         array. When both listener and route specify hostnames, there
                         MUST be an intersection between the values for a Route to
                         be accepted. For more information, refer to the Route specific
-                        Hostnames documentation. \n Support: Core"
+                        Hostnames documentation. \n Hostnames that are prefixed with
+                        a wildcard label (`*.`) are interpreted as a suffix match.
+                        That means that a match for `*.example.com` would match both
+                        `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+                        \n Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$

--- a/config/crd/stable/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_httproutes.yaml
@@ -63,17 +63,21 @@ spec:
                   * A Listener with `*.example.com` as the hostname matches HTTPRoutes
                   \  that have either not specified any hostnames or have specified
                   at least   one hostname that matches the Listener hostname. For
-                  example,   `test.example.com` and `*.example.com` would both match.
-                  On the other   hand, `example.com` and `test.example.net` would
-                  not match. \n If both the Listener and HTTPRoute have specified
-                  hostnames, any HTTPRoute hostnames that do not match the Listener
-                  hostname MUST be ignored. For example, if a Listener specified `*.example.com`,
-                  and the HTTPRoute specified `test.example.com` and `test.example.net`,
-                  `test.example.net` must not be considered for a match. \n If both
-                  the Listener and HTTPRoute have specified hostnames, and none match
-                  with the criteria above, then the HTTPRoute is not accepted. The
-                  implementation must raise an 'Accepted' Condition with a status
-                  of `False` in the corresponding RouteParentStatus. \n Support: Core"
+                  example,   `*.example.com`, `test.example.com`, and `foo.test.example.com`
+                  would   all match. On the other hand, `example.com` and `test.example.net`
+                  would   not match. \n Hostnames that are prefixed with a wildcard
+                  label (`*.`) are interpreted as a suffix match. That means that
+                  a match for `*.example.com` would match both `test.example.com`,
+                  and `foo.test.example.com`, but not `example.com`. \n If both the
+                  Listener and HTTPRoute have specified hostnames, any HTTPRoute hostnames
+                  that do not match the Listener hostname MUST be ignored. For example,
+                  if a Listener specified `*.example.com`, and the HTTPRoute specified
+                  `test.example.com` and `test.example.net`, `test.example.net` must
+                  not be considered for a match. \n If both the Listener and HTTPRoute
+                  have specified hostnames, and none match with the criteria above,
+                  then the HTTPRoute is not accepted. The implementation must raise
+                  an 'Accepted' Condition with a status of `False` in the corresponding
+                  RouteParentStatus. \n Support: Core"
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with

--- a/conformance/tests/httproute-listener-hostname-matching.go
+++ b/conformance/tests/httproute-listener-hostname-matching.go
@@ -66,7 +66,15 @@ var HTTPRouteListenerHostnameMatching = suite.ConformanceTest{
 			Backend:   "infra-backend-v3",
 			Namespace: ns,
 		}, {
-			Request:    http.ExpectedRequest{Host: "too.many.prefixes.bar.com", Path: "/"},
+			Request:   http.ExpectedRequest{Host: "multiple.prefixes.bar.com", Path: "/"},
+			Backend:   "infra-backend-v3",
+			Namespace: ns,
+		}, {
+			Request:   http.ExpectedRequest{Host: "multiple.prefixes.foo.com", Path: "/"},
+			Backend:   "infra-backend-v3",
+			Namespace: ns,
+		}, {
+			Request:    http.ExpectedRequest{Host: "foo.com", Path: "/"},
 			StatusCode: 404,
 		}, {
 			Request:    http.ExpectedRequest{Host: "no.matching.host", Path: "/"},

--- a/conformance/tests/httproute-listener-hostname-matching.yaml
+++ b/conformance/tests/httproute-listener-hostname-matching.yaml
@@ -27,6 +27,13 @@ spec:
       namespaces:
         from: Same
     hostname: "*.bar.com"
+  - name: listener-4
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: "*.foo.com"
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
@@ -68,6 +75,9 @@ spec:
   - name: httproute-listener-hostname-matching
     namespace: gateway-conformance-infra
     sectionName: listener-3
+  - name: httproute-listener-hostname-matching
+    namespace: gateway-conformance-infra
+    sectionName: listener-4
   rules:
   - backendRefs:
     - name: infra-backend-v3


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/area conformance

**What this PR does / why we need it**:
This is a follow up from #1159 that clarifies that wildcard hostname matching should be considered equivalent to suffix matching. This is a change from the Ingress spec but is more widely implementable and matches the most widespread default behavior, including nginx, envoy, GCP, and Azure.

**Which issue(s) this PR fixes**:
Fixes #1159

**Does this PR introduce a user-facing change?**:
```release-note
Wildcard hostname matching behavior has been documented as equivalent to suffix matching.
```

If merged, this will cause conformance tests to start failing for some implementations, adding a temporary hold so everyone has a chance to weigh in.

/hold

/cc @bowei @shaneutt @youngnick @mikemorris @howardjohn 