### PR TITLE
Conformance: fix Listener ConditionReason

### DIFF
--- a/conformance/tests/gateway-secret-invalid-reference-grant.go
+++ b/conformance/tests/gateway-secret-invalid-reference-grant.go
@@ -39,7 +39,7 @@ var GatewaySecretInvalidReferenceGrant = suite.ConformanceTest{
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "gateway-secret-invalid-reference-grant", Namespace: "gateway-conformance-infra"}
 
-		t.Run("Gateway listener should have a false ResolvedRefs condition with reason InvalidCertificateRef", func(t *testing.T) {
+		t.Run("Gateway listener should have a false ResolvedRefs condition with reason RefNotPermitted", func(t *testing.T) {
 			listeners := []v1alpha2.ListenerStatus{{
 				Name: v1alpha2.SectionName("https"),
 				SupportedKinds: []v1alpha2.RouteGroupKind{{
@@ -49,7 +49,7 @@ var GatewaySecretInvalidReferenceGrant = suite.ConformanceTest{
 				Conditions: []metav1.Condition{{
 					Type:   string(v1alpha2.ListenerConditionResolvedRefs),
 					Status: metav1.ConditionFalse,
-					Reason: string(v1alpha2.ListenerReasonInvalidCertificateRef),
+					Reason: string(v1alpha2.ListenerReasonRefNotPermitted),
 				}},
 			}}
 

--- a/conformance/tests/gateway-secret-missing-reference-grant.go
+++ b/conformance/tests/gateway-secret-missing-reference-grant.go
@@ -39,7 +39,7 @@ var GatewaySecretMissingReferenceGrant = suite.ConformanceTest{
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "gateway-secret-missing-reference-grant", Namespace: "gateway-conformance-infra"}
 
-		t.Run("Gateway listener should have a false ResolvedRefs condition with reason InvalidCertificateRef", func(t *testing.T) {
+		t.Run("Gateway listener should have a false ResolvedRefs condition with reason RefNotPermitted", func(t *testing.T) {
 			listeners := []v1alpha2.ListenerStatus{{
 				Name: v1alpha2.SectionName("https"),
 				SupportedKinds: []v1alpha2.RouteGroupKind{{
@@ -49,7 +49,7 @@ var GatewaySecretMissingReferenceGrant = suite.ConformanceTest{
 				Conditions: []metav1.Condition{{
 					Type:   string(v1alpha2.ListenerConditionResolvedRefs),
 					Status: metav1.ConditionFalse,
-					Reason: string(v1alpha2.ListenerReasonInvalidCertificateRef),
+					Reason: string(v1alpha2.ListenerReasonRefNotPermitted),
 				}},
 			}}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**What this PR does / why we need it**:
In the "GatewaySecretInvalidReferenceGrant" and "GatewaySecretMissingReferenceGrant" conformance tests for gateways, the expected condition has been changed from `InvalidCertificateRef` to `RefNotPermitted`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1297 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
To be conformant with the API, if there is no ReferenceGrant that grants a listener to reference a secret in another namespace, the ListenerConditionReason for the condition ResolvedRefs must be set to RefNotPermitted instead of InvalidCertificateRef.
```
