### PR TITLE
add HTTP query param matching conformance test

### DIFF
--- a/conformance/tests/httproute-query-param-matching.go
+++ b/conformance/tests/httproute-query-param-matching.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteQueryParamMatching)
+}
+
+var HTTPRouteQueryParamMatching = suite.ConformanceTest{
+	ShortName:   "HTTPRouteQueryParamMatching",
+	Description: "A single HTTPRoute with query param matching for different backends",
+	Manifests:   []string{"tests/httproute-query-param-matching.yaml"},
+	Features:    []suite.SupportedFeature{suite.SupportHTTPRouteQueryParamMatching},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		var (
+			ns      = "gateway-conformance-infra"
+			routeNN = types.NamespacedName{Namespace: ns, Name: "query-param-matching"}
+			gwNN    = types.NamespacedName{Namespace: ns, Name: "same-namespace"}
+			gwAddr  = kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		)
+
+		testCases := []http.ExpectedResponse{{
+			Request:   http.Request{Path: "/?animal=whale"},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Path: "/?animal=dolphin"},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Path: "/?animal=dolphin&color=blue"},
+			Backend:   "infra-backend-v3",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Path: "/?ANIMAL=Whale"},
+			Backend:   "infra-backend-v3",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Path: "/?animal=whale&otherparam=irrelevant"},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Path: "/?animal=dolphin&color=yellow"},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}, {
+			Request:    http.Request{Path: "/?color=blue"},
+			StatusCode: 404,
+		}, {
+			Request:    http.Request{Path: "/?animal=dog"},
+			StatusCode: 404,
+		}, {
+			Request:    http.Request{Path: "/?animal=whaledolphin"},
+			StatusCode: 404,
+		}, {
+			Request:    http.Request{Path: "/"},
+			StatusCode: 404,
+		}}
+
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(testName(tc, i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-query-param-matching.yaml
+++ b/conformance/tests/httproute-query-param-matching.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: query-param-matching
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - queryParams:
+      - name: animal
+        value: whale
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - matches:
+    - queryParams:
+      - name: animal
+        value: dolphin
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080
+  - matches:
+    - queryParams:
+      - name: animal
+        value: dolphin
+      - name: color
+        value: blue
+    - queryParams:
+      - name: ANIMAL
+        value: Whale
+    backendRefs:
+    - name: infra-backend-v3
+      port: 8080

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -90,10 +90,12 @@ func MakeRequestAndExpectEventuallyConsistentResponse(t *testing.T, r roundtripp
 
 	t.Logf("Making %s request to http://%s%s", expected.Request.Method, gwAddr, expected.Request.Path)
 
+	path, query, _ := strings.Cut(expected.Request.Path, "?")
+
 	req := roundtripper.Request{
 		Method:   expected.Request.Method,
 		Host:     expected.Request.Host,
-		URL:      url.URL{Scheme: "http", Host: gwAddr, Path: expected.Request.Path},
+		URL:      url.URL{Scheme: "http", Host: gwAddr, Path: path, RawQuery: query},
 		Protocol: "HTTP",
 	}
 

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -45,6 +45,9 @@ type SupportedFeature string
 const (
 	// This option indicates support for the ReferenceGrant object.
 	SupportReferenceGrant SupportedFeature = "ReferenceGrant"
+
+	// This option indicates support for HTTPRoute query param matching (extended conformance).
+	SupportHTTPRouteQueryParamMatching SupportedFeature = "HTTPRouteQueryParamMatching"
 )
 
 // ConformanceTestSuite defines the test suite used to run Gateway API


### PR DESCRIPTION
**What type of PR is this?**
/area conformance

**What this PR does / why we need it**:

Adds a conformance test for HTTP query param
matching, requiring a supported feature of
"HTTPRouteQueryParamMatching" to be specified
since this is an extended conformance feature.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Updates #1102 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
