### PR TITLE
conformance: fix copy-paste errors in unknown backend kind test

### DIFF
--- a/conformance/tests/httproute-invalid-backendref-unknown-kind.go
+++ b/conformance/tests/httproute-invalid-backendref-unknown-kind.go
@@ -34,10 +34,10 @@ func init() {
 
 var HTTPRouteInvalidBackendRefUnknownKind = suite.ConformanceTest{
 	ShortName:   "HTTPRouteInvalidBackendRefUnknownKind",
-	Description: "A single HTTPRoute in the gateway-conformance-infra namespace should set a ResolvedRefs status False with reason RefNotPermitted when attempting to bind to a Gateway in the same namespace if the route has a BackendRef that points to an unknown Kind.",
-	Manifests:   []string{"tests/httproute-invalid-cross-namespace-backend-ref.yaml"},
+	Description: "A single HTTPRoute in the gateway-conformance-infra namespace should set a ResolvedRefs status False with reason InvalidKind when attempting to bind to a Gateway in the same namespace if the route has a BackendRef that points to an unknown Kind.",
+	Manifests:   []string{"tests/httproute-invalid-backendref-unknown-kind.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
-		routeNN := types.NamespacedName{Name: "invalid-cross-namespace-backend-ref", Namespace: "gateway-conformance-infra"}
+		routeNN := types.NamespacedName{Name: "invalid-backend-ref-unknown-kind", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 
 		// Both the Gateway and the Route are Accepted.

--- a/conformance/tests/httproute-invalid-backendref-unknown-kind.yaml
+++ b/conformance/tests/httproute-invalid-backendref-unknown-kind.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: HTTPRoute
 metadata:
-  name: invalid-cross-namespace-backend-ref
+  name: invalid-backend-ref-unknown-kind
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
@@ -10,6 +10,5 @@ spec:
   - backendRefs:
     - group: unknownkind.example.com
       kind: NonExistent
-      name: web-backend
-      namespace: gateway-conformance-web-backend
+      name: infra-backend-v1
       port: 8080


### PR DESCRIPTION
/area conformance

**What this PR does / why we need it**:
Fixes a couple of copy-paste errors in the "unknown backend kind" conformance test that were causing invalid results.

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
