### PR TITLE
docs: display beta before alpha in API spec

### DIFF
--- a/hack/api-docs/pkg.tpl
+++ b/hack/api-docs/pkg.tpl
@@ -1,45 +1,52 @@
+{{ define "link" }}
+<li>
+    <a href="#{{- packageAnchorID . -}}">{{ packageDisplayName . }}</a>
+</li>
+{{ end }}
+
+{{ define "package" }}
+<h2 id="{{- packageAnchorID . -}}">
+    {{- packageDisplayName . -}}
+</h2>
+
+{{ with (index .GoPackages 0 )}}
+    {{ with .DocComments }}
+    <p>
+        {{ safe (renderComments .) }}
+    </p>
+    {{ end }}
+{{ end }}
+
+Resource Types:
+<ul>
+{{- range (visibleTypes (sortedTypes .Types)) -}}
+    {{ if isExportedType . -}}
+    <li>
+        <a href="{{ linkForType . }}">{{ typeDisplayName . }}</a>
+    </li>
+    {{- end }}
+{{- end -}}
+</ul>
+
+{{ range (visibleTypes (sortedTypes .Types))}}
+    {{ template "type" .  }}
+{{ end }}
+<hr/>
+{{ end }}
+
+
 {{ define "packages" }}
 
-{{ with .packages}}
+{{/* we manually iterate the packages slice so that we feature beta before alpha */}}
+
 <p>Packages:</p>
 <ul>
-    {{ range . }}
-    <li>
-        <a href="#{{- packageAnchorID . -}}">{{ packageDisplayName . }}</a>
-    </li>
-    {{ end }}
+    {{ template "link" index .packages 1 }}
+    {{ template "link" index .packages 0 }}
 </ul>
-{{ end}}
 
-{{ range .packages }}
-    <h2 id="{{- packageAnchorID . -}}">
-        {{- packageDisplayName . -}}
-    </h2>
-
-    {{ with (index .GoPackages 0 )}}
-        {{ with .DocComments }}
-        <p>
-            {{ safe (renderComments .) }}
-        </p>
-        {{ end }}
-    {{ end }}
-
-    Resource Types:
-    <ul>
-    {{- range (visibleTypes (sortedTypes .Types)) -}}
-        {{ if isExportedType . -}}
-        <li>
-            <a href="{{ linkForType . }}">{{ typeDisplayName . }}</a>
-        </li>
-        {{- end }}
-    {{- end -}}
-    </ul>
-
-    {{ range (visibleTypes (sortedTypes .Types))}}
-        {{ template "type" .  }}
-    {{ end }}
-    <hr/>
-{{ end }}
+{{ template "package" index .packages 1 }}
+{{ template "package" index .packages 0 }}
 
 <p><em>
     Generated with <code>gen-crd-api-reference-docs</code>.


### PR DESCRIPTION
We display the alpha types in the API spec before the beta types. So readers see all of our types - including experimental and deprecated - before seeing the package with the more limited set of "standard" types.

Reverse this by manually iterating the packages list so that the beta package is displayed before the alpha package.

I could buy that this is too much of a hack to be worth it though!

/kind documentation