### PR TITLE
Fix certificateRefs optionality.

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -327,7 +327,7 @@ type GatewayTLSConfig struct {
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=64
-	CertificateRefs []*SecretObjectReference `json:"certificateRefs,omitempty"`
+	CertificateRefs []SecretObjectReference `json:"certificateRefs,omitempty"`
 
 	// Options are a list of key/value pairs to enable extended TLS
 	// configuration for each implementation. For example, configuring the

--- a/apis/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/v1alpha2/zz_generated.deepcopy.go
@@ -391,13 +391,9 @@ func (in *GatewayTLSConfig) DeepCopyInto(out *GatewayTLSConfig) {
 	}
 	if in.CertificateRefs != nil {
 		in, out := &in.CertificateRefs, &out.CertificateRefs
-		*out = make([]*SecretObjectReference, len(*in))
+		*out = make([]SecretObjectReference, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(SecretObjectReference)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Options != nil {


### PR DESCRIPTION
The GatewayTLSConfig CertificateRefs member is a slice of pointer to struct which implies that the struct is optional.  Change this to a slice of struct to better fit with API type conventions.

/kind cleanup