### PR TITLE
gep-1324: add a definition of "gateway" to glossary

### DIFF
--- a/site-src/geps/gep-1324.md
+++ b/site-src/geps/gep-1324.md
@@ -127,6 +127,34 @@ A service **consumer** is someone that utilizes a service by communicating with 
 
 Consumer and producer are personas, not concrete workloads or resources. One important aspect of these personas is that they may live in different trust boundaries (typically namespace).
 
+### **Gateway**
+
+We use the term “gateway” in reference to an abstract concept capturing the idea of a component which translates network traffic.
+
+We are using the term in a deliberately abstract way, therefore it is important that readers do not confuse this abstract interpretation of the term - and associated terms - with more concrete interpretations in more specific contexts. For example, we are specifically not referring to the meaning of “gateway” in IP packet routing, nor even the meaning of “translation” in that context.
+
+We can think of a gateway as being a component (aka “network element”) which implements a layer of indirection between a sender of traffic (e.g. a consumer) and its receivers (e.g. a producer). Senders and receivers are all known as “network endpoints”. Gateways consume
+“reachability information” describing endpoints in order to gain knowledge of available receivers.
+
+We can describe the capabilities of this layer of indirection in various ways:
+
+* Routing - choosing a receiver endpoint based on data (routing discriminators like IP addresses, TCP/UDP ports, TLS SNI, HTTP headers, etc.) in the traffic and rules configured owners (or privileged users) of the gateway.
+* Load-balancing - choosing a receiver endpoint from several valid endpoints based on knowledge of previous traffic from this or other sender endpoints, or knowledge of receiver endpoints status.
+* Filtering - modifying the traffic in various ways before forwarding, for example modifying headers or URLs, or redirecting/mirroring the traffic to alternative endpoints.
+* Encryption - some combination of decrypting traffic from sender endpoints and/or encrypting traffic before forwarding to receiver endpoints.
+
+A concrete implementation of these abstract ideas might modify traffic in the following ways:
+
+* Translation of IP addresses or TCP/UDP ports - the packet is forwarded after some address modifications (aka Network Address Translation, or NAT).
+* Proxying of TCP/UDP packets or HTTP request/responses - the payload to be separated from the original protocol headers and new headers are constructed. A proxy acts as a server to receive traffic and as a client to forward the traffic onwards.
+* Encapsulation of IP/TCP/UP packets in another protocol - the packet is wrapped in new protocol headers and must be de-encapsulated (“terminated”) by another gateway before being forwarded to the receiver endpoint.
+
+While a gateway may be a single-instance component through which traffic must flow - e.g. an IP router, or HTTP proxy - a gateway can also be deployed with multiple, redundant instances, or it can be a “logical” entity such that the traffic forwarding rules are distributed to many different parts of a network. Similarly, many “logical” gateway descriptions could potentially be combined or collapsed into a single concrete gateway configuration.
+
+Gateways are often used to “segment” endpoints on a network in various ways - we sometimes use “North/South” to describe traffic flowing across a segment boundary, and “East/West” to describe traffic flowing within a segment. Segmentation can be useful, for example, to separate tenants from one another to increase security. The concepts of “micro-segmentation” and “zero trust” describes the idea that security should be enforced even between trusted endpoints with a system, leading to smaller “micro” segments, even to the point of each endpoint occupying its own segment and trusting “zero” other endpoints. A gateway implements segmentation by being responsible for forwarding traffic between segments, and enforcing segmentation policy at that point.
+
+Gateways whose rule set describes how traffic should be translated as it “enters” a segment are known as “ingress gateways”. In contrast, gateways who provide some translation function to traffic leaving a segment are known as “egress gateways”. In other words, an ingress gateway is located on a segment boundary in front of service producers and an egress gateway is located on a segment boundary in front of service consumers.
+
 ## Deferred Goals
 
 These are goals that we aren’t explicitly excluding, but will reconsider at a later point in time


### PR DESCRIPTION
The glossary section goes to great length to create a clear understanding of some terms that are especially important in the
context of a discussion of supporting mesh use-cases in the API.

However, we don't currently define the "gateway" term. Rectify this by adding a definition that makes reference to many other terms that might crop up in this conversation - e.g. traffic translation, network elements, network endpoints, senders/receivers, consumers/producers, reachability information, routing and routing discriminators, load-balancing, filtering, encryption, NAT, proxying, encapsulation, logical gateways, distributed gateways, segmentation, North/South vs East/West, micro-segmentation and zero-trust, and ingress vs egress gateways. Phew!

Hopefully this is neither hilariously incorrect or wildly out of kilter with ongoing GAMMA discussions. The idea is to generate some discussion about whether we all understand the abstract idea of a "gateway" in the same way. HTH

/kind design

