### PR TITLE
Clarify BackendObjectReference Port field godoc

### DIFF
--- a/apis/v1alpha2/object_reference_types.go
+++ b/apis/v1alpha2/object_reference_types.go
@@ -123,7 +123,8 @@ type BackendObjectReference struct {
 	Namespace *Namespace `json:"namespace,omitempty"`
 
 	// Port specifies the destination port number to use for this resource.
-	// Port is required when the referent is a Kubernetes Service.
+	// Port is required when the referent is a Kubernetes Service. In this
+	// case, the port number is the service port number, not the target port.
 	// For other resources, destination port might be derived from the referent
 	// resource or this field.
 	//

--- a/apis/v1beta1/object_reference_types.go
+++ b/apis/v1beta1/object_reference_types.go
@@ -123,7 +123,8 @@ type BackendObjectReference struct {
 	Namespace *Namespace `json:"namespace,omitempty"`
 
 	// Port specifies the destination port number to use for this resource.
-	// Port is required when the referent is a Kubernetes Service.
+	// Port is required when the referent is a Kubernetes Service. In this
+	// case, the port number is the service port number, not the target port.
 	// For other resources, destination port might be derived from the referent
 	// resource or this field.
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -492,7 +492,9 @@ spec:
                                           description: Port specifies the destination
                                             port number to use for this resource.
                                             Port is required when the referent is
-                                            a Kubernetes Service. For other resources,
+                                            a Kubernetes Service. In this case, the
+                                            port number is the service port number,
+                                            not the target port. For other resources,
                                             destination port might be derived from
                                             the referent resource or this field.
                                           format: int32
@@ -579,9 +581,10 @@ spec:
                           port:
                             description: Port specifies the destination port number
                               to use for this resource. Port is required when the
-                              referent is a Kubernetes Service. For other resources,
-                              destination port might be derived from the referent
-                              resource or this field.
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -827,9 +830,11 @@ spec:
                                   port:
                                     description: Port specifies the destination port
                                       number to use for this resource. Port is required
-                                      when the referent is a Kubernetes Service. For
-                                      other resources, destination port might be derived
-                                      from the referent resource or this field.
+                                      when the referent is a Kubernetes Service. In
+                                      this case, the port number is the service port
+                                      number, not the target port. For other resources,
+                                      destination port might be derived from the referent
+                                      resource or this field.
                                     format: int32
                                     maximum: 65535
                                     minimum: 1

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -474,7 +474,9 @@ spec:
                                           description: Port specifies the destination
                                             port number to use for this resource.
                                             Port is required when the referent is
-                                            a Kubernetes Service. For other resources,
+                                            a Kubernetes Service. In this case, the
+                                            port number is the service port number,
+                                            not the target port. For other resources,
                                             destination port might be derived from
                                             the referent resource or this field.
                                           format: int32
@@ -733,9 +735,10 @@ spec:
                           port:
                             description: Port specifies the destination port number
                               to use for this resource. Port is required when the
-                              referent is a Kubernetes Service. For other resources,
-                              destination port might be derived from the referent
-                              resource or this field.
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -987,9 +990,11 @@ spec:
                                   port:
                                     description: Port specifies the destination port
                                       number to use for this resource. Port is required
-                                      when the referent is a Kubernetes Service. For
-                                      other resources, destination port might be derived
-                                      from the referent resource or this field.
+                                      when the referent is a Kubernetes Service. In
+                                      this case, the port number is the service port
+                                      number, not the target port. For other resources,
+                                      destination port might be derived from the referent
+                                      resource or this field.
                                     format: int32
                                     maximum: 65535
                                     minimum: 1
@@ -2072,7 +2077,9 @@ spec:
                                           description: Port specifies the destination
                                             port number to use for this resource.
                                             Port is required when the referent is
-                                            a Kubernetes Service. For other resources,
+                                            a Kubernetes Service. In this case, the
+                                            port number is the service port number,
+                                            not the target port. For other resources,
                                             destination port might be derived from
                                             the referent resource or this field.
                                           format: int32
@@ -2331,9 +2338,10 @@ spec:
                           port:
                             description: Port specifies the destination port number
                               to use for this resource. Port is required when the
-                              referent is a Kubernetes Service. For other resources,
-                              destination port might be derived from the referent
-                              resource or this field.
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -2584,9 +2592,11 @@ spec:
                                   port:
                                     description: Port specifies the destination port
                                       number to use for this resource. Port is required
-                                      when the referent is a Kubernetes Service. For
-                                      other resources, destination port might be derived
-                                      from the referent resource or this field.
+                                      when the referent is a Kubernetes Service. In
+                                      this case, the port number is the service port
+                                      number, not the target port. For other resources,
+                                      destination port might be derived from the referent
+                                      resource or this field.
                                     format: int32
                                     maximum: 65535
                                     minimum: 1

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -212,9 +212,10 @@ spec:
                           port:
                             description: Port specifies the destination port number
                               to use for this resource. Port is required when the
-                              referent is a Kubernetes Service. For other resources,
-                              destination port might be derived from the referent
-                              resource or this field.
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
                             format: int32
                             maximum: 65535
                             minimum: 1

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -261,9 +261,10 @@ spec:
                           port:
                             description: Port specifies the destination port number
                               to use for this resource. Port is required when the
-                              referent is a Kubernetes Service. For other resources,
-                              destination port might be derived from the referent
-                              resource or this field.
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
                             format: int32
                             maximum: 65535
                             minimum: 1

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -212,9 +212,10 @@ spec:
                           port:
                             description: Port specifies the destination port number
                               to use for this resource. Port is required when the
-                              referent is a Kubernetes Service. For other resources,
-                              destination port might be derived from the referent
-                              resource or this field.
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
                             format: int32
                             maximum: 65535
                             minimum: 1

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -448,7 +448,9 @@ spec:
                                           description: Port specifies the destination
                                             port number to use for this resource.
                                             Port is required when the referent is
-                                            a Kubernetes Service. For other resources,
+                                            a Kubernetes Service. In this case, the
+                                            port number is the service port number,
+                                            not the target port. For other resources,
                                             destination port might be derived from
                                             the referent resource or this field.
                                           format: int32
@@ -594,9 +596,10 @@ spec:
                           port:
                             description: Port specifies the destination port number
                               to use for this resource. Port is required when the
-                              referent is a Kubernetes Service. For other resources,
-                              destination port might be derived from the referent
-                              resource or this field.
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -848,9 +851,11 @@ spec:
                                   port:
                                     description: Port specifies the destination port
                                       number to use for this resource. Port is required
-                                      when the referent is a Kubernetes Service. For
-                                      other resources, destination port might be derived
-                                      from the referent resource or this field.
+                                      when the referent is a Kubernetes Service. In
+                                      this case, the port number is the service port
+                                      number, not the target port. For other resources,
+                                      destination port might be derived from the referent
+                                      resource or this field.
                                     format: int32
                                     maximum: 65535
                                     minimum: 1
@@ -1775,7 +1780,9 @@ spec:
                                           description: Port specifies the destination
                                             port number to use for this resource.
                                             Port is required when the referent is
-                                            a Kubernetes Service. For other resources,
+                                            a Kubernetes Service. In this case, the
+                                            port number is the service port number,
+                                            not the target port. For other resources,
                                             destination port might be derived from
                                             the referent resource or this field.
                                           format: int32
@@ -1921,9 +1928,10 @@ spec:
                           port:
                             description: Port specifies the destination port number
                               to use for this resource. Port is required when the
-                              referent is a Kubernetes Service. For other resources,
-                              destination port might be derived from the referent
-                              resource or this field.
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -2174,9 +2182,11 @@ spec:
                                   port:
                                     description: Port specifies the destination port
                                       number to use for this resource. Port is required
-                                      when the referent is a Kubernetes Service. For
-                                      other resources, destination port might be derived
-                                      from the referent resource or this field.
+                                      when the referent is a Kubernetes Service. In
+                                      this case, the port number is the service port
+                                      number, not the target port. For other resources,
+                                      destination port might be derived from the referent
+                                      resource or this field.
                                     format: int32
                                     maximum: 65535
                                     minimum: 1


### PR DESCRIPTION
* `apis/v1alpha2/object_reference_types.go` (`BackendObjectReference`): 
* `apis/v1beta1/object_reference_types.go` (`BackendObjectReference`): Clarify that the `Port` field references the service port number when the backend is a Kubernetes Service.
* `config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml`: 
* `config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml`: 
* `config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml`: 
* `config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml`: 
* `config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml`: 
* `config/crd/standard/gateway.networking.k8s.io_httproutes.yaml`: Regenerate.

-------

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind documentation

**What this PR does / why we need it**:

Clarify that `BackendObjectReference`'s `Port` field specifies a service port, not a target port, when the backend is a Kubernetes Service.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1331.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Clarify that BackendObjectReference's Port field specifies a service port, not a target port, for Kubernetes Service backends.
```