### PR TITLE
docs: update description of GatewayAddresses

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -469,10 +469,10 @@ type GatewayAddress struct {
 
 // GatewayStatus defines the observed state of Gateway.
 type GatewayStatus struct {
-	// Addresses lists the IP addresses that have actually been
-	// bound to the Gateway. These addresses may differ from the
-	// addresses in the Spec, e.g. if the Gateway automatically
-	// assigns an address from a reserved pool.
+	// Addresses lists the IP addresses that are used to serve ingress traffic from
+	// outside the cluster to the Gateway. These addresses may differ from the
+	// addresses in the Spec, e.g. if the Gateway automatically assigns an address
+	// from a reserved pool.
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=16

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -468,10 +468,10 @@ type GatewayAddress struct {
 
 // GatewayStatus defines the observed state of Gateway.
 type GatewayStatus struct {
-	// Addresses lists the IP addresses that have actually been
-	// bound to the Gateway. These addresses may differ from the
-	// addresses in the Spec, e.g. if the Gateway automatically
-	// assigns an address from a reserved pool.
+	// Addresses lists the IP addresses that are used to serve ingress traffic from
+	// outside the cluster to the Gateway. These addresses may differ from the
+	// addresses in the Spec, e.g. if the Gateway automatically assigns an address
+	// from a reserved pool.
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=16

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -455,10 +455,10 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: Addresses lists the IP addresses that have actually been
-                  bound to the Gateway. These addresses may differ from the addresses
-                  in the Spec, e.g. if the Gateway automatically assigns an address
-                  from a reserved pool.
+                description: Addresses lists the IP addresses that are used to serve
+                  ingress traffic from outside the cluster to the Gateway. These addresses
+                  may differ from the addresses in the Spec, e.g. if the Gateway automatically
+                  assigns an address from a reserved pool.
                 items:
                   description: GatewayAddress describes an address that can be bound
                     to a Gateway.
@@ -1146,10 +1146,10 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: Addresses lists the IP addresses that have actually been
-                  bound to the Gateway. These addresses may differ from the addresses
-                  in the Spec, e.g. if the Gateway automatically assigns an address
-                  from a reserved pool.
+                description: Addresses lists the IP addresses that are used to serve
+                  ingress traffic from outside the cluster to the Gateway. These addresses
+                  may differ from the addresses in the Spec, e.g. if the Gateway automatically
+                  assigns an address from a reserved pool.
                 items:
                   description: GatewayAddress describes an address that can be bound
                     to a Gateway.

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -455,10 +455,10 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: Addresses lists the IP addresses that have actually been
-                  bound to the Gateway. These addresses may differ from the addresses
-                  in the Spec, e.g. if the Gateway automatically assigns an address
-                  from a reserved pool.
+                description: Addresses lists the IP addresses that are used to serve
+                  ingress traffic from outside the cluster to the Gateway. These addresses
+                  may differ from the addresses in the Spec, e.g. if the Gateway automatically
+                  assigns an address from a reserved pool.
                 items:
                   description: GatewayAddress describes an address that can be bound
                     to a Gateway.
@@ -1146,10 +1146,10 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: Addresses lists the IP addresses that have actually been
-                  bound to the Gateway. These addresses may differ from the addresses
-                  in the Spec, e.g. if the Gateway automatically assigns an address
-                  from a reserved pool.
+                description: Addresses lists the IP addresses that are used to serve
+                  ingress traffic from outside the cluster to the Gateway. These addresses
+                  may differ from the addresses in the Spec, e.g. if the Gateway automatically
+                  assigns an address from a reserved pool.
                 items:
                   description: GatewayAddress describes an address that can be bound
                     to a Gateway.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Related to a conversation that I brought up in a community meeting, the purpose of this PR is to tweak the wording for `GatewayAddresses` so that it's more clear that the current intention is for these addresses to be addresses like `LoadBalancer` service addresses, or otherwise addresses used for the Gateway to service ingress traffic from outside the cluster, and not simply every kind of address any particular `Gateway` implementation might have. The previous language was just "all addresses bound to the Gateway", but we're not currently expecting (for instance) that implementations would add cluster or pod IPs here.

In that same talk we discussed the possibility of a GEP where could try and add networking contexts to `GatewayAddresses`, but at least for now I felt this distinction was a small helpful thing that could be done for the moment, and we could think about grander improvements later.

**Does this PR introduce a user-facing change?**:

```release-note
The documentation around the GatewayAddress type now makes the distinction that these are meant to be "public" IPs (not necessarily public internet, but at least addresses that route traffic from outside of the cluster network in).
```