### PR TITLE
Add Gateway to core reference from kinds

### DIFF
--- a/apis/v1alpha2/referencegrant_types.go
+++ b/apis/v1alpha2/referencegrant_types.go
@@ -92,13 +92,14 @@ type ReferenceGrantFrom struct {
 	Group Group `json:"group"`
 
 	// Kind is the kind of the referent. Although implementations may support
-	// additional resources, the following Route types are part of the "Core"
+	// additional resources, the following types are part of the "Core"
 	// support level for this field:
 	//
 	// * HTTPRoute
 	// * TCPRoute
 	// * TLSRoute
 	// * UDPRoute
+	// * Gateway
 	Kind Kind `json:"kind"`
 
 	// Namespace is the namespace of the referent.

--- a/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
@@ -69,9 +69,9 @@ spec:
                       type: string
                     kind:
                       description: "Kind is the kind of the referent. Although implementations
-                        may support additional resources, the following Route types
-                        are part of the \"Core\" support level for this field: \n
-                        * HTTPRoute * TCPRoute * TLSRoute * UDPRoute"
+                        may support additional resources, the following types are
+                        part of the \"Core\" support level for this field: \n * HTTPRoute
+                        * TCPRoute * TLSRoute * UDPRoute * Gateway"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_referencepolicies.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_referencepolicies.yaml
@@ -74,9 +74,9 @@ spec:
                       type: string
                     kind:
                       description: "Kind is the kind of the referent. Although implementations
-                        may support additional resources, the following Route types
-                        are part of the \"Core\" support level for this field: \n
-                        * HTTPRoute * TCPRoute * TLSRoute * UDPRoute"
+                        may support additional resources, the following types are
+                        part of the \"Core\" support level for this field: \n * HTTPRoute
+                        * TCPRoute * TLSRoute * UDPRoute * Gateway"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/kind api-change

**What this PR does / why we need it**:
Adds Gateway to the list of kinds ReferenceGrantFrom must support for core support

https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.SecretObjectReference states:

> Note that when a namespace is specified, a ReferenceGrant object is required in the referent namespace to allow that namespace’s owner to accept the reference. See the ReferenceGrant documentation for details.
> Support: Core

This indicates cross-namespace SecretObjectReferences are required for core support. This doesn't clarify how you should check their validity, though a Gateway ReferenceGrantFrom entry appears correct, as it's the only independent type that can include a SecretObjectReference (via Listener->GatewayTLSConfig). By extension, it appears you must support Gateways in addition to the currently listed Route types.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
Maybe? This seems like it was already implied, but just omitted from docs, and this is more a clarification point to say "yes, you should check for a Gateway from rule, not a GatewayTLSConfig from rule". I'm ambivalent as to whether this should instead be:

> Added Gateway to the list of core required kinds in ReferenceGrantFrom