### PR TITLE
conformance/utils/suite: Move timeout setup before building roundtripper

### DIFF
--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -93,6 +93,8 @@ type Options struct {
 
 // New returns a new ConformanceTestSuite.
 func New(s Options) *ConformanceTestSuite {
+	config.SetupTimeoutConfig(&s.TimeoutConfig)
+
 	roundTripper := s.RoundTripper
 	if roundTripper == nil {
 		roundTripper = &roundtripper.DefaultRoundTripper{Debug: s.Debug, TimeoutConfig: s.TimeoutConfig}
@@ -113,7 +115,6 @@ func New(s Options) *ConformanceTestSuite {
 		SupportedFeatures: s.SupportedFeatures,
 		TimeoutConfig:     s.TimeoutConfig,
 	}
-	config.SetupTimeoutConfig(&suite.TimeoutConfig)
 
 	// apply defaults
 	if suite.BaseManifests == "" {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Previously timeout config was passed to roundtripper before defaults
were set. When suite was run with default timeouts, for example HTTP requests were
set up with a context deadline of 0, meaning they failed immediately.

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
NONE
