### PR TITLE
conformance: fix HTTPRouteListenerHostnameMatching

### DIFF
--- a/conformance/tests/httproute-listener-hostname-matching.go
+++ b/conformance/tests/httproute-listener-hostname-matching.go
@@ -42,12 +42,16 @@ var HTTPRouteListenerHostnameMatching = suite.ConformanceTest{
 		kubernetes.NamespacesMustBeReady(t, suite.Client, []string{ns}, 300)
 
 		gwNN := types.NamespacedName{Name: "httproute-listener-hostname-matching", Namespace: ns}
-		routes := []types.NamespacedName{
-			{Namespace: ns, Name: "backend-v1"},
-			{Namespace: ns, Name: "backend-v2"},
-			{Namespace: ns, Name: "backend-v3"},
-		}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routes...)
+
+		_ = kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-1"),
+			types.NamespacedName{Namespace: ns, Name: "backend-v1"},
+		)
+		_ = kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-2"),
+			types.NamespacedName{Namespace: ns, Name: "backend-v2"},
+		)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-3", "listener-4"),
+			types.NamespacedName{Namespace: ns, Name: "backend-v3"},
+		)
 
 		testCases := []http.ExpectedResponse{{
 			Request:   http.ExpectedRequest{Host: "bar.com", Path: "/"},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes the test (which was already broken) with the API from #1228

Is there a reason not to just derive the correct status parent ref from the `parentRefs` in the `HTTPRoute` resource?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
