### PR TITLE
Update examples to v1beta1

### DIFF
--- a/examples/experimental/v1alpha2/http-redirect-rewrite/httproute-redirect-full.yaml
+++ b/examples/experimental/v1alpha2/http-redirect-rewrite/httproute-redirect-full.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/experimental/v1alpha2/http-redirect-rewrite/httproute-redirect-https.yaml
+++ b/examples/experimental/v1alpha2/http-redirect-rewrite/httproute-redirect-https.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/experimental/v1alpha2/http-redirect-rewrite/httproute-redirect-prefix.yaml
+++ b/examples/experimental/v1alpha2/http-redirect-rewrite/httproute-redirect-prefix.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/experimental/v1alpha2/http-redirect-rewrite/httproute-rewrite-path.yaml
+++ b/examples/experimental/v1alpha2/http-redirect-rewrite/httproute-rewrite-path.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/experimental/v1alpha2/http-redirect-rewrite/httproute-rewrite.yaml
+++ b/examples/experimental/v1alpha2/http-redirect-rewrite/httproute-rewrite.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/experimental/v1beta1/http-redirect-rewrite/httproute-redirect-full.yaml
+++ b/examples/experimental/v1beta1/http-redirect-rewrite/httproute-redirect-full.yaml
@@ -1,3 +1,5 @@
+#$ Used in:
+#$ - site-src/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/examples/experimental/v1beta1/http-redirect-rewrite/httproute-redirect-https.yaml
+++ b/examples/experimental/v1beta1/http-redirect-rewrite/httproute-redirect-https.yaml
@@ -1,3 +1,5 @@
+#$ Used in:
+#$ - site-src/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/examples/experimental/v1beta1/http-redirect-rewrite/httproute-redirect-prefix.yaml
+++ b/examples/experimental/v1beta1/http-redirect-rewrite/httproute-redirect-prefix.yaml
@@ -1,3 +1,5 @@
+#$ Used in:
+#$ - site-src/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/examples/experimental/v1beta1/http-redirect-rewrite/httproute-rewrite-path.yaml
+++ b/examples/experimental/v1beta1/http-redirect-rewrite/httproute-rewrite-path.yaml
@@ -1,3 +1,5 @@
+#$ Used in:
+#$ - site-src/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/examples/experimental/v1beta1/http-redirect-rewrite/httproute-rewrite.yaml
+++ b/examples/experimental/v1beta1/http-redirect-rewrite/httproute-rewrite.yaml
@@ -1,3 +1,5 @@
+#$ Used in:
+#$ - site-src/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/basic-http.yaml
+++ b/examples/v1alpha2/basic-http.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: GatewayClass
 metadata:

--- a/examples/v1alpha2/cross-namespace-routing/0-namespaces.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/0-namespaces.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/guides/multiple-ns.md
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/examples/v1alpha2/cross-namespace-routing/gateway.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/gateway.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/guides/multiple-ns.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/cross-namespace-routing/site-route.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/site-route.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/guides/multiple-ns.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/cross-namespace-routing/store-route.yaml
+++ b/examples/v1alpha2/cross-namespace-routing/store-route.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/guides/multiple-ns.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/http-filter.yaml
+++ b/examples/v1alpha2/http-filter.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/http-route-attachment/gateway-namespaces.yaml
+++ b/examples/v1alpha2/http-route-attachment/gateway-namespaces.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/concepts/api-overview.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/http-route-attachment/gateway-strict.yaml
+++ b/examples/v1alpha2/http-route-attachment/gateway-strict.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/concepts/api-overview.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/http-route-attachment/httproute.yaml
+++ b/examples/v1alpha2/http-route-attachment/httproute.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/concepts/api-overview.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/http-routing/bar-httproute.yaml
+++ b/examples/v1alpha2/http-routing/bar-httproute.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/guides/http-routing.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/http-routing/foo-httproute.yaml
+++ b/examples/v1alpha2/http-routing/foo-httproute.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/guides/http-routing.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/http-routing/gateway.yaml
+++ b/examples/v1alpha2/http-routing/gateway.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/guides/http-routing.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/simple-gateway/gateway.yaml
+++ b/examples/v1alpha2/simple-gateway/gateway.yaml
@@ -1,6 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/guides/traffic-splitting.md
-#$ - site-src/v1alpha2/guides/simple-gateway.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/simple-gateway/httproute.yaml
+++ b/examples/v1alpha2/simple-gateway/httproute.yaml
@@ -1,5 +1,4 @@
 #$ Used in:
-#$ - site-src/v1alpha2/guides/simple-gateway.md
 #$ - site-src/blog/2021/introducing-v1alpha2.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute

--- a/examples/v1alpha2/tls-basic.yaml
+++ b/examples/v1alpha2/tls-basic.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/guides/tls.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1alpha2/traffic-splitting/simple-split.yaml
+++ b/examples/v1alpha2/traffic-splitting/simple-split.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/guides/traffic-splitting.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/traffic-splitting/traffic-split-1.yaml
+++ b/examples/v1alpha2/traffic-splitting/traffic-split-1.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/guides/traffic-splitting.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/traffic-splitting/traffic-split-2.yaml
+++ b/examples/v1alpha2/traffic-splitting/traffic-split-2.yaml
@@ -1,6 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/guides/traffic-splitting.md
-#$ - site-src/v1alpha2/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/traffic-splitting/traffic-split-3.yaml
+++ b/examples/v1alpha2/traffic-splitting/traffic-split-3.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/guides/traffic-splitting.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:

--- a/examples/v1alpha2/wildcard-tls-gateway.yaml
+++ b/examples/v1alpha2/wildcard-tls-gateway.yaml
@@ -1,5 +1,3 @@
-#$ Used in:
-#$ - site-src/v1alpha2/guides/tls.md
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: Gateway
 metadata:

--- a/examples/v1beta1/basic-http.yaml
+++ b/examples/v1beta1/basic-http.yaml
@@ -1,5 +1,5 @@
 #$ Used in:
-#$ - site-src/v1beta1/api-types/httproute.md
+#$ - site-src/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:

--- a/examples/v1beta1/cross-namespace-routing/0-namespaces.yaml
+++ b/examples/v1beta1/cross-namespace-routing/0-namespaces.yaml
@@ -1,5 +1,5 @@
 #$ Used in:
-#$ - site-src/v1beta1/guides/multiple-ns.md
+#$ - site-src/guides/multiple-ns.md
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/examples/v1beta1/cross-namespace-routing/gateway.yaml
+++ b/examples/v1beta1/cross-namespace-routing/gateway.yaml
@@ -1,5 +1,5 @@
 #$ Used in:
-#$ - site-src/v1beta1/guides/multiple-ns.md
+#$ - site-src/guides/multiple-ns.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:

--- a/examples/v1beta1/cross-namespace-routing/site-route.yaml
+++ b/examples/v1beta1/cross-namespace-routing/site-route.yaml
@@ -1,5 +1,5 @@
 #$ Used in:
-#$ - site-src/v1beta1/guides/multiple-ns.md
+#$ - site-src/guides/multiple-ns.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/examples/v1beta1/cross-namespace-routing/store-route.yaml
+++ b/examples/v1beta1/cross-namespace-routing/store-route.yaml
@@ -1,5 +1,5 @@
 #$ Used in:
-#$ - site-src/v1beta1/guides/multiple-ns.md
+#$ - site-src/guides/multiple-ns.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/examples/v1beta1/http-filter.yaml
+++ b/examples/v1beta1/http-filter.yaml
@@ -1,5 +1,5 @@
 #$ Used in:
-#$ - site-src/v1beta1/api-types/httproute.md
+#$ - site-src/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/examples/v1beta1/http-routing/bar-httproute.yaml
+++ b/examples/v1beta1/http-routing/bar-httproute.yaml
@@ -1,5 +1,5 @@
 #$ Used in:
-#$ - site-src/v1beta1/guides/http-routing.md
+#$ - site-src/guides/http-routing.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/examples/v1beta1/http-routing/foo-httproute.yaml
+++ b/examples/v1beta1/http-routing/foo-httproute.yaml
@@ -1,5 +1,5 @@
 #$ Used in:
-#$ - site-src/v1beta1/guides/http-routing.md
+#$ - site-src/guides/http-routing.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/examples/v1beta1/http-routing/gateway.yaml
+++ b/examples/v1beta1/http-routing/gateway.yaml
@@ -1,5 +1,5 @@
 #$ Used in:
-#$ - site-src/v1beta1/guides/http-routing.md
+#$ - site-src/guides/http-routing.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:

--- a/examples/v1beta1/simple-gateway/gateway.yaml
+++ b/examples/v1beta1/simple-gateway/gateway.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
-#$ - site-src/v1beta1/guides/traffic-splitting.md
-#$ - site-src/v1beta1/guides/simple-gateway.md
+#$ - site-src/guides/traffic-splitting.md
+#$ - site-src/guides/simple-gateway.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:

--- a/examples/v1beta1/simple-gateway/httproute.yaml
+++ b/examples/v1beta1/simple-gateway/httproute.yaml
@@ -1,5 +1,5 @@
 #$ Used in:
-#$ - site-src/v1beta1/guides/simple-gateway.md
+#$ - site-src/guides/simple-gateway.md
 #$ - site-src/blog/2021/introducing-v1beta1.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute

--- a/examples/v1beta1/tls-basic.yaml
+++ b/examples/v1beta1/tls-basic.yaml
@@ -1,5 +1,5 @@
 #$ Used in:
-#$ - site-src/v1beta1/guides/tls.md
+#$ - site-src/guides/tls.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:

--- a/examples/v1beta1/traffic-splitting/simple-split.yaml
+++ b/examples/v1beta1/traffic-splitting/simple-split.yaml
@@ -1,5 +1,5 @@
 #$ Used in:
-#$ - site-src/v1beta1/guides/traffic-splitting.md
+#$ - site-src/guides/traffic-splitting.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/examples/v1beta1/traffic-splitting/traffic-split-1.yaml
+++ b/examples/v1beta1/traffic-splitting/traffic-split-1.yaml
@@ -1,5 +1,5 @@
 #$ Used in:
-#$ - site-src/v1beta1/guides/traffic-splitting.md
+#$ - site-src/guides/traffic-splitting.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/examples/v1beta1/traffic-splitting/traffic-split-2.yaml
+++ b/examples/v1beta1/traffic-splitting/traffic-split-2.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
-#$ - site-src/v1beta1/guides/traffic-splitting.md
-#$ - site-src/v1beta1/api-types/httproute.md
+#$ - site-src/guides/traffic-splitting.md
+#$ - site-src/api-types/httproute.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/examples/v1beta1/traffic-splitting/traffic-split-3.yaml
+++ b/examples/v1beta1/traffic-splitting/traffic-split-3.yaml
@@ -1,5 +1,5 @@
 #$ Used in:
-#$ - site-src/v1beta1/guides/traffic-splitting.md
+#$ - site-src/guides/traffic-splitting.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/examples/v1beta1/wildcard-tls-gateway.yaml
+++ b/examples/v1beta1/wildcard-tls-gateway.yaml
@@ -1,5 +1,5 @@
 #$ Used in:
-#$ - site-src/v1beta1/guides/tls.md
+#$ - site-src/guides/tls.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:

--- a/site-src/api-types/gatewayclass.md
+++ b/site-src/api-types/gatewayclass.md
@@ -135,5 +135,5 @@ example.net/gateway/v2.1 // Use version 2.1
 example.net/gateway      // Use the default version
 ```
 
-[gatewayclass]: /references/spec/#gateway.networking.k8s.io/v1alpha2.GatewayClass
+[gatewayclass]: /references/spec/#gateway.networking.k8s.io/v1beta1.GatewayClass
 [ingress-class-api]: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class

--- a/site-src/api-types/gatewayclass.md
+++ b/site-src/api-types/gatewayclass.md
@@ -135,5 +135,5 @@ example.net/gateway/v2.1 // Use version 2.1
 example.net/gateway      // Use the default version
 ```
 
-[gatewayclass]: https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.GatewayClass
+[gatewayclass]: /references/spec/#gateway.networking.k8s.io/v1alpha2.GatewayClass
 [ingress-class-api]: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class

--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -197,12 +197,12 @@ only one Route rule may match each request. For more information on how conflict
 resolution applies to merging, refer to the [API specification][httprouterule].
 
 
-[httproute]: /references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRoute
-[httprouterule]: /references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRouteRule
-[hostname]: /references/spec/#gateway.networking.k8s.io/v1alpha2.Hostname
+[httproute]: /references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute
+[httprouterule]: /references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteRule
+[hostname]: /references/spec/#gateway.networking.k8s.io/v1beta1.Hostname
 [rfc-3986]: https://tools.ietf.org/html/rfc3986
-[matches]: /references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRouteMatch
-[filters]: /references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRouteFilter
-[backendRef]: /references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPBackendRef
-[parentRef]: /references/spec/#gateway.networking.k8s.io/v1alpha2.ParentRef
+[matches]: /references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteMatch
+[filters]: /references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteFilter
+[backendRef]: /references/spec/#gateway.networking.k8s.io/v1beta1.HTTPBackendRef
+[parentRef]: /references/spec/#gateway.networking.k8s.io/v1beta1.ParentRef
 

--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -27,7 +27,7 @@ here for implementations to support other types of parent resources.
 
 The following example shows how a Route would attach to the `acme-lb` Gateway:
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: httproute-example
@@ -56,7 +56,7 @@ rules and filters (optional).
 
 The following example defines hostname "my.example.com":
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: httproute-example
@@ -78,7 +78,7 @@ independent, i.e. this rule will be matched if any single match is satisfied.
 
 Take the following matches configuration as an example:
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 ...
 matches:
@@ -111,7 +111,7 @@ strategies, rate-limiting, and traffic shaping.
 The following example adds header "my-header: foo" to HTTP requests with Host
 header "my.filter.com".
 ```yaml
-{% include 'v1alpha2/http-filter.yaml' %}
+{% include 'v1beta1/http-filter.yaml' %}
 ```
 
 API conformance is defined based on the filter type. The effects of ordering
@@ -143,14 +143,14 @@ The following example forwards HTTP requests for prefix `/bar` to service
 "my-service1" on port `8080` and HTTP requests for prefix `/some/thing` with
 header `magic: foo` to service "my-service2" on port `8080`:
 ```yaml
-{% include 'v1alpha2/basic-http.yaml' %}
+{% include 'v1beta1/basic-http.yaml' %}
 ```
 
 The following example uses the `weight` field to forward 90% of HTTP requests to
 `foo.example.com` to the "foo-v1" Service and the other 10% to the "foo-v2"
 Service:
 ```yaml
-{% include 'v1alpha2/traffic-splitting/traffic-split-2.yaml' %}
+{% include 'v1beta1/traffic-splitting/traffic-split-2.yaml' %}
 ```
 
 Reference the [backendRef][backendRef] API documentation for additional details
@@ -176,7 +176,7 @@ appropriate when the route is modified.
 The following example indicates HTTPRoute "http-example" has been accepted by
 Gateway "gw-example" in namespace "gw-example-ns":
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: http-example

--- a/site-src/concepts/api-overview.md
+++ b/site-src/concepts/api-overview.md
@@ -239,20 +239,20 @@ The following `my-route` Route wants to attach to the `foo-gateway` in the
 attachment from HTTPRoutes in the namespace `gateway-api-example-ns2`.
 
 ```yaml
-{% include 'v1alpha2/http-route-attachment/httproute.yaml' %}
+{% include 'v1beta1/http-route-attachment/httproute.yaml' %}
 ```
 
 This `foo-gateway` allows the `my-route` HTTPRoute to attach.
 
 ```yaml
-{% include 'v1alpha2/http-route-attachment/gateway-strict.yaml' %}
+{% include 'v1beta1/http-route-attachment/gateway-strict.yaml' %}
 ```
 
 For a more permissive example, the below Gateway will allow all HTTPRoute resources
 to attach from Namespaces with the "expose-apps: true" label.
 
 ```yaml
-{% include 'v1alpha2/http-route-attachment/gateway-namespaces.yaml' %}
+{% include 'v1beta1/http-route-attachment/gateway-namespaces.yaml' %}
 ```
 
 ### Combined types

--- a/site-src/faq.md
+++ b/site-src/faq.md
@@ -75,4 +75,4 @@
 [2]: https://github.com/kubernetes-sigs/gateway-api/releases
 [tls]:https://en.wikipedia.org/wiki/Transport_Layer_Security
 [tlsroute]:/concepts/api-overview#tlsroute
-[tlsguide]:/v1alpha2/guides/tls
+[tlsguide]:/guides/tls

--- a/site-src/guides/http-redirect-rewrite.md
+++ b/site-src/guides/http-redirect-rewrite.md
@@ -21,7 +21,7 @@ example, to issue a permanent redirect (301) from HTTP to HTTPS, configure
 `requestRedirect.statusCode=301` and `requestRedirect.scheme="https"`:
 
 ```yaml
-{% include 'experimental/v1alpha2/http-redirect-rewrite/httproute-redirect-https.yaml' %}
+{% include 'experimental/v1beta1/http-redirect-rewrite/httproute-redirect-https.yaml' %}
 ```
 
 Redirects change configured URL components to match the redirect configuration
@@ -44,7 +44,7 @@ prefixes. For example, the HTTPRoute below will issue a 302 redirect to all
 `redirect.example` requests whose path begins with `/cayenne` to `/paprika`:
 
 ```yaml
-{% include 'experimental/v1alpha2/http-redirect-rewrite/httproute-redirect-full.yaml' %}
+{% include 'experimental/v1beta1/http-redirect-rewrite/httproute-redirect-full.yaml' %}
 ```
 
 Both requests to
@@ -56,7 +56,7 @@ The other path redirect type, `ReplacePrefixMatch`, replaces only the path
 portion matching `matches.path.value`. Changing the filter in the above to:
 
 ```yaml
-{% include 'experimental/v1alpha2/http-redirect-rewrite/httproute-redirect-prefix.yaml' %}
+{% include 'experimental/v1beta1/http-redirect-rewrite/httproute-redirect-prefix.yaml' %}
 ```
 
 will result in redirects with `location:
@@ -81,7 +81,7 @@ following HTTPRoute will accept a request for
 rewrite.example`.
 
 ```yaml
-{% include 'experimental/v1alpha2/http-redirect-rewrite/httproute-rewrite.yaml' %}
+{% include 'experimental/v1beta1/http-redirect-rewrite/httproute-rewrite.yaml' %}
 ```
 
 Path rewrites also make use of HTTP Path Modifiers. The HTTPRoute below
@@ -91,5 +91,5 @@ Instead using `type: ReplacePrefixMatch` and `replacePrefixMatch: /fennel` will
 request `https://elsewhere.example/fennel/smidgen` upstream.
 
 ```yaml
-{% include 'experimental/v1alpha2/http-redirect-rewrite/httproute-rewrite.yaml' %}
+{% include 'experimental/v1beta1/http-redirect-rewrite/httproute-rewrite.yaml' %}
 ```

--- a/site-src/guides/http-redirect-rewrite.md
+++ b/site-src/guides/http-redirect-rewrite.md
@@ -12,7 +12,7 @@ use both filter types at once.
 
 Redirects return HTTP 3XX responses to a client, instructing it to retrive a
 different resource. [`RequestRedirect` rule
-filters](/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRequestRedirectFilter)
+filters](/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRequestRedirectFilter)
 instruct Gateways to emit a redirect response to requests matching a filtered
 HTTPRoute rule.
 
@@ -73,7 +73,7 @@ https://redirect.example/paprika/teaspoon` response headers.
 
 Rewrites modify components of a client request before proxying it upstream. A
 [`URLRewrite`
-filter](/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPURLRewriteFilter)
+filter](/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPURLRewriteFilter)
 can change the upstream request hostname and/or path. For example, the
 following HTTPRoute will accept a request for
 `https://rewrite.example/cardamom` and send it upstream to `example-svc` with

--- a/site-src/guides/http-routing.md
+++ b/site-src/guides/http-routing.md
@@ -28,7 +28,7 @@ should be attached to. The following example shows how the combination
 of `Gateway` and `HTTPRoute` would be configured to serve HTTP traffic:
 
 ```yaml
-{% include 'v1alpha2/http-routing/gateway.yaml' %}
+{% include 'v1beta1/http-routing/gateway.yaml' %}
 ```
 
 An HTTPRoute can match against a [single set of hostnames][spec].
@@ -44,7 +44,7 @@ forwarded. Traffic to any other paths that do not begin with `/login` will not
 be matched by this Route.
 
 ```yaml
-{% include 'v1alpha2/http-routing/foo-httproute.yaml' %}
+{% include 'v1beta1/http-routing/foo-httproute.yaml' %}
 ```
 
 Similarly, the `bar-route` HTTPRoute matches traffic for `bar.example.com`. All
@@ -54,7 +54,7 @@ canary` header will be forwarded to `bar-svc-canary` and if the header is
 missing or not `canary` then it'll be forwarded to `bar-svc`.
 
 ```yaml
-{% include 'v1alpha2/http-routing/bar-httproute.yaml' %}
+{% include 'v1beta1/http-routing/bar-httproute.yaml' %}
 ```
 
 [gateway]: /references/spec/#gateway.networking.k8s.io/v1alpha2.Gateway

--- a/site-src/guides/http-routing.md
+++ b/site-src/guides/http-routing.md
@@ -57,6 +57,6 @@ missing or not `canary` then it'll be forwarded to `bar-svc`.
 {% include 'v1beta1/http-routing/bar-httproute.yaml' %}
 ```
 
-[gateway]: /references/spec/#gateway.networking.k8s.io/v1alpha2.Gateway
-[spec]: /references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRouteSpec
+[gateway]: /references/spec/#gateway.networking.k8s.io/v1beta1.Gateway
+[spec]: /references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteSpec
 [svc]:https://kubernetes.io/docs/concepts/services-networking/service/

--- a/site-src/guides/multiple-ns.md
+++ b/site-src/guides/multiple-ns.md
@@ -72,7 +72,7 @@ The infrastructure team deploys the `shared-gateway` Gateway into the `infra-ns`
 Namespace:
 
 ```yaml
-{% include 'v1alpha2/cross-namespace-routing/gateway.yaml' %}
+{% include 'v1beta1/cross-namespace-routing/gateway.yaml' %}
 ```
 
 The `https` listener in the above Gateway matches traffic for the
@@ -94,7 +94,7 @@ or which apps can use this Gateway by allowlisting a set of Namespaces.
 
 
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 spec:
   listeners:
@@ -114,7 +114,7 @@ a `parentRef`  for `infra-ns/shared-gateway`, it would be ignored by the
 Gateway because the  attachment constraint (Namespace label) was not met.
 
 ```yaml
-{% include 'v1alpha2/cross-namespace-routing/0-namespaces.yaml' %}
+{% include 'v1beta1/cross-namespace-routing/0-namespaces.yaml' %}
 ```
 
 Note that attachment constraints on the Gateway are not required, but they are
@@ -130,7 +130,7 @@ The store team deploys their route for the `store` Service in the `store-ns`
 Namespace:
 
 ```yaml
-{% include 'v1alpha2/cross-namespace-routing/store-route.yaml' %}
+{% include 'v1beta1/cross-namespace-routing/store-route.yaml' %}
 ```
 
 This Route has straightforward routing logic as it just matches for
@@ -151,7 +151,7 @@ specifies `gateway/shared-gateway` in the `infra-ns` Namespace as the only
 Gateway that these Routes want to attach to.
 
 ```yaml
-{% include 'v1alpha2/cross-namespace-routing/site-route.yaml' %}
+{% include 'v1beta1/cross-namespace-routing/site-route.yaml' %}
 ```
 
 After these three Routes are deployed, they will all be attached to the

--- a/site-src/guides/multiple-ns.md
+++ b/site-src/guides/multiple-ns.md
@@ -156,7 +156,7 @@ Gateway that these Routes want to attach to.
 
 After these three Routes are deployed, they will all be attached to the
 `shared-gateway` Gateway. The Gateway merges these Routes into a single flat
-list of routing rules. [Routing precedence](/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRouteRule)
+list of routing rules. [Routing precedence](/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteRule)
 between these routing rules is determined by most specific match and
 conflicts are handled according to [conflict
 resolution](/concepts/guidelines#conflicts). This provides predictable and

--- a/site-src/guides/simple-gateway.md
+++ b/site-src/guides/simple-gateway.md
@@ -9,7 +9,7 @@ match all HTTP traffic and directs it to a single Service named `foo-svc`.
 ![Simple Gateway](/images/single-service-gateway.png)
 
 ```yaml  
-{% include 'v1alpha2/simple-gateway/gateway.yaml' %}
+{% include 'v1beta1/simple-gateway/gateway.yaml' %}
 ```
 
 The Gateway represents the instantation of a logical load balancer. It's
@@ -30,7 +30,7 @@ will match all HTTP traffic that arrives at port 80 of the load balancer and
 send it to the `foo-svc` Pods. 
 
 ```yaml  
-{% include 'v1alpha2/simple-gateway/httproute.yaml' %}
+{% include 'v1beta1/simple-gateway/httproute.yaml' %}
 ```
 
 While Route resources are often used to filter traffic to many different

--- a/site-src/guides/tcp.md
+++ b/site-src/guides/tcp.md
@@ -49,8 +49,8 @@ In this way each `TCPRoute` "attaches" itself to a different port on the
 `Gateway` so that the service `my-foo-service` is taking traffic for port `8080`
 from outside the cluster and `my-bar-service` takes the port `8090` traffic.
 
-[tcproute]:/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute
+[tcproute]:/references/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute
 [tcp]:https://datatracker.ietf.org/doc/html/rfc793
-[httproute]:/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRoute
-[gateway]:/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.Gateway
+[httproute]:/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRoute
+[gateway]:/references/spec/#gateway.networking.k8s.io/v1alpha2.Gateway
 [svc]:https://kubernetes.io/docs/concepts/services-networking/service/

--- a/site-src/guides/tls.md
+++ b/site-src/guides/tls.md
@@ -75,7 +75,7 @@ In this example, the Gateway is configured to serve the `foo.example.com` and
 in the Gateway.
 
 ```yaml
-{% include 'v1alpha2/tls-basic.yaml' %}
+{% include 'v1beta1/tls-basic.yaml' %}
 ```
 
 #### Wildcard TLS listeners
@@ -87,7 +87,7 @@ Since a specific match takes priority, the Gateway will serve
 `wildcard-example-com-cert` for all other requests.
 
 ```yaml
-{% include 'v1alpha2/wildcard-tls-gateway.yaml' %}
+{% include 'v1beta1/wildcard-tls-gateway.yaml' %}
 ```
 
 #### Cross namespace certificate references

--- a/site-src/guides/traffic-splitting.md
+++ b/site-src/guides/traffic-splitting.md
@@ -41,7 +41,7 @@ production user traffic for `foo.example.com`. The following HTTPRoute has no
 recieve 100% of the traffic matched by each of their route rules. A canary
 route rule is used (matching the header `traffic=test`) to send synthetic test
 traffic before splitting any production user traffic to `foo-v2`.
-[Routing precedence](/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRouteRule)
+[Routing precedence](/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteRule)
 ensures that all traffic with the matching host and header 
 (the most specific match) will be sent to `foo-v2`.
 

--- a/site-src/guides/traffic-splitting.md
+++ b/site-src/guides/traffic-splitting.md
@@ -12,7 +12,7 @@ will split traffic 90% to `foo-v1` and 10% to `foo-v2`.
 ![Traffic splitting](/images/simple-split.png)
 
 ```yaml
-{% include 'v1alpha2/traffic-splitting/simple-split.yaml' %}  
+{% include 'v1beta1/traffic-splitting/simple-split.yaml' %}
 ```
 
 `weight` indicates a proportional split of traffic (rather than percentage)
@@ -30,7 +30,7 @@ is used to manage the gradual splitting of traffic from v1 to v2.
 This example assumes that the following Gateway is deployed:
 
 ```yaml 
-{% include 'v1alpha2/simple-gateway/gateway.yaml' %}   
+{% include 'v1beta1/simple-gateway/gateway.yaml' %}
 ```
 
 ## Canary traffic rollout
@@ -49,7 +49,7 @@ ensures that all traffic with the matching host and header
 
 
 ```yaml
-{% include 'v1alpha2/traffic-splitting/traffic-split-1.yaml' %}
+{% include 'v1beta1/traffic-splitting/traffic-split-1.yaml' %}
 ```
 
 ## Blue-green traffic rollout
@@ -65,7 +65,7 @@ as a backend along with weights. The weights add up to a total of 100 so
 
 
 ```yaml
-{% include 'v1alpha2/traffic-splitting/traffic-split-2.yaml' %}  
+{% include 'v1beta1/traffic-splitting/traffic-split-2.yaml' %}
 ```
 
 ## Completing the rollout
@@ -78,7 +78,7 @@ Finally, if all signals are positive, it is time to fully shift traffic to
 
 
 ```yaml
-{% include 'v1alpha2/traffic-splitting/traffic-split-3.yaml' %}  
+{% include 'v1beta1/traffic-splitting/traffic-split-3.yaml' %}
 ```
 
 At this point 100% of the traffic is being routed to `foo-v2` and the


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/hold
(hold until the recommended version is >= 0.5.0)

**What this PR does / why we need it**:
This change was originall part of #1238, but it was agreed that updating the documentation's examples themselves should wait until 0.5.0 is the recommended version (currently it is still 0.4.x). This PR is those remaining changes which can be merged as and when they are needed.

This updates all examples to use v1beta1 variants, where possible, and links to the API Specification to use the v1beta1 versions.

It does **not** do any of the following:

- GEPs are not touched
- The "introducing v1alpha2" blog post still uses v1alpha2 for all of its examples
- Examples that require the use of v1alpha2 resources, will continue to use v1alpha2 variants for their whole example, even for beta-graduated resources like the `Gateway`. This is in line with the [advice][api-advice] to continue to use v1alpha2 internally, if you want to use alpha features. (The main examples of this are `guides/tcp` which uses exclusively v1alpha2 examples, and `guides/tls` which will use v1beta1 for examples that can be impleneted using _just_ v1beta1 resources, or v1alpha2 for examples that require the alpha Reference Grant).

[api-advice]: https://kubernetes.slack.com/archives/CR0H13KGA/p1656533075102939

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Update documentation examples to v1beta1
```
