### PR TITLE
conformance: add HTTPRoute method matching test

### DIFF
--- a/conformance/tests/httproute-method-matching.go
+++ b/conformance/tests/httproute-method-matching.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteMethodMatching)
+}
+
+var HTTPRouteMethodMatching = suite.ConformanceTest{
+	ShortName:   "HTTPRouteMethodMatching",
+	Description: "A single HTTPRoute with method matching for different backends",
+	Manifests:   []string{"tests/httproute-method-matching.yaml"},
+	Features:    []suite.SupportedFeature{suite.SupportHTTPRouteMethodMatching},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Name: "method-matching", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				Request:   http.Request{Method: "POST", Path: "/"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			}, {
+				Request:   http.Request{Method: "GET", Path: "/"},
+				Backend:   "infra-backend-v2",
+				Namespace: ns,
+			}, {
+				Request:    http.Request{Method: "HEAD", Path: "/"},
+				StatusCode: 404,
+			},
+		}
+
+		for i := range testCases {
+			// Declare tc here to avoid loop variable
+			// reuse issues across parallel tests.
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-method-matching.yaml
+++ b/conformance/tests/httproute-method-matching.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: HTTPRoute
+metadata:
+  name: method-matching
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - method: POST
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - matches:
+    - method: GET
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -49,6 +49,9 @@ const (
 
 	// This option indicates support for HTTPRoute query param matching (extended conformance).
 	SupportHTTPRouteQueryParamMatching SupportedFeature = "HTTPRouteQueryParamMatching"
+
+	// This option indicates support for HTTPRoute method matching (extended conformance).
+	SupportHTTPRouteMethodMatching SupportedFeature = "HTTPRouteMethodMatching"
 )
 
 // ConformanceTestSuite defines the test suite used to run Gateway API


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

**What type of PR is this?**
/area conformance

**What this PR does / why we need it**:
Adds an opt-in conformance test for HTTPRoute method matching (extended conformance).

**Which issue(s) this PR fixes**:
Updates #1102.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
