### PR TITLE
conformance: fix gateway listener ports for multiple calls to MustApplyWithCleanup

### DIFF
--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -42,7 +42,6 @@ import (
 // Applier prepares manifests depending on the available options and applies
 // them to the Kubernetes cluster.
 type Applier struct {
-	NamespaceLabels map[string]string
 	// ValidUniqueListenerPorts maps each listener port of each Gateway in the
 	// manifests to a valid, unique port. There must be as many
 	// ValidUniqueListenerPorts as there are listeners in the set of manifests.

--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -84,9 +84,10 @@ func NewApplier(namespaceLabels map[string]string, validPorts []v1beta1.PortNumb
 	}
 }
 
-// freePortsFor is used to mark ports used by a Gateway as available. It does
-// not lock the availablePorts map.
-func (a *Applier) freePortsFor(name types.NamespacedName) {
+// markPortsAvailable is used to mark ports used by a Gateway as available. It does
+// not lock the availablePorts map because it's intended to be called within a
+// critical section.
+func (a *Applier) markPortsAvailable(name types.NamespacedName) {
 	ports, ok := a.assignedPorts[name]
 	if !ok {
 		return
@@ -100,11 +101,15 @@ func (a *Applier) freePortsFor(name types.NamespacedName) {
 // prepareGateway adjusts both listener ports and the gatewayClassName. It
 // returns the ports used by the listeners if they came from validPorts.
 func (a *Applier) prepareGateway(t *testing.T, uObj *unstructured.Unstructured) {
+	a.portsLock.Lock()
+	defer a.portsLock.Unlock()
+
 	name := types.NamespacedName{
 		Namespace: uObj.GetNamespace(),
 		Name:      uObj.GetName(),
 	}
-	a.freePortsFor(name)
+	// Mark the ports allocated to this Gateway as available
+	a.markPortsAvailable(name)
 
 	err := unstructured.SetNestedField(uObj.Object, a.GatewayClass, "spec", "gatewayClassName")
 	require.NoErrorf(t, err, "error setting `spec.gatewayClassName` on %s Gateway resource", uObj.GetName())
@@ -129,7 +134,7 @@ func (a *Applier) prepareGateway(t *testing.T, uObj *unstructured.Unstructured) 
 			newPort, ok := newPorts[port]
 			if !ok {
 				var portIsValid bool
-				newPort, portIsValid = a.availablePorts.AssignAvailablePort()
+				newPort, portIsValid = a.availablePorts.PopPort()
 				require.True(t, portIsValid, "not enough unassigned valid ports for Gateway resource")
 				newPorts[port] = newPort
 			}
@@ -181,9 +186,6 @@ func prepareNamespace(t *testing.T, uObj *unstructured.Unstructured, namespaceLa
 // a set of manifests.
 func (a *Applier) prepareResources(t *testing.T, decoder *yaml.YAMLOrJSONDecoder) ([]unstructured.Unstructured, error) {
 	var resources []unstructured.Unstructured
-	a.portsLock.Lock()
-	defer a.portsLock.Unlock()
-
 	for {
 		uObj := unstructured.Unstructured{}
 		if err := decoder.Decode(&uObj); err != nil {
@@ -284,7 +286,7 @@ func (a *Applier) MustApplyWithCleanup(t *testing.T, c client.Client, timeoutCon
 						require.NoErrorf(t, err, "error deleting resource")
 					}
 					a.portsLock.Lock()
-					a.freePortsFor(namespacedName)
+					a.markPortsAvailable(namespacedName)
 					a.portsLock.Unlock()
 				})
 			}
@@ -305,7 +307,7 @@ func (a *Applier) MustApplyWithCleanup(t *testing.T, c client.Client, timeoutCon
 					require.NoErrorf(t, err, "error deleting resource")
 				}
 				a.portsLock.Lock()
-				a.freePortsFor(namespacedName)
+				a.markPortsAvailable(namespacedName)
 				a.portsLock.Unlock()
 			})
 		}

--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -76,7 +76,7 @@ type Applier struct {
 // Gateway with 2 listeners on different ports, there should be at least three
 // validPorts.
 // If empty or nil, Gateway listener ports are not modified.
-func NewApplier(namespaceLabels map[string]string, validPorts []v1alpha2.PortNumber) *Applier {
+func NewApplier(namespaceLabels map[string]string, validPorts []v1beta1.PortNumber) *Applier {
 	return &Applier{
 		namespaceLabels: namespaceLabels,
 		availablePorts:  validPorts,

--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -45,14 +45,19 @@ type Applier struct {
 	// Labels to apply to namespaces created by the Applier
 	NamespaceLabels map[string]string
 
-	// ValidUniqueListenerPorts maps each listener port of each Gateway in the
-	// manifests to a valid, unique port.
+	// ValidUniqueListenerPorts is the set of ports that listeners may be
+	// assigned. This ensures that listeners are assigned only ports from
+	// this set, as opposed to the defaults that are set in the manifests.
+	// This is useful when the test infrastructure is constrained to exposing
+	// only a limited set of ports outside of the cluster.
+	// The Applier maps each listener port of each Gateway in the manifests
+	// to a port from ValidUniqueListenerPorts.
 	// There must be as many validPorts as the maximum number of ports
 	// used by listeners simultaneously.
 	// For example, given one Gateway with 2 listeners on the same port and one
 	// Gateway with 2 listeners on different ports, there should be at least three
 	// validPorts.
-	// If empty or nil, ports are not modified.
+	// If empty or nil, listener ports are not modified.
 	ValidUniqueListenerPorts PortStack
 
 	// GatewayClass will be used as the spec.gatewayClassName when applying Gateway resources

--- a/conformance/utils/kubernetes/apply_test.go
+++ b/conformance/utils/kubernetes/apply_test.go
@@ -40,7 +40,7 @@ func TestPrepareResources(t *testing.T) {
 		applier *Applier
 	}{{
 		name:    "empty namespace labels",
-		applier: NewApplier(nil, nil),
+		applier: &Applier{},
 		givens: []given{{
 			resources: `
 apiVersion: v1
@@ -60,12 +60,11 @@ metadata:
 		}},
 	}, {
 		name: "simple namespace labels",
-		applier: NewApplier(
-			map[string]string{
+		applier: &Applier{
+			NamespaceLabels: map[string]string{
 				"test": "false",
 			},
-			nil,
-		),
+		},
 		givens: []given{{
 			resources: `
 apiVersion: v1
@@ -88,12 +87,11 @@ metadata:
 		}},
 	}, {
 		name: "overwrite namespace labels",
-		applier: NewApplier(
-			map[string]string{
+		applier: &Applier{
+			NamespaceLabels: map[string]string{
 				"test": "true",
 			},
-			nil,
-		),
+		},
 		givens: []given{{
 			resources: `
 apiVersion: v1
@@ -118,7 +116,7 @@ metadata:
 		}},
 	}, {
 		name:    "no listener ports given",
-		applier: NewApplier(nil, nil),
+		applier: &Applier{},
 		givens: []given{{
 			resources: `
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -162,10 +160,9 @@ spec:
 		}},
 	}, {
 		name: "multiple gateways each with multiple listeners",
-		applier: NewApplier(
-			nil,
-			[]v1beta1.PortNumber{8000, 8001, 8002, 8003},
-		),
+		applier: &Applier{
+			ValidUniqueListenerPorts: []v1beta1.PortNumber{8000, 8001, 8002, 8003},
+		},
 		givens: []given{{
 			resources: `
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -277,8 +274,10 @@ spec:
 			}},
 		}},
 	}, {
-		name:    "gateway with multiple listeners on the same port",
-		applier: NewApplier(nil, []v1beta1.PortNumber{8000}),
+		name: "gateway with multiple listeners on the same port",
+		applier: &Applier{
+			ValidUniqueListenerPorts: []v1beta1.PortNumber{8000},
+		},
 		givens: []given{{
 			resources: `
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -342,9 +341,9 @@ spec:
 		}},
 	}, {
 		name: "multiple calls to apply with gateways",
-		applier: NewApplier(
-			nil, []v1beta1.PortNumber{8000, 8001},
-		),
+		applier: &Applier{
+			ValidUniqueListenerPorts: []v1beta1.PortNumber{8000, 8001},
+		},
 		givens: []given{{
 			resources: `
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -428,9 +427,9 @@ spec:
 		}},
 	}, {
 		name: "multiple calls to apply with gateways, free ports",
-		applier: NewApplier(
-			nil, []v1beta1.PortNumber{8000, 8001},
-		),
+		applier: &Applier{
+			ValidUniqueListenerPorts: []v1beta1.PortNumber{8000, 8001},
+		},
 		givens: []given{{
 			resources: `
 apiVersion: gateway.networking.k8s.io/v1beta1

--- a/conformance/utils/kubernetes/apply_test.go
+++ b/conformance/utils/kubernetes/apply_test.go
@@ -429,7 +429,7 @@ spec:
 	}, {
 		name: "multiple calls to apply with gateways, free ports",
 		applier: NewApplier(
-			nil, []v1beta1.PortNumber{8000},
+			nil, []v1beta1.PortNumber{8000, 8001},
 		),
 		givens: []given{{
 			resources: `
@@ -442,6 +442,12 @@ spec:
   listeners:
     - name: http
       port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: http-other
+      port: 81
       protocol: HTTP
       allowedRoutes:
         namespaces:
@@ -460,6 +466,16 @@ spec:
 							map[string]interface{}{
 								"name":     "http",
 								"port":     int64(8000),
+								"protocol": "HTTP",
+								"allowedRoutes": map[string]interface{}{
+									"namespaces": map[string]interface{}{
+										"from": "Same",
+									},
+								},
+							},
+							map[string]interface{}{
+								"name":     "http-other",
+								"port":     int64(8001),
 								"protocol": "HTTP",
 								"allowedRoutes": map[string]interface{}{
 									"namespaces": map[string]interface{}{
@@ -486,6 +502,12 @@ spec:
       allowedRoutes:
         namespaces:
           from: Same
+    - name: http-other
+      port: 81
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
 `,
 			expected: []unstructured.Unstructured{{
 				Object: map[string]interface{}{
@@ -500,6 +522,16 @@ spec:
 							map[string]interface{}{
 								"name":     "http",
 								"port":     int64(8000),
+								"protocol": "HTTP",
+								"allowedRoutes": map[string]interface{}{
+									"namespaces": map[string]interface{}{
+										"from": "Same",
+									},
+								},
+							},
+							map[string]interface{}{
+								"name":     "http-other",
+								"port":     int64(8001),
 								"protocol": "HTTP",
 								"allowedRoutes": map[string]interface{}{
 									"namespaces": map[string]interface{}{

--- a/conformance/utils/kubernetes/portset.go
+++ b/conformance/utils/kubernetes/portset.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// PortSet is a wrapper for handling sets of ports.
+type PortSet []v1alpha2.PortNumber
+
+func (s *PortSet) AssignAvailablePort() (v1alpha2.PortNumber, bool) {
+	if len(*s) == 0 {
+		return 0, false
+	}
+
+	newPort := v1alpha2.PortNumber((*s)[0])
+	*s = (*s)[1:]
+	return newPort, true
+}

--- a/conformance/utils/kubernetes/portset.go
+++ b/conformance/utils/kubernetes/portset.go
@@ -17,18 +17,18 @@ limitations under the License.
 package kubernetes
 
 import (
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // PortSet is a wrapper for handling sets of ports.
-type PortSet []v1alpha2.PortNumber
+type PortSet []v1beta1.PortNumber
 
-func (s *PortSet) AssignAvailablePort() (v1alpha2.PortNumber, bool) {
+func (s *PortSet) AssignAvailablePort() (v1beta1.PortNumber, bool) {
 	if len(*s) == 0 {
 		return 0, false
 	}
 
-	newPort := v1alpha2.PortNumber((*s)[0])
+	newPort := v1beta1.PortNumber((*s)[0])
 	*s = (*s)[1:]
 	return newPort, true
 }

--- a/conformance/utils/kubernetes/portset.go
+++ b/conformance/utils/kubernetes/portset.go
@@ -23,7 +23,7 @@ import (
 // PortSet is a wrapper for handling sets of ports.
 type PortSet []v1beta1.PortNumber
 
-func (s *PortSet) AssignAvailablePort() (v1beta1.PortNumber, bool) {
+func (s *PortSet) PopPort() (v1beta1.PortNumber, bool) {
 	if len(*s) == 0 {
 		return 0, false
 	}

--- a/conformance/utils/kubernetes/portset.go
+++ b/conformance/utils/kubernetes/portset.go
@@ -20,10 +20,10 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-// PortSet is a wrapper for handling sets of ports.
-type PortSet []v1beta1.PortNumber
+// PortStack is a wrapper for handling sets of ports.
+type PortStack []v1beta1.PortNumber
 
-func (s *PortSet) PopPort() (v1beta1.PortNumber, bool) {
+func (s *PortStack) PopPort() (v1beta1.PortNumber, bool) {
 	if len(*s) == 0 {
 		return 0, false
 	}

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -44,7 +44,7 @@ type ConformanceTestSuite struct {
 	Cleanup           bool
 	BaseManifests     string
 	MeshManifests     string
-	Applier           kubernetes.Applier
+	Applier           *kubernetes.Applier
 	SupportedFeatures sets.Set[SupportedFeature]
 	TimeoutConfig     config.TimeoutConfig
 	SkipTests         sets.Set[string]
@@ -116,10 +116,10 @@ func New(s Options) *ConformanceTestSuite {
 		Cleanup:          s.CleanupBaseResources,
 		BaseManifests:    s.BaseManifests,
 		MeshManifests:    s.MeshManifests,
-		Applier: kubernetes.Applier{
-			NamespaceLabels:          s.NamespaceLabels,
-			ValidUniqueListenerPorts: s.ValidUniqueListenerPorts,
-		},
+		Applier: kubernetes.NewApplier(
+			s.NamespaceLabels,
+			s.ValidUniqueListenerPorts,
+		),
 		SupportedFeatures: s.SupportedFeatures,
 		TimeoutConfig:     s.TimeoutConfig,
 		SkipTests:         sets.New(s.SkipTests...),

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -116,10 +116,10 @@ func New(s Options) *ConformanceTestSuite {
 		Cleanup:          s.CleanupBaseResources,
 		BaseManifests:    s.BaseManifests,
 		MeshManifests:    s.MeshManifests,
-		Applier: kubernetes.NewApplier(
-			s.NamespaceLabels,
-			s.ValidUniqueListenerPorts,
-		),
+		Applier: &kubernetes.Applier{
+			NamespaceLabels:          s.NamespaceLabels,
+			ValidUniqueListenerPorts: s.ValidUniqueListenerPorts,
+		},
 		SupportedFeatures: s.SupportedFeatures,
 		TimeoutConfig:     s.TimeoutConfig,
 		SkipTests:         sets.New(s.SkipTests...),

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -62,12 +62,19 @@ type Options struct {
 	BaseManifests    string
 	MeshManifests    string
 	NamespaceLabels  map[string]string
-	// ValidUniqueListenerPorts maps each listener port of each Gateway in the
-	// manifests to a valid, unique port. There must be as many
-	// ValidUniqueListenerPorts as there are listeners in the set of manifests.
-	// For example, given two Gateways, each with 2 listeners, there should be
-	// four ValidUniqueListenerPorts.
-	// If empty or nil, ports are not modified.
+	// ValidUniqueListenerPorts is the set of ports that listeners may be
+	// assigned. This ensures that listeners are assigned only ports from
+	// this set, as opposed to the defaults that are set in the manifests.
+	// This is useful when the test infrastructure is constrained to exposing
+	// only a limited set of ports outside of the cluster.
+	// The Applier maps each listener port of each Gateway in the manifests
+	// to a port from ValidUniqueListenerPorts.
+	// There must be as many validPorts as the maximum number of ports
+	// used by listeners simultaneously.
+	// For example, given one Gateway with 2 listeners on the same port and one
+	// Gateway with 2 listeners on different ports, there should be at least three
+	// validPorts.
+	// If empty or nil, listener ports are not modified.
 	ValidUniqueListenerPorts []v1beta1.PortNumber
 
 	// CleanupBaseResources indicates whether or not the base test


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the logic for managing `Gateway` listener ports added in https://github.com/kubernetes-sigs/gateway-api/pull/1101 for new tests where the `Applier` needs to keep track of which ports are assigned to which `Gateway`s for correctness.
Tests are added.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
