### PR TITLE
docs: minor update to community bugs and feedback

### DIFF
--- a/site-src/v1alpha2/contributing/community.md
+++ b/site-src/v1alpha2/contributing/community.md
@@ -3,11 +3,24 @@
 This page contains links to all of the meeting notes, design docs and related
 discussions around the APIs.
 
-## Feedback and Bug Reports
+## Feedback and Questions
 
-Feedback and bug reports should be filed as [Github Issues][gh-issues] on this repo.
+For general feedback, questions or to share ideas please feel free to [create a
+new discussion][gh-disc].
+
+[gh-disc]:https://github.com/kubernetes-sigs/gateway-api/discussions/new
+
+## Bug Reports
+
+Bug reports should be filed as [Github Issues][gh-issues] on this repo.
+
+**NOTE**: If you're reporting a bug that applies to a specific implementation of
+Gateway API and not the API specification itself, please check our
+[implementations page][implementations] to find links to the repositories where
+you can get help with your specific implementation.
 
 [gh-issues]: https://github.com/kubernetes-sigs/gateway-api/issues/new/choose
+[implementations]:https://gateway-api.sigs.k8s.io/implementations/
 
 ## Communications
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This is just a minor docs patch: I was reading the community page and thought it may be helpful to point our our discussions board for feedback, questions or other discussions that don't really fit into the mold of an issue.

Also I added a reminder to people viewing this page to navigate to bug reports that implementation specific bugs aren't meant to be filed here, and provided a link to the implementations page in hopes this will be a small help in getting people to the right places.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
