### PR TITLE
Clarifying how ReplacePrefixMatch works

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -716,6 +716,12 @@ const (
 	// replaced by the substitution value. For example, a path with a prefix
 	// match of "/foo" and a ReplacePrefixMatch substitution of "/bar" will have
 	// the "/foo" prefix replaced with "/bar" in matching requests.
+	//
+	// Note that this matches the behavior of the PathPrefix match type. This
+	// matches full path elements. A path element refers to the list of labels
+	// in the path split by the `/` separator. When specified, a trailing `/` is
+	// ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+	// match the prefix `/abc`, but the path `/abcd` would not.
 	PrefixMatchHTTPPathModifier HTTPPathModifierType = "ReplacePrefixMatch"
 )
 
@@ -740,6 +746,12 @@ type HTTPPathModifier struct {
 	// ReplacePrefixMatch specifies the value with which to replace the prefix
 	// match of a request during a rewrite or redirect. For example, a request
 	// to "/foo/bar" with a prefix match of "/foo" would be modified to "/bar".
+	//
+	// Note that this matches the behavior of the PathPrefix match type. This
+	// matches full path elements. A path element refers to the list of labels
+	// in the path split by the `/` separator. When specified, a trailing `/` is
+	// ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
+	// match the prefix `/abc`, but the path `/abcd` would not.
 	//
 	// <gateway:experimental>
 	// +kubebuilder:validation:MaxLength=1024

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -511,7 +511,16 @@ spec:
                                             match of a request during a rewrite or
                                             redirect. For example, a request to \"/foo/bar\"
                                             with a prefix match of \"/foo\" would
-                                            be modified to \"/bar\". \n <gateway:experimental>"
+                                            be modified to \"/bar\". \n Note that
+                                            this matches the behavior of the PathPrefix
+                                            match type. This matches full path elements.
+                                            A path element refers to the list of labels
+                                            in the path split by the `/` separator.
+                                            When specified, a trailing `/` is ignored.
+                                            For example, the paths `/abc`, `/abc/`,
+                                            and `/abc/def` would all match the prefix
+                                            `/abc`, but the path `/abcd` would not.
+                                            \n <gateway:experimental>"
                                           maxLength: 1024
                                           type: string
                                         type:
@@ -615,7 +624,16 @@ spec:
                                             match of a request during a rewrite or
                                             redirect. For example, a request to \"/foo/bar\"
                                             with a prefix match of \"/foo\" would
-                                            be modified to \"/bar\". \n <gateway:experimental>"
+                                            be modified to \"/bar\". \n Note that
+                                            this matches the behavior of the PathPrefix
+                                            match type. This matches full path elements.
+                                            A path element refers to the list of labels
+                                            in the path split by the `/` separator.
+                                            When specified, a trailing `/` is ignored.
+                                            For example, the paths `/abc`, `/abc/`,
+                                            and `/abc/def` would all match the prefix
+                                            `/abc`, but the path `/abcd` would not.
+                                            \n <gateway:experimental>"
                                           maxLength: 1024
                                           type: string
                                         type:
@@ -965,7 +983,14 @@ spec:
                                       of a request during a rewrite or redirect. For
                                       example, a request to \"/foo/bar\" with a prefix
                                       match of \"/foo\" would be modified to \"/bar\".
-                                      \n <gateway:experimental>"
+                                      \n Note that this matches the behavior of the
+                                      PathPrefix match type. This matches full path
+                                      elements. A path element refers to the list
+                                      of labels in the path split by the `/` separator.
+                                      When specified, a trailing `/` is ignored. For
+                                      example, the paths `/abc`, `/abc/`, and `/abc/def`
+                                      would all match the prefix `/abc`, but the path
+                                      `/abcd` would not. \n <gateway:experimental>"
                                     maxLength: 1024
                                     type: string
                                   type:
@@ -1066,7 +1091,14 @@ spec:
                                       of a request during a rewrite or redirect. For
                                       example, a request to \"/foo/bar\" with a prefix
                                       match of \"/foo\" would be modified to \"/bar\".
-                                      \n <gateway:experimental>"
+                                      \n Note that this matches the behavior of the
+                                      PathPrefix match type. This matches full path
+                                      elements. A path element refers to the list
+                                      of labels in the path split by the `/` separator.
+                                      When specified, a trailing `/` is ignored. For
+                                      example, the paths `/abc`, `/abc/`, and `/abc/def`
+                                      would all match the prefix `/abc`, but the path
+                                      `/abcd` would not. \n <gateway:experimental>"
                                     maxLength: 1024
                                     type: string
                                   type:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
This is a follow up from the [comments](https://github.com/kubernetes-sigs/gateway-api/pull/1086#discussion_r883131526) by @thockin and @aojea. Although I think we've clearly defined how the PathPrefix match works, we haven't been as clear with the corresponding path rewrite. This copies some of the text we have for prefix path matching so it's also clearly documented here.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```