### PR TITLE
docs: couple of ReferenceGrant cleanups

### DIFF
--- a/hack/api-docs/config.json
+++ b/hack/api-docs/config.json
@@ -4,7 +4,8 @@
     ],
     "hideTypePatterns": [
         "ParseError$",
-        "List$"
+        "List$",
+        "ReferencePolicy$"
     ],
     "externalPackages": [
         {

--- a/site-src/api-types/referencegrant.md
+++ b/site-src/api-types/referencegrant.md
@@ -14,7 +14,7 @@ A ReferenceGrant can be used to enable cross namespace references within
 Gateway API. In particular, Routes may forward traffic to backends in other
 namespaces, or Gateways may refer to Secrets in another namespace.
 
-![Reference Grant](/site-src/images/referencegrant-simple.png)
+![Reference Grant](/images/referencegrant-simple.png)
 
 In the past, we've seen that forwarding traffic across namespace boundaries is a
 desired feature, but without a safeguard like ReferenceGrant,


### PR DESCRIPTION
Remove deprecated ReferencePolicy using the hideTypePatterns config for the API docs generator.

ReferencePolicy has been renamed to ReferenceGrant, but we have retained ReferencePolicy as a deprecated type in order to make migration easier.

Keeping ReferencePolicy around in the docs is confusing for readers and probably doesn't provide any value.

Also fix path of ReferenceGrant image.

/kind cleanup