### PR TITLE
Move error status code from 503 to 500

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -219,7 +219,7 @@ type HTTPRouteRule struct {
 	// MUST receive a 500 status code.
 	//
 	// When a BackendRef refers to a Service that has no ready endpoints, it is
-	// recommended to return a 503 status code.
+	// recommended to return a 500 status code.
 	//
 	// Support: Core for Kubernetes Service
 	// Support: Custom for any other resource

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -218,7 +218,7 @@ type HTTPRouteRule struct {
 	// MUST receive a 500 status code.
 	//
 	// When a BackendRef refers to a Service that has no ready endpoints, it is
-	// recommended to return a 503 status code.
+	// recommended to return a 500 status code.
 	//
 	// Support: Core for Kubernetes Service
 	// Support: Custom for any other resource

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -231,7 +231,7 @@ spec:
                         invalid, the proportion of requests that would otherwise have
                         been routed to an invalid backend MUST receive a 500 status
                         code. \n When a BackendRef refers to a Service that has no
-                        ready endpoints, it is recommended to return a 503 status
+                        ready endpoints, it is recommended to return a 500 status
                         code. \n Support: Core for Kubernetes Service Support: Custom
                         for any other resource \n Support for weight: Core"
                       items:
@@ -1763,7 +1763,7 @@ spec:
                         invalid, the proportion of requests that would otherwise have
                         been routed to an invalid backend MUST receive a 500 status
                         code. \n When a BackendRef refers to a Service that has no
-                        ready endpoints, it is recommended to return a 503 status
+                        ready endpoints, it is recommended to return a 500 status
                         code. \n Support: Core for Kubernetes Service Support: Custom
                         for any other resource \n Support for weight: Core"
                       items:

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -205,7 +205,7 @@ spec:
                         invalid, the proportion of requests that would otherwise have
                         been routed to an invalid backend MUST receive a 500 status
                         code. \n When a BackendRef refers to a Service that has no
-                        ready endpoints, it is recommended to return a 503 status
+                        ready endpoints, it is recommended to return a 500 status
                         code. \n Support: Core for Kubernetes Service Support: Custom
                         for any other resource \n Support for weight: Core"
                       items:
@@ -1492,7 +1492,7 @@ spec:
                         invalid, the proportion of requests that would otherwise have
                         been routed to an invalid backend MUST receive a 500 status
                         code. \n When a BackendRef refers to a Service that has no
-                        ready endpoints, it is recommended to return a 503 status
+                        ready endpoints, it is recommended to return a 500 status
                         code. \n Support: Core for Kubernetes Service Support: Custom
                         for any other resource \n Support for weight: Core"
                       items:


### PR DESCRIPTION
Update HTTPRouteRule API spec to return 500 http status code if it
refers to a Service that has no ready endpoints for both v1alpha2 & v1beta1

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind api-change

**What this PR does / why we need it**:
Update status code requirements to return 500 if there are no backends for the route instead of 503

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1200

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The Gateway API now requires to return http 500 status code if there are no backends for existing route
```
