### PR TITLE
Bumping versions to v0.6.0-dev

### DIFF
--- a/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: referencegrants.gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_referencepolicies.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_referencepolicies.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: referencepolicies.gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: tcproutes.gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: tlsroutes.gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: udproutes.gateway.networking.k8s.io

--- a/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1086
-    gateway.networking.k8s.io/bundle-version: v0.5.0
+    gateway.networking.k8s.io/bundle-version: v0.6.0-dev
     gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -35,7 +35,7 @@ const (
 	channelAnnotation       = "gateway.networking.k8s.io/channel"
 
 	// These values must be updated during the release process
-	bundleVersion = "v0.5.0"
+	bundleVersion = "v0.6.0-dev"
 	approvalLink  = "https://github.com/kubernetes-sigs/gateway-api/pull/1086"
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Now that we've released v0.5.0, we need to bump our version refs throughout to avoid future API changes being included in CRDs labeled "v0.5.0".

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
