### PR TITLE
fix ReferencePolicyList.Items type

### DIFF
--- a/apis/v1alpha2/referencepolicy_types.go
+++ b/apis/v1alpha2/referencepolicy_types.go
@@ -58,5 +58,5 @@ type ReferencePolicy struct {
 type ReferencePolicyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []ReferenceGrant `json:"items"`
+	Items           []ReferencePolicy `json:"items"`
 }

--- a/apis/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/v1alpha2/zz_generated.deepcopy.go
@@ -1179,7 +1179,7 @@ func (in *ReferencePolicyList) DeepCopyInto(out *ReferencePolicyList) {
 	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
-		*out = make([]ReferenceGrant, len(*in))
+		*out = make([]ReferencePolicy, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
-->

**What this PR does / why we need it**:

When the ReferencePolicy type was added back the list type for that resource actually returns ReferenceGrants instead of ReferencePolicy. This isn't a huge deal but a lot of code generation around k8s types assume a pattern of `XResource` with a `XResourceList` having an `Items` type of `[]XResource`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
ReferencePolicyList Items is an array of ReferencePolicy again
```
