### PR TITLE
[WIP] conformance: add local filesystem path support to getContentsFromPathOrURL helper

### DIFF
--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -228,6 +229,15 @@ func getContentsFromPathOrURL(location string) (*bytes.Buffer, error) {
 			return nil, fmt.Errorf("received %d bytes from %s, expected %d", count, location, resp.ContentLength)
 		}
 		return manifests, nil
+	} else if strings.HasPrefix(location, "local://") {
+		_, path, _ := strings.Cut(location, "local://")
+
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+
+		return bytes.NewBuffer(b), nil
 	}
 	b, err := conformance.Manifests.ReadFile(location)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Consul API Gateway currently needs to slightly tweak the conformance tests base manifests with kustomize (to add an annotation to Deployments and reduce replicas to 1 due to resource limitations in GitHub Actions). Specifying a string path for [`BaseManifests`](https://github.com/kubernetes-sigs/gateway-api/blob/d1b86648e2771763d5f782bfd762c33936034fd2/conformance/utils/suite/suite.go#L71) _is_ currently supported as an option when initializing a `ConformanceTestSuite` struct, but unless the string is a remote path beginning with `https://`, it is hardcoded to [only read from the read-only embedded filesystem](https://github.com/kubernetes-sigs/gateway-api/blob/d1b86648e2771763d5f782bfd762c33936034fd2/conformance/utils/kubernetes/apply.go#L232).

This is currently marked as WIP as it may need some additional input validation checks.

**Which issue(s) this PR fixes**:
Fixes #1180 

**Does this PR introduce a user-facing change?**:
```release-note
conformance: allow configuring BaseManifests from local filesystem with "local://" path prefix
```
