### PR TITLE
Move error status code from 404 to 500

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -202,7 +202,7 @@ type HTTPRouteRule struct {
 	// BackendRefs defines the backend(s) where matching requests should be
 	// sent.
 	//
-	// A 404 status code MUST be returned if there are no BackendRefs or filters
+	// A 500 status code MUST be returned if there are no BackendRefs or filters
 	// specified that would result in a response being sent.
 	//
 	// A BackendRef is considered invalid when it refers to:
@@ -212,11 +212,11 @@ type HTTPRouteRule struct {
 	// * a resource in another namespace when the reference has not been
 	//   explicitly allowed by a ReferenceGrant (or equivalent concept).
 	//
-	// When a BackendRef is invalid, 404 status codes MUST be returned for
+	// When a BackendRef is invalid, 500 status codes MUST be returned for
 	// requests that would have otherwise been routed to an invalid backend. If
 	// multiple backends are specified, and some are invalid, the proportion of
 	// requests that would otherwise have been routed to an invalid backend
-	// MUST receive a 404 status code.
+	// MUST receive a 500 status code.
 	//
 	// When a BackendRef refers to a Service that has no ready endpoints, it is
 	// recommended to return a 503 status code.

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -201,7 +201,7 @@ type HTTPRouteRule struct {
 	// BackendRefs defines the backend(s) where matching requests should be
 	// sent.
 	//
-	// A 404 status code MUST be returned if there are no BackendRefs or filters
+	// A 500 status code MUST be returned if there are no BackendRefs or filters
 	// specified that would result in a response being sent.
 	//
 	// A BackendRef is considered invalid when it refers to:
@@ -211,11 +211,11 @@ type HTTPRouteRule struct {
 	// * a resource in another namespace when the reference has not been
 	//   explicitly allowed by a ReferenceGrant (or equivalent concept).
 	//
-	// When a BackendRef is invalid, 404 status codes MUST be returned for
+	// When a BackendRef is invalid, 500 status codes MUST be returned for
 	// requests that would have otherwise been routed to an invalid backend. If
 	// multiple backends are specified, and some are invalid, the proportion of
 	// requests that would otherwise have been routed to an invalid backend
-	// MUST receive a 404 status code.
+	// MUST receive a 500 status code.
 	//
 	// When a BackendRef refers to a Service that has no ready endpoints, it is
 	// recommended to return a 503 status code.

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -218,18 +218,18 @@ spec:
                   properties:
                     backendRefs:
                       description: "BackendRefs defines the backend(s) where matching
-                        requests should be sent. \n A 404 status code MUST be returned
+                        requests should be sent. \n A 500 status code MUST be returned
                         if there are no BackendRefs or filters specified that would
                         result in a response being sent. \n A BackendRef is considered
                         invalid when it refers to: \n * an unknown or unsupported
                         kind of resource * a resource that does not exist * a resource
                         in another namespace when the reference has not been   explicitly
                         allowed by a ReferenceGrant (or equivalent concept). \n When
-                        a BackendRef is invalid, 404 status codes MUST be returned
+                        a BackendRef is invalid, 500 status codes MUST be returned
                         for requests that would have otherwise been routed to an invalid
                         backend. If multiple backends are specified, and some are
                         invalid, the proportion of requests that would otherwise have
-                        been routed to an invalid backend MUST receive a 404 status
+                        been routed to an invalid backend MUST receive a 500 status
                         code. \n When a BackendRef refers to a Service that has no
                         ready endpoints, it is recommended to return a 503 status
                         code. \n Support: Core for Kubernetes Service Support: Custom
@@ -1750,18 +1750,18 @@ spec:
                   properties:
                     backendRefs:
                       description: "BackendRefs defines the backend(s) where matching
-                        requests should be sent. \n A 404 status code MUST be returned
+                        requests should be sent. \n A 500 status code MUST be returned
                         if there are no BackendRefs or filters specified that would
                         result in a response being sent. \n A BackendRef is considered
                         invalid when it refers to: \n * an unknown or unsupported
                         kind of resource * a resource that does not exist * a resource
                         in another namespace when the reference has not been   explicitly
                         allowed by a ReferenceGrant (or equivalent concept). \n When
-                        a BackendRef is invalid, 404 status codes MUST be returned
+                        a BackendRef is invalid, 500 status codes MUST be returned
                         for requests that would have otherwise been routed to an invalid
                         backend. If multiple backends are specified, and some are
                         invalid, the proportion of requests that would otherwise have
-                        been routed to an invalid backend MUST receive a 404 status
+                        been routed to an invalid backend MUST receive a 500 status
                         code. \n When a BackendRef refers to a Service that has no
                         ready endpoints, it is recommended to return a 503 status
                         code. \n Support: Core for Kubernetes Service Support: Custom

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -192,18 +192,18 @@ spec:
                   properties:
                     backendRefs:
                       description: "BackendRefs defines the backend(s) where matching
-                        requests should be sent. \n A 404 status code MUST be returned
+                        requests should be sent. \n A 500 status code MUST be returned
                         if there are no BackendRefs or filters specified that would
                         result in a response being sent. \n A BackendRef is considered
                         invalid when it refers to: \n * an unknown or unsupported
                         kind of resource * a resource that does not exist * a resource
                         in another namespace when the reference has not been   explicitly
                         allowed by a ReferenceGrant (or equivalent concept). \n When
-                        a BackendRef is invalid, 404 status codes MUST be returned
+                        a BackendRef is invalid, 500 status codes MUST be returned
                         for requests that would have otherwise been routed to an invalid
                         backend. If multiple backends are specified, and some are
                         invalid, the proportion of requests that would otherwise have
-                        been routed to an invalid backend MUST receive a 404 status
+                        been routed to an invalid backend MUST receive a 500 status
                         code. \n When a BackendRef refers to a Service that has no
                         ready endpoints, it is recommended to return a 503 status
                         code. \n Support: Core for Kubernetes Service Support: Custom
@@ -1479,18 +1479,18 @@ spec:
                   properties:
                     backendRefs:
                       description: "BackendRefs defines the backend(s) where matching
-                        requests should be sent. \n A 404 status code MUST be returned
+                        requests should be sent. \n A 500 status code MUST be returned
                         if there are no BackendRefs or filters specified that would
                         result in a response being sent. \n A BackendRef is considered
                         invalid when it refers to: \n * an unknown or unsupported
                         kind of resource * a resource that does not exist * a resource
                         in another namespace when the reference has not been   explicitly
                         allowed by a ReferenceGrant (or equivalent concept). \n When
-                        a BackendRef is invalid, 404 status codes MUST be returned
+                        a BackendRef is invalid, 500 status codes MUST be returned
                         for requests that would have otherwise been routed to an invalid
                         backend. If multiple backends are specified, and some are
                         invalid, the proportion of requests that would otherwise have
-                        been routed to an invalid backend MUST receive a 404 status
+                        been routed to an invalid backend MUST receive a 500 status
                         code. \n When a BackendRef refers to a Service that has no
                         ready endpoints, it is recommended to return a 503 status
                         code. \n Support: Core for Kubernetes Service Support: Custom


### PR DESCRIPTION
* If there are no matching routes, a 404 should be generated
* If there are matching routes but no/missing backends/endpoints to
  route to, a 500 (specifically) should be generated.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:

/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind api-change

**What this PR does / why we need it**:
Update status code requirements to return 500 if there are no backends for the route instead of 404

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1200

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The Gateway API now requires to return http 500 status code if there are no backends for existing route
```
