### PR TITLE
Replacing webhook validation with CRD validation for AddressType

### DIFF
--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -487,12 +487,13 @@ type AnnotationValue string
 //
 // Values `IPAddress` and `Hostname` have Extended support.
 //
-// All other values, including domain-prefixed values have Custom support,
-// which are used in implementation-specific behaviors.
+// All other values, including domain-prefixed values have Custom support, which
+// are used in implementation-specific behaviors. Support for additional
+// predefined CamelCase identifiers may be added in future releases.
 //
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^([a-zA-Z0-9])+$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\/[a-zA-Z0-9]+$`
+// +kubebuilder:validation:Pattern=`^Hostname|IPAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`
 type AddressType string
 
 const (

--- a/apis/v1alpha2/validation/gateway_test.go
+++ b/apis/v1alpha2/validation/gateway_test.go
@@ -82,34 +82,6 @@ func TestValidateGateway(t *testing.T) {
 			},
 			expectErrsOnFields: []string{"spec.listeners[0].hostname"},
 		},
-		"Address present with IPAddress": {
-			mutate: func(gw *gatewayv1a2.Gateway) {
-				ip := gatewayv1a2.IPAddressType
-				gw.Spec.Addresses[0].Type = &ip
-			},
-			expectErrsOnFields: []string{},
-		},
-		"Address present with Hostname": {
-			mutate: func(gw *gatewayv1a2.Gateway) {
-				host := gatewayv1a2.HostnameAddressType
-				gw.Spec.Addresses[0].Type = &host
-			},
-			expectErrsOnFields: []string{},
-		},
-		"Address present with example.com/CustomAddress": {
-			mutate: func(gw *gatewayv1a2.Gateway) {
-				customAddress := gatewayv1a2.AddressType("example.com/CustomAddress")
-				gw.Spec.Addresses[0].Type = &customAddress
-			},
-			expectErrsOnFields: []string{},
-		},
-		"Address present with invalid Type": {
-			mutate: func(gw *gatewayv1a2.Gateway) {
-				customAddress := gatewayv1a2.AddressType("CustomAddress")
-				gw.Spec.Addresses[0].Type = &customAddress
-			},
-			expectErrsOnFields: []string{"spec.addresses[0].type"},
-		},
 	}
 
 	for name, tc := range testCases {

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -480,6 +480,20 @@ type AnnotationKey string
 type AnnotationValue string
 
 // AddressType defines how a network address is represented as a text string.
+// This may take two possible forms:
+//
+// * A predefined CamelCase string identifier (currently limited to `IPAddress` or `Hostname`)
+// * A domain-prefixed string identifier (like `acme.io/CustomAddressType`)
+//
+// Values `IPAddress` and `Hostname` have Extended support.
+//
+// All other values, including domain-prefixed values have Custom support, which
+// are used in implementation-specific behaviors. Support for additional
+// predefined CamelCase identifiers may be added in future releases.
+//
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern=`^Hostname|IPAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`
 type AddressType string
 
 const (
@@ -502,11 +516,4 @@ const (
 	//
 	// Support: Extended
 	HostnameAddressType AddressType = "Hostname"
-
-	// A NamedAddress provides a way to reference a specific IP address by name.
-	// For example, this may be a name or other unique identifier that refers
-	// to a resource on a cloud provider such as a static IP.
-	//
-	// Support: Implementation-Specific
-	NamedAddressType AddressType = "NamedAddress"
 )

--- a/apis/v1beta1/validation/gateway_test.go
+++ b/apis/v1beta1/validation/gateway_test.go
@@ -82,34 +82,6 @@ func TestValidateGateway(t *testing.T) {
 			},
 			expectErrsOnFields: []string{"spec.listeners[0].hostname"},
 		},
-		"Address present with IPAddress": {
-			mutate: func(gw *gatewayv1a2.Gateway) {
-				ip := gatewayv1a2.IPAddressType
-				gw.Spec.Addresses[0].Type = &ip
-			},
-			expectErrsOnFields: []string{},
-		},
-		"Address present with Hostname": {
-			mutate: func(gw *gatewayv1a2.Gateway) {
-				host := gatewayv1a2.HostnameAddressType
-				gw.Spec.Addresses[0].Type = &host
-			},
-			expectErrsOnFields: []string{},
-		},
-		"Address present with example.com/CustomAddress": {
-			mutate: func(gw *gatewayv1a2.Gateway) {
-				customAddress := gatewayv1a2.AddressType("example.com/CustomAddress")
-				gw.Spec.Addresses[0].Type = &customAddress
-			},
-			expectErrsOnFields: []string{},
-		},
-		"Address present with invalid Type": {
-			mutate: func(gw *gatewayv1a2.Gateway) {
-				customAddress := gatewayv1a2.AddressType("CustomAddress")
-				gw.Spec.Addresses[0].Type = &customAddress
-			},
-			expectErrsOnFields: []string{"spec.addresses[0].type"},
-		},
 	}
 
 	for name, tc := range testCases {

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -80,7 +80,7 @@ spec:
                       description: Type of the address.
                       maxLength: 253
                       minLength: 1
-                      pattern: ^([a-zA-Z0-9])+$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\/[a-zA-Z0-9]+$
+                      pattern: ^Hostname|IPAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                       type: string
                     value:
                       description: "Value of the address. The validity of the values
@@ -468,7 +468,7 @@ spec:
                       description: Type of the address.
                       maxLength: 253
                       minLength: 1
-                      pattern: ^([a-zA-Z0-9])+$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\/[a-zA-Z0-9]+$
+                      pattern: ^Hostname|IPAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                       type: string
                     value:
                       description: "Value of the address. The validity of the values
@@ -772,6 +772,9 @@ spec:
                     type:
                       default: IPAddress
                       description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                       type: string
                     value:
                       description: "Value of the address. The validity of the values
@@ -1157,6 +1160,9 @@ spec:
                     type:
                       default: IPAddress
                       description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                       type: string
                     value:
                       description: "Value of the address. The validity of the values

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -80,7 +80,7 @@ spec:
                       description: Type of the address.
                       maxLength: 253
                       minLength: 1
-                      pattern: ^([a-zA-Z0-9])+$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\/[a-zA-Z0-9]+$
+                      pattern: ^Hostname|IPAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                       type: string
                     value:
                       description: "Value of the address. The validity of the values
@@ -468,7 +468,7 @@ spec:
                       description: Type of the address.
                       maxLength: 253
                       minLength: 1
-                      pattern: ^([a-zA-Z0-9])+$|^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\/[a-zA-Z0-9]+$
+                      pattern: ^Hostname|IPAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                       type: string
                     value:
                       description: "Value of the address. The validity of the values
@@ -772,6 +772,9 @@ spec:
                     type:
                       default: IPAddress
                       description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                       type: string
                     value:
                       description: "Value of the address. The validity of the values
@@ -1157,6 +1160,9 @@ spec:
                     type:
                       default: IPAddress
                       description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                       type: string
                     value:
                       description: "Value of the address. The validity of the values


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In response to feedback on #1086, this moves validation from the webhook into the CRD.

**Which issue(s) this PR fixes**:
Fixes #1202

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
