### PR TITLE
Adding Shane Utt as Gateway API Maintainer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,7 +16,10 @@ aliases:
   gateway-api-maintainers:
     - bowei
     - hbagdi
-    - jpeach
     - robscott
-    - thockin
+    - shaneutt
     - youngnick
+
+  emeritus-gateway-api-maintainers:
+    - danehans
+    - jpeach


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This adds Shane Utt as a Gateway API Maintainer. It also formally recognizes @jpeach and @danehans as emeritus maintainers and removes Tim from the list so he gets slightly less spam from GitHub now :). 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
