### PR TITLE
docs: backlinks from example manifests to guides

### DIFF
--- a/examples/v1alpha1/basic-http.yaml
+++ b/examples/v1alpha1/basic-http.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/api-types/httproute.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: GatewayClass
 metadata:

--- a/examples/v1alpha1/basic-tcp.yaml
+++ b/examples/v1alpha1/basic-tcp.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/guides/tcp.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: GatewayClass
 metadata:

--- a/examples/v1alpha1/cross-namespace-routing/gateway.yaml
+++ b/examples/v1alpha1/cross-namespace-routing/gateway.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/guides/multiple-ns.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: Gateway
 metadata:

--- a/examples/v1alpha1/cross-namespace-routing/site-route.yaml
+++ b/examples/v1alpha1/cross-namespace-routing/site-route.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/guides/multiple-ns.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/cross-namespace-routing/store-route.yaml
+++ b/examples/v1alpha1/cross-namespace-routing/store-route.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/guides/multiple-ns.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/http-filter.yaml
+++ b/examples/v1alpha1/http-filter.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/api-types/httproute.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: GatewayClass
 metadata:

--- a/examples/v1alpha1/http-routing/bar-httproute.yaml
+++ b/examples/v1alpha1/http-routing/bar-httproute.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/guides/http-routing.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/http-routing/foo-httproute.yaml
+++ b/examples/v1alpha1/http-routing/foo-httproute.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/guides/http-routing.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/http-routing/gateway.yaml
+++ b/examples/v1alpha1/http-routing/gateway.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/guides/http-routing.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: Gateway
 metadata:

--- a/examples/v1alpha1/http-trafficsplit.yaml
+++ b/examples/v1alpha1/http-trafficsplit.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/api-types/httproute.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: GatewayClass
 metadata:

--- a/examples/v1alpha1/simple-gateway/gateway.yaml
+++ b/examples/v1alpha1/simple-gateway/gateway.yaml
@@ -1,3 +1,6 @@
+## Used in:
+## - site-src/v1alpha1/guides/traffic-splitting.md
+## - site-src/v1alpha1/guides/simple-gateway.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: Gateway
 metadata:

--- a/examples/v1alpha1/simple-gateway/httproute.yaml
+++ b/examples/v1alpha1/simple-gateway/httproute.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/guides/simple-gateway.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/tls-basic.yaml
+++ b/examples/v1alpha1/tls-basic.yaml
@@ -1,3 +1,6 @@
+## Used in:
+## - site-src/v1alpha1/guides/tls.md
+## - site-src/v1alpha1/api-types/httproute.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: Gateway
 metadata:

--- a/examples/v1alpha1/tls-cert-in-route.yaml
+++ b/examples/v1alpha1/tls-cert-in-route.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/guides/tls.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: Gateway
 metadata:

--- a/examples/v1alpha1/traffic-splitting/simple-split.yaml
+++ b/examples/v1alpha1/traffic-splitting/simple-split.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/guides/traffic-splitting.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/traffic-splitting/traffic-split-1.yaml
+++ b/examples/v1alpha1/traffic-splitting/traffic-split-1.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/guides/traffic-splitting.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/traffic-splitting/traffic-split-2.yaml
+++ b/examples/v1alpha1/traffic-splitting/traffic-split-2.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/guides/traffic-splitting.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/traffic-splitting/traffic-split-3.yaml
+++ b/examples/v1alpha1/traffic-splitting/traffic-split-3.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/guides/traffic-splitting.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/upstream-tls.yaml
+++ b/examples/v1alpha1/upstream-tls.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/guides/tls.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: BackendPolicy
 metadata:

--- a/examples/v1alpha1/wildcard-tls-gateway.yaml
+++ b/examples/v1alpha1/wildcard-tls-gateway.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha1/guides/tls.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/basic-http.yaml
+++ b/examples/v1alpha2/basic-http.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: GatewayClass
 metadata:

--- a/examples/v1alpha2/basic-tcp.yaml
+++ b/examples/v1alpha2/basic-tcp.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/guides/tcp.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/cross-namespace-routing/0-namespaces.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/0-namespaces.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/guides/multiple-ns.md
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/examples/v1alpha2/cross-namespace-routing/gateway.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/gateway.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/guides/multiple-ns.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/cross-namespace-routing/site-route.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/site-route.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/guides/multiple-ns.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/cross-namespace-routing/store-route.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/store-route.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/guides/multiple-ns.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/http-filter.yaml
+++ b/examples/v1alpha2/http-filter.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/http-route-attachment/gateway-namespaces.yaml
+++ b/examples/v1alpha2/http-route-attachment/gateway-namespaces.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/concepts/api-overview.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/http-route-attachment/gateway-strict.yaml
+++ b/examples/v1alpha2/http-route-attachment/gateway-strict.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/concepts/api-overview.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/http-route-attachment/httproute.yaml
+++ b/examples/v1alpha2/http-route-attachment/httproute.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/concepts/api-overview.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/http-routing/bar-httproute.yaml
+++ b/examples/v1alpha2/http-routing/bar-httproute.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/guides/http-routing.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/http-routing/foo-httproute.yaml
+++ b/examples/v1alpha2/http-routing/foo-httproute.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/guides/http-routing.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/http-routing/gateway.yaml
+++ b/examples/v1alpha2/http-routing/gateway.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/guides/http-routing.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/reference-policy.yaml
+++ b/examples/v1alpha2/reference-policy.yaml
@@ -1,3 +1,6 @@
+## Used in:
+## - site-src/concepts/security-model.md
+## - site-src/blog/2021/introducing-v1alpha2.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: ReferencePolicy
 metadata:

--- a/examples/v1alpha2/simple-gateway/gateway.yaml
+++ b/examples/v1alpha2/simple-gateway/gateway.yaml
@@ -1,3 +1,6 @@
+## Used in:
+## - site-src/v1alpha2/guides/traffic-splitting.md
+## - site-src/v1alpha2/guides/simple-gateway.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/simple-gateway/httproute.yaml
+++ b/examples/v1alpha2/simple-gateway/httproute.yaml
@@ -1,3 +1,6 @@
+## Used in:
+## - site-src/v1alpha2/guides/simple-gateway.md
+## - site-src/blog/2021/introducing-v1alpha2.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/tls-basic.yaml
+++ b/examples/v1alpha2/tls-basic.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/guides/tls.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/tls-cert-cross-namespace.yaml
+++ b/examples/v1alpha2/tls-cert-cross-namespace.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/guides/tls.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/traffic-splitting/simple-split.yaml
+++ b/examples/v1alpha2/traffic-splitting/simple-split.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/guides/traffic-splitting.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/traffic-splitting/traffic-split-1.yaml
+++ b/examples/v1alpha2/traffic-splitting/traffic-split-1.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/guides/traffic-splitting.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/traffic-splitting/traffic-split-2.yaml
+++ b/examples/v1alpha2/traffic-splitting/traffic-split-2.yaml
@@ -1,3 +1,6 @@
+## Used in:
+## - site-src/v1alpha2/guides/traffic-splitting.md
+## - site-src/v1alpha2/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/traffic-splitting/traffic-split-3.yaml
+++ b/examples/v1alpha2/traffic-splitting/traffic-split-3.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/guides/traffic-splitting.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/wildcard-tls-gateway.yaml
+++ b/examples/v1alpha2/wildcard-tls-gateway.yaml
@@ -1,3 +1,5 @@
+## Used in:
+## - site-src/v1alpha2/guides/tls.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ plugins:
   - awesome-pages
   - macros:
       include_dir: examples
+      j2_line_comment_prefix: "##"
 markdown_extensions:
   - admonition
   - meta


### PR DESCRIPTION
Fixes #446

Based on #1083

We would like our example YAML files to include comments that do not show up in the guides where the files are used as jinja templates, while still ensuring they are valid YAML files.

Configuring the jinja Environment with "line_comment_prefix" allows you to control the syntax of the jinja comment directive. If we set that to "##", then such lines are ommitted during jinja templating, and are treated as YAML comments.

See also https://jinja.palletsprojects.com/en/2.11.x/templates/#line-statements

Generated the comments using this awfulness:

```
$ sed -i '1s/^/## Used in:\n/' $( \
    for iii in $(git grep -l '{% include' site-src/); do \
      awk -F "'" '/{% include/ { print "examples/"$2 }' $iii ; \
    done | sort | uniq)

$ for iii in $(git grep -l '{% include' site-src/); do \
    for jjj in $(awk -F "'" '/{% include/ { print "examples/"$2 }' $iii); do \
      sed -i "2s|^|## - $iii\n|" $jjj; \
    done; \
  done
```

/kind documentation