### PR TITLE
Fixing docs to have subheaders again, removing custom alignment

### DIFF
--- a/examples/v1alpha1/basic-http.yaml
+++ b/examples/v1alpha1/basic-http.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/api-types/httproute.md
+#$ Used in:
+#$ - site-src/v1alpha1/api-types/httproute.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: GatewayClass
 metadata:

--- a/examples/v1alpha1/basic-tcp.yaml
+++ b/examples/v1alpha1/basic-tcp.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/guides/tcp.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/tcp.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: GatewayClass
 metadata:

--- a/examples/v1alpha1/cross-namespace-routing/gateway.yaml
+++ b/examples/v1alpha1/cross-namespace-routing/gateway.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/guides/multiple-ns.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/multiple-ns.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: Gateway
 metadata:

--- a/examples/v1alpha1/cross-namespace-routing/site-route.yaml
+++ b/examples/v1alpha1/cross-namespace-routing/site-route.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/guides/multiple-ns.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/multiple-ns.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/cross-namespace-routing/store-route.yaml
+++ b/examples/v1alpha1/cross-namespace-routing/store-route.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/guides/multiple-ns.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/multiple-ns.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/http-filter.yaml
+++ b/examples/v1alpha1/http-filter.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/api-types/httproute.md
+#$ Used in:
+#$ - site-src/v1alpha1/api-types/httproute.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: GatewayClass
 metadata:

--- a/examples/v1alpha1/http-routing/bar-httproute.yaml
+++ b/examples/v1alpha1/http-routing/bar-httproute.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/guides/http-routing.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/http-routing.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/http-routing/foo-httproute.yaml
+++ b/examples/v1alpha1/http-routing/foo-httproute.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/guides/http-routing.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/http-routing.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/http-routing/gateway.yaml
+++ b/examples/v1alpha1/http-routing/gateway.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/guides/http-routing.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/http-routing.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: Gateway
 metadata:

--- a/examples/v1alpha1/http-trafficsplit.yaml
+++ b/examples/v1alpha1/http-trafficsplit.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/api-types/httproute.md
+#$ Used in:
+#$ - site-src/v1alpha1/api-types/httproute.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: GatewayClass
 metadata:

--- a/examples/v1alpha1/simple-gateway/gateway.yaml
+++ b/examples/v1alpha1/simple-gateway/gateway.yaml
@@ -1,6 +1,6 @@
-## Used in:
-## - site-src/v1alpha1/guides/traffic-splitting.md
-## - site-src/v1alpha1/guides/simple-gateway.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/traffic-splitting.md
+#$ - site-src/v1alpha1/guides/simple-gateway.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: Gateway
 metadata:

--- a/examples/v1alpha1/simple-gateway/httproute.yaml
+++ b/examples/v1alpha1/simple-gateway/httproute.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/guides/simple-gateway.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/simple-gateway.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/tls-basic.yaml
+++ b/examples/v1alpha1/tls-basic.yaml
@@ -1,6 +1,6 @@
-## Used in:
-## - site-src/v1alpha1/guides/tls.md
-## - site-src/v1alpha1/api-types/httproute.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/tls.md
+#$ - site-src/v1alpha1/api-types/httproute.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: Gateway
 metadata:

--- a/examples/v1alpha1/tls-cert-in-route.yaml
+++ b/examples/v1alpha1/tls-cert-in-route.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/guides/tls.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/tls.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: Gateway
 metadata:

--- a/examples/v1alpha1/traffic-splitting/simple-split.yaml
+++ b/examples/v1alpha1/traffic-splitting/simple-split.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/guides/traffic-splitting.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/traffic-splitting.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/traffic-splitting/traffic-split-1.yaml
+++ b/examples/v1alpha1/traffic-splitting/traffic-split-1.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/guides/traffic-splitting.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/traffic-splitting.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/traffic-splitting/traffic-split-2.yaml
+++ b/examples/v1alpha1/traffic-splitting/traffic-split-2.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/guides/traffic-splitting.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/traffic-splitting.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/traffic-splitting/traffic-split-3.yaml
+++ b/examples/v1alpha1/traffic-splitting/traffic-split-3.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/guides/traffic-splitting.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/traffic-splitting.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha1/upstream-tls.yaml
+++ b/examples/v1alpha1/upstream-tls.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/guides/tls.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/tls.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: BackendPolicy
 metadata:

--- a/examples/v1alpha1/wildcard-tls-gateway.yaml
+++ b/examples/v1alpha1/wildcard-tls-gateway.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha1/guides/tls.md
+#$ Used in:
+#$ - site-src/v1alpha1/guides/tls.md
 apiVersion: networking.x-k8s.io/v1alpha1
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/basic-http.yaml
+++ b/examples/v1alpha2/basic-http.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/api-types/httproute.md
+#$ Used in:
+#$ - site-src/v1alpha2/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: GatewayClass
 metadata:

--- a/examples/v1alpha2/basic-tcp.yaml
+++ b/examples/v1alpha2/basic-tcp.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/guides/tcp.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/tcp.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/cross-namespace-routing/0-namespaces.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/0-namespaces.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/guides/multiple-ns.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/multiple-ns.md
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/examples/v1alpha2/cross-namespace-routing/gateway.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/gateway.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/guides/multiple-ns.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/multiple-ns.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/cross-namespace-routing/site-route.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/site-route.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/guides/multiple-ns.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/multiple-ns.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/cross-namespace-routing/store-route.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/store-route.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/guides/multiple-ns.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/multiple-ns.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/http-filter.yaml
+++ b/examples/v1alpha2/http-filter.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/api-types/httproute.md
+#$ Used in:
+#$ - site-src/v1alpha2/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/http-route-attachment/gateway-namespaces.yaml
+++ b/examples/v1alpha2/http-route-attachment/gateway-namespaces.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/concepts/api-overview.md
+#$ Used in:
+#$ - site-src/concepts/api-overview.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/http-route-attachment/gateway-strict.yaml
+++ b/examples/v1alpha2/http-route-attachment/gateway-strict.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/concepts/api-overview.md
+#$ Used in:
+#$ - site-src/concepts/api-overview.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/http-route-attachment/httproute.yaml
+++ b/examples/v1alpha2/http-route-attachment/httproute.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/concepts/api-overview.md
+#$ Used in:
+#$ - site-src/concepts/api-overview.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/http-routing/bar-httproute.yaml
+++ b/examples/v1alpha2/http-routing/bar-httproute.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/guides/http-routing.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/http-routing.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/http-routing/foo-httproute.yaml
+++ b/examples/v1alpha2/http-routing/foo-httproute.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/guides/http-routing.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/http-routing.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/http-routing/gateway.yaml
+++ b/examples/v1alpha2/http-routing/gateway.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/guides/http-routing.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/http-routing.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/reference-grant.yaml
+++ b/examples/v1alpha2/reference-grant.yaml
@@ -1,6 +1,6 @@
-## Used in:
-## - site-src/concepts/security-model.md
-## - site-src/blog/2021/introducing-v1alpha2.md
+#$ Used in:
+#$ - site-src/concepts/security-model.md
+#$ - site-src/blog/2021/introducing-v1alpha2.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: ReferenceGrant
 metadata:

--- a/examples/v1alpha2/simple-gateway/gateway.yaml
+++ b/examples/v1alpha2/simple-gateway/gateway.yaml
@@ -1,6 +1,6 @@
-## Used in:
-## - site-src/v1alpha2/guides/traffic-splitting.md
-## - site-src/v1alpha2/guides/simple-gateway.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/traffic-splitting.md
+#$ - site-src/v1alpha2/guides/simple-gateway.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/simple-gateway/httproute.yaml
+++ b/examples/v1alpha2/simple-gateway/httproute.yaml
@@ -1,6 +1,6 @@
-## Used in:
-## - site-src/v1alpha2/guides/simple-gateway.md
-## - site-src/blog/2021/introducing-v1alpha2.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/simple-gateway.md
+#$ - site-src/blog/2021/introducing-v1alpha2.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/tls-basic.yaml
+++ b/examples/v1alpha2/tls-basic.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/guides/tls.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/tls.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/tls-cert-cross-namespace.yaml
+++ b/examples/v1alpha2/tls-cert-cross-namespace.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/guides/tls.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/tls.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/traffic-splitting/simple-split.yaml
+++ b/examples/v1alpha2/traffic-splitting/simple-split.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/guides/traffic-splitting.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/traffic-splitting.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/traffic-splitting/traffic-split-1.yaml
+++ b/examples/v1alpha2/traffic-splitting/traffic-split-1.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/guides/traffic-splitting.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/traffic-splitting.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/traffic-splitting/traffic-split-2.yaml
+++ b/examples/v1alpha2/traffic-splitting/traffic-split-2.yaml
@@ -1,6 +1,6 @@
-## Used in:
-## - site-src/v1alpha2/guides/traffic-splitting.md
-## - site-src/v1alpha2/api-types/httproute.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/traffic-splitting.md
+#$ - site-src/v1alpha2/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/traffic-splitting/traffic-split-3.yaml
+++ b/examples/v1alpha2/traffic-splitting/traffic-split-3.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/guides/traffic-splitting.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/traffic-splitting.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/wildcard-tls-gateway.yaml
+++ b/examples/v1alpha2/wildcard-tls-gateway.yaml
@@ -1,5 +1,5 @@
-## Used in:
-## - site-src/v1alpha2/guides/tls.md
+#$ Used in:
+#$ - site-src/v1alpha2/guides/tls.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,14 +14,12 @@ theme:
     - navigation.tabs
     - navigation.top
 edit_uri: edit/master/site-src/
-extra_css:
-  - css/extra.css
 plugins:
   - search
   - awesome-pages
   - macros:
       include_dir: examples
-      j2_line_comment_prefix: "##"
+      j2_line_comment_prefix: "#$"
 markdown_extensions:
   - admonition
   - meta

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Click==7.0
 htmlmin==0.1.12
 Jinja2==2.11.1
-jsmin==2.2.2
+jsmin==3.0.0
 livereload==2.6.1
 Markdown==3.3.4
 MarkupSafe==1.1.1

--- a/site-src/css/extra.css
+++ b/site-src/css/extra.css
@@ -1,3 +1,0 @@
-p {
-  text-align: justify;
-}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
This fixes a regression introduced by https://github.com/kubernetes-sigs/gateway-api/pull/1177. By removing all lines prefixed with `##` we accidentally removed all subheadings 😄. I don't really have any strong preference on what our custom prefix is here, but changing it to `#$` works here. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
