### PR TITLE
Fix typos and remove obsolete Service APIs reference

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -143,7 +143,7 @@ type HTTPRouteRule struct {
 	//
 	// Proxy or Load Balancer routing configuration generated from HTTPRoutes
 	// MUST prioritize rules based on the following criteria, continuing on
-	// ties. Precedence must be given to the the Rule with the largest number
+	// ties. Precedence must be given to the Rule with the largest number
 	// of:
 	//
 	// * Characters in a matching non-wildcard hostname.

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -284,7 +284,7 @@ type RouteParentStatus struct {
 	//
 	// * The Route refers to a non-existent parent.
 	// * The Route is of a type that the controller does not support.
-	// * The Route is in a namespace the the controller does not have access to.
+	// * The Route is in a namespace the controller does not have access to.
 	//
 	// +listType=map
 	// +listMapKey=type

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -142,7 +142,7 @@ type HTTPRouteRule struct {
 	//
 	// Proxy or Load Balancer routing configuration generated from HTTPRoutes
 	// MUST prioritize rules based on the following criteria, continuing on
-	// ties. Precedence must be given to the the Rule with the largest number
+	// ties. Precedence must be given to the Rule with the largest number
 	// of:
 	//
 	// * Characters in a matching non-wildcard hostname.

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -284,7 +284,7 @@ type RouteParentStatus struct {
 	//
 	// * The Route refers to a non-existent parent.
 	// * The Route is of a type that the controller does not support.
-	// * The Route is in a namespace the the controller does not have access to.
+	// * The Route is in a namespace the controller does not have access to.
 	//
 	// +listType=map
 	// +listMapKey=type

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -1147,7 +1147,7 @@ spec:
                         every HTTP request. \n Proxy or Load Balancer routing configuration
                         generated from HTTPRoutes MUST prioritize rules based on the
                         following criteria, continuing on ties. Precedence must be
-                        given to the the Rule with the largest number of: \n * Characters
+                        given to the Rule with the largest number of: \n * Characters
                         in a matching non-wildcard hostname. * Characters in a matching
                         hostname. * Characters in a matching path. * Header matches.
                         * Query param matches. \n If ties still exist across multiple
@@ -1359,7 +1359,7 @@ spec:
                         condition may not be set due to lack of controller visibility,
                         that includes when: \n * The Route refers to a non-existent
                         parent. * The Route is of a type that the controller does
-                        not support. * The Route is in a namespace the the controller
+                        not support. * The Route is in a namespace the controller
                         does not have access to."
                       items:
                         description: "Condition contains details for one aspect of
@@ -2684,7 +2684,7 @@ spec:
                         every HTTP request. \n Proxy or Load Balancer routing configuration
                         generated from HTTPRoutes MUST prioritize rules based on the
                         following criteria, continuing on ties. Precedence must be
-                        given to the the Rule with the largest number of: \n * Characters
+                        given to the Rule with the largest number of: \n * Characters
                         in a matching non-wildcard hostname. * Characters in a matching
                         hostname. * Characters in a matching path. * Header matches.
                         * Query param matches. \n If ties still exist across multiple
@@ -2896,7 +2896,7 @@ spec:
                         condition may not be set due to lack of controller visibility,
                         that includes when: \n * The Route refers to a non-existent
                         parent. * The Route is of a type that the controller does
-                        not support. * The Route is in a namespace the the controller
+                        not support. * The Route is in a namespace the controller
                         does not have access to."
                       items:
                         description: "Condition contains details for one aspect of

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -286,7 +286,7 @@ spec:
                         condition may not be set due to lack of controller visibility,
                         that includes when: \n * The Route refers to a non-existent
                         parent. * The Route is of a type that the controller does
-                        not support. * The Route is in a namespace the the controller
+                        not support. * The Route is in a namespace the controller
                         does not have access to."
                       items:
                         description: "Condition contains details for one aspect of

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -335,7 +335,7 @@ spec:
                         condition may not be set due to lack of controller visibility,
                         that includes when: \n * The Route refers to a non-existent
                         parent. * The Route is of a type that the controller does
-                        not support. * The Route is in a namespace the the controller
+                        not support. * The Route is in a namespace the controller
                         does not have access to."
                       items:
                         description: "Condition contains details for one aspect of

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -286,7 +286,7 @@ spec:
                         condition may not be set due to lack of controller visibility,
                         that includes when: \n * The Route refers to a non-existent
                         parent. * The Route is of a type that the controller does
-                        not support. * The Route is in a namespace the the controller
+                        not support. * The Route is in a namespace the controller
                         does not have access to."
                       items:
                         description: "Condition contains details for one aspect of

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -930,7 +930,7 @@ spec:
                         every HTTP request. \n Proxy or Load Balancer routing configuration
                         generated from HTTPRoutes MUST prioritize rules based on the
                         following criteria, continuing on ties. Precedence must be
-                        given to the the Rule with the largest number of: \n * Characters
+                        given to the Rule with the largest number of: \n * Characters
                         in a matching non-wildcard hostname. * Characters in a matching
                         hostname. * Characters in a matching path. * Header matches.
                         * Query param matches. \n If ties still exist across multiple
@@ -1142,7 +1142,7 @@ spec:
                         condition may not be set due to lack of controller visibility,
                         that includes when: \n * The Route refers to a non-existent
                         parent. * The Route is of a type that the controller does
-                        not support. * The Route is in a namespace the the controller
+                        not support. * The Route is in a namespace the controller
                         does not have access to."
                       items:
                         description: "Condition contains details for one aspect of
@@ -2222,7 +2222,7 @@ spec:
                         every HTTP request. \n Proxy or Load Balancer routing configuration
                         generated from HTTPRoutes MUST prioritize rules based on the
                         following criteria, continuing on ties. Precedence must be
-                        given to the the Rule with the largest number of: \n * Characters
+                        given to the Rule with the largest number of: \n * Characters
                         in a matching non-wildcard hostname. * Characters in a matching
                         hostname. * Characters in a matching path. * Header matches.
                         * Query param matches. \n If ties still exist across multiple
@@ -2434,7 +2434,7 @@ spec:
                         condition may not be set due to lack of controller visibility,
                         that includes when: \n * The Route refers to a non-existent
                         parent. * The Route is of a type that the controller does
-                        not support. * The Route is in a namespace the the controller
+                        not support. * The Route is in a namespace the controller
                         does not have access to."
                       items:
                         description: "Condition contains details for one aspect of

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -33,7 +33,7 @@ type ExemptFeature string
 
 const (
 	// This option indicates the implementation is exempting itself from the
-	// requirement of a ReferenceGrant to allow cross-namesapce references,
+	// requirement of a ReferenceGrant to allow cross-namespace references,
 	// and has instead implemented alternative safeguards.
 	ExemptReferenceGrant ExemptFeature = "ReferenceGrant"
 )

--- a/site-src/geps/gep-1016.md
+++ b/site-src/geps/gep-1016.md
@@ -52,7 +52,7 @@ an addition.
 - The encapsulated protocol has a significant user base, particularly in the Kubernetes community.
 
 gRPC meets _all_ of these criteria and is therefore, we contend, a strong
-candidate for inclusion in the Gateway APIs.
+candidate for inclusion in the Gateway API.
 
 #### HTTP/2 Cleartext
 
@@ -82,7 +82,7 @@ The user experience would also degrade significantly if forced to route at the l
 
 The gRPC library supports proxyless service mesh, a system by which routing
 configuration is received and acted upon not by an in-line proxy or sidecar
-proxy but by the client itself. Eventually, `GRPCRoute` in the Gateway APIs
+proxy but by the client itself. Eventually, `GRPCRoute` in the Gateway API
 should support this feature.  However, to date, there are no HTTP client
 libraries capable of participating in a proxyless service mesh.
 
@@ -93,7 +93,7 @@ libraries capable of participating in a proxyless service mesh.
 Occasionally, gRPC users will place gRPC services on the same hostname/port
 combination as HTTP services. For example, `foo.com:443/v1` might serve
 REST+JSON while `foo.com:443/com.foo.WidgetService/` serves gRPC. Such an
-arrangement in the Gateway APIs poses complex technical challenges. How are
+arrangement in the Gateway API poses complex technical challenges. How are
 GRPCRoutes to be reconciled with HTTPRoutes? And how should invididual
 implementations accomplisht this?
 

--- a/site-src/guides/getting-started.md
+++ b/site-src/guides/getting-started.md
@@ -1,4 +1,4 @@
-# Getting started with Gateway APIs
+# Getting started with Gateway API
 
 **1.**  **[Install a Gateway controller](#installing-a-gateway-controller)**
  _OR_  **[install the Gateway API CRDs manually](#installing-a-gateway-api-bundle)**

--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -169,7 +169,7 @@ Kuma is actively working on an implementation of Gateway API specification for t
 
 ### NGINX Kubernetes Gateway
 
-[NGINX Kubernetes Gateway][nginx-kubernetes-gateway] is an open-source project that provides an implementation of the Gateway API using [NGINX][nginx] as the data plane. The goal of this project is to implement the core Gateway APIs -- Gateway, GatewayClass, HTTPRoute, TCPRoute, TLSRoute, and UDPRoute -- to configure an HTTP or TCP/UDP load balancer, reverse-proxy, or API gateway for applications running on Kubernetes. NGINX Kubernetes Gateway is currently under development and supports a subset of the Gateway API.
+[NGINX Kubernetes Gateway][nginx-kubernetes-gateway] is an open-source project that provides an implementation of the Gateway API using [NGINX][nginx] as the data plane. The goal of this project is to implement the core Gateway API -- Gateway, GatewayClass, HTTPRoute, TCPRoute, TLSRoute, and UDPRoute -- to configure an HTTP or TCP/UDP load balancer, reverse-proxy, or API gateway for applications running on Kubernetes. NGINX Kubernetes Gateway is currently under development and supports a subset of the Gateway API.
 
 [nginx-kubernetes-gateway]:https://github.com/nginxinc/nginx-kubernetes-gateway
 [nginx]:https://nginx.org/

--- a/site-src/index.md
+++ b/site-src/index.md
@@ -7,9 +7,6 @@ in Kubernetes. These resources - `GatewayClass`,`Gateway`, `HTTPRoute`,
 expressive, extensible, and role-oriented interfaces that are implemented by 
 many vendors and have broad industry support. 
 
-*Note: This project was previously named "Service APIs" until being renamed to
-"Gateway API" in February 2021.*
-
 ![Gateway API Model](./images/api-model.png)
 
 ## Getting started


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
This fixes several typos, removes an obsolete Service APIs ref, and updates any remaining "Gateway APIs" refs to "Gateway API".

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
