### PR TITLE
apis: validate header and query param matches

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -403,6 +403,10 @@ type HTTPQueryParamMatch struct {
 	// exact string match. (See
 	// https://tools.ietf.org/html/rfc7230#section-2.7.3).
 	//
+	// If multiple entries specify equivalent query param names, only the first
+	// entry with an equivalent name MUST be considered for a match. Subsequent
+	// entries with an equivalent query param name MUST be ignored.
+	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
 	Name string `json:"name"`

--- a/apis/v1alpha2/validation/httproute.go
+++ b/apis/v1alpha2/validation/httproute.go
@@ -54,14 +54,16 @@ func validateHTTPRouteSpec(spec *gatewayv1a2.HTTPRouteSpec, path *field.Path) fi
 			errs = append(errs, validateHTTPRouteFilters(backendRef.Filters, rule.Matches, path.Child("rules").Index(i).Child("backendsrefs").Index(j))...)
 		}
 		for j, m := range rule.Matches {
+			path := path.Child("rules").Index(i).Child("matches").Index(j)
+
 			if m.Path != nil {
-				errs = append(errs, validateHTTPPathMatch(m.Path, path.Child("matches").Index(j).Child("path"))...)
+				errs = append(errs, validateHTTPPathMatch(m.Path, path.Child("path"))...)
 			}
 			if len(m.Headers) > 0 {
-				errs = append(errs, validateHTTPHeaderMatches(m.Headers, path.Child("matches").Index(j).Child("headers"))...)
+				errs = append(errs, validateHTTPHeaderMatches(m.Headers, path.Child("headers"))...)
 			}
 			if len(m.QueryParams) > 0 {
-				errs = append(errs, validateHTTPQueryParamMatches(m.QueryParams, path.Child("matches").Index(j).Child("queryParams"))...)
+				errs = append(errs, validateHTTPQueryParamMatches(m.QueryParams, path.Child("queryParams"))...)
 			}
 		}
 	}

--- a/apis/v1alpha2/validation/httproute.go
+++ b/apis/v1alpha2/validation/httproute.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -55,6 +56,12 @@ func validateHTTPRouteSpec(spec *gatewayv1a2.HTTPRouteSpec, path *field.Path) fi
 		for j, m := range rule.Matches {
 			if m.Path != nil {
 				errs = append(errs, validateHTTPPathMatch(m.Path, path.Child("matches").Index(j).Child("path"))...)
+			}
+			if len(m.Headers) > 0 {
+				errs = append(errs, validateHTTPHeaderMatches(m.Headers, path.Child("matches").Index(j).Child("headers"))...)
+			}
+			if len(m.QueryParams) > 0 {
+				errs = append(errs, validateHTTPQueryParamMatches(m.QueryParams, path.Child("matches").Index(j).Child("queryParams"))...)
 			}
 		}
 	}
@@ -157,6 +164,46 @@ func validateHTTPPathMatch(path *gatewayv1a2.HTTPPathMatch, fldPath *field.Path)
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("type"), *path.Type, pathTypes))
 	}
 	return allErrs
+}
+
+// validateHTTPHeaderMatches validates that no header name
+// is matched more than once (case-insensitive).
+func validateHTTPHeaderMatches(matches []gatewayv1a2.HTTPHeaderMatch, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	counts := map[string]int{}
+
+	for _, match := range matches {
+		// Header names are case-insensitive.
+		counts[strings.ToLower(string(match.Name))]++
+	}
+
+	for name, count := range counts {
+		if count > 1 {
+			errs = append(errs, field.Invalid(path, http.CanonicalHeaderKey(name), "cannot match the same header multiple times in the same rule"))
+		}
+	}
+
+	return errs
+}
+
+// validateHTTPQueryParamMatches validates that no query param name
+// is matched more than once (case-sensitive).
+func validateHTTPQueryParamMatches(matches []gatewayv1a2.HTTPQueryParamMatch, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	counts := map[string]int{}
+
+	for _, match := range matches {
+		// Query param names are case-sensitive.
+		counts[string(match.Name)]++
+	}
+
+	for name, count := range counts {
+		if count > 1 {
+			errs = append(errs, field.Invalid(path, name, "cannot match the same query parameter multiple times in the same rule"))
+		}
+	}
+
+	return errs
 }
 
 // validateHTTPRouteFilterTypeMatchesValue validates that only the expected fields are

--- a/apis/v1alpha2/validation/httproute.go
+++ b/apis/v1alpha2/validation/httproute.go
@@ -54,16 +54,16 @@ func validateHTTPRouteSpec(spec *gatewayv1a2.HTTPRouteSpec, path *field.Path) fi
 			errs = append(errs, validateHTTPRouteFilters(backendRef.Filters, rule.Matches, path.Child("rules").Index(i).Child("backendsrefs").Index(j))...)
 		}
 		for j, m := range rule.Matches {
-			path := path.Child("rules").Index(i).Child("matches").Index(j)
+			matchPath := path.Child("rules").Index(i).Child("matches").Index(j)
 
 			if m.Path != nil {
-				errs = append(errs, validateHTTPPathMatch(m.Path, path.Child("path"))...)
+				errs = append(errs, validateHTTPPathMatch(m.Path, matchPath.Child("path"))...)
 			}
 			if len(m.Headers) > 0 {
-				errs = append(errs, validateHTTPHeaderMatches(m.Headers, path.Child("headers"))...)
+				errs = append(errs, validateHTTPHeaderMatches(m.Headers, matchPath.Child("headers"))...)
 			}
 			if len(m.QueryParams) > 0 {
-				errs = append(errs, validateHTTPQueryParamMatches(m.QueryParams, path.Child("queryParams"))...)
+				errs = append(errs, validateHTTPQueryParamMatches(m.QueryParams, matchPath.Child("queryParams"))...)
 			}
 		}
 	}

--- a/apis/v1alpha2/validation/httproute_test.go
+++ b/apis/v1alpha2/validation/httproute_test.go
@@ -19,6 +19,8 @@ package validation
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilpointer "k8s.io/utils/pointer"
 
@@ -576,11 +578,11 @@ func TestValidateHTTPHeaderMatches(t *testing.T) {
 	tests := []struct {
 		name          string
 		headerMatches []gatewayv1a2.HTTPHeaderMatch
-		errCount      int
+		expectErr     string
 	}{{
 		name:          "no header matches",
 		headerMatches: nil,
-		errCount:      0,
+		expectErr:     "",
 	}, {
 		name: "no header matched more than once",
 		headerMatches: []gatewayv1a2.HTTPHeaderMatch{
@@ -588,7 +590,7 @@ func TestValidateHTTPHeaderMatches(t *testing.T) {
 			{Name: "Header-Name-2", Value: "val-2"},
 			{Name: "Header-Name-3", Value: "val-3"},
 		},
-		errCount: 0,
+		expectErr: "",
 	}, {
 		name: "header matched more than once (same case)",
 		headerMatches: []gatewayv1a2.HTTPHeaderMatch{
@@ -596,7 +598,7 @@ func TestValidateHTTPHeaderMatches(t *testing.T) {
 			{Name: "Header-Name-2", Value: "val-2"},
 			{Name: "Header-Name-1", Value: "val-3"},
 		},
-		errCount: 1,
+		expectErr: "spec.rules[0].matches[0].headers: Invalid value: \"Header-Name-1\": cannot match the same header multiple times in the same rule",
 	}, {
 		name: "header matched more than once (different case)",
 		headerMatches: []gatewayv1a2.HTTPHeaderMatch{
@@ -604,7 +606,7 @@ func TestValidateHTTPHeaderMatches(t *testing.T) {
 			{Name: "Header-Name-2", Value: "val-2"},
 			{Name: "HEADER-NAME-2", Value: "val-3"},
 		},
-		errCount: 1,
+		expectErr: "spec.rules[0].matches[0].headers: Invalid value: \"Header-Name-2\": cannot match the same header multiple times in the same rule",
 	}}
 
 	for _, tc := range tests {
@@ -626,8 +628,11 @@ func TestValidateHTTPHeaderMatches(t *testing.T) {
 			}}
 
 			errs := ValidateHTTPRoute(&route)
-			if len(errs) != tc.errCount {
-				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
+			if len(tc.expectErr) == 0 {
+				assert.Emptyf(t, errs, "expected no errors, got %d errors: %s", len(errs), errs)
+			} else {
+				require.Lenf(t, errs, 1, "expected one error, got %d errors: %s", len(errs), errs)
+				assert.Equal(t, tc.expectErr, errs[0].Error())
 			}
 		})
 	}
@@ -637,11 +642,11 @@ func TestValidateHTTPQueryParamMatches(t *testing.T) {
 	tests := []struct {
 		name              string
 		queryParamMatches []gatewayv1a2.HTTPQueryParamMatch
-		errCount          int
+		expectErr         string
 	}{{
 		name:              "no query param matches",
 		queryParamMatches: nil,
-		errCount:          0,
+		expectErr:         "",
 	}, {
 		name: "no query param matched more than once",
 		queryParamMatches: []gatewayv1a2.HTTPQueryParamMatch{
@@ -649,7 +654,7 @@ func TestValidateHTTPQueryParamMatches(t *testing.T) {
 			{Name: "query-param-2", Value: "val-2"},
 			{Name: "query-param-3", Value: "val-3"},
 		},
-		errCount: 0,
+		expectErr: "",
 	}, {
 		name: "query param matched more than once",
 		queryParamMatches: []gatewayv1a2.HTTPQueryParamMatch{
@@ -657,7 +662,7 @@ func TestValidateHTTPQueryParamMatches(t *testing.T) {
 			{Name: "query-param-2", Value: "val-2"},
 			{Name: "query-param-1", Value: "val-3"},
 		},
-		errCount: 1,
+		expectErr: "spec.rules[0].matches[0].queryParams: Invalid value: \"query-param-1\": cannot match the same query parameter multiple times in the same rule",
 	}, {
 		name: "query param names with different casing are not considered duplicates",
 		queryParamMatches: []gatewayv1a2.HTTPQueryParamMatch{
@@ -665,7 +670,7 @@ func TestValidateHTTPQueryParamMatches(t *testing.T) {
 			{Name: "query-param-2", Value: "val-2"},
 			{Name: "QUERY-PARAM-1", Value: "val-3"},
 		},
-		errCount: 0,
+		expectErr: "",
 	}}
 
 	for _, tc := range tests {
@@ -687,8 +692,11 @@ func TestValidateHTTPQueryParamMatches(t *testing.T) {
 			}}
 
 			errs := ValidateHTTPRoute(&route)
-			if len(errs) != tc.errCount {
-				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
+			if len(tc.expectErr) == 0 {
+				assert.Emptyf(t, errs, "expected no errors, got %d errors: %s", len(errs), errs)
+			} else {
+				require.Lenf(t, errs, 1, "expected one error, got %d errors: %s", len(errs), errs)
+				assert.Equal(t, tc.expectErr, errs[0].Error())
 			}
 		})
 	}

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -402,6 +402,10 @@ type HTTPQueryParamMatch struct {
 	// exact string match. (See
 	// https://tools.ietf.org/html/rfc7230#section-2.7.3).
 	//
+	// If multiple entries specify equivalent query param names, only the first
+	// entry with an equivalent name MUST be considered for a match. Subsequent
+	// entries with an equivalent query param name MUST be ignored.
+	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
 	Name string `json:"name"`

--- a/apis/v1beta1/validation/httproute.go
+++ b/apis/v1beta1/validation/httproute.go
@@ -54,14 +54,16 @@ func validateHTTPRouteSpec(spec *gatewayv1a2.HTTPRouteSpec, path *field.Path) fi
 			errs = append(errs, validateHTTPRouteFilters(backendRef.Filters, rule.Matches, path.Child("rules").Index(i).Child("backendsrefs").Index(j))...)
 		}
 		for j, m := range rule.Matches {
+			path := path.Child("rules").Index(i).Child("matches").Index(j)
+
 			if m.Path != nil {
-				errs = append(errs, validateHTTPPathMatch(m.Path, path.Child("matches").Index(j).Child("path"))...)
+				errs = append(errs, validateHTTPPathMatch(m.Path, path.Child("path"))...)
 			}
 			if len(m.Headers) > 0 {
-				errs = append(errs, validateHTTPHeaderMatches(m.Headers, path.Child("matches").Index(j).Child("headers"))...)
+				errs = append(errs, validateHTTPHeaderMatches(m.Headers, path.Child("headers"))...)
 			}
 			if len(m.QueryParams) > 0 {
-				errs = append(errs, validateHTTPQueryParamMatches(m.QueryParams, path.Child("matches").Index(j).Child("queryParams"))...)
+				errs = append(errs, validateHTTPQueryParamMatches(m.QueryParams, path.Child("queryParams"))...)
 			}
 		}
 	}

--- a/apis/v1beta1/validation/httproute.go
+++ b/apis/v1beta1/validation/httproute.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -55,6 +56,12 @@ func validateHTTPRouteSpec(spec *gatewayv1a2.HTTPRouteSpec, path *field.Path) fi
 		for j, m := range rule.Matches {
 			if m.Path != nil {
 				errs = append(errs, validateHTTPPathMatch(m.Path, path.Child("matches").Index(j).Child("path"))...)
+			}
+			if len(m.Headers) > 0 {
+				errs = append(errs, validateHTTPHeaderMatches(m.Headers, path.Child("matches").Index(j).Child("headers"))...)
+			}
+			if len(m.QueryParams) > 0 {
+				errs = append(errs, validateHTTPQueryParamMatches(m.QueryParams, path.Child("matches").Index(j).Child("queryParams"))...)
 			}
 		}
 	}
@@ -157,6 +164,46 @@ func validateHTTPPathMatch(path *gatewayv1a2.HTTPPathMatch, fldPath *field.Path)
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("type"), *path.Type, pathTypes))
 	}
 	return allErrs
+}
+
+// validateHTTPHeaderMatches validates that no header name
+// is matched more than once (case-insensitive).
+func validateHTTPHeaderMatches(matches []gatewayv1a2.HTTPHeaderMatch, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	counts := map[string]int{}
+
+	for _, match := range matches {
+		// Header names are case-insensitive.
+		counts[strings.ToLower(string(match.Name))]++
+	}
+
+	for name, count := range counts {
+		if count > 1 {
+			errs = append(errs, field.Invalid(path, http.CanonicalHeaderKey(name), "cannot match the same header multiple times in the same rule"))
+		}
+	}
+
+	return errs
+}
+
+// validateHTTPQueryParamMatches validates that no query param name
+// is matched more than once (case-sensitive).
+func validateHTTPQueryParamMatches(matches []gatewayv1a2.HTTPQueryParamMatch, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	counts := map[string]int{}
+
+	for _, match := range matches {
+		// Query param names are case-sensitive.
+		counts[string(match.Name)]++
+	}
+
+	for name, count := range counts {
+		if count > 1 {
+			errs = append(errs, field.Invalid(path, name, "cannot match the same query parameter multiple times in the same rule"))
+		}
+	}
+
+	return errs
 }
 
 // validateHTTPRouteFilterTypeMatchesValue validates that only the expected fields are

--- a/apis/v1beta1/validation/httproute.go
+++ b/apis/v1beta1/validation/httproute.go
@@ -54,16 +54,16 @@ func validateHTTPRouteSpec(spec *gatewayv1a2.HTTPRouteSpec, path *field.Path) fi
 			errs = append(errs, validateHTTPRouteFilters(backendRef.Filters, rule.Matches, path.Child("rules").Index(i).Child("backendsrefs").Index(j))...)
 		}
 		for j, m := range rule.Matches {
-			path := path.Child("rules").Index(i).Child("matches").Index(j)
+			matchPath := path.Child("rules").Index(i).Child("matches").Index(j)
 
 			if m.Path != nil {
-				errs = append(errs, validateHTTPPathMatch(m.Path, path.Child("path"))...)
+				errs = append(errs, validateHTTPPathMatch(m.Path, matchPath.Child("path"))...)
 			}
 			if len(m.Headers) > 0 {
-				errs = append(errs, validateHTTPHeaderMatches(m.Headers, path.Child("headers"))...)
+				errs = append(errs, validateHTTPHeaderMatches(m.Headers, matchPath.Child("headers"))...)
 			}
 			if len(m.QueryParams) > 0 {
-				errs = append(errs, validateHTTPQueryParamMatches(m.QueryParams, path.Child("queryParams"))...)
+				errs = append(errs, validateHTTPQueryParamMatches(m.QueryParams, matchPath.Child("queryParams"))...)
 			}
 		}
 	}

--- a/apis/v1beta1/validation/httproute_test.go
+++ b/apis/v1beta1/validation/httproute_test.go
@@ -19,6 +19,8 @@ package validation
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilpointer "k8s.io/utils/pointer"
 
@@ -576,11 +578,11 @@ func TestValidateHTTPHeaderMatches(t *testing.T) {
 	tests := []struct {
 		name          string
 		headerMatches []gatewayv1a2.HTTPHeaderMatch
-		errCount      int
+		expectErr     string
 	}{{
 		name:          "no header matches",
 		headerMatches: nil,
-		errCount:      0,
+		expectErr:     "",
 	}, {
 		name: "no header matched more than once",
 		headerMatches: []gatewayv1a2.HTTPHeaderMatch{
@@ -588,7 +590,7 @@ func TestValidateHTTPHeaderMatches(t *testing.T) {
 			{Name: "Header-Name-2", Value: "val-2"},
 			{Name: "Header-Name-3", Value: "val-3"},
 		},
-		errCount: 0,
+		expectErr: "",
 	}, {
 		name: "header matched more than once (same case)",
 		headerMatches: []gatewayv1a2.HTTPHeaderMatch{
@@ -596,7 +598,7 @@ func TestValidateHTTPHeaderMatches(t *testing.T) {
 			{Name: "Header-Name-2", Value: "val-2"},
 			{Name: "Header-Name-1", Value: "val-3"},
 		},
-		errCount: 1,
+		expectErr: "spec.rules[0].matches[0].headers: Invalid value: \"Header-Name-1\": cannot match the same header multiple times in the same rule",
 	}, {
 		name: "header matched more than once (different case)",
 		headerMatches: []gatewayv1a2.HTTPHeaderMatch{
@@ -604,7 +606,7 @@ func TestValidateHTTPHeaderMatches(t *testing.T) {
 			{Name: "Header-Name-2", Value: "val-2"},
 			{Name: "HEADER-NAME-2", Value: "val-3"},
 		},
-		errCount: 1,
+		expectErr: "spec.rules[0].matches[0].headers: Invalid value: \"Header-Name-2\": cannot match the same header multiple times in the same rule",
 	}}
 
 	for _, tc := range tests {
@@ -626,8 +628,11 @@ func TestValidateHTTPHeaderMatches(t *testing.T) {
 			}}
 
 			errs := ValidateHTTPRoute(&route)
-			if len(errs) != tc.errCount {
-				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
+			if len(tc.expectErr) == 0 {
+				assert.Emptyf(t, errs, "expected no errors, got %d errors: %s", len(errs), errs)
+			} else {
+				require.Lenf(t, errs, 1, "expected one error, got %d errors: %s", len(errs), errs)
+				assert.Equal(t, tc.expectErr, errs[0].Error())
 			}
 		})
 	}
@@ -637,11 +642,11 @@ func TestValidateHTTPQueryParamMatches(t *testing.T) {
 	tests := []struct {
 		name              string
 		queryParamMatches []gatewayv1a2.HTTPQueryParamMatch
-		errCount          int
+		expectErr         string
 	}{{
 		name:              "no query param matches",
 		queryParamMatches: nil,
-		errCount:          0,
+		expectErr:         "",
 	}, {
 		name: "no query param matched more than once",
 		queryParamMatches: []gatewayv1a2.HTTPQueryParamMatch{
@@ -649,7 +654,7 @@ func TestValidateHTTPQueryParamMatches(t *testing.T) {
 			{Name: "query-param-2", Value: "val-2"},
 			{Name: "query-param-3", Value: "val-3"},
 		},
-		errCount: 0,
+		expectErr: "",
 	}, {
 		name: "query param matched more than once",
 		queryParamMatches: []gatewayv1a2.HTTPQueryParamMatch{
@@ -657,7 +662,7 @@ func TestValidateHTTPQueryParamMatches(t *testing.T) {
 			{Name: "query-param-2", Value: "val-2"},
 			{Name: "query-param-1", Value: "val-3"},
 		},
-		errCount: 1,
+		expectErr: "spec.rules[0].matches[0].queryParams: Invalid value: \"query-param-1\": cannot match the same query parameter multiple times in the same rule",
 	}, {
 		name: "query param names with different casing are not considered duplicates",
 		queryParamMatches: []gatewayv1a2.HTTPQueryParamMatch{
@@ -665,7 +670,7 @@ func TestValidateHTTPQueryParamMatches(t *testing.T) {
 			{Name: "query-param-2", Value: "val-2"},
 			{Name: "QUERY-PARAM-1", Value: "val-3"},
 		},
-		errCount: 0,
+		expectErr: "",
 	}}
 
 	for _, tc := range tests {
@@ -687,8 +692,11 @@ func TestValidateHTTPQueryParamMatches(t *testing.T) {
 			}}
 
 			errs := ValidateHTTPRoute(&route)
-			if len(errs) != tc.errCount {
-				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
+			if len(tc.expectErr) == 0 {
+				assert.Emptyf(t, errs, "expected no errors, got %d errors: %s", len(errs), errs)
+			} else {
+				require.Lenf(t, errs, 1, "expected one error, got %d errors: %s", len(errs), errs)
+				assert.Equal(t, tc.expectErr, errs[0].Error())
 			}
 		})
 	}

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -1275,9 +1275,14 @@ spec:
                                 a HTTP route by matching HTTP query parameters.
                               properties:
                                 name:
-                                  description: Name is the name of the HTTP query
+                                  description: "Name is the name of the HTTP query
                                     param to be matched. This must be an exact string
                                     match. (See https://tools.ietf.org/html/rfc7230#section-2.7.3).
+                                    \n If multiple entries specify equivalent query
+                                    param names, only the first entry with an equivalent
+                                    name MUST be considered for a match. Subsequent
+                                    entries with an equivalent query param name MUST
+                                    be ignored."
                                   maxLength: 256
                                   minLength: 1
                                   type: string
@@ -2807,9 +2812,14 @@ spec:
                                 a HTTP route by matching HTTP query parameters.
                               properties:
                                 name:
-                                  description: Name is the name of the HTTP query
+                                  description: "Name is the name of the HTTP query
                                     param to be matched. This must be an exact string
                                     match. (See https://tools.ietf.org/html/rfc7230#section-2.7.3).
+                                    \n If multiple entries specify equivalent query
+                                    param names, only the first entry with an equivalent
+                                    name MUST be considered for a match. Subsequent
+                                    entries with an equivalent query param name MUST
+                                    be ignored."
                                   maxLength: 256
                                   minLength: 1
                                   type: string

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -1058,9 +1058,14 @@ spec:
                                 a HTTP route by matching HTTP query parameters.
                               properties:
                                 name:
-                                  description: Name is the name of the HTTP query
+                                  description: "Name is the name of the HTTP query
                                     param to be matched. This must be an exact string
                                     match. (See https://tools.ietf.org/html/rfc7230#section-2.7.3).
+                                    \n If multiple entries specify equivalent query
+                                    param names, only the first entry with an equivalent
+                                    name MUST be considered for a match. Subsequent
+                                    entries with an equivalent query param name MUST
+                                    be ignored."
                                   maxLength: 256
                                   minLength: 1
                                   type: string
@@ -2345,9 +2350,14 @@ spec:
                                 a HTTP route by matching HTTP query parameters.
                               properties:
                                 name:
-                                  description: Name is the name of the HTTP query
+                                  description: "Name is the name of the HTTP query
                                     param to be matched. This must be an exact string
                                     match. (See https://tools.ietf.org/html/rfc7230#section-2.7.3).
+                                    \n If multiple entries specify equivalent query
+                                    param names, only the first entry with an equivalent
+                                    name MUST be considered for a match. Subsequent
+                                    entries with an equivalent query param name MUST
+                                    be ignored."
                                   maxLength: 256
                                   minLength: 1
                                   type: string


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds webhook validation to ensure that no
HTTP header or query param is matched more
than once in a given route rule. Also updates
the godoc for HTTPQueryParamMatch to be
consistent with HTTPHeaderMatch.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1225 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Adds webhook validation to ensure that no HTTP header or query param is matched more than once in a given route rule.
```
