### PR TITLE
Renaming stable channel to standard channel

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,6 @@ apis/generated/** linguist-generated=true
 apis/**/generated.pb.go linguist-generated=true
 apis/**/generated.proto linguist-generated=true
 config/crd/experimental/** linguist-generated=true
-config/crd/stable/** linguist-generated=true
+config/crd/standard/** linguist-generated=true
 pkg/client/** linguist-generated=true
 

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,8 +1,8 @@
 resources:
-- stable/gateway.networking.k8s.io_gatewayclasses.yaml
-- stable/gateway.networking.k8s.io_gateways.yaml
-- stable/gateway.networking.k8s.io_httproutes.yaml
-- stable/gateway.networking.k8s.io_referencegrants.yaml
-- stable/gateway.networking.k8s.io_tcproutes.yaml
-- stable/gateway.networking.k8s.io_tlsroutes.yaml
-- stable/gateway.networking.k8s.io_udproutes.yaml
+- standard/gateway.networking.k8s.io_gatewayclasses.yaml
+- standard/gateway.networking.k8s.io_gateways.yaml
+- standard/gateway.networking.k8s.io_httproutes.yaml
+- standard/gateway.networking.k8s.io_referencegrants.yaml
+- standard/gateway.networking.k8s.io_tcproutes.yaml
+- standard/gateway.networking.k8s.io_tlsroutes.yaml
+- standard/gateway.networking.k8s.io_udproutes.yaml

--- a/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
     gateway.networking.k8s.io/bundle-version: v0.5.0-dev
-    gateway.networking.k8s.io/channel: stable
+    gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io
 spec:

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
     gateway.networking.k8s.io/bundle-version: v0.5.0-dev
-    gateway.networking.k8s.io/channel: stable
+    gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io
 spec:

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
     gateway.networking.k8s.io/bundle-version: v0.5.0-dev
-    gateway.networking.k8s.io/channel: stable
+    gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io
 spec:

--- a/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
     gateway.networking.k8s.io/bundle-version: v0.5.0-dev
-    gateway.networking.k8s.io/channel: stable
+    gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: referencegrants.gateway.networking.k8s.io
 spec:

--- a/config/crd/standard/gateway.networking.k8s.io_referencepolicies.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_referencepolicies.yaml
@@ -1,0 +1,145 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
+    gateway.networking.k8s.io/bundle-version: v0.5.0-dev
+    gateway.networking.k8s.io/channel: standard
+  creationTimestamp: null
+  name: referencegrants.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: ReferenceGrant
+    listKind: ReferenceGrantList
+    plural: referencegrants
+    shortNames:
+    - refpol
+    singular: referencegrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: "ReferenceGrant identifies kinds of resources in other namespaces
+          that are trusted to reference the specified kinds of resources in the same
+          namespace as the policy. \n Each ReferenceGrant can be used to represent
+          a unique trust relationship. Additional Reference Policies can be used to
+          add to the set of trusted sources of inbound references for the namespace
+          they are defined within. \n All cross-namespace references in Gateway API
+          (with the exception of cross-namespace Gateway-route attachment) require
+          a ReferenceGrant. \n Support: Core"
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ReferenceGrant.
+            properties:
+              from:
+                description: "From describes the trusted namespaces and kinds that
+                  can reference the resources described in \"To\". Each entry in this
+                  list must be considered to be an additional place that references
+                  can be valid from, or to put this another way, entries must be combined
+                  using OR. \n Support: Core"
+                items:
+                  description: ReferenceGrantFrom describes trusted namespaces and
+                    kinds.
+                  properties:
+                    group:
+                      description: "Group is the group of the referent. When empty,
+                        the Kubernetes core API group is inferred. \n Support: Core"
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: "Kind is the kind of the referent. Although implementations
+                        may support additional resources, the following Route types
+                        are part of the \"Core\" support level for this field: \n
+                        * HTTPRoute * TCPRoute * TLSRoute * UDPRoute"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    namespace:
+                      description: "Namespace is the namespace of the referent. \n
+                        Support: Core"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - namespace
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+              to:
+                description: "To describes the resources that may be referenced by
+                  the resources described in \"From\". Each entry in this list must
+                  be considered to be an additional place that references can be valid
+                  to, or to put this another way, entries must be combined using OR.
+                  \n Support: Core"
+                items:
+                  description: ReferenceGrantTo describes what Kinds are allowed as
+                    targets of the references.
+                  properties:
+                    group:
+                      description: "Group is the group of the referent. When empty,
+                        the Kubernetes core API group is inferred. \n Support: Core"
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: "Kind is the kind of the referent. Although implementations
+                        may support additional resources, the following types are
+                        part of the \"Core\" support level for this field: \n * Service"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the referent. When unspecified,
+                        this policy refers to all resources of the specified Group
+                        and Kind in the local namespace.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - from
+            - to
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/standard/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_tcproutes.yaml
@@ -4,18 +4,18 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
     gateway.networking.k8s.io/bundle-version: v0.5.0-dev
-    gateway.networking.k8s.io/channel: stable
+    gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
-  name: tlsroutes.gateway.networking.k8s.io
+  name: tcproutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
   names:
     categories:
     - gateway-api
-    kind: TLSRoute
-    listKind: TLSRouteList
-    plural: tlsroutes
-    singular: tlsroute
+    kind: TCPRoute
+    listKind: TCPRouteList
+    plural: tcproutes
+    singular: tcproute
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -25,11 +25,9 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: "The TLSRoute resource is similar to TCPRoute, but can be configured
-          to match against TLS-specific metadata. This allows more flexibility in
-          matching streams for a given TLS listener. \n If you need to forward traffic
-          to a single target for a TLS listener, you could choose to use a TCPRoute
-          with a TLS listener."
+        description: TCPRoute provides a way to route TCP requests. When combined
+          with a Gateway listener, it can be used to forward connections on the port
+          specified by the listener to a set of backends specified by the TCPRoute.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -44,52 +42,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: Spec defines the desired state of TLSRoute.
+            description: Spec defines the desired state of TCPRoute.
             properties:
-              hostnames:
-                description: "Hostnames defines a set of SNI names that should match
-                  against the SNI attribute of TLS ClientHello message in TLS handshake.
-                  This matches the RFC 1123 definition of a hostname with 2 notable
-                  exceptions: \n 1. IPs are not allowed in SNI names per RFC 6066.
-                  2. A hostname may be prefixed with a wildcard label (`*.`). The
-                  wildcard    label must appear by itself as the first label. \n If
-                  a hostname is specified by both the Listener and TLSRoute, there
-                  must be at least one intersecting hostname for the TLSRoute to be
-                  attached to the Listener. For example: \n * A Listener with `test.example.com`
-                  as the hostname matches TLSRoutes   that have either not specified
-                  any hostnames, or have specified at   least one of `test.example.com`
-                  or `*.example.com`. * A Listener with `*.example.com` as the hostname
-                  matches TLSRoutes   that have either not specified any hostnames
-                  or have specified at least   one hostname that matches the Listener
-                  hostname. For example,   `test.example.com` and `*.example.com`
-                  would both match. On the other   hand, `example.com` and `test.example.net`
-                  would not match. \n If both the Listener and TLSRoute have specified
-                  hostnames, any TLSRoute hostnames that do not match the Listener
-                  hostname MUST be ignored. For example, if a Listener specified `*.example.com`,
-                  and the TLSRoute specified `test.example.com` and `test.example.net`,
-                  `test.example.net` must not be considered for a match. \n If both
-                  the Listener and TLSRoute have specified hostnames, and none match
-                  with the criteria above, then the TLSRoute is not accepted. The
-                  implementation must raise an 'Accepted' Condition with a status
-                  of `False` in the corresponding RouteParentStatus. \n Support: Core"
-                items:
-                  description: "Hostname is the fully qualified domain name of a network
-                    host. This matches the RFC 1123 definition of a hostname with
-                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                    may be prefixed with a wildcard label (`*.`). The wildcard    label
-                    must appear by itself as the first label. \n Hostname can be \"precise\"
-                    which is a domain name without the terminating dot of a network
-                    host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
-                    name prefixed with a single wildcard label (e.g. `*.example.com`).
-                    \n Note that as per RFC1035 and RFC1123, a *label* must consist
-                    of lower case alphanumeric characters or '-', and must start and
-                    end with an alphanumeric character. No other punctuation is allowed."
-                  maxLength: 253
-                  minLength: 1
-                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                  type: string
-                maxItems: 16
-                type: array
               parentRefs:
                 description: "ParentRefs references the resources (usually Gateways)
                   that a Route wants to be attached to. Note that the referenced parent
@@ -173,23 +127,20 @@ spec:
                 maxItems: 32
                 type: array
               rules:
-                description: Rules are a list of TLS matchers and actions.
+                description: Rules are a list of TCP matchers and actions.
                 items:
-                  description: TLSRouteRule is the configuration for a given rule.
+                  description: TCPRouteRule is the configuration for a given rule.
                   properties:
                     backendRefs:
                       description: "BackendRefs defines the backend(s) where matching
                         requests should be sent. If unspecified or invalid (refers
                         to a non-existent resource or a Service with no endpoints),
-                        the rule performs no forwarding; if no filters are specified
-                        that would result in a response being sent, the underlying
-                        implementation must actively reject request attempts to this
-                        backend, by rejecting the connection or returning a 404 status
-                        code. Request rejections must respect weight; if an invalid
-                        backend is requested to have 80% of requests, then 80% of
-                        requests must be rejected instead. \n Support: Core for Kubernetes
-                        Service Support: Custom for any other resource \n Support
-                        for weight: Extended"
+                        the underlying implementation MUST actively reject connection
+                        attempts to this backend. Connection rejections must respect
+                        weight; if an invalid backend is requested to have 80% of
+                        connections, then 80% of connections must be rejected instead.
+                        \n Support: Core for Kubernetes Service Support: Custom for
+                        any other resource \n Support for weight: Extended"
                       items:
                         description: "BackendRef defines how a Route should forward
                           a request to a Kubernetes resource. \n Note that when a
@@ -275,7 +226,7 @@ spec:
             - rules
             type: object
           status:
-            description: Status defines the current state of TLSRoute.
+            description: Status defines the current state of TCPRoute.
             properties:
               parents:
                 description: "Parents is a list of parent resources (usually Gateways)

--- a/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
@@ -4,18 +4,18 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
     gateway.networking.k8s.io/bundle-version: v0.5.0-dev
-    gateway.networking.k8s.io/channel: stable
+    gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
-  name: tcproutes.gateway.networking.k8s.io
+  name: tlsroutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
   names:
     categories:
     - gateway-api
-    kind: TCPRoute
-    listKind: TCPRouteList
-    plural: tcproutes
-    singular: tcproute
+    kind: TLSRoute
+    listKind: TLSRouteList
+    plural: tlsroutes
+    singular: tlsroute
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -25,9 +25,11 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: TCPRoute provides a way to route TCP requests. When combined
-          with a Gateway listener, it can be used to forward connections on the port
-          specified by the listener to a set of backends specified by the TCPRoute.
+        description: "The TLSRoute resource is similar to TCPRoute, but can be configured
+          to match against TLS-specific metadata. This allows more flexibility in
+          matching streams for a given TLS listener. \n If you need to forward traffic
+          to a single target for a TLS listener, you could choose to use a TCPRoute
+          with a TLS listener."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -42,8 +44,52 @@ spec:
           metadata:
             type: object
           spec:
-            description: Spec defines the desired state of TCPRoute.
+            description: Spec defines the desired state of TLSRoute.
             properties:
+              hostnames:
+                description: "Hostnames defines a set of SNI names that should match
+                  against the SNI attribute of TLS ClientHello message in TLS handshake.
+                  This matches the RFC 1123 definition of a hostname with 2 notable
+                  exceptions: \n 1. IPs are not allowed in SNI names per RFC 6066.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The
+                  wildcard    label must appear by itself as the first label. \n If
+                  a hostname is specified by both the Listener and TLSRoute, there
+                  must be at least one intersecting hostname for the TLSRoute to be
+                  attached to the Listener. For example: \n * A Listener with `test.example.com`
+                  as the hostname matches TLSRoutes   that have either not specified
+                  any hostnames, or have specified at   least one of `test.example.com`
+                  or `*.example.com`. * A Listener with `*.example.com` as the hostname
+                  matches TLSRoutes   that have either not specified any hostnames
+                  or have specified at least   one hostname that matches the Listener
+                  hostname. For example,   `test.example.com` and `*.example.com`
+                  would both match. On the other   hand, `example.com` and `test.example.net`
+                  would not match. \n If both the Listener and TLSRoute have specified
+                  hostnames, any TLSRoute hostnames that do not match the Listener
+                  hostname MUST be ignored. For example, if a Listener specified `*.example.com`,
+                  and the TLSRoute specified `test.example.com` and `test.example.net`,
+                  `test.example.net` must not be considered for a match. \n If both
+                  the Listener and TLSRoute have specified hostnames, and none match
+                  with the criteria above, then the TLSRoute is not accepted. The
+                  implementation must raise an 'Accepted' Condition with a status
+                  of `False` in the corresponding RouteParentStatus. \n Support: Core"
+                items:
+                  description: "Hostname is the fully qualified domain name of a network
+                    host. This matches the RFC 1123 definition of a hostname with
+                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    must appear by itself as the first label. \n Hostname can be \"precise\"
+                    which is a domain name without the terminating dot of a network
+                    host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
+                    name prefixed with a single wildcard label (e.g. `*.example.com`).
+                    \n Note that as per RFC1035 and RFC1123, a *label* must consist
+                    of lower case alphanumeric characters or '-', and must start and
+                    end with an alphanumeric character. No other punctuation is allowed."
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
               parentRefs:
                 description: "ParentRefs references the resources (usually Gateways)
                   that a Route wants to be attached to. Note that the referenced parent
@@ -127,20 +173,23 @@ spec:
                 maxItems: 32
                 type: array
               rules:
-                description: Rules are a list of TCP matchers and actions.
+                description: Rules are a list of TLS matchers and actions.
                 items:
-                  description: TCPRouteRule is the configuration for a given rule.
+                  description: TLSRouteRule is the configuration for a given rule.
                   properties:
                     backendRefs:
                       description: "BackendRefs defines the backend(s) where matching
                         requests should be sent. If unspecified or invalid (refers
                         to a non-existent resource or a Service with no endpoints),
-                        the underlying implementation MUST actively reject connection
-                        attempts to this backend. Connection rejections must respect
-                        weight; if an invalid backend is requested to have 80% of
-                        connections, then 80% of connections must be rejected instead.
-                        \n Support: Core for Kubernetes Service Support: Custom for
-                        any other resource \n Support for weight: Extended"
+                        the rule performs no forwarding; if no filters are specified
+                        that would result in a response being sent, the underlying
+                        implementation must actively reject request attempts to this
+                        backend, by rejecting the connection or returning a 404 status
+                        code. Request rejections must respect weight; if an invalid
+                        backend is requested to have 80% of requests, then 80% of
+                        requests must be rejected instead. \n Support: Core for Kubernetes
+                        Service Support: Custom for any other resource \n Support
+                        for weight: Extended"
                       items:
                         description: "BackendRef defines how a Route should forward
                           a request to a Kubernetes resource. \n Note that when a
@@ -226,7 +275,7 @@ spec:
             - rules
             type: object
           status:
-            description: Status defines the current state of TCPRoute.
+            description: Status defines the current state of TLSRoute.
             properties:
               parents:
                 description: "Parents is a list of parent resources (usually Gateways)

--- a/config/crd/standard/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_udproutes.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
     gateway.networking.k8s.io/bundle-version: v0.5.0-dev
-    gateway.networking.k8s.io/channel: stable
+    gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: udproutes.gateway.networking.k8s.io
 spec:

--- a/hack/build-install-yaml.sh
+++ b/hack/build-install-yaml.sh
@@ -31,11 +31,11 @@ cat << EOF >> release/experimental-install.yaml
 #
 EOF
 
-cat hack/boilerplate/boilerplate.sh.txt > release/stable-install.yaml
-sed -i "s/YEAR/$thisyear/g" release/stable-install.yaml
-cat << EOF >> release/stable-install.yaml
+cat hack/boilerplate/boilerplate.sh.txt > release/standard-install.yaml
+sed -i "s/YEAR/$thisyear/g" release/standard-install.yaml
+cat << EOF >> release/standard-install.yaml
 #
-# Gateway API Stable channel install
+# Gateway API Standard channel install
 #
 EOF
 
@@ -48,13 +48,13 @@ do
     cat $file >> release/experimental-install.yaml
 done
 
-for file in `ls config/webhook/*.yaml config/crd/stable/*.yaml`
+for file in `ls config/webhook/*.yaml config/crd/standard/*.yaml`
 do
-    echo "---" >> release/stable-install.yaml
-    echo "#" >> release/stable-install.yaml
-    echo "# $file" >> release/stable-install.yaml
-    echo "#" >> release/stable-install.yaml
-    cat $file >> release/stable-install.yaml
+    echo "---" >> release/standard-install.yaml
+    echo "#" >> release/standard-install.yaml
+    echo "# $file" >> release/standard-install.yaml
+    echo "#" >> release/standard-install.yaml
+    cat $file >> release/standard-install.yaml
 done
 
 echo "Generated:" release/*-install.yaml

--- a/hack/verify-examples-kind.sh
+++ b/hack/verify-examples-kind.sh
@@ -69,7 +69,7 @@ for check in {1..10}; do
   echo "Webhook not ready yet, will check again in 5 seconds"
 done
 
-for CHANNEL in experimental stable; do
+for CHANNEL in experimental standard; do
   ##### Test v1alpha2 CRD apply and that invalid examples are invalid.
   # Install CRDs
   kubectl apply -f "config/crd/${CHANNEL}" || res=$?

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -80,7 +80,7 @@ func main() {
 		log.Fatalf("no objects in the roots")
 	}
 
-	channels := []string{"stable", "experimental"}
+	channels := []string{"standard", "experimental"}
 	for _, channel := range channels {
 		for groupKind := range kubeKinds {
 			log.Printf("generating %s CRD for %v\n", channel, groupKind)
@@ -126,7 +126,7 @@ func main() {
 func channelTweaks(channel string, props map[string]apiext.JSONSchemaProps) map[string]apiext.JSONSchemaProps {
 	for name := range props {
 		jsonProps, _ := props[name]
-		if channel == "stable" && strings.Contains(jsonProps.Description, "<gateway:experimental>") {
+		if channel == "standard" && strings.Contains(jsonProps.Description, "<gateway:experimental>") {
 			delete(props, name)
 			continue
 		}

--- a/site-src/concepts/versioning.md
+++ b/site-src/concepts/versioning.md
@@ -20,21 +20,21 @@ documentation](https://kubernetes.io/docs/reference/using-api/#api-versioning).
 ![Lifecycle of New Gateway API Resources](/images/lifecycle-new-resources.png)
 <!-- Source: https://docs.google.com/presentation/d/1sfZTV-vlisDUIie_iK_B2HqKia_querT6m6T2_vbAk0/edit -->
 
-### Release Channels (e.g. Experimental, Stable)
-Gateway API provides 2 release channels: an Experimental one and a Stable one.
+### Release Channels (e.g. Experimental, Standard)
+Gateway API provides 2 release channels: an Experimental one and a Standard one.
 
-The Stable release channel includes:
+The Standard release channel includes:
 
 * Resources that have graduated to beta
-* All fields that have graduated to stable and are no longer considered
+* All fields that have graduated to standard and are no longer considered
   experimental
 
-The Experimental release channel includes everything in the Stable release
+The Experimental release channel includes everything in the Standard release
 channel, plus:
 
 * Alpha API resources
 * New fields that are considered experimental and have not yet graduated to the
-  stable channel
+  standard channel
 
 ![Release Channel Overlap](/images/release-channel-overlap.png)
 <!-- Source: https://docs.google.com/presentation/d/1sfZTV-vlisDUIie_iK_B2HqKia_querT6m6T2_vbAk0/edit -->
@@ -49,7 +49,7 @@ Unfortunately, CRDs do not have a similar concept yet.
 Instead of trying to recreate feature gates in this project, we've introduced
 release channels. Starting in v0.5.0, all new fields and features will start in
 the Experimental release channel. From that point, these may graduate to the
-Stable release channel or be dropped from the API entirely. See
+Standard release channel or be dropped from the API entirely. See
 [GEP-922](/geps/gep-922) for a more detailed discussion of this approach to new
 fields and features.
 
@@ -62,7 +62,7 @@ and channel:
 
 ```
 gateway.networking.k8s.io/bundle-version: v0.4.0
-gateway.networking.k8s.io/channel: stable|experimental
+gateway.networking.k8s.io/channel: standard|experimental
 ```
 
 ## What can Change
@@ -81,7 +81,7 @@ change across API versions.
 * Making required fields optional
 * Removal of experimental fields
 * Removal of experimental resources
-* Graduation of fields or resources from experimental to stable track
+* Graduation of fields or resources from experimental to standard track
 * Introduction of a new **API version**, which may also include:
   * Renamed fields
   * Anything else that is valid in a new Kubernetes API version
@@ -118,18 +118,18 @@ A resource to graduate from beta to GA must meet the following criteria:
 
 ### Fields
 
-#### Experimental -> Stable
+#### Experimental -> Standard
 As described above, field level stability is layered on top of beta and GA
-resources (no fields in alpha resources can be considered stable). The
-requirements for a field to graduate from experimental to stable depend on the
+resources (no fields in alpha resources can be considered standard). The
+requirements for a field to graduate from experimental to standard depend on the
 API version of the resource it is a part of. For a field to be considered
-stable, it needs to meet the same criteria of the resource it is contained in.
+standard, it needs to meet the same criteria of the resource it is contained in.
 
 If a resource has graduated to beta, an experimental field must meet all of the
-beta graduation criteria before graduating to stable. Similarly, if a resource
+beta graduation criteria before graduating to standard. Similarly, if a resource
 has graduated to GA, a field must meet all of the beta and GA graduation
 criteria. There is one slight variation here, instead of 6 months of soak time
-as a beta API, a field graduating to stable requires 6 months of soak time as an
+as a beta API, a field graduating to standard requires 6 months of soak time as an
 experimental field.
 
 ## Out of Scope

--- a/site-src/geps/gep-820.md
+++ b/site-src/geps/gep-820.md
@@ -20,7 +20,7 @@ not well understood.
 ## Introduction
 
 As the API moves towards `v1alpha2`, the maintainers intend to make the API
-stable and forward compatible for the foreseeable future. To that end,
+standard and forward compatible for the foreseeable future. To that end,
 maintainers intend to minimize (eliminate if possible) breaking changes post
 `v1alpha2`. This GEP is part of that initiative.
 

--- a/site-src/geps/gep-922.md
+++ b/site-src/geps/gep-922.md
@@ -6,10 +6,10 @@
 ## TLDR
 Each Gateway API release will be represented by a bundle version that represents
 that specific combination of CRDs, API versions, and validating webhook. To
-enable experimental fields, future releases of the API will include stable and
+enable experimental fields, future releases of the API will include standard and
 experimental CRD tracks. Users will be able to access experimental features by
 installing the experimental CRDs. A cluster can contain either an experimental
-or stable CRD for any resource at a given time. 
+or standard CRD for any resource at a given time. 
 
 
 ## Goals
@@ -73,7 +73,7 @@ responsibilities to ensure we're providing a consistent experience.
     * Making required fields optional
     * Removal of experimental fields
     * Removal of experimental resources
-    * Graduation of fields or resources from experimental to stable track
+    * Graduation of fields or resources from experimental to standard track
 * MAY introduce a new **API version** with a new bundle minor version, which may
   include:
     * Everything that is valid in a minor release
@@ -112,13 +112,13 @@ API we will accomplish by releasing experimental versions of our CRDs.
 With this approach, we achieve a similar result. Instead of using feature gates
 and validation to prevent fields from being set, we just release separate CRDs.
 Once the API reaches beta, each bundle release can include 2 sets of CRDs,
-stable and experimental.
+standard and experimental.
 
 New fields will be added to the experimental set of CRDs first, and may graduate
-to stable APIs later. Experimental fields will be marked with the
+to the standard set of APIs later. Experimental fields will be marked with the
 `+experimental` annotation in Go type definitions. Gateway API CRD generation
-will exclude these fields from stable CRDs. Experimental fields may be removed
-from the API. Due to the experimental nature of these CRDs, they are not
+will exclude these fields from standard set of CRDs. Experimental fields may be
+removed from the API. Due to the experimental nature of these CRDs, they are not
 recommended for production use.
 
 If experimental fields are removed or renamed, the original field name should be
@@ -130,7 +130,7 @@ and channel:
 
 ```
 gateway.networking.k8s.io/bundle-version: v0.4.0
-gateway.networking.k8s.io/channel: stable|experimental
+gateway.networking.k8s.io/channel: standard|experimental
 ```
 
 ## Alternatives Considered

--- a/site-src/v1alpha2/contributing/devguide.md
+++ b/site-src/v1alpha2/contributing/devguide.md
@@ -64,7 +64,7 @@ make
 Starting with v0.5.0, all additions to the API must start in the experimental
 release channel. Experimental fields must be marked with the
 `<gateway:experimental>` annotation in Go type definitions. Gateway API CRD
-generation will exclude these fields from stable CRDs.
+generation will only include these fields in the experimental set of CRDs.
 
 If experimental fields are removed or renamed, the original field name should be
 removed from the go struct, with a tombstone comment


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation
/kind api-change

**What this PR does / why we need it**:
As a follow up to https://github.com/kubernetes-sigs/gateway-api/discussions/1172, this renames the stable channel to standard channel, leaving room for a future third release channel for GA-only resources if we want that in the future.

**Does this PR introduce a user-facing change?**:
```release-note
The stable release channel has been renamed to standard
```
