### PR TITLE
Update HTTPRoute BackendRef docs to clarify error behavior

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -207,7 +207,7 @@ type HTTPRouteRule struct {
 	//
 	// If *all* entries in BackendRefs are invalid, and there are also no filters
 	// specified in this route rule, *all* traffic which matches this rule MUST
-	// recieve a 500 status code (exactly).
+	// receive a 500 status code (exactly).
 	//
 	// See the HTTPBackendRef definition for the rules about what makes a single
 	// HTTPBackendRef invalid.

--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -207,7 +207,7 @@ type HTTPRouteRule struct {
 	//
 	// If *all* entries in BackendRefs are invalid, and there are also no filters
 	// specified in this route rule, *all* traffic which matches this rule MUST
-	// receive a 500 status code (exactly).
+	// receive a 500 status code.
 	//
 	// See the HTTPBackendRef definition for the rules about what makes a single
 	// HTTPBackendRef invalid.
@@ -221,9 +221,6 @@ type HTTPRouteRule struct {
 	// For example, if two backends are specified with equal weights, and one is
 	// invalid, 50 percent of traffic must receive a 500. Implementations may
 	// choose how that 50 percent is determined.
-	//
-	// When a HTTPBackendRef refers to a Service that has no ready endpoints,
-	// implementations MAY return a 503 for requests to that backend instead.
 	//
 	// Support: Core for Kubernetes Service
 	//

--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -202,24 +202,27 @@ type HTTPRouteRule struct {
 	// BackendRefs defines the backend(s) where matching requests should be
 	// sent.
 	//
-	// A 500 status code MUST be returned if there are no BackendRefs or filters
-	// specified that would result in a response being sent.
+	// Failure behavior here depends on how many BackendRefs are specified and
+	// how many are invalid.
 	//
-	// A BackendRef is considered invalid when it refers to:
+	// If *all* entries in BackendRefs are invalid, and there are also no filters
+	// specified in this route rule, *all* traffic which matches this rule MUST
+	// recieve a 500 status code (exactly).
 	//
-	// * an unknown or unsupported kind of resource
-	// * a resource that does not exist
-	// * a resource in another namespace when the reference has not been
-	//   explicitly allowed by a ReferenceGrant (or equivalent concept).
+	// See the HTTPBackendRef definition for the rules about what makes a single
+	// HTTPBackendRef invalid.
 	//
-	// When a BackendRef is invalid, 500 status codes MUST be returned for
+	// When a HTTPBackendRef is invalid, 500 status codes MUST be returned for
 	// requests that would have otherwise been routed to an invalid backend. If
 	// multiple backends are specified, and some are invalid, the proportion of
 	// requests that would otherwise have been routed to an invalid backend
 	// MUST receive a 500 status code.
 	//
-	// When a BackendRef refers to a Service that has no ready endpoints, it is
-	// recommended to return a 503 status code.
+	// For example, if two backends are specified with equal weights, and one is
+	// invalid, 50 percent of traffic must randomly receive a 500.
+	//
+	// When a HTTPBackendRef refers to a Service that has no ready endpoints,
+	// implementations MAY return a 503 for requests to that backend instead.
 	//
 	// Support: Core for Kubernetes Service
 	//
@@ -933,21 +936,30 @@ type HTTPRequestMirrorFilter struct {
 type HTTPBackendRef struct {
 	// BackendRef is a reference to a backend to forward matched requests to.
 	//
-	// If the referent cannot be found, this HTTPBackendRef is invalid and must
-	// be dropped from the Gateway. The controller must ensure the
-	// "ResolvedRefs" condition on the Route is set to `status: False` and not
-	// configure this backend in the underlying implementation.
+	// A BackendRef can be invalid for the following reasons. In all cases, the
+	// implementation MUST ensure the `ResolvedRefs` Condition on the Route
+	// is set to `status: False`, with a Reason and Message that indicate
+	// what is the cause of the error.
 	//
-	// If there is a cross-namespace reference to an *existing* object
-	// that is not covered by a ReferenceGrant, the controller must ensure the
-	// "ResolvedRefs"  condition on the Route is set to `status: False`,
-	// with the "RefNotPermitted" reason and not configure this backend in the
-	// underlying implementation.
+	// A BackendRef is invalid if:
 	//
-	// In either error case, the Message of the `ResolvedRefs` Condition
-	// should be used to provide more detail about the problem.
+	// * It refers to an unknown or unsupported kind of resource. In this
+	//   case, the Reason and Message of the Condition must explain which kind
+	//   of resource is unknown or unsupported.
 	//
-	// Support: Custom
+	// * It refers to a resource that does not exist. In this case, the Reason
+	//   and Message of the Condition must explain which resource does not exist.
+	//
+	// * It refers a resource in another namespace when the reference has not been
+	//   explicitly allowed by a ReferenceGrant (or equivalent concept). In this
+	//   case, the Reason and Message of the Condition must explain which cross-
+	//   namespace reference is not allowed.
+	//
+	// Support: Core for Kubernetes Service
+	//
+	// Support: Custom for any other resource
+	//
+	// Support for weight: Core
 	//
 	// +optional
 	BackendRef `json:",inline"`

--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -944,16 +944,17 @@ type HTTPBackendRef struct {
 	// A BackendRef is invalid if:
 	//
 	// * It refers to an unknown or unsupported kind of resource. In this
-	//   case, the Reason and Message of the Condition must explain which kind
-	//   of resource is unknown or unsupported.
+	//   case, the Reason must be set to `InvalidKind` and Message of the
+	//   Condition must explain which kind of resource is unknown or unsupported.
 	//
-	// * It refers to a resource that does not exist. In this case, the Reason
-	//   and Message of the Condition must explain which resource does not exist.
+	// * It refers to a resource that does not exist. In this case, the Reason must
+	//   be set to `BackendNotFound` and the Message of the Condition must explain
+	//   which resource does not exist.
 	//
 	// * It refers a resource in another namespace when the reference has not been
 	//   explicitly allowed by a ReferenceGrant (or equivalent concept). In this
-	//   case, the Reason and Message of the Condition must explain which cross-
-	//   namespace reference is not allowed.
+	//   case, the Reason must be set to `RefNotPermitted` and the Message of the
+	//   Condition must explain which cross-namespace reference is not allowed.
 	//
 	// Support: Core for Kubernetes Service
 	//

--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -219,7 +219,8 @@ type HTTPRouteRule struct {
 	// MUST receive a 500 status code.
 	//
 	// For example, if two backends are specified with equal weights, and one is
-	// invalid, 50 percent of traffic must randomly receive a 500.
+	// invalid, 50 percent of traffic must receive a 500. Implementations may
+	// choose how that 50 percent is determined.
 	//
 	// When a HTTPBackendRef refers to a Service that has no ready endpoints,
 	// implementations MAY return a 503 for requests to that backend instead.

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -246,6 +246,15 @@ const (
 	// another namespace, where the object in the other namespace does
 	// not have a ReferenceGrant explicitly allowing the reference.
 	RouteReasonRefNotPermitted RouteConditionReason = "RefNotPermitted"
+
+	// This reason is used with the "ResolvedRefs" condition when
+	// one of the Route's rules has a reference to an unknown or unsupported
+	// Group and/or Kind.
+	RouteReasonInvalidKind RouteConditionReason = "InvalidKind"
+
+	// This reason is used with the "ResolvedRefs" condition when
+	// one of the Route's rules has a reference to a resource that does not exist.
+	RouteReasonBackendNotFound RouteConditionReason = "BackendNotFound"
 )
 
 // RouteParentStatus describes the status of a route with respect to an

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -252,8 +252,8 @@ const (
 	// Group and/or Kind.
 	RouteReasonInvalidKind RouteConditionReason = "InvalidKind"
 
-	// This reason is used with the "ResolvedRefs" condition when
-	// one of the Route's rules has a reference to a resource that does not exist.
+	// This reason is used with the "ResolvedRefs" condition when one of the
+	// Route's rules has a reference to a resource that does not exist.
 	RouteReasonBackendNotFound RouteConditionReason = "BackendNotFound"
 )
 

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -206,7 +206,7 @@ type HTTPRouteRule struct {
 	//
 	// If *all* entries in BackendRefs are invalid, and there are also no filters
 	// specified in this route rule, *all* traffic which matches this rule MUST
-	// receive a 500 status code (exactly).
+	// receive a 500 status code.
 	//
 	// See the HTTPBackendRef definition for the rules about what makes a single
 	// HTTPBackendRef invalid.
@@ -220,9 +220,6 @@ type HTTPRouteRule struct {
 	// For example, if two backends are specified with equal weights, and one is
 	// invalid, 50 percent of traffic must receive a 500. Implementations may
 	// choose how that 50 percent is determined.
-	//
-	// When a HTTPBackendRef refers to a Service that has no ready endpoints,
-	// implementations MAY return a 503 for requests to that backend instead.
 	//
 	// Support: Core for Kubernetes Service
 	//

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -201,24 +201,28 @@ type HTTPRouteRule struct {
 	// BackendRefs defines the backend(s) where matching requests should be
 	// sent.
 	//
-	// A 500 status code MUST be returned if there are no BackendRefs or filters
-	// specified that would result in a response being sent.
+	// Failure behavior here depends on how many BackendRefs are specified and
+	// how many are invalid.
 	//
-	// A BackendRef is considered invalid when it refers to:
+	// If *all* entries in BackendRefs are invalid, and there are also no filters
+	// specified in this route rule, *all* traffic which matches this rule MUST
+	// recieve a 500 status code (exactly).
 	//
-	// * an unknown or unsupported kind of resource
-	// * a resource that does not exist
-	// * a resource in another namespace when the reference has not been
-	//   explicitly allowed by a ReferenceGrant (or equivalent concept).
+	// See the HTTPBackendRef definition for the rules about what makes a single
+	// HTTPBackendRef invalid.
 	//
-	// When a BackendRef is invalid, 500 status codes MUST be returned for
+	// When a HTTPBackendRef is invalid, 500 status codes MUST be returned for
 	// requests that would have otherwise been routed to an invalid backend. If
 	// multiple backends are specified, and some are invalid, the proportion of
 	// requests that would otherwise have been routed to an invalid backend
 	// MUST receive a 500 status code.
 	//
-	// When a BackendRef refers to a Service that has no ready endpoints, it is
-	// recommended to return a 503 status code.
+	// For example, if two backends are specified with equal weights, and one is
+	// invalid, 50 percent of traffic must receive a 500. Implementations may
+	// choose how that 50 percent is determined.
+	//
+	// When a HTTPBackendRef refers to a Service that has no ready endpoints,
+	// implementations MAY return a 503 for requests to that backend instead.
 	//
 	// Support: Core for Kubernetes Service
 	//
@@ -932,21 +936,31 @@ type HTTPRequestMirrorFilter struct {
 type HTTPBackendRef struct {
 	// BackendRef is a reference to a backend to forward matched requests to.
 	//
-	// If the referent cannot be found, this HTTPBackendRef is invalid and must
-	// be dropped from the Gateway. The controller must ensure the
-	// "ResolvedRefs" condition on the Route is set to `status: False` and not
-	// configure this backend in the underlying implementation.
+	// A BackendRef can be invalid for the following reasons. In all cases, the
+	// implementation MUST ensure the `ResolvedRefs` Condition on the Route
+	// is set to `status: False`, with a Reason and Message that indicate
+	// what is the cause of the error.
 	//
-	// If there is a cross-namespace reference to an *existing* object
-	// that is not covered by a ReferenceGrant, the controller must ensure the
-	// "ResolvedRefs"  condition on the Route is set to `status: False`,
-	// with the "RefNotPermitted" reason and not configure this backend in the
-	// underlying implementation.
+	// A BackendRef is invalid if:
 	//
-	// In either error case, the Message of the `ResolvedRefs` Condition
-	// should be used to provide more detail about the problem.
+	// * It refers to an unknown or unsupported kind of resource. In this
+	//   case, the Reason must be set to `InvalidKind` and Message of the
+	//   Condition must explain which kind of resource is unknown or unsupported.
 	//
-	// Support: Custom
+	// * It refers to a resource that does not exist. In this case, the Reason must
+	//   be set to `BackendNotFound` and the Message of the Condition must explain
+	//   which resource does not exist.
+	//
+	// * It refers a resource in another namespace when the reference has not been
+	//   explicitly allowed by a ReferenceGrant (or equivalent concept). In this
+	//   case, the Reason must be set to `RefNotPermitted` and the Message of the
+	//   Condition must explain which cross-namespace reference is not allowed.
+	//
+	// Support: Core for Kubernetes Service
+	//
+	// Support: Custom for any other resource
+	//
+	// Support for weight: Core
 	//
 	// +optional
 	BackendRef `json:",inline"`

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -206,7 +206,7 @@ type HTTPRouteRule struct {
 	//
 	// If *all* entries in BackendRefs are invalid, and there are also no filters
 	// specified in this route rule, *all* traffic which matches this rule MUST
-	// recieve a 500 status code (exactly).
+	// receive a 500 status code (exactly).
 	//
 	// See the HTTPBackendRef definition for the rules about what makes a single
 	// HTTPBackendRef invalid.

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -246,6 +246,15 @@ const (
 	// another namespace, where the object in the other namespace does
 	// not have a ReferenceGrant explicitly allowing the reference.
 	RouteReasonRefNotPermitted RouteConditionReason = "RefNotPermitted"
+
+	// This reason is used with the "ResolvedRefs" condition when
+	// one of the Route's rules has a reference to an unknown or unsupported
+	// Group and/or Kind.
+	RouteReasonInvalidKind RouteConditionReason = "InvalidKind"
+
+	// This reason is used with the "ResolvedRefs" condition when
+	// one of the Route's rules has a reference to a resource that does not exist.
+	RouteReasonBackendNotFound RouteConditionReason = "BackendNotFound"
 )
 
 // RouteParentStatus describes the status of a route with respect to an

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -252,8 +252,8 @@ const (
 	// Group and/or Kind.
 	RouteReasonInvalidKind RouteConditionReason = "InvalidKind"
 
-	// This reason is used with the "ResolvedRefs" condition when
-	// one of the Route's rules has a reference to a resource that does not exist.
+	// This reason is used with the "ResolvedRefs" condition when one of the
+	// Route's rules has a reference to a resource that does not exist.
 	RouteReasonBackendNotFound RouteConditionReason = "BackendNotFound"
 )
 

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -1821,8 +1821,8 @@ spec:
                         on how many BackendRefs are specified and how many are invalid.
                         \n If *all* entries in BackendRefs are invalid, and there
                         are also no filters specified in this route rule, *all* traffic
-                        which matches this rule MUST receive a 500 status code (exactly).
-                        \n See the HTTPBackendRef definition for the rules about what
+                        which matches this rule MUST receive a 500 status code. \n
+                        See the HTTPBackendRef definition for the rules about what
                         makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
                         is invalid, 500 status codes MUST be returned for requests
                         that would have otherwise been routed to an invalid backend.
@@ -1832,11 +1832,8 @@ spec:
                         \n For example, if two backends are specified with equal weights,
                         and one is invalid, 50 percent of traffic must receive a 500.
                         Implementations may choose how that 50 percent is determined.
-                        \n When a HTTPBackendRef refers to a Service that has no ready
-                        endpoints, implementations MAY return a 503 for requests to
-                        that backend instead. \n Support: Core for Kubernetes Service
-                        \n Support: Custom for any other resource \n Support for weight:
-                        Core"
+                        \n Support: Core for Kubernetes Service \n Support: Custom
+                        for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
                           forward an HTTP request.

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -218,22 +218,26 @@ spec:
                   properties:
                     backendRefs:
                       description: "BackendRefs defines the backend(s) where matching
-                        requests should be sent. \n A 500 status code MUST be returned
-                        if there are no BackendRefs or filters specified that would
-                        result in a response being sent. \n A BackendRef is considered
-                        invalid when it refers to: \n * an unknown or unsupported
-                        kind of resource * a resource that does not exist * a resource
-                        in another namespace when the reference has not been   explicitly
-                        allowed by a ReferenceGrant (or equivalent concept). \n When
-                        a BackendRef is invalid, 500 status codes MUST be returned
-                        for requests that would have otherwise been routed to an invalid
-                        backend. If multiple backends are specified, and some are
-                        invalid, the proportion of requests that would otherwise have
-                        been routed to an invalid backend MUST receive a 500 status
-                        code. \n When a BackendRef refers to a Service that has no
-                        ready endpoints, it is recommended to return a 503 status
-                        code. \n Support: Core for Kubernetes Service \n Support:
-                        Custom for any other resource \n Support for weight: Core"
+                        requests should be sent. \n Failure behavior here depends
+                        on how many BackendRefs are specified and how many are invalid.
+                        \n If *all* entries in BackendRefs are invalid, and there
+                        are also no filters specified in this route rule, *all* traffic
+                        which matches this rule MUST recieve a 500 status code (exactly).
+                        \n See the HTTPBackendRef definition for the rules about what
+                        makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
+                        is invalid, 500 status codes MUST be returned for requests
+                        that would have otherwise been routed to an invalid backend.
+                        If multiple backends are specified, and some are invalid,
+                        the proportion of requests that would otherwise have been
+                        routed to an invalid backend MUST receive a 500 status code.
+                        \n For example, if two backends are specified with equal weights,
+                        and one is invalid, 50 percent of traffic must receive a 500.
+                        Implementations may choose how that 50 percent is determined.
+                        \n When a HTTPBackendRef refers to a Service that has no ready
+                        endpoints, implementations MAY return a 503 for requests to
+                        that backend instead. \n Support: Core for Kubernetes Service
+                        \n Support: Custom for any other resource \n Support for weight:
+                        Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
                           forward an HTTP request.
@@ -1816,22 +1820,26 @@ spec:
                   properties:
                     backendRefs:
                       description: "BackendRefs defines the backend(s) where matching
-                        requests should be sent. \n A 500 status code MUST be returned
-                        if there are no BackendRefs or filters specified that would
-                        result in a response being sent. \n A BackendRef is considered
-                        invalid when it refers to: \n * an unknown or unsupported
-                        kind of resource * a resource that does not exist * a resource
-                        in another namespace when the reference has not been   explicitly
-                        allowed by a ReferenceGrant (or equivalent concept). \n When
-                        a BackendRef is invalid, 500 status codes MUST be returned
-                        for requests that would have otherwise been routed to an invalid
-                        backend. If multiple backends are specified, and some are
-                        invalid, the proportion of requests that would otherwise have
-                        been routed to an invalid backend MUST receive a 500 status
-                        code. \n When a BackendRef refers to a Service that has no
-                        ready endpoints, it is recommended to return a 503 status
-                        code. \n Support: Core for Kubernetes Service \n Support:
-                        Custom for any other resource \n Support for weight: Core"
+                        requests should be sent. \n Failure behavior here depends
+                        on how many BackendRefs are specified and how many are invalid.
+                        \n If *all* entries in BackendRefs are invalid, and there
+                        are also no filters specified in this route rule, *all* traffic
+                        which matches this rule MUST recieve a 500 status code (exactly).
+                        \n See the HTTPBackendRef definition for the rules about what
+                        makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
+                        is invalid, 500 status codes MUST be returned for requests
+                        that would have otherwise been routed to an invalid backend.
+                        If multiple backends are specified, and some are invalid,
+                        the proportion of requests that would otherwise have been
+                        routed to an invalid backend MUST receive a 500 status code.
+                        \n For example, if two backends are specified with equal weights,
+                        and one is invalid, 50 percent of traffic must receive a 500.
+                        Implementations may choose how that 50 percent is determined.
+                        \n When a HTTPBackendRef refers to a Service that has no ready
+                        endpoints, implementations MAY return a 503 for requests to
+                        that backend instead. \n Support: Core for Kubernetes Service
+                        \n Support: Custom for any other resource \n Support for weight:
+                        Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
                           forward an HTTP request.

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -222,8 +222,8 @@ spec:
                         on how many BackendRefs are specified and how many are invalid.
                         \n If *all* entries in BackendRefs are invalid, and there
                         are also no filters specified in this route rule, *all* traffic
-                        which matches this rule MUST receive a 500 status code (exactly).
-                        \n See the HTTPBackendRef definition for the rules about what
+                        which matches this rule MUST receive a 500 status code. \n
+                        See the HTTPBackendRef definition for the rules about what
                         makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
                         is invalid, 500 status codes MUST be returned for requests
                         that would have otherwise been routed to an invalid backend.
@@ -233,11 +233,8 @@ spec:
                         \n For example, if two backends are specified with equal weights,
                         and one is invalid, 50 percent of traffic must receive a 500.
                         Implementations may choose how that 50 percent is determined.
-                        \n When a HTTPBackendRef refers to a Service that has no ready
-                        endpoints, implementations MAY return a 503 for requests to
-                        that backend instead. \n Support: Core for Kubernetes Service
-                        \n Support: Custom for any other resource \n Support for weight:
-                        Core"
+                        \n Support: Core for Kubernetes Service \n Support: Custom
+                        for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
                           forward an HTTP request.

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -222,7 +222,7 @@ spec:
                         on how many BackendRefs are specified and how many are invalid.
                         \n If *all* entries in BackendRefs are invalid, and there
                         are also no filters specified in this route rule, *all* traffic
-                        which matches this rule MUST recieve a 500 status code (exactly).
+                        which matches this rule MUST receive a 500 status code (exactly).
                         \n See the HTTPBackendRef definition for the rules about what
                         makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
                         is invalid, 500 status codes MUST be returned for requests
@@ -1824,7 +1824,7 @@ spec:
                         on how many BackendRefs are specified and how many are invalid.
                         \n If *all* entries in BackendRefs are invalid, and there
                         are also no filters specified in this route rule, *all* traffic
-                        which matches this rule MUST recieve a 500 status code (exactly).
+                        which matches this rule MUST receive a 500 status code (exactly).
                         \n See the HTTPBackendRef definition for the rules about what
                         makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
                         is invalid, 500 status codes MUST be returned for requests

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -1524,8 +1524,8 @@ spec:
                         on how many BackendRefs are specified and how many are invalid.
                         \n If *all* entries in BackendRefs are invalid, and there
                         are also no filters specified in this route rule, *all* traffic
-                        which matches this rule MUST receive a 500 status code (exactly).
-                        \n See the HTTPBackendRef definition for the rules about what
+                        which matches this rule MUST receive a 500 status code. \n
+                        See the HTTPBackendRef definition for the rules about what
                         makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
                         is invalid, 500 status codes MUST be returned for requests
                         that would have otherwise been routed to an invalid backend.
@@ -1535,11 +1535,8 @@ spec:
                         \n For example, if two backends are specified with equal weights,
                         and one is invalid, 50 percent of traffic must receive a 500.
                         Implementations may choose how that 50 percent is determined.
-                        \n When a HTTPBackendRef refers to a Service that has no ready
-                        endpoints, implementations MAY return a 503 for requests to
-                        that backend instead. \n Support: Core for Kubernetes Service
-                        \n Support: Custom for any other resource \n Support for weight:
-                        Core"
+                        \n Support: Core for Kubernetes Service \n Support: Custom
+                        for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
                           forward an HTTP request.

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -196,7 +196,7 @@ spec:
                         on how many BackendRefs are specified and how many are invalid.
                         \n If *all* entries in BackendRefs are invalid, and there
                         are also no filters specified in this route rule, *all* traffic
-                        which matches this rule MUST recieve a 500 status code (exactly).
+                        which matches this rule MUST receive a 500 status code (exactly).
                         \n See the HTTPBackendRef definition for the rules about what
                         makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
                         is invalid, 500 status codes MUST be returned for requests
@@ -1527,7 +1527,7 @@ spec:
                         on how many BackendRefs are specified and how many are invalid.
                         \n If *all* entries in BackendRefs are invalid, and there
                         are also no filters specified in this route rule, *all* traffic
-                        which matches this rule MUST recieve a 500 status code (exactly).
+                        which matches this rule MUST receive a 500 status code (exactly).
                         \n See the HTTPBackendRef definition for the rules about what
                         makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
                         is invalid, 500 status codes MUST be returned for requests

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -196,8 +196,8 @@ spec:
                         on how many BackendRefs are specified and how many are invalid.
                         \n If *all* entries in BackendRefs are invalid, and there
                         are also no filters specified in this route rule, *all* traffic
-                        which matches this rule MUST receive a 500 status code (exactly).
-                        \n See the HTTPBackendRef definition for the rules about what
+                        which matches this rule MUST receive a 500 status code. \n
+                        See the HTTPBackendRef definition for the rules about what
                         makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
                         is invalid, 500 status codes MUST be returned for requests
                         that would have otherwise been routed to an invalid backend.
@@ -207,11 +207,8 @@ spec:
                         \n For example, if two backends are specified with equal weights,
                         and one is invalid, 50 percent of traffic must receive a 500.
                         Implementations may choose how that 50 percent is determined.
-                        \n When a HTTPBackendRef refers to a Service that has no ready
-                        endpoints, implementations MAY return a 503 for requests to
-                        that backend instead. \n Support: Core for Kubernetes Service
-                        \n Support: Custom for any other resource \n Support for weight:
-                        Core"
+                        \n Support: Core for Kubernetes Service \n Support: Custom
+                        for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
                           forward an HTTP request.

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -192,22 +192,26 @@ spec:
                   properties:
                     backendRefs:
                       description: "BackendRefs defines the backend(s) where matching
-                        requests should be sent. \n A 500 status code MUST be returned
-                        if there are no BackendRefs or filters specified that would
-                        result in a response being sent. \n A BackendRef is considered
-                        invalid when it refers to: \n * an unknown or unsupported
-                        kind of resource * a resource that does not exist * a resource
-                        in another namespace when the reference has not been   explicitly
-                        allowed by a ReferenceGrant (or equivalent concept). \n When
-                        a BackendRef is invalid, 500 status codes MUST be returned
-                        for requests that would have otherwise been routed to an invalid
-                        backend. If multiple backends are specified, and some are
-                        invalid, the proportion of requests that would otherwise have
-                        been routed to an invalid backend MUST receive a 500 status
-                        code. \n When a BackendRef refers to a Service that has no
-                        ready endpoints, it is recommended to return a 503 status
-                        code. \n Support: Core for Kubernetes Service \n Support:
-                        Custom for any other resource \n Support for weight: Core"
+                        requests should be sent. \n Failure behavior here depends
+                        on how many BackendRefs are specified and how many are invalid.
+                        \n If *all* entries in BackendRefs are invalid, and there
+                        are also no filters specified in this route rule, *all* traffic
+                        which matches this rule MUST recieve a 500 status code (exactly).
+                        \n See the HTTPBackendRef definition for the rules about what
+                        makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
+                        is invalid, 500 status codes MUST be returned for requests
+                        that would have otherwise been routed to an invalid backend.
+                        If multiple backends are specified, and some are invalid,
+                        the proportion of requests that would otherwise have been
+                        routed to an invalid backend MUST receive a 500 status code.
+                        \n For example, if two backends are specified with equal weights,
+                        and one is invalid, 50 percent of traffic must receive a 500.
+                        Implementations may choose how that 50 percent is determined.
+                        \n When a HTTPBackendRef refers to a Service that has no ready
+                        endpoints, implementations MAY return a 503 for requests to
+                        that backend instead. \n Support: Core for Kubernetes Service
+                        \n Support: Custom for any other resource \n Support for weight:
+                        Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
                           forward an HTTP request.
@@ -1519,22 +1523,26 @@ spec:
                   properties:
                     backendRefs:
                       description: "BackendRefs defines the backend(s) where matching
-                        requests should be sent. \n A 500 status code MUST be returned
-                        if there are no BackendRefs or filters specified that would
-                        result in a response being sent. \n A BackendRef is considered
-                        invalid when it refers to: \n * an unknown or unsupported
-                        kind of resource * a resource that does not exist * a resource
-                        in another namespace when the reference has not been   explicitly
-                        allowed by a ReferenceGrant (or equivalent concept). \n When
-                        a BackendRef is invalid, 500 status codes MUST be returned
-                        for requests that would have otherwise been routed to an invalid
-                        backend. If multiple backends are specified, and some are
-                        invalid, the proportion of requests that would otherwise have
-                        been routed to an invalid backend MUST receive a 500 status
-                        code. \n When a BackendRef refers to a Service that has no
-                        ready endpoints, it is recommended to return a 503 status
-                        code. \n Support: Core for Kubernetes Service \n Support:
-                        Custom for any other resource \n Support for weight: Core"
+                        requests should be sent. \n Failure behavior here depends
+                        on how many BackendRefs are specified and how many are invalid.
+                        \n If *all* entries in BackendRefs are invalid, and there
+                        are also no filters specified in this route rule, *all* traffic
+                        which matches this rule MUST recieve a 500 status code (exactly).
+                        \n See the HTTPBackendRef definition for the rules about what
+                        makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
+                        is invalid, 500 status codes MUST be returned for requests
+                        that would have otherwise been routed to an invalid backend.
+                        If multiple backends are specified, and some are invalid,
+                        the proportion of requests that would otherwise have been
+                        routed to an invalid backend MUST receive a 500 status code.
+                        \n For example, if two backends are specified with equal weights,
+                        and one is invalid, 50 percent of traffic must receive a 500.
+                        Implementations may choose how that 50 percent is determined.
+                        \n When a HTTPBackendRef refers to a Service that has no ready
+                        endpoints, implementations MAY return a 503 for requests to
+                        that backend instead. \n Support: Core for Kubernetes Service
+                        \n Support: Custom for any other resource \n Support for weight:
+                        Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
                           forward an HTTP request.

--- a/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go
+++ b/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go
@@ -50,6 +50,7 @@ var GatewaySecretReferenceGrantAllInNamespace = suite.ConformanceTest{
 					{
 						Type:   string(v1alpha2.ListenerConditionReady),
 						Status: metav1.ConditionTrue,
+						Reason: string(v1alpha2.ListenerReasonReady),
 					},
 				},
 			}}

--- a/conformance/tests/gateway-secret-reference-grant-specific.go
+++ b/conformance/tests/gateway-secret-reference-grant-specific.go
@@ -50,6 +50,7 @@ var GatewaySecretReferenceGrantSpecific = suite.ConformanceTest{
 					{
 						Type:   string(v1alpha2.ListenerConditionReady),
 						Status: metav1.ConditionTrue,
+						Reason: string(v1alpha2.ListenerReasonReady),
 					},
 				},
 			}}

--- a/conformance/tests/httproute-hostname-intersection.go
+++ b/conformance/tests/httproute-hostname-intersection.go
@@ -199,6 +199,7 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 					{
 						Type:   string(v1alpha2.RouteConditionAccepted),
 						Status: metav1.ConditionFalse,
+						Reason: string(v1alpha2.RouteReasonNoMatchingListenerHostname),
 					},
 				},
 			}}

--- a/conformance/tests/httproute-invalid-backendref-nonexistent.go
+++ b/conformance/tests/httproute-invalid-backendref-nonexistent.go
@@ -44,14 +44,13 @@ var HTTPRouteInvalidNonExistentBackendRef = suite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		t.Run("HTTPRoute with only a nonexistent BackendRef has a ResolvedRefs Condition with status False and Reason BackendNotFound", func(t *testing.T) {
-
 			resolvedRefsCond := metav1.Condition{
 				Type:   string(v1alpha2.RouteConditionResolvedRefs),
 				Status: metav1.ConditionFalse,
 				Reason: string(v1alpha2.RouteReasonBackendNotFound),
 			}
 
-			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, routeNN, resolvedRefsCond, 60)
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, routeNN, gwNN, resolvedRefsCond, 60)
 		})
 
 		t.Run("HTTP Request to invalid nonexistent backend receive a 500", func(t *testing.T) {

--- a/conformance/tests/httproute-invalid-backendref-nonexistent.go
+++ b/conformance/tests/httproute-invalid-backendref-nonexistent.go
@@ -29,7 +29,7 @@ import (
 )
 
 func init() {
-	ConformanceTests = append(ConformanceTests, HTTPRouteInvalidCrossNamespaceBackendRef)
+	ConformanceTests = append(ConformanceTests, HTTPRouteInvalidNonExistentBackendRef)
 }
 
 var HTTPRouteInvalidNonExistentBackendRef = suite.ConformanceTest{

--- a/conformance/tests/httproute-invalid-backendref-nonexistent.go
+++ b/conformance/tests/httproute-invalid-backendref-nonexistent.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteInvalidCrossNamespaceBackendRef)
+}
+
+var HTTPRouteInvalidNonExistentBackendRef = suite.ConformanceTest{
+	ShortName:   "HTTPRouteInvalidNonExistentBackendRef",
+	Description: "A single HTTPRoute in the gateway-conformance-infra namespace should set a ResolvedRefs status False with reason RefNotPermitted and return 500 when binding to a Gateway in the same namespace if the route has a BackendRef Service that does not exist",
+	Exemptions: []suite.ExemptFeature{
+		suite.ExemptReferenceGrant,
+	},
+	Manifests: []string{"tests/httproute-invalid-backendref-nonexistent.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		routeNN := types.NamespacedName{Name: "invalid-nonexistent-backend-ref", Namespace: "gateway-conformance-infra"}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
+
+		ns := v1alpha2.Namespace(gwNN.Namespace)
+		kind := v1alpha2.Kind("Gateway")
+
+		// TODO(mikemorris): Add check for Accepted condition once
+		// https://github.com/kubernetes-sigs/gateway-api/issues/1112
+		// has been resolved
+		t.Run("Route status should have a route parent status with a ResolvedRefs condition with status False and reason RefNotPermitted", func(t *testing.T) {
+			parents := []v1alpha2.RouteParentStatus{{
+				ParentRef: v1alpha2.ParentReference{
+					Group:     (*v1alpha2.Group)(&v1alpha2.GroupVersion.Group),
+					Kind:      &kind,
+					Name:      v1alpha2.ObjectName(gwNN.Name),
+					Namespace: &ns,
+				},
+				ControllerName: v1alpha2.GatewayController(suite.ControllerName),
+				Conditions: []metav1.Condition{{
+					Type:   string(v1alpha2.RouteConditionResolvedRefs),
+					Status: metav1.ConditionFalse,
+					Reason: string(v1alpha2.RouteReasonBackendNotFound),
+				}},
+			}}
+
+			kubernetes.HTTPRouteMustHaveParents(t, suite.Client, routeNN, parents, false, 60)
+		})
+
+		// TODO(mikemorris): Add check for Listener attached routes or
+		// Listener ResolvedRefs RefNotPermitted condition once
+		// https://github.com/kubernetes-sigs/gateway-api/issues/1112
+		// has been resolved
+
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN))
+		t.Run("HTTP Request to invalid nonexistent backend receive a 500", func(t *testing.T) {
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, http.ExpectedResponse{
+				Request: http.ExpectedRequest{
+					Method: "GET",
+					Path:   "/v2",
+				},
+				StatusCode: 500,
+			})
+		})
+
+	},
+}

--- a/conformance/tests/httproute-invalid-backendref-nonexistent.go
+++ b/conformance/tests/httproute-invalid-backendref-nonexistent.go
@@ -56,7 +56,7 @@ var HTTPRouteInvalidNonExistentBackendRef = suite.ConformanceTest{
 
 		t.Run("HTTP Request to invalid nonexistent backend receive a 500", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, http.ExpectedResponse{
-				Request: http.ExpectedRequest{
+				Request: http.Request{
 					Method: "GET",
 					Path:   "/",
 				},

--- a/conformance/tests/httproute-invalid-backendref-nonexistent.yaml
+++ b/conformance/tests/httproute-invalid-backendref-nonexistent.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: invalid-nonexistent-backend-ref
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: nonexistent
+      namespace: gateway-conformance-infra
+      port: 8080

--- a/conformance/tests/httproute-invalid-backendref-unknown-kind.go
+++ b/conformance/tests/httproute-invalid-backendref-unknown-kind.go
@@ -57,7 +57,7 @@ var HTTPRouteInvalidBackendRefUnknownKind = suite.ConformanceTest{
 
 		t.Run("HTTP Request to invalid backend with invalid Kind receives a 500", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, http.ExpectedResponse{
-				Request: http.ExpectedRequest{
+				Request: http.Request{
 					Method: "GET",
 					Path:   "/v2",
 				},

--- a/conformance/tests/httproute-invalid-backendref-unknown-kind.go
+++ b/conformance/tests/httproute-invalid-backendref-unknown-kind.go
@@ -29,7 +29,7 @@ import (
 )
 
 func init() {
-	ConformanceTests = append(ConformanceTests, HTTPRouteInvalidCrossNamespaceBackendRef)
+	ConformanceTests = append(ConformanceTests, HTTPRouteInvalidBackendRefUnknownKind)
 }
 
 var HTTPRouteInvalidBackendRefUnknownKind = suite.ConformanceTest{

--- a/conformance/tests/httproute-invalid-backendref-unknown-kind.go
+++ b/conformance/tests/httproute-invalid-backendref-unknown-kind.go
@@ -45,14 +45,13 @@ var HTTPRouteInvalidBackendRefUnknownKind = suite.ConformanceTest{
 
 		// The Route must have a ResolvedRefs Condition with a InvalidKind Reason.
 		t.Run("HTTPRoute with Invalid Kind has a ResolvedRefs Condition with status False and Reason InvalidKind", func(t *testing.T) {
-
 			resolvedRefsCond := metav1.Condition{
 				Type:   string(v1alpha2.RouteConditionResolvedRefs),
 				Status: metav1.ConditionFalse,
 				Reason: string(v1alpha2.RouteReasonInvalidKind),
 			}
 
-			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, routeNN, resolvedRefsCond, 60)
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, routeNN, gwNN, resolvedRefsCond, 60)
 		})
 
 		t.Run("HTTP Request to invalid backend with invalid Kind receives a 500", func(t *testing.T) {

--- a/conformance/tests/httproute-invalid-backendref-unknown-kind.go
+++ b/conformance/tests/httproute-invalid-backendref-unknown-kind.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteInvalidCrossNamespaceBackendRef)
+}
+
+var HTTPRouteInvalidBackendRefUnknownKind = suite.ConformanceTest{
+	ShortName:   "HTTPRouteInvalidBackendRefUnknownKind",
+	Description: "A single HTTPRoute in the gateway-conformance-infra namespace should set a ResolvedRefs status False with reason RefNotPermitted when attempting to bind to a Gateway in the same namespace if the route has a BackendRef that points to an unknown Kind.",
+	Exemptions: []suite.ExemptFeature{
+		suite.ExemptReferenceGrant,
+	},
+	Manifests: []string{"tests/httproute-invalid-cross-namespace-backend-ref.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		routeNN := types.NamespacedName{Name: "invalid-cross-namespace-backend-ref", Namespace: "gateway-conformance-infra"}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
+
+		ns := v1alpha2.Namespace(gwNN.Namespace)
+		kind := v1alpha2.Kind("Gateway")
+
+		// TODO(mikemorris): Add check for Accepted condition once
+		// https://github.com/kubernetes-sigs/gateway-api/issues/1112
+		// has been resolved
+		t.Run("Route status should have a route parent status with a ResolvedRefs condition with status False and reason RefNotPermitted", func(t *testing.T) {
+			parents := []v1alpha2.RouteParentStatus{{
+				ParentRef: v1alpha2.ParentReference{
+					Group:     (*v1alpha2.Group)(&v1alpha2.GroupVersion.Group),
+					Kind:      &kind,
+					Name:      v1alpha2.ObjectName(gwNN.Name),
+					Namespace: &ns,
+				},
+				ControllerName: v1alpha2.GatewayController(suite.ControllerName),
+				Conditions: []metav1.Condition{{
+					Type:   string(v1alpha2.RouteConditionResolvedRefs),
+					Status: metav1.ConditionFalse,
+					Reason: string(v1alpha2.RouteReasonInvalidKind),
+				}},
+			}}
+
+			kubernetes.HTTPRouteMustHaveParents(t, suite.Client, routeNN, parents, false, 60)
+		})
+
+		// TODO(mikemorris): Add check for Listener attached routes or
+		// Listener ResolvedRefs RefNotPermitted condition once
+		// https://github.com/kubernetes-sigs/gateway-api/issues/1112
+		// has been resolved
+
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN))
+		t.Run("HTTP Request to invalid cross-namespace backend receive a 500", func(t *testing.T) {
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, http.ExpectedResponse{
+				Request: http.ExpectedRequest{
+					Method: "GET",
+					Path:   "/v2",
+				},
+				StatusCode: 500,
+			})
+		})
+
+	},
+}

--- a/conformance/tests/httproute-invalid-backendref-unknown-kind.yaml
+++ b/conformance/tests/httproute-invalid-backendref-unknown-kind.yaml
@@ -8,7 +8,7 @@ spec:
   - name: same-namespace
   rules:
   - backendRefs:
-    - group: unknownkind.io
+    - group: unknownkind.example.com
       kind: NonExistent
       name: web-backend
       namespace: gateway-conformance-web-backend

--- a/conformance/tests/httproute-invalid-backendref-unknown-kind.yaml
+++ b/conformance/tests/httproute-invalid-backendref-unknown-kind.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: invalid-cross-namespace-backend-ref
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - group: unknownkind.io
+      kind: NonExistent
+      name: web-backend
+      namespace: gateway-conformance-web-backend
+      port: 8080

--- a/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
@@ -43,42 +43,25 @@ var HTTPRouteInvalidCrossNamespaceBackendRef = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "invalid-cross-namespace-backend-ref", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 
-		ns := v1alpha2.Namespace(gwNN.Namespace)
-		kind := v1alpha2.Kind("Gateway")
+		// The Route must be Attached.
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
-		// TODO(mikemorris): Add check for Accepted condition once
-		// https://github.com/kubernetes-sigs/gateway-api/issues/1112
-		// has been resolved
-		t.Run("Route status should have a route parent status with a ResolvedRefs condition with status False and reason RefNotPermitted", func(t *testing.T) {
-			parents := []v1alpha2.RouteParentStatus{{
-				ParentRef: v1alpha2.ParentReference{
-					Group:     (*v1alpha2.Group)(&v1alpha2.GroupVersion.Group),
-					Kind:      &kind,
-					Name:      v1alpha2.ObjectName(gwNN.Name),
-					Namespace: &ns,
-				},
-				ControllerName: v1alpha2.GatewayController(suite.ControllerName),
-				Conditions: []metav1.Condition{{
-					Type:   string(v1alpha2.RouteConditionResolvedRefs),
-					Status: metav1.ConditionFalse,
-					Reason: string(v1alpha2.RouteReasonRefNotPermitted),
-				}},
-			}}
+		t.Run("HTTPRoute with only a nonexistent BackendRef has a ResolvedRefs Condition with status False and Reason RefNotPermitted", func(t *testing.T) {
 
-			kubernetes.HTTPRouteMustHaveParents(t, suite.Client, routeNN, parents, false, 60)
+			resolvedRefsCond := metav1.Condition{
+				Type:   string(v1alpha2.RouteConditionResolvedRefs),
+				Status: metav1.ConditionFalse,
+				Reason: string(v1alpha2.RouteReasonRefNotPermitted),
+			}
+
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, routeNN, resolvedRefsCond, 60)
 		})
 
-		// TODO(mikemorris): Add check for Listener attached routes or
-		// Listener ResolvedRefs RefNotPermitted condition once
-		// https://github.com/kubernetes-sigs/gateway-api/issues/1112
-		// has been resolved
-
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN))
-		t.Run("HTTP Request to invalid cross-namespace backend receive a 500", func(t *testing.T) {
+		t.Run("HTTP Request to invalid cross-namespace backend must receive a 500", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, http.ExpectedResponse{
 				Request: http.ExpectedRequest{
 					Method: "GET",
-					Path:   "/v2",
+					Path:   "/",
 				},
 				StatusCode: 500,
 			})

--- a/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
@@ -46,7 +46,7 @@ var HTTPRouteInvalidCrossNamespaceBackendRef = suite.ConformanceTest{
 		// The Route must be Attached.
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
-		t.Run("HTTPRoute with only a nonexistent BackendRef has a ResolvedRefs Condition with status False and Reason RefNotPermitted", func(t *testing.T) {
+		t.Run("HTTPRoute with a cross-namespace BackendRef and no ReferenceGrant has a ResolvedRefs Condition with status False and Reason RefNotPermitted", func(t *testing.T) {
 
 			resolvedRefsCond := metav1.Condition{
 				Type:   string(v1alpha2.RouteConditionResolvedRefs),

--- a/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
@@ -54,7 +54,7 @@ var HTTPRouteInvalidCrossNamespaceBackendRef = suite.ConformanceTest{
 				Reason: string(v1alpha2.RouteReasonRefNotPermitted),
 			}
 
-			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, routeNN, resolvedRefsCond, 60)
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, routeNN, gwNN, resolvedRefsCond, 60)
 		})
 
 		t.Run("HTTP Request to invalid cross-namespace backend must receive a 500", func(t *testing.T) {

--- a/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
@@ -59,7 +59,7 @@ var HTTPRouteInvalidCrossNamespaceBackendRef = suite.ConformanceTest{
 
 		t.Run("HTTP Request to invalid cross-namespace backend must receive a 500", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, http.ExpectedResponse{
-				Request: http.ExpectedRequest{
+				Request: http.Request{
 					Method: "GET",
 					Path:   "/",
 				},

--- a/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 )
@@ -71,5 +72,17 @@ var HTTPRouteInvalidCrossNamespaceBackendRef = suite.ConformanceTest{
 		// Listener ResolvedRefs RefNotPermitted condition once
 		// https://github.com/kubernetes-sigs/gateway-api/issues/1112
 		// has been resolved
+
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN))
+		t.Run("HTTP Request to invalid cross-namespace backend receive a 500", func(t *testing.T) {
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, http.ExpectedResponse{
+				Request: http.ExpectedRequest{
+					Method: "GET",
+					Path:   "/v2",
+				},
+				StatusCode: 500,
+			})
+		})
+
 	},
 }

--- a/conformance/tests/httproute-invalid-reference-grant.go
+++ b/conformance/tests/httproute-invalid-reference-grant.go
@@ -98,13 +98,13 @@ var HTTPRouteInvalidReferenceGrant = suite.ConformanceTest{
 		// at least one allowed BackendRef should be accepted by a Gateway
 		// and partially configured.
 
-		t.Run("Simple HTTP request should not reach app-backend-v2", func(t *testing.T) {
+		t.Run("HTTP Request to invalid backend with missing referenceGrant should receive a 500", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, gwAddr, http.ExpectedResponse{
 				Request: http.Request{
 					Method: "GET",
 					Path:   "/v2",
 				},
-				StatusCode: 404,
+				StatusCode: 500,
 			})
 		})
 	},

--- a/conformance/tests/httproute-invalid-reference-grant.go
+++ b/conformance/tests/httproute-invalid-reference-grant.go
@@ -69,7 +69,7 @@ var HTTPRouteInvalidReferenceGrant = suite.ConformanceTest{
 
 		t.Run("HTTP Request to valid sibling backend should succeed", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, gwAddr, http.ExpectedResponse{
-				Request: http.ExpectedRequest{
+				Request: http.Request{
 					Method: "GET",
 					Path:   "/",
 				},

--- a/conformance/tests/httproute-invalid-reference-grant.go
+++ b/conformance/tests/httproute-invalid-reference-grant.go
@@ -43,60 +43,19 @@ var HTTPRouteInvalidReferenceGrant = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "invalid-reference-grant", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 
-		ns := v1alpha2.Namespace(gwNN.Namespace)
-		gwKind := v1alpha2.Kind("Gateway")
+		// Route and Gateway must be Attached.
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, s.Client, s.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
-		t.Run("Route status should have a route parent status with a ResolvedRefs condition with status False and reason RefNotPermitted", func(t *testing.T) {
-			parents := []v1alpha2.RouteParentStatus{{
-				ParentRef: v1alpha2.ParentReference{
-					Group:     (*v1alpha2.Group)(&v1alpha2.GroupVersion.Group),
-					Kind:      &gwKind,
-					Name:      v1alpha2.ObjectName(gwNN.Name),
-					Namespace: &ns,
-				},
-				ControllerName: v1alpha2.GatewayController(s.ControllerName),
-				Conditions: []metav1.Condition{{
-					Type:   string(v1alpha2.RouteConditionResolvedRefs),
-					Status: metav1.ConditionFalse,
-					Reason: string(v1alpha2.RouteReasonRefNotPermitted),
-				}},
-			}}
+		t.Run("HTTPRoute with BackendRef in another namespace and no ReferenceGrant covering the Service has a ResolvedRefs Condition with status False and Reason RefNotPermitted", func(t *testing.T) {
 
-			kubernetes.HTTPRouteMustHaveParents(t, s.Client, routeNN, parents, false, 60)
+			resolvedRefsCond := metav1.Condition{
+				Type:   string(v1alpha2.RouteConditionResolvedRefs),
+				Status: metav1.ConditionFalse,
+				Reason: string(v1alpha2.RouteReasonRefNotPermitted),
+			}
+
+			kubernetes.HTTPRouteMustHaveCondition(t, s.Client, routeNN, resolvedRefsCond, 60)
 		})
-
-		// TODO(mikemorris): Un-comment check for Listener ResolvedRefs
-		// RefNotPermitted condition and/or add check for attached
-		// routes and any expected Listener conditions once
-		// https://github.com/kubernetes-sigs/gateway-api/issues/1112
-		// has been resolved
-		// t.Run("Gateway listener should have a ResolvedRefs condition with status False and reason RefNotPermitted", func(t *testing.T) {
-		// 	listeners := []v1alpha2.ListenerStatus{{
-		// 		Name: v1alpha2.SectionName("http"),
-		// 		SupportedKinds: []v1alpha2.RouteGroupKind{{
-		// 			Group: (*v1alpha2.Group)(&v1alpha2.GroupVersion.Group),
-		// 			Kind:  v1alpha2.Kind("HTTPRoute"),
-		// 		}},
-		// 		Conditions: []metav1.Condition{{
-		// 			Type:   string(v1alpha2.RouteConditionResolvedRefs),
-		// 			Status: metav1.ConditionFalse,
-		// 			Reason: string(v1alpha2.RouteReasonRefNotPermitted),
-		// 		}},
-		// 	}}
-
-		// 	kubernetes.GatewayStatusMustHaveListeners(t, s.Client, gwNN, listeners, 60)
-		// })
-
-		// TODO(mikemorris): Add routeNN to the end of the arguments below
-		// to add check for Accepted condition once
-		// https://github.com/kubernetes-sigs/gateway-api/issues/1112
-		// has been resolved
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, s.Client, s.ControllerName, kubernetes.NewGatewayRef(gwNN))
-
-		// TODO(mikemorris): Add check for HTTP requests successfully reaching
-		// app-backend-v1 at path "/" if it is determined that a Route with at
-		// at least one allowed BackendRef should be accepted by a Gateway
-		// and partially configured.
 
 		t.Run("HTTP Request to invalid backend with missing referenceGrant should receive a 500", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, gwAddr, http.ExpectedResponse{
@@ -107,5 +66,16 @@ var HTTPRouteInvalidReferenceGrant = suite.ConformanceTest{
 				StatusCode: 500,
 			})
 		})
+
+		t.Run("HTTP Request to valid sibling backend should succeed", func(t *testing.T) {
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, gwAddr, http.ExpectedResponse{
+				Request: http.ExpectedRequest{
+					Method: "GET",
+					Path:   "/",
+				},
+				StatusCode: 200,
+			})
+		})
+
 	},
 }

--- a/conformance/tests/httproute-invalid-reference-grant.go
+++ b/conformance/tests/httproute-invalid-reference-grant.go
@@ -74,6 +74,8 @@ var HTTPRouteInvalidReferenceGrant = suite.ConformanceTest{
 					Path:   "/",
 				},
 				StatusCode: 200,
+				Backend:    "app-backend-v1",
+				Namespace:  "gateway-conformance-app-backend",
 			})
 		})
 

--- a/conformance/tests/httproute-invalid-reference-grant.go
+++ b/conformance/tests/httproute-invalid-reference-grant.go
@@ -54,7 +54,7 @@ var HTTPRouteInvalidReferenceGrant = suite.ConformanceTest{
 				Reason: string(v1alpha2.RouteReasonRefNotPermitted),
 			}
 
-			kubernetes.HTTPRouteMustHaveCondition(t, s.Client, routeNN, resolvedRefsCond, 60)
+			kubernetes.HTTPRouteMustHaveCondition(t, s.Client, routeNN, gwNN, resolvedRefsCond, 60)
 		})
 
 		t.Run("HTTP Request to invalid backend with missing referenceGrant should receive a 500", func(t *testing.T) {

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -81,7 +81,8 @@ func GWCMustBeAccepted(t *testing.T, c client.Client, gwcName string, seconds in
 		}
 
 		controllerName = string(gwc.Spec.ControllerName)
-		return findConditionInList(t, gwc.Status.Conditions, "Accepted", "True", "Accepted"), nil
+		// Passing an empty string as the Reason means that any Reason will do.
+		return findConditionInList(t, gwc.Status.Conditions, "Accepted", "True", ""), nil
 	})
 	require.NoErrorf(t, waitErr, "error waiting for %s GatewayClass to have Accepted condition set to True: %v", gwcName, waitErr)
 
@@ -106,7 +107,8 @@ func NamespacesMustBeReady(t *testing.T, c client.Client, namespaces []string, s
 				t.Errorf("Error listing Gateways: %v", err)
 			}
 			for _, gw := range gwList.Items {
-				if !findConditionInList(t, gw.Status.Conditions, "Ready", "True", "Ready") {
+				// Passing an empty string as the Reason means that any Reason will do.
+				if !findConditionInList(t, gw.Status.Conditions, "Ready", "True", "") {
 					t.Logf("%s/%s Gateway not ready yet", ns, gw.Name)
 					return false, nil
 				}

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -345,7 +345,7 @@ func GatewayStatusMustHaveListeners(t *testing.T, client client.Client, gwNN typ
 
 // HTTPRouteMustHaveConditions checks that the supplied HTTPRoute has the supplied Condition,
 // halting after the specified timeout is exceeded.
-func HTTPRouteMustHaveCondition(t *testing.T, client client.Client, routeNN types.NamespacedName, condition metav1.Condition, seconds int) {
+func HTTPRouteMustHaveCondition(t *testing.T, client client.Client, routeNN types.NamespacedName, gwNN types.NamespacedName, condition metav1.Condition, seconds int) {
 	t.Helper()
 
 	waitFor := time.Duration(seconds) * time.Second
@@ -363,10 +363,11 @@ func HTTPRouteMustHaveCondition(t *testing.T, client client.Client, routeNN type
 
 		var conditionFound bool
 		for _, parent := range parents {
-			if findConditionInList(t, parent.Conditions, condition.Type, string(condition.Status), condition.Reason) {
-				conditionFound = true
+			if parent.ParentRef.Name == v1alpha2.ObjectName(gwNN.Name) && string(*parent.ParentRef.Namespace) == gwNN.Namespace {
+				if findConditionInList(t, parent.Conditions, condition.Type, string(condition.Status), condition.Reason) {
+					conditionFound = true
+				}
 			}
-
 		}
 
 		return conditionFound, nil

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -165,6 +165,7 @@ func GatewayAndHTTPRoutesMustBeReady(t *testing.T, c client.Client, controllerNa
 					{
 						Type:   string(v1alpha2.RouteConditionAccepted),
 						Status: metav1.ConditionTrue,
+						Reason: string(v1alpha2.RouteReasonAccepted),
 					},
 				},
 			})


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup
/kind documentation


**What this PR does / why we need it**:

- Moves reasons for an individual BackendRef to be invalid so they are included in the HTTPBackendRef struct docs ( the BackendRef field).
- Clarifies rules for handling invalid BackendRefs in the BackendRefs field of the HTTPRouteRule struct.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1211
Updates #1112

**Does this PR introduce a user-facing change?**:
```release-note
The rules for BackendRefs have been updated to make clear that invalid BackendRefs must produce HTTP response codes of 500 in most cases.
```

This PR is still WIP, since I will need to change the conformance tests to check for the behavior. But I wanted to check that we really are in agreement on this behavior while I work on those.