### PR TITLE
Ensure that "Supports:" statements stand alone in the docs

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -222,6 +222,7 @@ type HTTPRouteRule struct {
 	// recommended to return a 503 status code.
 	//
 	// Support: Core for Kubernetes Service
+	//
 	// Support: Custom for any other resource
 	//
 	// Support for weight: Core
@@ -550,6 +551,7 @@ type HTTPRouteFilter struct {
 	RequestRedirect *HTTPRequestRedirectFilter `json:"requestRedirect,omitempty"`
 
 	// URLRewrite defines a schema for a filter that modifies a request during forwarding.
+	//
 	// Support: Extended
 	//
 	// <gateway:experimental>
@@ -820,8 +822,9 @@ type HTTPRequestRedirectFilter struct {
 // forwarding. At most one of these filters may be used on a Route rule. This
 // MUST NOT be used on the same Route rule as a HTTPRequestRedirect filter.
 //
-// <gateway:experimental>
 // Support: Extended
+//
+// <gateway:experimental>
 type HTTPURLRewriteFilter struct {
 	// Hostname is the value to be used to replace the Host header value during
 	// forwarding.
@@ -860,6 +863,7 @@ type HTTPRequestMirrorFilter struct {
 	// should be used to provide more detail about the problem.
 	//
 	// Support: Extended for Kubernetes Service
+	//
 	// Support: Custom for any other resource
 	BackendRef BackendObjectReference `json:"backendRef"`
 }

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -39,6 +39,7 @@ type ParentReference struct {
 	// Kind is kind of the referent.
 	//
 	// Support: Core (Gateway)
+	//
 	// Support: Custom (Other Resources)
 	//
 	// +kubebuilder:default=Gateway

--- a/apis/v1alpha2/tcproute_types.go
+++ b/apis/v1alpha2/tcproute_types.go
@@ -67,6 +67,7 @@ type TCPRouteRule struct {
 	// connections, then 80% of connections must be rejected instead.
 	//
 	// Support: Core for Kubernetes Service
+	//
 	// Support: Custom for any other resource
 	//
 	// Support for weight: Extended

--- a/apis/v1alpha2/tlsroute_types.go
+++ b/apis/v1alpha2/tlsroute_types.go
@@ -111,6 +111,7 @@ type TLSRouteRule struct {
 	// instead.
 	//
 	// Support: Core for Kubernetes Service
+	//
 	// Support: Custom for any other resource
 	//
 	// Support for weight: Extended

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -549,6 +549,7 @@ type HTTPRouteFilter struct {
 	RequestRedirect *HTTPRequestRedirectFilter `json:"requestRedirect,omitempty"`
 
 	// URLRewrite defines a schema for a filter that modifies a request during forwarding.
+	//
 	// Support: Extended
 	//
 	// <gateway:experimental>
@@ -819,8 +820,9 @@ type HTTPRequestRedirectFilter struct {
 // forwarding. At most one of these filters may be used on a Route rule. This
 // MUST NOT be used on the same Route rule as a HTTPRequestRedirect filter.
 //
-// <gateway:experimental>
 // Support: Extended
+//
+// <gateway:experimental>
 type HTTPURLRewriteFilter struct {
 	// Hostname is the value to be used to replace the Host header value during
 	// forwarding.
@@ -859,6 +861,7 @@ type HTTPRequestMirrorFilter struct {
 	// should be used to provide more detail about the problem.
 	//
 	// Support: Extended for Kubernetes Service
+	//
 	// Support: Custom for any other resource
 	BackendRef BackendObjectReference `json:"backendRef"`
 }

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -39,6 +39,7 @@ type ParentReference struct {
 	// Kind is kind of the referent.
 	//
 	// Support: Core (Gateway)
+	//
 	// Support: Custom (Other Resources)
 	//
 	// +kubebuilder:default=Gateway

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -131,7 +131,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Custom (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -232,8 +232,8 @@ spec:
                         been routed to an invalid backend MUST receive a 500 status
                         code. \n When a BackendRef refers to a Service that has no
                         ready endpoints, it is recommended to return a 503 status
-                        code. \n Support: Core for Kubernetes Service Support: Custom
-                        for any other resource \n Support for weight: Core"
+                        code. \n Support: Core for Kubernetes Service \n Support:
+                        Custom for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
                           forward an HTTP request.
@@ -420,7 +420,7 @@ spec:
                                         Message of the `ResolvedRefs` Condition should
                                         be used to provide more detail about the problem.
                                         \n Support: Extended for Kubernetes Service
-                                        Support: Custom for any other resource"
+                                        \n Support: Custom for any other resource"
                                       properties:
                                         group:
                                           default: ""
@@ -597,7 +597,7 @@ spec:
                                 urlRewrite:
                                   description: "URLRewrite defines a schema for a
                                     filter that modifies a request during forwarding.
-                                    Support: Extended \n <gateway:experimental>"
+                                    \n Support: Extended \n <gateway:experimental>"
                                   properties:
                                     hostname:
                                       description: "Hostname is the value to be used
@@ -904,7 +904,7 @@ spec:
                                   In either error case, the Message of the `ResolvedRefs`
                                   Condition should be used to provide more detail
                                   about the problem. \n Support: Extended for Kubernetes
-                                  Service Support: Custom for any other resource"
+                                  Service \n Support: Custom for any other resource"
                                 properties:
                                   group:
                                     default: ""
@@ -1070,7 +1070,7 @@ spec:
                             type: string
                           urlRewrite:
                             description: "URLRewrite defines a schema for a filter
-                              that modifies a request during forwarding. Support:
+                              that modifies a request during forwarding. \n Support:
                               Extended \n <gateway:experimental>"
                             properties:
                               hostname:
@@ -1460,7 +1460,7 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Custom (Other Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1663,7 +1663,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Custom (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1952,7 +1952,7 @@ spec:
                                         Message of the `ResolvedRefs` Condition should
                                         be used to provide more detail about the problem.
                                         \n Support: Extended for Kubernetes Service
-                                        Support: Custom for any other resource"
+                                        \n Support: Custom for any other resource"
                                       properties:
                                         group:
                                           default: ""
@@ -2129,7 +2129,7 @@ spec:
                                 urlRewrite:
                                   description: "URLRewrite defines a schema for a
                                     filter that modifies a request during forwarding.
-                                    Support: Extended \n <gateway:experimental>"
+                                    \n Support: Extended \n <gateway:experimental>"
                                   properties:
                                     hostname:
                                       description: "Hostname is the value to be used
@@ -2436,7 +2436,7 @@ spec:
                                   In either error case, the Message of the `ResolvedRefs`
                                   Condition should be used to provide more detail
                                   about the problem. \n Support: Extended for Kubernetes
-                                  Service Support: Custom for any other resource"
+                                  Service \n Support: Custom for any other resource"
                                 properties:
                                   group:
                                     default: ""
@@ -2602,7 +2602,7 @@ spec:
                             type: string
                           urlRewrite:
                             description: "URLRewrite defines a schema for a filter
-                              that modifies a request during forwarding. Support:
+                              that modifies a request during forwarding. \n Support:
                               Extended \n <gateway:experimental>"
                             properties:
                               hostname:
@@ -2992,7 +2992,7 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Custom (Other Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -79,7 +79,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Custom (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -165,8 +165,8 @@ spec:
                         attempts to this backend. Connection rejections must respect
                         weight; if an invalid backend is requested to have 80% of
                         connections, then 80% of connections must be rejected instead.
-                        \n Support: Core for Kubernetes Service Support: Custom for
-                        any other resource \n Support for weight: Extended"
+                        \n Support: Core for Kubernetes Service \n Support: Custom
+                        for any other resource \n Support for weight: Extended"
                       items:
                         description: "BackendRef defines how a Route should forward
                           a request to a Kubernetes resource. \n Note that when a
@@ -394,7 +394,7 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Custom (Other Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -125,7 +125,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Custom (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -214,7 +214,7 @@ spec:
                         code. Request rejections must respect weight; if an invalid
                         backend is requested to have 80% of requests, then 80% of
                         requests must be rejected instead. \n Support: Core for Kubernetes
-                        Service Support: Custom for any other resource \n Support
+                        Service \n Support: Custom for any other resource \n Support
                         for weight: Extended"
                       items:
                         description: "BackendRef defines how a Route should forward
@@ -443,7 +443,7 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Custom (Other Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -79,7 +79,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Custom (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -394,7 +394,7 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Custom (Other Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -131,7 +131,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Custom (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -206,8 +206,8 @@ spec:
                         been routed to an invalid backend MUST receive a 500 status
                         code. \n When a BackendRef refers to a Service that has no
                         ready endpoints, it is recommended to return a 503 status
-                        code. \n Support: Core for Kubernetes Service Support: Custom
-                        for any other resource \n Support for weight: Core"
+                        code. \n Support: Core for Kubernetes Service \n Support:
+                        Custom for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
                           forward an HTTP request.
@@ -394,7 +394,7 @@ spec:
                                         Message of the `ResolvedRefs` Condition should
                                         be used to provide more detail about the problem.
                                         \n Support: Extended for Kubernetes Service
-                                        Support: Custom for any other resource"
+                                        \n Support: Custom for any other resource"
                                       properties:
                                         group:
                                           default: ""
@@ -779,7 +779,7 @@ spec:
                                   In either error case, the Message of the `ResolvedRefs`
                                   Condition should be used to provide more detail
                                   about the problem. \n Support: Extended for Kubernetes
-                                  Service Support: Custom for any other resource"
+                                  Service \n Support: Custom for any other resource"
                                 properties:
                                   group:
                                     default: ""
@@ -1243,7 +1243,7 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Custom (Other Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1418,7 +1418,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Custom (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1681,7 +1681,7 @@ spec:
                                         Message of the `ResolvedRefs` Condition should
                                         be used to provide more detail about the problem.
                                         \n Support: Extended for Kubernetes Service
-                                        Support: Custom for any other resource"
+                                        \n Support: Custom for any other resource"
                                       properties:
                                         group:
                                           default: ""
@@ -2066,7 +2066,7 @@ spec:
                                   In either error case, the Message of the `ResolvedRefs`
                                   Condition should be used to provide more detail
                                   about the problem. \n Support: Extended for Kubernetes
-                                  Service Support: Custom for any other resource"
+                                  Service \n Support: Custom for any other resource"
                                 properties:
                                   group:
                                     default: ""
@@ -2530,7 +2530,7 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Custom (Other Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Some of the "Supports:" statements in the doc didn't have an empty
line preceding them so the markdown engine squashed them into the end
of the previous paragraph. More diligent people than I probably
noticed this but I missed one completely so this change ensures that
each is its own paragraph. In most cases this is simply adding a blank
line.

**Does this PR introduce a user-facing change?**:
```release-note
Spacing has been improved around the documentation of feature-level core/extended support for better readability and clarity.
```
