### PR TITLE
Enum details update

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -351,6 +351,9 @@ type GatewayTLSConfig struct {
 
 // TLSModeType type defines how a Gateway handles TLS sessions.
 //
+// Note that values may be added to this enum, implementations
+// must ensure that unknown values will not cause a crash.
+//
 // +kubebuilder:validation:Enum=Terminate;Passthrough
 type TLSModeType string
 
@@ -397,6 +400,9 @@ type AllowedRoutes struct {
 
 // FromNamespaces specifies namespace from which Routes may be attached to a
 // Gateway.
+//
+// Note that values may be added to this enum, implementations
+// must ensure that unknown values will not cause a crash.
 //
 // +kubebuilder:validation:Enum=All;Selector;Same
 type FromNamespaces string

--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -354,6 +354,10 @@ type GatewayTLSConfig struct {
 // Note that values may be added to this enum, implementations
 // must ensure that unknown values will not cause a crash.
 //
+// Unknown values here must result in the implementation setting the
+// Ready Condition for the Listener to `status: False`, with a
+// Reason of `Invalid`.
+//
 // +kubebuilder:validation:Enum=Terminate;Passthrough
 type TLSModeType string
 
@@ -403,6 +407,10 @@ type AllowedRoutes struct {
 //
 // Note that values may be added to this enum, implementations
 // must ensure that unknown values will not cause a crash.
+//
+// Unknown values here must result in the implementation setting the
+// Ready Condition for the Listener to `status: False`, with a
+// Reason of `Invalid`.
 //
 // +kubebuilder:validation:Enum=All;Selector;Same
 type FromNamespaces string

--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -247,6 +247,10 @@ type HTTPRouteRule struct {
 // Note that values may be added to this enum, implementations
 // must ensure that unknown values will not cause a crash.
 //
+// Unknown values here must result in the implementation setting the
+// Ready Condition for the Listener to `status: False`, with a
+// Reason of `Invalid`.
+//
 // +kubebuilder:validation:Enum=Exact;PathPrefix;RegularExpression
 type PathMatchType string
 

--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -244,6 +244,9 @@ type HTTPRouteRule struct {
 // - Must begin with the `/` character
 // - Must not contain consecutive `/` characters (e.g. `/foo///`, `//`).
 //
+// Note that values may be added to this enum, implementations
+// must ensure that unknown values will not cause a crash.
+//
 // +kubebuilder:validation:Enum=Exact;PathPrefix;RegularExpression
 type PathMatchType string
 
@@ -298,6 +301,9 @@ type HTTPPathMatch struct {
 //
 // * "Exact"
 // * "RegularExpression"
+//
+// Note that values may be added to this enum, implementations
+// must ensure that unknown values will not cause a crash.
 //
 // +kubebuilder:validation:Enum=Exact;RegularExpression
 type HeaderMatchType string
@@ -373,6 +379,9 @@ type HTTPHeaderMatch struct {
 // * "Exact"
 // * "RegularExpression"
 //
+// Note that values may be added to this enum, implementations
+// must ensure that unknown values will not cause a crash.
+//
 // +kubebuilder:validation:Enum=Exact;RegularExpression
 type QueryParamMatchType string
 
@@ -424,6 +433,10 @@ type HTTPQueryParamMatch struct {
 // [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-4) and
 // [RFC 5789](https://datatracker.ietf.org/doc/html/rfc5789#section-2).
 // The value is expected in upper case.
+//
+// Note that values may be added to this enum, implementations
+// must ensure that unknown values will not cause a crash.
+//
 // +kubebuilder:validation:Enum=GET;HEAD;POST;PUT;DELETE;CONNECT;OPTIONS;TRACE;PATCH
 type HTTPMethod string
 
@@ -523,6 +536,9 @@ type HTTPRouteFilter struct {
 	// If a reference to a custom filter type cannot be resolved, the filter
 	// MUST NOT be skipped. Instead, requests that would have been processed by
 	// that filter MUST receive a HTTP error response.
+	//
+	// Note that values may be added to this enum, implementations
+	// must ensure that unknown values will not cause a crash.
 	//
 	// +unionDiscriminator
 	// +kubebuilder:validation:Enum=RequestHeaderModifier;RequestMirror;RequestRedirect;ExtensionRef
@@ -743,6 +759,9 @@ type HTTPPathModifier struct {
 	// Type defines the type of path modifier. Additional types may be
 	// added in a future release of the API.
 	//
+	// Note that values may be added to this enum, implementations
+	// must ensure that unknown values will not cause a crash.
+	//
 	// <gateway:experimental>
 	// +kubebuilder:validation:Enum=ReplaceFullPath;ReplacePrefixMatch
 	Type HTTPPathModifierType `json:"type"`
@@ -780,6 +799,9 @@ type HTTPRequestRedirectFilter struct {
 	//
 	// Support: Extended
 	//
+	// Note that values may be added to this enum, implementations
+	// must ensure that unknown values will not cause a crash.
+	//
 	// +optional
 	// +kubebuilder:validation:Enum=http;https
 	Scheme *string `json:"scheme,omitempty"`
@@ -815,6 +837,9 @@ type HTTPRequestRedirectFilter struct {
 	// StatusCode is the HTTP status code to be used in response.
 	//
 	// Support: Core
+	//
+	// Note that values may be added to this enum, implementations
+	// must ensure that unknown values will not cause a crash.
 	//
 	// +optional
 	// +kubebuilder:default=302

--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -248,8 +248,8 @@ type HTTPRouteRule struct {
 // must ensure that unknown values will not cause a crash.
 //
 // Unknown values here must result in the implementation setting the
-// Ready Condition for the Listener to `status: False`, with a
-// Reason of `Invalid`.
+// Attached Condition for the Route to `status: False`, with a
+// Reason of `InvalidEnumValue`.
 //
 // +kubebuilder:validation:Enum=Exact;PathPrefix;RegularExpression
 type PathMatchType string
@@ -308,6 +308,10 @@ type HTTPPathMatch struct {
 //
 // Note that values may be added to this enum, implementations
 // must ensure that unknown values will not cause a crash.
+//
+// Unknown values here must result in the implementation setting the
+// Attached Condition for the Route to `status: False`, with a
+// Reason of `InvalidEnumValue`.
 //
 // +kubebuilder:validation:Enum=Exact;RegularExpression
 type HeaderMatchType string
@@ -386,6 +390,10 @@ type HTTPHeaderMatch struct {
 // Note that values may be added to this enum, implementations
 // must ensure that unknown values will not cause a crash.
 //
+// Unknown values here must result in the implementation setting the
+// Attached Condition for the Route to `status: False`, with a
+// Reason of `InvalidEnumValue`.
+//
 // +kubebuilder:validation:Enum=Exact;RegularExpression
 type QueryParamMatchType string
 
@@ -440,6 +448,10 @@ type HTTPQueryParamMatch struct {
 //
 // Note that values may be added to this enum, implementations
 // must ensure that unknown values will not cause a crash.
+//
+// Unknown values here must result in the implementation setting the
+// Attached Condition for the Route to `status: False`, with a
+// Reason of `InvalidEnumValue`.
 //
 // +kubebuilder:validation:Enum=GET;HEAD;POST;PUT;DELETE;CONNECT;OPTIONS;TRACE;PATCH
 type HTTPMethod string
@@ -543,6 +555,10 @@ type HTTPRouteFilter struct {
 	//
 	// Note that values may be added to this enum, implementations
 	// must ensure that unknown values will not cause a crash.
+	//
+	// Unknown values here must result in the implementation setting the
+	// Attached Condition for the Route to `status: False`, with a
+	// Reason of `InvalidEnumValue`.
 	//
 	// +unionDiscriminator
 	// +kubebuilder:validation:Enum=RequestHeaderModifier;RequestMirror;RequestRedirect;ExtensionRef
@@ -766,6 +782,10 @@ type HTTPPathModifier struct {
 	// Note that values may be added to this enum, implementations
 	// must ensure that unknown values will not cause a crash.
 	//
+	// Unknown values here must result in the implementation setting the
+	// Attached Condition for the Route to `status: False`, with a
+	// Reason of `InvalidEnumValue`.
+	//
 	// <gateway:experimental>
 	// +kubebuilder:validation:Enum=ReplaceFullPath;ReplacePrefixMatch
 	Type HTTPPathModifierType `json:"type"`
@@ -806,6 +826,10 @@ type HTTPRequestRedirectFilter struct {
 	// Note that values may be added to this enum, implementations
 	// must ensure that unknown values will not cause a crash.
 	//
+	// Unknown values here must result in the implementation setting the
+	// Attached Condition for the Route to `status: False`, with a
+	// Reason of `InvalidEnumValue`.
+	//
 	// +optional
 	// +kubebuilder:validation:Enum=http;https
 	Scheme *string `json:"scheme,omitempty"`
@@ -844,6 +868,10 @@ type HTTPRequestRedirectFilter struct {
 	//
 	// Note that values may be added to this enum, implementations
 	// must ensure that unknown values will not cause a crash.
+	//
+	// Unknown values here must result in the implementation setting the
+	// Attached Condition for the Route to `status: False`, with a
+	// Reason of `InvalidEnumValue`.
 	//
 	// +optional
 	// +kubebuilder:default=302

--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -249,7 +249,7 @@ type HTTPRouteRule struct {
 //
 // Unknown values here must result in the implementation setting the
 // Attached Condition for the Route to `status: False`, with a
-// Reason of `InvalidEnumValue`.
+// Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=Exact;PathPrefix;RegularExpression
 type PathMatchType string
@@ -311,7 +311,7 @@ type HTTPPathMatch struct {
 //
 // Unknown values here must result in the implementation setting the
 // Attached Condition for the Route to `status: False`, with a
-// Reason of `InvalidEnumValue`.
+// Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=Exact;RegularExpression
 type HeaderMatchType string
@@ -392,7 +392,7 @@ type HTTPHeaderMatch struct {
 //
 // Unknown values here must result in the implementation setting the
 // Attached Condition for the Route to `status: False`, with a
-// Reason of `InvalidEnumValue`.
+// Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=Exact;RegularExpression
 type QueryParamMatchType string
@@ -451,7 +451,7 @@ type HTTPQueryParamMatch struct {
 //
 // Unknown values here must result in the implementation setting the
 // Attached Condition for the Route to `status: False`, with a
-// Reason of `InvalidEnumValue`.
+// Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=GET;HEAD;POST;PUT;DELETE;CONNECT;OPTIONS;TRACE;PATCH
 type HTTPMethod string
@@ -558,7 +558,7 @@ type HTTPRouteFilter struct {
 	//
 	// Unknown values here must result in the implementation setting the
 	// Attached Condition for the Route to `status: False`, with a
-	// Reason of `InvalidEnumValue`.
+	// Reason of `UnsupportedValue`.
 	//
 	// +unionDiscriminator
 	// +kubebuilder:validation:Enum=RequestHeaderModifier;RequestMirror;RequestRedirect;ExtensionRef
@@ -784,7 +784,7 @@ type HTTPPathModifier struct {
 	//
 	// Unknown values here must result in the implementation setting the
 	// Attached Condition for the Route to `status: False`, with a
-	// Reason of `InvalidEnumValue`.
+	// Reason of `UnsupportedValue`.
 	//
 	// <gateway:experimental>
 	// +kubebuilder:validation:Enum=ReplaceFullPath;ReplacePrefixMatch
@@ -828,7 +828,7 @@ type HTTPRequestRedirectFilter struct {
 	//
 	// Unknown values here must result in the implementation setting the
 	// Attached Condition for the Route to `status: False`, with a
-	// Reason of `InvalidEnumValue`.
+	// Reason of `UnsupportedValue`.
 	//
 	// +optional
 	// +kubebuilder:validation:Enum=http;https
@@ -871,7 +871,7 @@ type HTTPRequestRedirectFilter struct {
 	//
 	// Unknown values here must result in the implementation setting the
 	// Attached Condition for the Route to `status: False`, with a
-	// Reason of `InvalidEnumValue`.
+	// Reason of `UnsupportedValue`.
 	//
 	// +optional
 	// +kubebuilder:default=302

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -219,7 +219,7 @@ const (
 
 	// This reason is used with the "Accepted" condition when a value for an Enum
 	// is not recognized.
-	RouteReasonInvalidEnumValue RouteConditionReason = "InvalidEnumValue"
+	RouteReasonUnsupportedValue RouteConditionReason = "UnsupportedValue"
 
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the Route.

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -217,6 +217,10 @@ const (
 	// compatible Listeners whose Hostname matches the route
 	RouteReasonNoMatchingListenerHostname RouteConditionReason = "NoMatchingListenerHostname"
 
+	// This reason is used with the "Accepted" condition when a value for an Enum
+	// is not recognized.
+	RouteReasonInvalidEnumValue RouteConditionReason = "InvalidEnumValue"
+
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the Route.
 	//

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -248,7 +248,7 @@ type HTTPRouteRule struct {
 //
 // Unknown values here must result in the implementation setting the
 // Attached Condition for the Route to `status: False`, with a
-// Reason of `InvalidEnumValue`.
+// Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=Exact;PathPrefix;RegularExpression
 type PathMatchType string
@@ -310,7 +310,7 @@ type HTTPPathMatch struct {
 //
 // Unknown values here must result in the implementation setting the
 // Attached Condition for the Route to `status: False`, with a
-// Reason of `InvalidEnumValue`.
+// Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=Exact;RegularExpression
 type HeaderMatchType string
@@ -391,7 +391,7 @@ type HTTPHeaderMatch struct {
 //
 // Unknown values here must result in the implementation setting the
 // Attached Condition for the Route to `status: False`, with a
-// Reason of `InvalidEnumValue`.
+// Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=Exact;RegularExpression
 type QueryParamMatchType string
@@ -450,7 +450,7 @@ type HTTPQueryParamMatch struct {
 //
 // Unknown values here must result in the implementation setting the
 // Attached Condition for the Route to `status: False`, with a
-// Reason of `InvalidEnumValue`.
+// Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=GET;HEAD;POST;PUT;DELETE;CONNECT;OPTIONS;TRACE;PATCH
 type HTTPMethod string
@@ -557,7 +557,7 @@ type HTTPRouteFilter struct {
 	//
 	// Unknown values here must result in the implementation setting the
 	// Attached Condition for the Route to `status: False`, with a
-	// Reason of `InvalidEnumValue`.
+	// Reason of `UnsupportedValue`.
 	//
 	// +unionDiscriminator
 	// +kubebuilder:validation:Enum=RequestHeaderModifier;RequestMirror;RequestRedirect;ExtensionRef
@@ -783,7 +783,7 @@ type HTTPPathModifier struct {
 	//
 	// Unknown values here must result in the implementation setting the
 	// Attached Condition for the Route to `status: False`, with a
-	// Reason of `InvalidEnumValue`.
+	// Reason of `UnsupportedValue`.
 	//
 	// <gateway:experimental>
 	// +kubebuilder:validation:Enum=ReplaceFullPath;ReplacePrefixMatch
@@ -827,7 +827,7 @@ type HTTPRequestRedirectFilter struct {
 	//
 	// Unknown values here must result in the implementation setting the
 	// Attached Condition for the Route to `status: False`, with a
-	// Reason of `InvalidEnumValue`.
+	// Reason of `UnsupportedValue`.
 	//
 	// +optional
 	// +kubebuilder:validation:Enum=http;https
@@ -870,7 +870,7 @@ type HTTPRequestRedirectFilter struct {
 	//
 	// Unknown values here must result in the implementation setting the
 	// Attached Condition for the Route to `status: False`, with a
-	// Reason of `InvalidEnumValue`.
+	// Reason of `UnsupportedValue`.
 	//
 	// +optional
 	// +kubebuilder:default=302

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -221,6 +221,7 @@ type HTTPRouteRule struct {
 	// recommended to return a 503 status code.
 	//
 	// Support: Core for Kubernetes Service
+	//
 	// Support: Custom for any other resource
 	//
 	// Support for weight: Core
@@ -241,6 +242,13 @@ type HTTPRouteRule struct {
 //
 // - Must begin with the `/` character
 // - Must not contain consecutive `/` characters (e.g. `/foo///`, `//`).
+//
+// Note that values may be added to this enum, implementations
+// must ensure that unknown values will not cause a crash.
+//
+// Unknown values here must result in the implementation setting the
+// Attached Condition for the Route to `status: False`, with a
+// Reason of `InvalidEnumValue`.
 //
 // +kubebuilder:validation:Enum=Exact;PathPrefix;RegularExpression
 type PathMatchType string
@@ -296,6 +304,13 @@ type HTTPPathMatch struct {
 //
 // * "Exact"
 // * "RegularExpression"
+//
+// Note that values may be added to this enum, implementations
+// must ensure that unknown values will not cause a crash.
+//
+// Unknown values here must result in the implementation setting the
+// Attached Condition for the Route to `status: False`, with a
+// Reason of `InvalidEnumValue`.
 //
 // +kubebuilder:validation:Enum=Exact;RegularExpression
 type HeaderMatchType string
@@ -371,6 +386,13 @@ type HTTPHeaderMatch struct {
 // * "Exact"
 // * "RegularExpression"
 //
+// Note that values may be added to this enum, implementations
+// must ensure that unknown values will not cause a crash.
+//
+// Unknown values here must result in the implementation setting the
+// Attached Condition for the Route to `status: False`, with a
+// Reason of `InvalidEnumValue`.
+//
 // +kubebuilder:validation:Enum=Exact;RegularExpression
 type QueryParamMatchType string
 
@@ -422,6 +444,14 @@ type HTTPQueryParamMatch struct {
 // [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-4) and
 // [RFC 5789](https://datatracker.ietf.org/doc/html/rfc5789#section-2).
 // The value is expected in upper case.
+//
+// Note that values may be added to this enum, implementations
+// must ensure that unknown values will not cause a crash.
+//
+// Unknown values here must result in the implementation setting the
+// Attached Condition for the Route to `status: False`, with a
+// Reason of `InvalidEnumValue`.
+//
 // +kubebuilder:validation:Enum=GET;HEAD;POST;PUT;DELETE;CONNECT;OPTIONS;TRACE;PATCH
 type HTTPMethod string
 
@@ -521,6 +551,13 @@ type HTTPRouteFilter struct {
 	// If a reference to a custom filter type cannot be resolved, the filter
 	// MUST NOT be skipped. Instead, requests that would have been processed by
 	// that filter MUST receive a HTTP error response.
+	//
+	// Note that values may be added to this enum, implementations
+	// must ensure that unknown values will not cause a crash.
+	//
+	// Unknown values here must result in the implementation setting the
+	// Attached Condition for the Route to `status: False`, with a
+	// Reason of `InvalidEnumValue`.
 	//
 	// +unionDiscriminator
 	// +kubebuilder:validation:Enum=RequestHeaderModifier;RequestMirror;RequestRedirect;ExtensionRef
@@ -741,6 +778,13 @@ type HTTPPathModifier struct {
 	// Type defines the type of path modifier. Additional types may be
 	// added in a future release of the API.
 	//
+	// Note that values may be added to this enum, implementations
+	// must ensure that unknown values will not cause a crash.
+	//
+	// Unknown values here must result in the implementation setting the
+	// Attached Condition for the Route to `status: False`, with a
+	// Reason of `InvalidEnumValue`.
+	//
 	// <gateway:experimental>
 	// +kubebuilder:validation:Enum=ReplaceFullPath;ReplacePrefixMatch
 	Type HTTPPathModifierType `json:"type"`
@@ -778,6 +822,13 @@ type HTTPRequestRedirectFilter struct {
 	//
 	// Support: Extended
 	//
+	// Note that values may be added to this enum, implementations
+	// must ensure that unknown values will not cause a crash.
+	//
+	// Unknown values here must result in the implementation setting the
+	// Attached Condition for the Route to `status: False`, with a
+	// Reason of `InvalidEnumValue`.
+	//
 	// +optional
 	// +kubebuilder:validation:Enum=http;https
 	Scheme *string `json:"scheme,omitempty"`
@@ -813,6 +864,13 @@ type HTTPRequestRedirectFilter struct {
 	// StatusCode is the HTTP status code to be used in response.
 	//
 	// Support: Core
+	//
+	// Note that values may be added to this enum, implementations
+	// must ensure that unknown values will not cause a crash.
+	//
+	// Unknown values here must result in the implementation setting the
+	// Attached Condition for the Route to `status: False`, with a
+	// Reason of `InvalidEnumValue`.
 	//
 	// +optional
 	// +kubebuilder:default=302

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -219,7 +219,7 @@ const (
 
 	// This reason is used with the "Accepted" condition when a value for an Enum
 	// is not recognized.
-	RouteReasonInvalidEnumValue RouteConditionReason = "InvalidEnumValue"
+	RouteReasonUnsupportedValue RouteConditionReason = "UnsupportedValue"
 
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the Route.

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -217,6 +217,10 @@ const (
 	// compatible Listeners whose Hostname matches the route
 	RouteReasonNoMatchingListenerHostname RouteConditionReason = "NoMatchingListenerHostname"
 
+	// This reason is used with the "Accepted" condition when a value for an Enum
+	// is not recognized.
+	RouteReasonInvalidEnumValue RouteConditionReason = "InvalidEnumValue"
+
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the Route.
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -527,7 +527,14 @@ spec:
                                         type:
                                           description: "Type defines the type of path
                                             modifier. Additional types may be added
-                                            in a future release of the API. \n <gateway:experimental>"
+                                            in a future release of the API. \n Note
+                                            that values may be added to this enum,
+                                            implementations must ensure that unknown
+                                            values will not cause a crash. \n Unknown
+                                            values here must result in the implementation
+                                            setting the Attached Condition for the
+                                            Route to `status: False`, with a Reason
+                                            of `InvalidEnumValue`. \n <gateway:experimental>"
                                           enum:
                                           - ReplaceFullPath
                                           - ReplacePrefixMatch
@@ -548,7 +555,13 @@ spec:
                                       description: "Scheme is the scheme to be used
                                         in the value of the `Location` header in the
                                         response. When empty, the scheme of the request
-                                        is used. \n Support: Extended"
+                                        is used. \n Support: Extended \n Note that
+                                        values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause
+                                        a crash. \n Unknown values here must result
+                                        in the implementation setting the Attached
+                                        Condition for the Route to `status: False`,
+                                        with a Reason of `InvalidEnumValue`."
                                       enum:
                                       - http
                                       - https
@@ -556,7 +569,13 @@ spec:
                                     statusCode:
                                       default: 302
                                       description: "StatusCode is the HTTP status
-                                        code to be used in response. \n Support: Core"
+                                        code to be used in response. \n Support: Core
+                                        \n Note that values may be added to this enum,
+                                        implementations must ensure that unknown values
+                                        will not cause a crash. \n Unknown values
+                                        here must result in the implementation setting
+                                        the Attached Condition for the Route to `status:
+                                        False`, with a Reason of `InvalidEnumValue`."
                                       enum:
                                       - 301
                                       - 302
@@ -587,7 +606,13 @@ spec:
                                     \n If a reference to a custom filter type cannot
                                     be resolved, the filter MUST NOT be skipped. Instead,
                                     requests that would have been processed by that
-                                    filter MUST receive a HTTP error response. \n "
+                                    filter MUST receive a HTTP error response. \n
+                                    Note that values may be added to this enum, implementations
+                                    must ensure that unknown values will not cause
+                                    a crash. \n Unknown values here must result in
+                                    the implementation setting the Attached Condition
+                                    for the Route to `status: False`, with a Reason
+                                    of `InvalidEnumValue`. \n "
                                   enum:
                                   - RequestHeaderModifier
                                   - RequestMirror
@@ -640,7 +665,14 @@ spec:
                                         type:
                                           description: "Type defines the type of path
                                             modifier. Additional types may be added
-                                            in a future release of the API. \n <gateway:experimental>"
+                                            in a future release of the API. \n Note
+                                            that values may be added to this enum,
+                                            implementations must ensure that unknown
+                                            values will not cause a crash. \n Unknown
+                                            values here must result in the implementation
+                                            setting the Attached Condition for the
+                                            Route to `status: False`, with a Reason
+                                            of `InvalidEnumValue`. \n <gateway:experimental>"
                                           enum:
                                           - ReplaceFullPath
                                           - ReplacePrefixMatch
@@ -1004,7 +1036,13 @@ spec:
                                   type:
                                     description: "Type defines the type of path modifier.
                                       Additional types may be added in a future release
-                                      of the API. \n <gateway:experimental>"
+                                      of the API. \n Note that values may be added
+                                      to this enum, implementations must ensure that
+                                      unknown values will not cause a crash. \n Unknown
+                                      values here must result in the implementation
+                                      setting the Attached Condition for the Route
+                                      to `status: False`, with a Reason of `InvalidEnumValue`.
+                                      \n <gateway:experimental>"
                                     enum:
                                     - ReplaceFullPath
                                     - ReplacePrefixMatch
@@ -1025,7 +1063,12 @@ spec:
                                 description: "Scheme is the scheme to be used in the
                                   value of the `Location` header in the response.
                                   When empty, the scheme of the request is used. \n
-                                  Support: Extended"
+                                  Support: Extended \n Note that values may be added
+                                  to this enum, implementations must ensure that unknown
+                                  values will not cause a crash. \n Unknown values
+                                  here must result in the implementation setting the
+                                  Attached Condition for the Route to `status: False`,
+                                  with a Reason of `InvalidEnumValue`."
                                 enum:
                                 - http
                                 - https
@@ -1033,7 +1076,12 @@ spec:
                               statusCode:
                                 default: 302
                                 description: "StatusCode is the HTTP status code to
-                                  be used in response. \n Support: Core"
+                                  be used in response. \n Support: Core \n Note that
+                                  values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a
+                                  crash. \n Unknown values here must result in the
+                                  implementation setting the Attached Condition for
+                                  the Route to `status: False`, with a Reason of `InvalidEnumValue`."
                                 enum:
                                 - 301
                                 - 302
@@ -1062,7 +1110,12 @@ spec:
                               behavior. \n If a reference to a custom filter type
                               cannot be resolved, the filter MUST NOT be skipped.
                               Instead, requests that would have been processed by
-                              that filter MUST receive a HTTP error response. \n "
+                              that filter MUST receive a HTTP error response. \n Note
+                              that values may be added to this enum, implementations
+                              must ensure that unknown values will not cause a crash.
+                              \n Unknown values here must result in the implementation
+                              setting the Attached Condition for the Route to `status:
+                              False`, with a Reason of `InvalidEnumValue`. \n "
                             enum:
                             - RequestHeaderModifier
                             - RequestMirror
@@ -1112,7 +1165,13 @@ spec:
                                   type:
                                     description: "Type defines the type of path modifier.
                                       Additional types may be added in a future release
-                                      of the API. \n <gateway:experimental>"
+                                      of the API. \n Note that values may be added
+                                      to this enum, implementations must ensure that
+                                      unknown values will not cause a crash. \n Unknown
+                                      values here must result in the implementation
+                                      setting the Attached Condition for the Route
+                                      to `status: False`, with a Reason of `InvalidEnumValue`.
+                                      \n <gateway:experimental>"
                                     enum:
                                     - ReplaceFullPath
                                     - ReplacePrefixMatch
@@ -1771,8 +1830,8 @@ spec:
                         been routed to an invalid backend MUST receive a 500 status
                         code. \n When a BackendRef refers to a Service that has no
                         ready endpoints, it is recommended to return a 503 status
-                        code. \n Support: Core for Kubernetes Service Support: Custom
-                        for any other resource \n Support for weight: Core"
+                        code. \n Support: Core for Kubernetes Service \n Support:
+                        Custom for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
                           forward an HTTP request.
@@ -2065,7 +2124,14 @@ spec:
                                         type:
                                           description: "Type defines the type of path
                                             modifier. Additional types may be added
-                                            in a future release of the API. \n <gateway:experimental>"
+                                            in a future release of the API. \n Note
+                                            that values may be added to this enum,
+                                            implementations must ensure that unknown
+                                            values will not cause a crash. \n Unknown
+                                            values here must result in the implementation
+                                            setting the Attached Condition for the
+                                            Route to `status: False`, with a Reason
+                                            of `InvalidEnumValue`. \n <gateway:experimental>"
                                           enum:
                                           - ReplaceFullPath
                                           - ReplacePrefixMatch
@@ -2086,7 +2152,13 @@ spec:
                                       description: "Scheme is the scheme to be used
                                         in the value of the `Location` header in the
                                         response. When empty, the scheme of the request
-                                        is used. \n Support: Extended"
+                                        is used. \n Support: Extended \n Note that
+                                        values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause
+                                        a crash. \n Unknown values here must result
+                                        in the implementation setting the Attached
+                                        Condition for the Route to `status: False`,
+                                        with a Reason of `InvalidEnumValue`."
                                       enum:
                                       - http
                                       - https
@@ -2094,7 +2166,13 @@ spec:
                                     statusCode:
                                       default: 302
                                       description: "StatusCode is the HTTP status
-                                        code to be used in response. \n Support: Core"
+                                        code to be used in response. \n Support: Core
+                                        \n Note that values may be added to this enum,
+                                        implementations must ensure that unknown values
+                                        will not cause a crash. \n Unknown values
+                                        here must result in the implementation setting
+                                        the Attached Condition for the Route to `status:
+                                        False`, with a Reason of `InvalidEnumValue`."
                                       enum:
                                       - 301
                                       - 302
@@ -2125,7 +2203,13 @@ spec:
                                     \n If a reference to a custom filter type cannot
                                     be resolved, the filter MUST NOT be skipped. Instead,
                                     requests that would have been processed by that
-                                    filter MUST receive a HTTP error response. \n "
+                                    filter MUST receive a HTTP error response. \n
+                                    Note that values may be added to this enum, implementations
+                                    must ensure that unknown values will not cause
+                                    a crash. \n Unknown values here must result in
+                                    the implementation setting the Attached Condition
+                                    for the Route to `status: False`, with a Reason
+                                    of `InvalidEnumValue`. \n "
                                   enum:
                                   - RequestHeaderModifier
                                   - RequestMirror
@@ -2178,7 +2262,14 @@ spec:
                                         type:
                                           description: "Type defines the type of path
                                             modifier. Additional types may be added
-                                            in a future release of the API. \n <gateway:experimental>"
+                                            in a future release of the API. \n Note
+                                            that values may be added to this enum,
+                                            implementations must ensure that unknown
+                                            values will not cause a crash. \n Unknown
+                                            values here must result in the implementation
+                                            setting the Attached Condition for the
+                                            Route to `status: False`, with a Reason
+                                            of `InvalidEnumValue`. \n <gateway:experimental>"
                                           enum:
                                           - ReplaceFullPath
                                           - ReplacePrefixMatch
@@ -2541,7 +2632,13 @@ spec:
                                   type:
                                     description: "Type defines the type of path modifier.
                                       Additional types may be added in a future release
-                                      of the API. \n <gateway:experimental>"
+                                      of the API. \n Note that values may be added
+                                      to this enum, implementations must ensure that
+                                      unknown values will not cause a crash. \n Unknown
+                                      values here must result in the implementation
+                                      setting the Attached Condition for the Route
+                                      to `status: False`, with a Reason of `InvalidEnumValue`.
+                                      \n <gateway:experimental>"
                                     enum:
                                     - ReplaceFullPath
                                     - ReplacePrefixMatch
@@ -2562,7 +2659,12 @@ spec:
                                 description: "Scheme is the scheme to be used in the
                                   value of the `Location` header in the response.
                                   When empty, the scheme of the request is used. \n
-                                  Support: Extended"
+                                  Support: Extended \n Note that values may be added
+                                  to this enum, implementations must ensure that unknown
+                                  values will not cause a crash. \n Unknown values
+                                  here must result in the implementation setting the
+                                  Attached Condition for the Route to `status: False`,
+                                  with a Reason of `InvalidEnumValue`."
                                 enum:
                                 - http
                                 - https
@@ -2570,7 +2672,12 @@ spec:
                               statusCode:
                                 default: 302
                                 description: "StatusCode is the HTTP status code to
-                                  be used in response. \n Support: Core"
+                                  be used in response. \n Support: Core \n Note that
+                                  values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a
+                                  crash. \n Unknown values here must result in the
+                                  implementation setting the Attached Condition for
+                                  the Route to `status: False`, with a Reason of `InvalidEnumValue`."
                                 enum:
                                 - 301
                                 - 302
@@ -2599,7 +2706,12 @@ spec:
                               behavior. \n If a reference to a custom filter type
                               cannot be resolved, the filter MUST NOT be skipped.
                               Instead, requests that would have been processed by
-                              that filter MUST receive a HTTP error response. \n "
+                              that filter MUST receive a HTTP error response. \n Note
+                              that values may be added to this enum, implementations
+                              must ensure that unknown values will not cause a crash.
+                              \n Unknown values here must result in the implementation
+                              setting the Attached Condition for the Route to `status:
+                              False`, with a Reason of `InvalidEnumValue`. \n "
                             enum:
                             - RequestHeaderModifier
                             - RequestMirror
@@ -2649,7 +2761,13 @@ spec:
                                   type:
                                     description: "Type defines the type of path modifier.
                                       Additional types may be added in a future release
-                                      of the API. \n <gateway:experimental>"
+                                      of the API. \n Note that values may be added
+                                      to this enum, implementations must ensure that
+                                      unknown values will not cause a crash. \n Unknown
+                                      values here must result in the implementation
+                                      setting the Attached Condition for the Route
+                                      to `status: False`, with a Reason of `InvalidEnumValue`.
+                                      \n <gateway:experimental>"
                                     enum:
                                     - ReplaceFullPath
                                     - ReplacePrefixMatch

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -534,7 +534,7 @@ spec:
                                             values here must result in the implementation
                                             setting the Attached Condition for the
                                             Route to `status: False`, with a Reason
-                                            of `InvalidEnumValue`. \n <gateway:experimental>"
+                                            of `UnsupportedValue`. \n <gateway:experimental>"
                                           enum:
                                           - ReplaceFullPath
                                           - ReplacePrefixMatch
@@ -561,7 +561,7 @@ spec:
                                         a crash. \n Unknown values here must result
                                         in the implementation setting the Attached
                                         Condition for the Route to `status: False`,
-                                        with a Reason of `InvalidEnumValue`."
+                                        with a Reason of `UnsupportedValue`."
                                       enum:
                                       - http
                                       - https
@@ -575,7 +575,7 @@ spec:
                                         will not cause a crash. \n Unknown values
                                         here must result in the implementation setting
                                         the Attached Condition for the Route to `status:
-                                        False`, with a Reason of `InvalidEnumValue`."
+                                        False`, with a Reason of `UnsupportedValue`."
                                       enum:
                                       - 301
                                       - 302
@@ -612,7 +612,7 @@ spec:
                                     a crash. \n Unknown values here must result in
                                     the implementation setting the Attached Condition
                                     for the Route to `status: False`, with a Reason
-                                    of `InvalidEnumValue`. \n "
+                                    of `UnsupportedValue`. \n "
                                   enum:
                                   - RequestHeaderModifier
                                   - RequestMirror
@@ -672,7 +672,7 @@ spec:
                                             values here must result in the implementation
                                             setting the Attached Condition for the
                                             Route to `status: False`, with a Reason
-                                            of `InvalidEnumValue`. \n <gateway:experimental>"
+                                            of `UnsupportedValue`. \n <gateway:experimental>"
                                           enum:
                                           - ReplaceFullPath
                                           - ReplacePrefixMatch
@@ -1041,7 +1041,7 @@ spec:
                                       unknown values will not cause a crash. \n Unknown
                                       values here must result in the implementation
                                       setting the Attached Condition for the Route
-                                      to `status: False`, with a Reason of `InvalidEnumValue`.
+                                      to `status: False`, with a Reason of `UnsupportedValue`.
                                       \n <gateway:experimental>"
                                     enum:
                                     - ReplaceFullPath
@@ -1068,7 +1068,7 @@ spec:
                                   values will not cause a crash. \n Unknown values
                                   here must result in the implementation setting the
                                   Attached Condition for the Route to `status: False`,
-                                  with a Reason of `InvalidEnumValue`."
+                                  with a Reason of `UnsupportedValue`."
                                 enum:
                                 - http
                                 - https
@@ -1081,7 +1081,7 @@ spec:
                                   must ensure that unknown values will not cause a
                                   crash. \n Unknown values here must result in the
                                   implementation setting the Attached Condition for
-                                  the Route to `status: False`, with a Reason of `InvalidEnumValue`."
+                                  the Route to `status: False`, with a Reason of `UnsupportedValue`."
                                 enum:
                                 - 301
                                 - 302
@@ -1115,7 +1115,7 @@ spec:
                               must ensure that unknown values will not cause a crash.
                               \n Unknown values here must result in the implementation
                               setting the Attached Condition for the Route to `status:
-                              False`, with a Reason of `InvalidEnumValue`. \n "
+                              False`, with a Reason of `UnsupportedValue`. \n "
                             enum:
                             - RequestHeaderModifier
                             - RequestMirror
@@ -1170,7 +1170,7 @@ spec:
                                       unknown values will not cause a crash. \n Unknown
                                       values here must result in the implementation
                                       setting the Attached Condition for the Route
-                                      to `status: False`, with a Reason of `InvalidEnumValue`.
+                                      to `status: False`, with a Reason of `UnsupportedValue`.
                                       \n <gateway:experimental>"
                                     enum:
                                     - ReplaceFullPath
@@ -2131,7 +2131,7 @@ spec:
                                             values here must result in the implementation
                                             setting the Attached Condition for the
                                             Route to `status: False`, with a Reason
-                                            of `InvalidEnumValue`. \n <gateway:experimental>"
+                                            of `UnsupportedValue`. \n <gateway:experimental>"
                                           enum:
                                           - ReplaceFullPath
                                           - ReplacePrefixMatch
@@ -2158,7 +2158,7 @@ spec:
                                         a crash. \n Unknown values here must result
                                         in the implementation setting the Attached
                                         Condition for the Route to `status: False`,
-                                        with a Reason of `InvalidEnumValue`."
+                                        with a Reason of `UnsupportedValue`."
                                       enum:
                                       - http
                                       - https
@@ -2172,7 +2172,7 @@ spec:
                                         will not cause a crash. \n Unknown values
                                         here must result in the implementation setting
                                         the Attached Condition for the Route to `status:
-                                        False`, with a Reason of `InvalidEnumValue`."
+                                        False`, with a Reason of `UnsupportedValue`."
                                       enum:
                                       - 301
                                       - 302
@@ -2209,7 +2209,7 @@ spec:
                                     a crash. \n Unknown values here must result in
                                     the implementation setting the Attached Condition
                                     for the Route to `status: False`, with a Reason
-                                    of `InvalidEnumValue`. \n "
+                                    of `UnsupportedValue`. \n "
                                   enum:
                                   - RequestHeaderModifier
                                   - RequestMirror
@@ -2269,7 +2269,7 @@ spec:
                                             values here must result in the implementation
                                             setting the Attached Condition for the
                                             Route to `status: False`, with a Reason
-                                            of `InvalidEnumValue`. \n <gateway:experimental>"
+                                            of `UnsupportedValue`. \n <gateway:experimental>"
                                           enum:
                                           - ReplaceFullPath
                                           - ReplacePrefixMatch
@@ -2637,7 +2637,7 @@ spec:
                                       unknown values will not cause a crash. \n Unknown
                                       values here must result in the implementation
                                       setting the Attached Condition for the Route
-                                      to `status: False`, with a Reason of `InvalidEnumValue`.
+                                      to `status: False`, with a Reason of `UnsupportedValue`.
                                       \n <gateway:experimental>"
                                     enum:
                                     - ReplaceFullPath
@@ -2664,7 +2664,7 @@ spec:
                                   values will not cause a crash. \n Unknown values
                                   here must result in the implementation setting the
                                   Attached Condition for the Route to `status: False`,
-                                  with a Reason of `InvalidEnumValue`."
+                                  with a Reason of `UnsupportedValue`."
                                 enum:
                                 - http
                                 - https
@@ -2677,7 +2677,7 @@ spec:
                                   must ensure that unknown values will not cause a
                                   crash. \n Unknown values here must result in the
                                   implementation setting the Attached Condition for
-                                  the Route to `status: False`, with a Reason of `InvalidEnumValue`."
+                                  the Route to `status: False`, with a Reason of `UnsupportedValue`."
                                 enum:
                                 - 301
                                 - 302
@@ -2711,7 +2711,7 @@ spec:
                               must ensure that unknown values will not cause a crash.
                               \n Unknown values here must result in the implementation
                               setting the Attached Condition for the Route to `status:
-                              False`, with a Reason of `InvalidEnumValue`. \n "
+                              False`, with a Reason of `UnsupportedValue`. \n "
                             enum:
                             - RequestHeaderModifier
                             - RequestMirror
@@ -2766,7 +2766,7 @@ spec:
                                       unknown values will not cause a crash. \n Unknown
                                       values here must result in the implementation
                                       setting the Attached Condition for the Route
-                                      to `status: False`, with a Reason of `InvalidEnumValue`.
+                                      to `status: False`, with a Reason of `UnsupportedValue`.
                                       \n <gateway:experimental>"
                                     enum:
                                     - ReplaceFullPath

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -484,7 +484,7 @@ spec:
                                         a crash. \n Unknown values here must result
                                         in the implementation setting the Attached
                                         Condition for the Route to `status: False`,
-                                        with a Reason of `InvalidEnumValue`."
+                                        with a Reason of `UnsupportedValue`."
                                       enum:
                                       - http
                                       - https
@@ -498,7 +498,7 @@ spec:
                                         will not cause a crash. \n Unknown values
                                         here must result in the implementation setting
                                         the Attached Condition for the Route to `status:
-                                        False`, with a Reason of `InvalidEnumValue`."
+                                        False`, with a Reason of `UnsupportedValue`."
                                       enum:
                                       - 301
                                       - 302
@@ -535,7 +535,7 @@ spec:
                                     a crash. \n Unknown values here must result in
                                     the implementation setting the Attached Condition
                                     for the Route to `status: False`, with a Reason
-                                    of `InvalidEnumValue`. \n "
+                                    of `UnsupportedValue`. \n "
                                   enum:
                                   - RequestHeaderModifier
                                   - RequestMirror
@@ -883,7 +883,7 @@ spec:
                                   values will not cause a crash. \n Unknown values
                                   here must result in the implementation setting the
                                   Attached Condition for the Route to `status: False`,
-                                  with a Reason of `InvalidEnumValue`."
+                                  with a Reason of `UnsupportedValue`."
                                 enum:
                                 - http
                                 - https
@@ -896,7 +896,7 @@ spec:
                                   must ensure that unknown values will not cause a
                                   crash. \n Unknown values here must result in the
                                   implementation setting the Attached Condition for
-                                  the Route to `status: False`, with a Reason of `InvalidEnumValue`."
+                                  the Route to `status: False`, with a Reason of `UnsupportedValue`."
                                 enum:
                                 - 301
                                 - 302
@@ -930,7 +930,7 @@ spec:
                               must ensure that unknown values will not cause a crash.
                               \n Unknown values here must result in the implementation
                               setting the Attached Condition for the Route to `status:
-                              False`, with a Reason of `InvalidEnumValue`. \n "
+                              False`, with a Reason of `UnsupportedValue`. \n "
                             enum:
                             - RequestHeaderModifier
                             - RequestMirror
@@ -1810,7 +1810,7 @@ spec:
                                         a crash. \n Unknown values here must result
                                         in the implementation setting the Attached
                                         Condition for the Route to `status: False`,
-                                        with a Reason of `InvalidEnumValue`."
+                                        with a Reason of `UnsupportedValue`."
                                       enum:
                                       - http
                                       - https
@@ -1824,7 +1824,7 @@ spec:
                                         will not cause a crash. \n Unknown values
                                         here must result in the implementation setting
                                         the Attached Condition for the Route to `status:
-                                        False`, with a Reason of `InvalidEnumValue`."
+                                        False`, with a Reason of `UnsupportedValue`."
                                       enum:
                                       - 301
                                       - 302
@@ -1861,7 +1861,7 @@ spec:
                                     a crash. \n Unknown values here must result in
                                     the implementation setting the Attached Condition
                                     for the Route to `status: False`, with a Reason
-                                    of `InvalidEnumValue`. \n "
+                                    of `UnsupportedValue`. \n "
                                   enum:
                                   - RequestHeaderModifier
                                   - RequestMirror
@@ -2208,7 +2208,7 @@ spec:
                                   values will not cause a crash. \n Unknown values
                                   here must result in the implementation setting the
                                   Attached Condition for the Route to `status: False`,
-                                  with a Reason of `InvalidEnumValue`."
+                                  with a Reason of `UnsupportedValue`."
                                 enum:
                                 - http
                                 - https
@@ -2221,7 +2221,7 @@ spec:
                                   must ensure that unknown values will not cause a
                                   crash. \n Unknown values here must result in the
                                   implementation setting the Attached Condition for
-                                  the Route to `status: False`, with a Reason of `InvalidEnumValue`."
+                                  the Route to `status: False`, with a Reason of `UnsupportedValue`."
                                 enum:
                                 - 301
                                 - 302
@@ -2255,7 +2255,7 @@ spec:
                               must ensure that unknown values will not cause a crash.
                               \n Unknown values here must result in the implementation
                               setting the Attached Condition for the Route to `status:
-                              False`, with a Reason of `InvalidEnumValue`. \n "
+                              False`, with a Reason of `UnsupportedValue`. \n "
                             enum:
                             - RequestHeaderModifier
                             - RequestMirror

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -478,7 +478,13 @@ spec:
                                       description: "Scheme is the scheme to be used
                                         in the value of the `Location` header in the
                                         response. When empty, the scheme of the request
-                                        is used. \n Support: Extended"
+                                        is used. \n Support: Extended \n Note that
+                                        values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause
+                                        a crash. \n Unknown values here must result
+                                        in the implementation setting the Attached
+                                        Condition for the Route to `status: False`,
+                                        with a Reason of `InvalidEnumValue`."
                                       enum:
                                       - http
                                       - https
@@ -486,7 +492,13 @@ spec:
                                     statusCode:
                                       default: 302
                                       description: "StatusCode is the HTTP status
-                                        code to be used in response. \n Support: Core"
+                                        code to be used in response. \n Support: Core
+                                        \n Note that values may be added to this enum,
+                                        implementations must ensure that unknown values
+                                        will not cause a crash. \n Unknown values
+                                        here must result in the implementation setting
+                                        the Attached Condition for the Route to `status:
+                                        False`, with a Reason of `InvalidEnumValue`."
                                       enum:
                                       - 301
                                       - 302
@@ -517,7 +529,13 @@ spec:
                                     \n If a reference to a custom filter type cannot
                                     be resolved, the filter MUST NOT be skipped. Instead,
                                     requests that would have been processed by that
-                                    filter MUST receive a HTTP error response. \n "
+                                    filter MUST receive a HTTP error response. \n
+                                    Note that values may be added to this enum, implementations
+                                    must ensure that unknown values will not cause
+                                    a crash. \n Unknown values here must result in
+                                    the implementation setting the Attached Condition
+                                    for the Route to `status: False`, with a Reason
+                                    of `InvalidEnumValue`. \n "
                                   enum:
                                   - RequestHeaderModifier
                                   - RequestMirror
@@ -860,7 +878,12 @@ spec:
                                 description: "Scheme is the scheme to be used in the
                                   value of the `Location` header in the response.
                                   When empty, the scheme of the request is used. \n
-                                  Support: Extended"
+                                  Support: Extended \n Note that values may be added
+                                  to this enum, implementations must ensure that unknown
+                                  values will not cause a crash. \n Unknown values
+                                  here must result in the implementation setting the
+                                  Attached Condition for the Route to `status: False`,
+                                  with a Reason of `InvalidEnumValue`."
                                 enum:
                                 - http
                                 - https
@@ -868,7 +891,12 @@ spec:
                               statusCode:
                                 default: 302
                                 description: "StatusCode is the HTTP status code to
-                                  be used in response. \n Support: Core"
+                                  be used in response. \n Support: Core \n Note that
+                                  values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a
+                                  crash. \n Unknown values here must result in the
+                                  implementation setting the Attached Condition for
+                                  the Route to `status: False`, with a Reason of `InvalidEnumValue`."
                                 enum:
                                 - 301
                                 - 302
@@ -897,7 +925,12 @@ spec:
                               behavior. \n If a reference to a custom filter type
                               cannot be resolved, the filter MUST NOT be skipped.
                               Instead, requests that would have been processed by
-                              that filter MUST receive a HTTP error response. \n "
+                              that filter MUST receive a HTTP error response. \n Note
+                              that values may be added to this enum, implementations
+                              must ensure that unknown values will not cause a crash.
+                              \n Unknown values here must result in the implementation
+                              setting the Attached Condition for the Route to `status:
+                              False`, with a Reason of `InvalidEnumValue`. \n "
                             enum:
                             - RequestHeaderModifier
                             - RequestMirror
@@ -1500,8 +1533,8 @@ spec:
                         been routed to an invalid backend MUST receive a 500 status
                         code. \n When a BackendRef refers to a Service that has no
                         ready endpoints, it is recommended to return a 503 status
-                        code. \n Support: Core for Kubernetes Service Support: Custom
-                        for any other resource \n Support for weight: Core"
+                        code. \n Support: Core for Kubernetes Service \n Support:
+                        Custom for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
                           forward an HTTP request.
@@ -1771,7 +1804,13 @@ spec:
                                       description: "Scheme is the scheme to be used
                                         in the value of the `Location` header in the
                                         response. When empty, the scheme of the request
-                                        is used. \n Support: Extended"
+                                        is used. \n Support: Extended \n Note that
+                                        values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause
+                                        a crash. \n Unknown values here must result
+                                        in the implementation setting the Attached
+                                        Condition for the Route to `status: False`,
+                                        with a Reason of `InvalidEnumValue`."
                                       enum:
                                       - http
                                       - https
@@ -1779,7 +1818,13 @@ spec:
                                     statusCode:
                                       default: 302
                                       description: "StatusCode is the HTTP status
-                                        code to be used in response. \n Support: Core"
+                                        code to be used in response. \n Support: Core
+                                        \n Note that values may be added to this enum,
+                                        implementations must ensure that unknown values
+                                        will not cause a crash. \n Unknown values
+                                        here must result in the implementation setting
+                                        the Attached Condition for the Route to `status:
+                                        False`, with a Reason of `InvalidEnumValue`."
                                       enum:
                                       - 301
                                       - 302
@@ -1810,7 +1855,13 @@ spec:
                                     \n If a reference to a custom filter type cannot
                                     be resolved, the filter MUST NOT be skipped. Instead,
                                     requests that would have been processed by that
-                                    filter MUST receive a HTTP error response. \n "
+                                    filter MUST receive a HTTP error response. \n
+                                    Note that values may be added to this enum, implementations
+                                    must ensure that unknown values will not cause
+                                    a crash. \n Unknown values here must result in
+                                    the implementation setting the Attached Condition
+                                    for the Route to `status: False`, with a Reason
+                                    of `InvalidEnumValue`. \n "
                                   enum:
                                   - RequestHeaderModifier
                                   - RequestMirror
@@ -2152,7 +2203,12 @@ spec:
                                 description: "Scheme is the scheme to be used in the
                                   value of the `Location` header in the response.
                                   When empty, the scheme of the request is used. \n
-                                  Support: Extended"
+                                  Support: Extended \n Note that values may be added
+                                  to this enum, implementations must ensure that unknown
+                                  values will not cause a crash. \n Unknown values
+                                  here must result in the implementation setting the
+                                  Attached Condition for the Route to `status: False`,
+                                  with a Reason of `InvalidEnumValue`."
                                 enum:
                                 - http
                                 - https
@@ -2160,7 +2216,12 @@ spec:
                               statusCode:
                                 default: 302
                                 description: "StatusCode is the HTTP status code to
-                                  be used in response. \n Support: Core"
+                                  be used in response. \n Support: Core \n Note that
+                                  values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a
+                                  crash. \n Unknown values here must result in the
+                                  implementation setting the Attached Condition for
+                                  the Route to `status: False`, with a Reason of `InvalidEnumValue`."
                                 enum:
                                 - 301
                                 - 302
@@ -2189,7 +2250,12 @@ spec:
                               behavior. \n If a reference to a custom filter type
                               cannot be resolved, the filter MUST NOT be skipped.
                               Instead, requests that would have been processed by
-                              that filter MUST receive a HTTP error response. \n "
+                              that filter MUST receive a HTTP error response. \n Note
+                              that values may be added to this enum, implementations
+                              must ensure that unknown values will not cause a crash.
+                              \n Unknown values here must result in the implementation
+                              setting the Attached Condition for the Route to `status:
+                              False`, with a Reason of `InvalidEnumValue`. \n "
                             enum:
                             - RequestHeaderModifier
                             - RequestMirror


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation


**What this PR does / why we need it**:
This clarifies the rules around enum values to ensure that we document that additional values may be added in the future, and how implementations must handle unknown values.

I've left conformance tests for this behavior out for now, because it's a bit complex to test with (we'll need a way to push invalid things into Kube or some other workaround).

**Which issue(s) this PR fixes**:
Fixes #1014 

**Does this PR introduce a user-facing change?**:
```release-note
All Enum API fields have had updates to clarify that we may add values at any time, and that implementations must handle unknown Enum values.
```
