### PR TITLE
chore: updates for default branch rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,7 +154,7 @@ The following changes have been made since v0.3.0:
   GEP added in [#749](https://github.com/kubernetes-sigs/gateway-api/pull/749).
   Implemented in [#768](https://github.com/kubernetes-sigs/gateway-api/pull/768).
 
-  [GEP-851](https://github.com/kubernetes-sigs/gateway-api/blob/master/site-src/geps/gep-851.md)
+  [GEP-851](https://github.com/kubernetes-sigs/gateway-api/blob/main/site-src/geps/gep-851.md)
   was a follow up on this change that allowed multiple Certificate Refs per
   Gateway Listener. This was implemented in
   [#852](https://github.com/kubernetes-sigs/gateway-api/pull/852).
@@ -169,7 +169,7 @@ The following changes have been made since v0.3.0:
 ### Small Changes
 * Extension points within match blocks from all Routes have been removed
   [#829](https://github.com/kubernetes-sigs/gateway-api/pull/829). Implements
-  [GEP-820](https://github.com/kubernetes-sigs/gateway-api/blob/master/site-src/geps/gep-820.md).
+  [GEP-820](https://github.com/kubernetes-sigs/gateway-api/blob/main/site-src/geps/gep-820.md).
   These extension points have been removed because they are currently not used,
   are poorly understood, and we don't have good use cases for them. We may
   consider re-adding them in the future.
@@ -316,11 +316,11 @@ The following changes have been made since v0.4.0-rc1:
 ### GEP implementations
 * Replace `CertificateRef` field with `CertificateRefs` in `GatewayTLSConfig`.
 [#852](https://github.com/kubernetes-sigs/gateway-api/pull/852). This implements
-[GEP-851](https://github.com/kubernetes-sigs/gateway-api/blob/master/site-src/geps/gep-851.md),
+[GEP-851](https://github.com/kubernetes-sigs/gateway-api/blob/main/site-src/geps/gep-851.md),
 Allow Multiple Certificate Refs per Gateway Listener.
 * Extension points within match blocks from all Routes have been removed
 [#829](https://github.com/kubernetes-sigs/gateway-api/pull/829). Implements
-[GEP-820](https://github.com/kubernetes-sigs/gateway-api/blob/master/site-src/geps/gep-820.md).
+[GEP-820](https://github.com/kubernetes-sigs/gateway-api/blob/main/site-src/geps/gep-820.md).
 These extension points have been removed because they are currently not used,
 are poorly understood, and we don't have good use cases for them. We may
 consider re-adding them in the future.

--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,12 @@ export GIT_TAG ?= dev
 
 # Prow gives this the reference it's called on.
 # The test-infra config job only allows our cloudbuild to
-# be called on `master` and semver tags, so this will be
+# be called on `main` and semver tags, so this will be
 # set to one of those things.
-export BASE_REF ?= master
+export BASE_REF ?= main
 
 # The commit hash of the current checkout
-# Used to pass a binary version for master,
+# Used to pass a binary version for main,
 # overridden to semver for tagged versions.
 # Cloudbuild will set this in the environment to the
 # commit SHA, since the Prow does not seem to check out

--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
-# See the OWNERS_ALIASES file at https://github.com/kubernetes-sigs/gateway-api/blob/master/OWNERS_ALIASES for a list of members for each alias.
+# See the OWNERS_ALIASES file at https://github.com/kubernetes-sigs/gateway-api/blob/main/OWNERS_ALIASES for a list of members for each alias.
 
 approvers:
   - sig-network-leads

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,13 +2,13 @@
 # This file should be kept in sync with k/org.
 
 aliases:
-  # Reference: https://github.com/kubernetes/org/blob/master/OWNERS_ALIASES
+  # Reference: https://github.com/kubernetes/org/blob/main/OWNERS_ALIASES
   sig-network-leads:
     - caseydavenport
     - dcbw
     - thockin
 
-  # Reference: https://github.com/kubernetes/org/blob/master/config/kubernetes-sigs/sig-network/teams.yaml
+  # Reference: https://github.com/kubernetes/org/blob/main/config/kubernetes-sigs/sig-network/teams.yaml
   gateway-api-admins:
     - bowei
     - thockin

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ documentation].
 ## Releasing a new version
 
 - Write the [changelog](CHANGELOG.md) with user-visible API changes. This must
-  go through the regular PR review process and get merged into the `master` branch.
+  go through the regular PR review process and get merged into the `main` branch.
   Approval of the PR indicates community consensus for a new release.
 
 The following steps must be done by one of the [Gateway API maintainers][gateway-api-team]:
@@ -37,5 +37,5 @@ For all releases:
   the Github release.
 
 [release]: https://gateway-api.sigs.k8s.io/references/releases/
-[gateway-api-team]: https://github.com/kubernetes/org/blob/master/config/kubernetes-sigs/sig-network/teams.yaml
+[gateway-api-team]: https://github.com/kubernetes/org/blob/main/config/kubernetes-sigs/sig-network/teams.yaml
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,7 +21,7 @@ substitutions:
   # can be used as a substitution
   _GIT_TAG: '12345'
   # _PULL_BASE_REF will contain the ref that was pushed to to trigger this build -
-  # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
-  _PULL_BASE_REF: 'master'
+  # a branch like 'main' or 'release-0.2', or a tag like 'v0.2'.
+  _PULL_BASE_REF: 'main'
   # _PULL_BASE_SHA will contain the Git SHA of the commit that was pushed to trigger this build.
   _PULL_BASE_SHA: 'abcdef'

--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -44,16 +44,16 @@ then
     exit 1
 fi
 
-# If our base ref == "master" then we will tag :latest.
+# If our base ref == "main" then we will tag :latest.
 VERSION_TAG=latest
 
 # We tag the go binary with the git-based tag by default
 BINARY_TAG=$GIT_TAG
 
 # $BASE_REF has only two things that it can be set to by cloudbuild and Prow,
-# `master`, or a semver tag.
+# `main`, or a semver tag.
 # This is controlled by k8s.io/test-infra/config/jobs/image-pushing/k8s-staging-gateway-api.yaml.
-if [[ "${BASE_REF}" != "master" ]]
+if [[ "${BASE_REF}" != "main" ]]
 then
     # Since we know this is built from a tag or release branch, we can set the VERSION_TAG
     VERSION_TAG="${BASE_REF}"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,7 @@ theme:
     - search.highlight
     - navigation.tabs
     - navigation.top
-edit_uri: edit/master/site-src/
+edit_uri: edit/main/site-src/
 plugins:
   - search
   - awesome-pages

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,20 +6,20 @@
 
 # Standard Netlify redirects
 [[redirects]]
-    from = "https://master--kubernetes-sigs-gateway-api.netlify.com/*"
-    to = "https://master.gateway-api.sigs.k8s.io/:splat"
+    from = "https://main--kubernetes-sigs-gateway-api.netlify.com/*"
+    to = "https://main.gateway-api.sigs.k8s.io/:splat"
     status = 301
     force = true
 
 # HTTP-to-HTTPS rules
 [[redirects]]
-    from = "http://master.gateway-api.sigs.k8s.io/*"
-    to = "https://master.gateway-api.sigs.k8s.io/:splat"
+    from = "http://main.gateway-api.sigs.k8s.io/*"
+    to = "https://main.gateway-api.sigs.k8s.io/:splat"
     status = 301
     force = true
 
 [[redirects]]
-    from = "http://master--kubernetes-sigs-gateway-api.netlify.com/*"
-    to = "http://master.gateway-api.sigs.k8s.io/:splat"
+    from = "http://main--kubernetes-sigs-gateway-api.netlify.com/*"
+    to = "http://main.gateway-api.sigs.k8s.io/:splat"
     status = 301
     force = true

--- a/site-src/concepts/versioning.md
+++ b/site-src/concepts/versioning.md
@@ -134,8 +134,8 @@ experimental field.
 
 ## Out of Scope
 ### Unreleased APIs
-This project will have frequent updates to the master branch. There are no
-compatibility guarantees associated with code in any branch, including master,
+This project will have frequent updates to the main branch. There are no
+compatibility guarantees associated with code in any branch, including main,
 until it has been released. For example, changes may be reverted before a
 release is published. For the best results, use the latest published release of
 this project.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind documentation

**What this PR does / why we need it**:

This updates references to the default branch to the up-to-date name.

**Which issue(s) this PR fixes**:

Fixes #1195

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
