### PR TITLE
Adding docs covering conformance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Gateway API
 
-The Gateway API is a part of the [SIG Network][sn], and this repository contains
+The Gateway API is a part of [SIG Network][sn], and this repository contains
 the specification and Custom Resource Definitions (CRDs).
 
 ## Status

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
     - Introduction: index.md
     - Concepts:
         API overview: concepts/api-overview.md
+        Conformance: concepts/conformance.md
         Security Model: concepts/security-model.md
         Implementation Guidelines: concepts/guidelines.md
         Versioning: concepts/versioning.md

--- a/site-src/concepts/conformance.md
+++ b/site-src/concepts/conformance.md
@@ -1,0 +1,102 @@
+# Conformance
+
+This API covers a broad set of features and use cases and has been implemented
+widely. This combination of both a large feature set and variety of
+implementations requires clear conformance definitions and tests to ensure the
+API provides a consistent experience wherever it is used.
+
+When considering Gateway API conformance, there are three important concepts:
+
+## 1. Release Channels
+
+Within Gateway API, release channels are used to indicate the stability of a
+field or resource. The "standard" channel of the API includes fields and
+resources that have graduated to "beta". The "experimental" channel of the API
+includes everything in the "standard" channel, along with experimental fields
+and resources that may still be changed in breaking ways or removed altogether.
+For more information on this concept, refer to our
+[versioning](/concepts/versioning) documentation.
+
+## 2. Support Levels
+
+Unfortunately some implementations of the API will not be able to support every
+feature that has been defined. To address that, the API defines a corresponding
+support level for each feature:
+
+* **Core** features will be portable and we expect that there is a reasonable
+  roadmap for ALL implementations towards support of APIs in this category.
+* **Extended** features are those that are portable but not universally
+  supported across implementations. Those implementations that support the
+  feature will have the same behavior and semantics. It is expected that some
+  number of roadmap features will eventually migrate into the Core. Extended
+  features will be part of the API types and schema.
+* **Custom** features are those that are not portable and are vendor-specific.
+  Custom features will not have API types and schema except via generic
+  extension points.
+
+Behavior and feature in the Core and Extended set will be defined and validated
+via behavior-driven conformance tests. Custom features will not be covered by
+conformance tests.
+
+By including and standardizing Extended features in the API spec, we expect to
+be able to converge on portable subsets of the API among implementations without
+compromising overall API support. Lack of universal support will not be a
+blocker towards developing portable feature sets. Standardizing on spec will
+make it easier to eventually graduate to Core when support is widespread.
+
+### Overlapping Support Levels
+
+It is possible for support levels to overlap for a specific field. When this
+occurs, the minimum expressed support level should be interpreted. For example,
+an identical struct may be embedded in two different places. In one of those
+places, the struct is considered to have Core support while the other place only
+includes Extended support. Fields within this struct may express separate Core
+and Extended support levels, but those levels must not be interpreted as
+exceeding the support level of the parent struct they are embedded in.
+
+For a more concrete example, HTTPRoute includes Core support for filters defined
+within a Rule and Extended support when defined within BackendRef. Those filters
+may separately define support levels for each field. When interpreting
+overlapping support levels, the minimum value should be interpreted. That means
+if a field has a Core support level but is in a filter attached in a place with
+Extended support, the interpreted support level must be Extended.
+
+## 3. Conformance Tests
+
+Gateway API includes a set of conformance tests. These create a series of
+Gateways and Routes with the specified GatewayClass, and test that the
+implementation matches the API specification.
+
+Each release contains a set of conformance tests, these will continue to
+expand as the API evolves. Currently conformance tests cover the majority
+of Core capabilities in the standard channel, in addition to some Extended
+capabilities.
+
+### Running Tests
+
+By default, conformance tests will expect a `gateway-conformance` GatewayClass
+to be installed in the cluster and tests will be run against that. A different
+class can be specified with the `--gateway-class` flag along with the
+corresponding test command. For example:
+
+```shell
+go test ./conformance --gateway-class my-class
+```
+
+## Contributing to Conformance
+
+Many implementations run conformance tests as part of their full e2e test suite.
+Contributing conformance tests means that implementations can share the
+investment in test development and ensure that we're providing a consistent
+experience.
+
+All code related to conformance lives in the "/conformance" directory of the
+project. Test definitions are in "/conformance/tests" with each test including
+a pair of files. A YAML file contains the manifests to be applied as part of
+running the test. A Go file contains code that confirms that an implementation
+handles those manifests appropriately.
+
+Issues related to conformance are [labeled with
+"area/conformance"](https://github.com/kubernetes-sigs/gateway-api/issues?q=is%3Aissue+is%3Aopen+label%3Aarea%2Fconformance).
+These often cover adding new tests to improve our test coverage or fixing flaws
+or limitations in our existing tests.

--- a/site-src/concepts/guidelines.md
+++ b/site-src/concepts/guidelines.md
@@ -81,62 +81,7 @@ duplicating work, Gateway API maintainers are considering adding a shared
 validation package that implementations can use for this purpose. This is
 tracked by [#926](https://github.com/kubernetes-sigs/gateway-api/issues/926).
 
-## Conformance
-
-As this API aims to cover a wide set of implementations and use cases,
-it will not be possible for all implementations to support *all*
-features at the present. However, we do expect the set of features
-supported to converge eventually. For a given feature, users will be
-guaranteed that features in the API will be portable between providers
-if the feature is supported.
-
-To model this in the API, we are taking a similar approach as with
-[sig-arch][sig-arch-bdd] work on conformance profiles. Features as
-described in the API spec will be divided into three major categories:
-
-[sig-arch-bdd]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/960-conformance-behaviors
-
-* **CORE** features will be portable and we expect that there is a
-  reasonable roadmap for ALL implementations towards support of APIs
-  in this category.
-* **EXTENDED** features are those that are portable but not
-  universally supported across implementations. Those implementations
-  that support the feature will have the same behavior and
-  semantics. It is expected that some number of EXTENDED features will
-  eventually migrate into the CORE. EXTENDED features will be part of
-  the API types and schema.
-* **CUSTOM** features are those that are not portable and are
-  vendor-specific. CUSTOM features will not have API types and schema
-  except via generic extension points.
-
-Behavior and feature in the CORE and EXTENDED set will be defined and
-validated via behavior-driven conformance tests. CUSTOM features will
-not be covered by conformance tests.
-
-By including and standardizing EXTENDED features in the API spec, we
-expect to be able to converge on portable subsets of the API among
-implementations without compromising overall API support. Lack of
-universal support will not be a blocker towards developing portable
-feature sets. Standardizing on spec will make it easier to eventually
-graduate to CORE when support is widespread.
-
-### Overlapping Support Levels
-It is possible for support levels to overlap. When this occurs, the minimum
-expressed support level should be interpreted. For example, an identical struct
-may be embedded in two different places. In one of those places, the struct is
-considered to have CORE support while the other place only includes EXTENDED
-support. Fields within this struct may express separate CORE and EXTENDED
-support levels, but those levels may never be interpreted as exceeding the
-support level of the parent struct they are embedded in.
-
-For a more concrete example, HTTPRoute includes CORE support for filters defined
-within a Rule and EXTENDED support when defined within ForwardTo. Those filters
-may separately define support levels for each field. When interpreting
-overlapping support levels, the minimum value should be interpreted. That means
-if a field has a CORE support level but is in a filter attached in a place with
-EXTENDED support, the interpreted support level should be EXTENDED.
-
-### Conformance expectations
+### Expectations
 
 We expect there will be varying levels of conformance among the
 different providers in the early days of this API. Users can use the
@@ -193,32 +138,3 @@ although they are both lists.
 
 [1]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md
 
-### Conformance Tests
-
-Conformance tests are actively being developed to ensure that implementations of
-this API are conformant with the spec. Use `make conformance` to run these tests
-with the Kubernetes cluster you are currently connected to. 
-
-By default, conformance tests will expect a `gateway-conformance` GatewayClass
-to be installed in the cluster and tests will be run against that. A different
-class can be specified with the `--gateway-class` flag along with the
-corresponding test command. For example:
-
-```shell
-go test ./conformance --gateway-class my-class
-```
-
-Most conformance tests rely on a shared set of base manifests defined in
-`conformance/base/manifests.yaml`. These include a set of Namespaces, Services,
-and Deployments that can be used for routing.
-
-Conformance tests are defined with in `conformance/tests`. Each test definition
-includes:
-
-* A unique `shortName`
-* A description
-* A set of manifests to apply before running tests
-* A test function that implements the test
-
-These tests are currently in an alpha state. Please file a GitHub issue or ask
-in Slack if these are not working as expected.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This adds a new conformance page to our documentation. Much of this content was pulled from the "Implementation Guidelines" page, but that was getting pretty massive and conformance seemed broader than that.

**Which issue(s) this PR fixes**:
Fixes #1274

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
