### PR TITLE
Export DefaultTimeoutConfig.

### DIFF
--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -68,7 +68,8 @@ type TimeoutConfig struct {
 	RequestTimeout time.Duration
 }
 
-func defaultTimeoutConfig() TimeoutConfig {
+// DefaultTimeoutConfig populates a TimeoutConfig with the default values.
+func DefaultTimeoutConfig() TimeoutConfig {
 	return TimeoutConfig{
 		CreateTimeout:                  60 * time.Second,
 		DeleteTimeout:                  10 * time.Second,
@@ -86,7 +87,7 @@ func defaultTimeoutConfig() TimeoutConfig {
 }
 
 func SetupTimeoutConfig(timeoutConfig *TimeoutConfig) {
-	defaultTimeoutConfig := defaultTimeoutConfig()
+	defaultTimeoutConfig := DefaultTimeoutConfig()
 	if timeoutConfig.CreateTimeout == 0 {
 		timeoutConfig.CreateTimeout = defaultTimeoutConfig.CreateTimeout
 	}


### PR DESCRIPTION
Some exported methods like
MakeRequestAndExpectEventuallyConsistentResponse require the
TimeoutConfig resource.  Callers may want to use this with a sensible
default, so we should expose a way to get said value without requiring
the caller to understand which timeout values need to be configured.

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Make it easier to use MakeRequestAndExpectEventuallyConsistentResponse.

**Which issue(s) this PR fixes**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
