### PR TITLE
Move error status code from 404 to 500

### DIFF
--- a/apis/v1alpha2/tlsroute_types.go
+++ b/apis/v1alpha2/tlsroute_types.go
@@ -105,7 +105,7 @@ type TLSRouteRule struct {
 	// a Service with no endpoints), the rule performs no forwarding; if no
 	// filters are specified that would result in a response being sent, the
 	// underlying implementation must actively reject request attempts to this
-	// backend, by rejecting the connection or returning a 404 status code.
+	// backend, by rejecting the connection or returning a 500 status code.
 	// Request rejections must respect weight; if an invalid backend is
 	// requested to have 80% of requests, then 80% of requests must be rejected
 	// instead.

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -210,7 +210,7 @@ spec:
                         the rule performs no forwarding; if no filters are specified
                         that would result in a response being sent, the underlying
                         implementation must actively reject request attempts to this
-                        backend, by rejecting the connection or returning a 404 status
+                        backend, by rejecting the connection or returning a 500 status
                         code. Request rejections must respect weight; if an invalid
                         backend is requested to have 80% of requests, then 80% of
                         requests must be rejected instead. \n Support: Core for Kubernetes


### PR DESCRIPTION
Update API for TLSRouteRule to return 500 status code if there are
unspecified or invalid BackendRefs

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind api-change

**What this PR does / why we need it**:
Update status code requirements to return 500 if there are no backends for the route instead of 404 for TLSRouteRule

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1200

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The Gateway API now requires to return http 500 status code if there are no backends for existing TLSRouteRule
```
