### PR TITLE
fix: broken kustomize for crd deployment

### DIFF
--- a/config/crd/experimental/kustomization.yaml
+++ b/config/crd/experimental/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- gateway.networking.k8s.io_gatewayclasses.yaml
+- gateway.networking.k8s.io_gateways.yaml
+- gateway.networking.k8s.io_httproutes.yaml
+- gateway.networking.k8s.io_referencegrants.yaml
+- gateway.networking.k8s.io_tcproutes.yaml
+- gateway.networking.k8s.io_tlsroutes.yaml
+- gateway.networking.k8s.io_udproutes.yaml

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
-- gateway.networking.k8s.io_gatewayclasses.yaml
-- gateway.networking.k8s.io_gateways.yaml
-- gateway.networking.k8s.io_httproutes.yaml
+- standard/gateway.networking.k8s.io_gatewayclasses.yaml
+- standard/gateway.networking.k8s.io_gateways.yaml
+- standard/gateway.networking.k8s.io_httproutes.yaml

--- a/hack/verify-examples-kind.sh
+++ b/hack/verify-examples-kind.sh
@@ -72,7 +72,7 @@ done
 for CHANNEL in experimental standard; do
   ##### Test v1alpha2 CRD apply and that invalid examples are invalid.
   # Install CRDs
-  kubectl apply -f "config/crd/${CHANNEL}" || res=$?
+  kubectl apply -f "config/crd/${CHANNEL}/gateway*.yaml" || res=$?
 
   # Temporary workaround for https://github.com/kubernetes/kubernetes/issues/104090
   sleep 8


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Yesterday we broken the `kustomization.yaml` for our CRDs:

```
$ make crd
kubectl kustomize config/crd | kubectl apply -f -
error: accumulating resources: accumulation err='accumulating resources from 'gateway.networking.k8s.io_gatewayclasses.yaml': evalsymlink failure on '/home/shane/Code/gateway-api/config/crd/gateway.networking.k8s.io_gatewayclasses.yaml' : lstat /home/shane/Code/gateway-api/config/crd/gateway.networking.k8s.io_gatewayclasses.yaml: no such file or directory': evalsymlink failure on '/home/shane/Code/gateway-api/config/crd/gateway.networking.k8s.io_gatewayclasses.yaml' : lstat /home/shane/Code/gateway-api/config/crd/gateway.networking.k8s.io_gatewayclasses.yaml: no such file or directory
The connection to the server localhost:8080 was refused - did you specify the right host or port?
make: *** [Makefile:98: crd] Error 1
``

This patch fixes the paths.