### PR TITLE
Adds new tiny type for HTTPRoute Listeners in conformance tests

### DIFF
--- a/conformance/tests/httproute-cross-namespace.go
+++ b/conformance/tests/httproute-cross-namespace.go
@@ -37,7 +37,7 @@ var HTTPRouteCrossNamespace = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "cross-namespace", Namespace: "gateway-conformance-web-backend"}
 		gwNN := types.NamespacedName{Name: "backend-namespaces", Namespace: "gateway-conformance-infra"}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		t.Run("Simple HTTP request should reach web-backend", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, http.ExpectedResponse{

--- a/conformance/tests/httproute-exact-path-matching.go
+++ b/conformance/tests/httproute-exact-path-matching.go
@@ -38,7 +38,7 @@ var HTTPExactPathMatching = suite.ConformanceTest{
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "exact-matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		testCases := []http.ExpectedResponse{
 			{

--- a/conformance/tests/httproute-header-matching.go
+++ b/conformance/tests/httproute-header-matching.go
@@ -38,7 +38,7 @@ var HTTPRouteHeaderMatching = suite.ConformanceTest{
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "header-matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request:   http.ExpectedRequest{Path: "/", Headers: map[string]string{"Version": "one"}},

--- a/conformance/tests/httproute-hostname-intersection.go
+++ b/conformance/tests/httproute-hostname-intersection.go
@@ -51,7 +51,7 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 				{Namespace: ns, Name: "wildcard-host-matches-listener-specific-host"},
 				{Namespace: ns, Name: "wildcard-host-matches-listener-wildcard-host"},
 			}
-			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routes...)
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routes...)
 
 			var testCases []http.ExpectedResponse
 
@@ -189,7 +189,7 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 		})
 
 		t.Run("HTTPRoutes that do not intersect with listener hostnames", func(t *testing.T) {
-			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN)
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN))
 
 			routeName := types.NamespacedName{Namespace: ns, Name: "no-intersecting-hosts"}
 			parents := []v1alpha2.RouteParentStatus{{

--- a/conformance/tests/httproute-invalid-reference-grant.go
+++ b/conformance/tests/httproute-invalid-reference-grant.go
@@ -91,7 +91,7 @@ var HTTPRouteInvalidReferenceGrant = suite.ConformanceTest{
 		// to add check for Accepted condition once
 		// https://github.com/kubernetes-sigs/gateway-api/issues/1112
 		// has been resolved
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, s.Client, s.ControllerName, gwNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, s.Client, s.ControllerName, kubernetes.NewGatewayRef(gwNN))
 
 		// TODO(mikemorris): Add check for HTTP requests successfully reaching
 		// app-backend-v1 at path "/" if it is determined that a Route with at

--- a/conformance/tests/httproute-listener-hostname-matching.go
+++ b/conformance/tests/httproute-listener-hostname-matching.go
@@ -47,7 +47,7 @@ var HTTPRouteListenerHostnameMatching = suite.ConformanceTest{
 			{Namespace: ns, Name: "backend-v2"},
 			{Namespace: ns, Name: "backend-v3"},
 		}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routes...)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routes...)
 
 		testCases := []http.ExpectedResponse{{
 			Request:   http.ExpectedRequest{Host: "bar.com", Path: "/"},

--- a/conformance/tests/httproute-matching-across-routes.go
+++ b/conformance/tests/httproute-matching-across-routes.go
@@ -40,7 +40,7 @@ var HTTPRouteMatchingAcrossRoutes = suite.ConformanceTest{
 		routeNN1 := types.NamespacedName{Name: "matching-part1", Namespace: ns}
 		routeNN2 := types.NamespacedName{Name: "matching-part2", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN1, routeNN2)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN1, routeNN2)
 
 		testCases := []http.ExpectedResponse{{
 			Request: http.ExpectedRequest{

--- a/conformance/tests/httproute-matching.go
+++ b/conformance/tests/httproute-matching.go
@@ -38,7 +38,7 @@ var HTTPRouteMatching = suite.ConformanceTest{
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request:   http.ExpectedRequest{Path: "/"},

--- a/conformance/tests/httproute-reference-grant.go
+++ b/conformance/tests/httproute-reference-grant.go
@@ -40,7 +40,7 @@ var HTTPRouteReferenceGrant = suite.ConformanceTest{
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "reference-grant", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, s.Client, s.ControllerName, gwNN, routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, s.Client, s.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		t.Run("Simple HTTP request should reach web-backend", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, gwAddr, http.ExpectedResponse{

--- a/conformance/tests/httproute-simple-same-namespace.go
+++ b/conformance/tests/httproute-simple-same-namespace.go
@@ -39,7 +39,7 @@ var HTTPRouteSimpleSameNamespace = suite.ConformanceTest{
 		ns := v1alpha2.Namespace("gateway-conformance-infra")
 		routeNN := types.NamespacedName{Name: "gateway-conformance-infra-test", Namespace: string(ns)}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: string(ns)}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, gwNN, routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		t.Run("Simple HTTP request should reach infra-backend", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, http.ExpectedResponse{

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -36,6 +36,31 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
+// GatewayRef is a tiny type for specifying an HTTP Route ParentRef without
+// relying on a specific api version.
+type GatewayRef struct {
+	types.NamespacedName
+	listenerNames []*v1alpha2.SectionName
+}
+
+// NewGatewayRef creates a GatewayRef resource.  ListenerNames are optional.
+func NewGatewayRef(nn types.NamespacedName, listenerNames ...string) GatewayRef {
+	var listeners []*v1alpha2.SectionName
+
+	if len(listenerNames) == 0 {
+		listenerNames = append(listenerNames, "")
+	}
+
+	for _, listener := range listenerNames {
+		sectionName := v1alpha2.SectionName(listener)
+		listeners = append(listeners, &sectionName)
+	}
+	return GatewayRef{
+		NamespacedName: nn,
+		listenerNames:  listeners,
+	}
+}
+
 // GWCMustBeAccepted waits until the specified GatewayClass has an Accepted
 // condition set to true. It also returns the ControllerName for the
 // GatewayClass. This will cause the test to halt if the specified timeout is
@@ -110,33 +135,40 @@ func NamespacesMustBeReady(t *testing.T, c client.Client, namespaces []string, s
 // address assigned to it and the Route has a ParentRef referring to the
 // Gateway. The test will fail if these conditions are not met before the
 // timeouts.
-func GatewayAndHTTPRoutesMustBeReady(t *testing.T, c client.Client, controllerName string, gwNN types.NamespacedName, routeNNs ...types.NamespacedName) string {
+func GatewayAndHTTPRoutesMustBeReady(t *testing.T, c client.Client, controllerName string, gw GatewayRef, routeNNs ...types.NamespacedName) string {
 	t.Helper()
 
-	gwAddr, err := WaitForGatewayAddress(t, c, gwNN, 180)
+	gwAddr, err := WaitForGatewayAddress(t, c, gw.NamespacedName, 180)
 	require.NoErrorf(t, err, "timed out waiting for Gateway address to be assigned")
 
-	ns := v1alpha2.Namespace(gwNN.Namespace)
+	ns := v1alpha2.Namespace(gw.Namespace)
 	kind := v1alpha2.Kind("Gateway")
 
 	for _, routeNN := range routeNNs {
 		namespaceRequired := true
-		if routeNN.Namespace == gwNN.Namespace {
+		if routeNN.Namespace == gw.Namespace {
 			namespaceRequired = false
 		}
-		parents := []v1alpha2.RouteParentStatus{{
-			ParentRef: v1alpha2.ParentReference{
-				Group:     (*v1alpha2.Group)(&v1alpha2.GroupVersion.Group),
-				Kind:      &kind,
-				Name:      v1alpha2.ObjectName(gwNN.Name),
-				Namespace: &ns,
-			},
-			ControllerName: v1alpha2.GatewayController(controllerName),
-			Conditions: []metav1.Condition{{
-				Type:   string(v1alpha2.RouteConditionAccepted),
-				Status: metav1.ConditionTrue,
-			}},
-		}}
+
+		var parents []v1alpha2.RouteParentStatus
+		for _, listener := range gw.listenerNames {
+			parents = append(parents, v1alpha2.RouteParentStatus{
+				ParentRef: v1alpha2.ParentReference{
+					Group:       (*v1alpha2.Group)(&v1alpha2.GroupVersion.Group),
+					Kind:        &kind,
+					Name:        v1alpha2.ObjectName(gw.Name),
+					Namespace:   &ns,
+					SectionName: listener,
+				},
+				ControllerName: v1alpha2.GatewayController(controllerName),
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(v1alpha2.RouteConditionAccepted),
+						Status: metav1.ConditionTrue,
+					},
+				},
+			})
+		}
 		HTTPRouteMustHaveParents(t, c, routeNN, parents, namespaceRequired, 60)
 	}
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/kind failing-test

**What this PR does / why we need it**:

Adds a tiny type for specifying HTTPRoute ParentRefs to Gateways
in the conformance tests.  This allows us to test cases with 2 ParentRefs (to the same Gateway).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1219

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
