### PR TITLE
Update AddressType definition to add domain-prefixed strings as an option

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -450,7 +450,6 @@ type GatewayAddress struct {
 	// Type of the address.
 	//
 	// +optional
-	// +kubebuilder:validation:Enum=IPAddress;Hostname;NamedAddress
 	// +kubebuilder:default=IPAddress
 	Type *AddressType `json:"type,omitempty"`
 

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -482,7 +482,7 @@ type AnnotationValue string
 // AddressType defines how a network address is represented as a text string.
 // This may take two possible forms:
 //
-// * A CamelCase string identifier (like `IPAddress` or `Hostname`)
+// * A predefined CamelCase string identifier (currently limited to `IPAddress` or `Hostname`)
 // * A domain-prefixed string identifier (like `acme.io/CustomAddressType`)
 //
 // Values `IPAddress` and `Hostname` have Extended support.

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -488,8 +488,7 @@ type AnnotationValue string
 // Values `IPAddress` and `Hostname` have Extended support.
 //
 // All other values, including domain-prefixed values have Custom support,
-// and are expected to be used by implementations to implement custom behavior
-// in a compatible way.
+// which are used in implementation-specific behaviors.
 //
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=253

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -480,6 +480,20 @@ type AnnotationKey string
 type AnnotationValue string
 
 // AddressType defines how a network address is represented as a text string.
+// This may take two possible forms:
+//
+// * A CamelCase string identifier (like `IPAddress` or `Hostname`)
+// * A domain-prefixed string identifier (like `acme.io/CustomAddressType`)
+//
+// Values `IPAddress` and `Hostname` have Extended support.
+//
+// All other values, including domain-prefixed values have Custom support,
+// and are expected to be used by implementations to implement custom behavior
+// in a compatible way.
+//
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern=`^([a-zA-Z0-9])+$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\/[a-zA-Z0-9]+$`
 type AddressType string
 
 const (
@@ -502,11 +516,4 @@ const (
 	//
 	// Support: Extended
 	HostnameAddressType AddressType = "Hostname"
-
-	// A NamedAddress provides a way to reference a specific IP address by name.
-	// For example, this may be a name or other unique identifier that refers
-	// to a resource on a cloud provider such as a static IP.
-	//
-	// Support: Implementation-Specific
-	NamedAddressType AddressType = "NamedAddress"
 )

--- a/apis/v1alpha2/validation/gateway.go
+++ b/apis/v1alpha2/validation/gateway.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"fmt"
+	"regexp"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -36,6 +37,11 @@ var (
 		gatewayv1a2.UDPProtocolType:  {},
 		gatewayv1a2.TCPProtocolType:  {},
 	}
+
+	addressTypesValid = map[gatewayv1a2.AddressType]struct{}{
+		gatewayv1a2.HostnameAddressType: {},
+		gatewayv1a2.IPAddressType:       {},
+	}
 )
 
 // ValidateGateway validates gw according to the Gateway API specification.
@@ -51,7 +57,10 @@ func ValidateGateway(gw *gatewayv1a2.Gateway) field.ErrorList {
 // validateGatewaySpec validates whether required fields of spec are set according to the
 // Gateway API specification.
 func validateGatewaySpec(spec *gatewayv1a2.GatewaySpec, path *field.Path) field.ErrorList {
-	return validateGatewayListeners(spec.Listeners, path.Child("listeners"))
+	var errs field.ErrorList
+	errs = append(errs, validateGatewayListeners(spec.Listeners, path.Child("listeners"))...)
+	errs = append(errs, validateAddresses(spec.Addresses, path.Child("addresses"))...)
+	return errs
 }
 
 // validateGatewayListeners validates whether required fields of listeners are set according
@@ -86,6 +95,30 @@ func validateListenerHostname(listeners []gatewayv1a2.Listener, path *field.Path
 		if isProtocolInSubset(h.Protocol, protocolsHostnameInvalid) && h.Hostname != nil {
 			errs = append(errs, field.Forbidden(path.Index(i).Child("hostname"), fmt.Sprintf("should be empty for protocol %v", h.Protocol)))
 		}
+	}
+	return errs
+}
+
+// validateAddresses validates each listener address
+// if there are addresses set. Otherwise, returns no error.
+func validateAddresses(addresses []gatewayv1a2.GatewayAddress, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	re := regexp.MustCompile(`^([a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\/[a-zA-Z0-9]+$`)
+
+	for i, a := range addresses {
+		if a.Type == nil {
+			continue
+		}
+		_, ok := addressTypesValid[*a.Type]
+		if !ok {
+			// Found something that's not one of the upstream AddressTypes
+			// Next, check for a domain-prefixed string
+			match := re.Match([]byte(*a.Type))
+			if !match {
+				errs = append(errs, field.Invalid(path.Index(i).Child("type"), a.Type, "should either be a defined constant or a domain-prefixed string (example.com/Type)"))
+			}
+		}
+
 	}
 	return errs
 }

--- a/apis/v1alpha2/validation/gateway_test.go
+++ b/apis/v1alpha2/validation/gateway_test.go
@@ -30,6 +30,11 @@ func TestValidateGateway(t *testing.T) {
 			Hostname: nil,
 		},
 	}
+	addresses := []gatewayv1a2.GatewayAddress{
+		{
+			Type: nil,
+		},
+	}
 	baseGateway := gatewayv1a2.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
@@ -38,6 +43,7 @@ func TestValidateGateway(t *testing.T) {
 		Spec: gatewayv1a2.GatewaySpec{
 			GatewayClassName: "foo",
 			Listeners:        listeners,
+			Addresses:        addresses,
 		},
 	}
 	tlsConfig := gatewayv1a2.GatewayTLSConfig{}
@@ -75,6 +81,34 @@ func TestValidateGateway(t *testing.T) {
 				gw.Spec.Listeners[0].Protocol = gatewayv1a2.UDPProtocolType
 			},
 			expectErrsOnFields: []string{"spec.listeners[0].hostname"},
+		},
+		"Address present with IPAddress": {
+			mutate: func(gw *gatewayv1a2.Gateway) {
+				ip := gatewayv1a2.IPAddressType
+				gw.Spec.Addresses[0].Type = &ip
+			},
+			expectErrsOnFields: []string{},
+		},
+		"Address present with Hostname": {
+			mutate: func(gw *gatewayv1a2.Gateway) {
+				host := gatewayv1a2.HostnameAddressType
+				gw.Spec.Addresses[0].Type = &host
+			},
+			expectErrsOnFields: []string{},
+		},
+		"Address present with example.com/CustomAddress": {
+			mutate: func(gw *gatewayv1a2.Gateway) {
+				customAddress := gatewayv1a2.AddressType("example.com/CustomAddress")
+				gw.Spec.Addresses[0].Type = &customAddress
+			},
+			expectErrsOnFields: []string{},
+		},
+		"Address present with invalid Type": {
+			mutate: func(gw *gatewayv1a2.Gateway) {
+				customAddress := gatewayv1a2.AddressType("CustomAddress")
+				gw.Spec.Addresses[0].Type = &customAddress
+			},
+			expectErrsOnFields: []string{"spec.addresses[0].type"},
 		},
 	}
 

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -82,6 +82,9 @@ spec:
                       - IPAddress
                       - Hostname
                       - NamedAddress
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^([a-zA-Z0-9])+$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\/[a-zA-Z0-9]+$
                       type: string
                     value:
                       description: "Value of the address. The validity of the values
@@ -467,6 +470,9 @@ spec:
                       - IPAddress
                       - Hostname
                       - NamedAddress
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^([a-zA-Z0-9])+$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\/[a-zA-Z0-9]+$
                       type: string
                     value:
                       description: "Value of the address. The validity of the values

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -78,10 +78,6 @@ spec:
                     type:
                       default: IPAddress
                       description: Type of the address.
-                      enum:
-                      - IPAddress
-                      - Hostname
-                      - NamedAddress
                       maxLength: 253
                       minLength: 1
                       pattern: ^([a-zA-Z0-9])+$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\/[a-zA-Z0-9]+$
@@ -466,10 +462,6 @@ spec:
                     type:
                       default: IPAddress
                       description: Type of the address.
-                      enum:
-                      - IPAddress
-                      - Hostname
-                      - NamedAddress
                       maxLength: 253
                       minLength: 1
                       pattern: ^([a-zA-Z0-9])+$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\/[a-zA-Z0-9]+$

--- a/config/crd/stable/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_gateways.yaml
@@ -82,6 +82,9 @@ spec:
                       - IPAddress
                       - Hostname
                       - NamedAddress
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^([a-zA-Z0-9])+$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\/[a-zA-Z0-9]+$
                       type: string
                     value:
                       description: "Value of the address. The validity of the values
@@ -467,6 +470,9 @@ spec:
                       - IPAddress
                       - Hostname
                       - NamedAddress
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^([a-zA-Z0-9])+$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\/[a-zA-Z0-9]+$
                       type: string
                     value:
                       description: "Value of the address. The validity of the values

--- a/config/crd/stable/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/stable/gateway.networking.k8s.io_gateways.yaml
@@ -78,10 +78,6 @@ spec:
                     type:
                       default: IPAddress
                       description: Type of the address.
-                      enum:
-                      - IPAddress
-                      - Hostname
-                      - NamedAddress
                       maxLength: 253
                       minLength: 1
                       pattern: ^([a-zA-Z0-9])+$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\/[a-zA-Z0-9]+$
@@ -466,10 +462,6 @@ spec:
                     type:
                       default: IPAddress
                       description: Type of the address.
-                      enum:
-                      - IPAddress
-                      - Hostname
-                      - NamedAddress
                       maxLength: 253
                       minLength: 1
                       pattern: ^([a-zA-Z0-9])+$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\/[a-zA-Z0-9]+$


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind api-change

**What this PR does / why we need it**:
This PR changes the AddressType type to add validation on the type itself, rather than the spec.Gateway.addresses list where it's used, and updates that validation to allow domain-prefixed strings (`example.com/CustomAddressType` or similar).

This is a validation change, so it's a breaking API change, technically. However, I've made sure that the existing valid value "NamedAddress" is acceptable, it's just moved to Custom support (which it always was anyway), which is why #958 is blocking v0.5.0.

The intent here is to give implementations an option to extend this field safely and compatibly, and then bring other options back for Extended standardization if need be.

#958 talks about having a small GEP, but once I started working on it, I realized that the GEP would be almost nothing but the actual code change (which is itself quite small), so I thought that opening a PR would be quicker than doing the whole GEP process. Happy to take it to a GEP if anyone feels I'm wrong here though.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #958

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The "NamedAddress" value for Gateway's spec.addresses[].type field has been deprecated, and support for domain-prefixed values (like example.com/NamedAddress) has been added instead, to better represent the custom nature of this support.
```
