### PR TITLE
conformance: fix ExemptFeatures logic

### DIFF
--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -179,7 +179,7 @@ func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) {
 	// Check that no features exercised by the test have been opted out of by
 	// the suite.
 	for _, feature := range test.Exemptions {
-		if !slices.Contains(suite.ExemptFeatures, feature) {
+		if slices.Contains(suite.ExemptFeatures, feature) {
 			t.Skipf("Skipping %s: suite exempts %s", test.ShortName, feature)
 		}
 	}


### PR DESCRIPTION
Fixes the ExemptFeatures logic to skip
a test if it's tagged with a feature
that the suite has opted out of testing.

Signed-off-by: Steve Kriss <krisss@vmware.com>

**What type of PR is this?**
/area conformance

**What this PR does / why we need it**:
Fixes the ExemptFeatures logic to skip
a test if it's tagged with a feature
that the suite has opted out of testing.


**Which issue(s) this PR fixes**:
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
