### PR TITLE
conformance: fix GatewaySecretReferenceGrantAllInNamespace resources

### DIFF
--- a/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go
+++ b/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go
@@ -35,7 +35,7 @@ var GatewaySecretReferenceGrantAllInNamespace = suite.ConformanceTest{
 	ShortName:   "GatewaySecretReferenceGrantAllInNamespace",
 	Description: "A Gateway in the gateway-conformance-infra namespace should become ready if the Gateway has a certificateRef for a Secret in the gateway-conformance-web-backend namespace and a ReferenceGrant granting permission to all Secrets in the namespace exists",
 	Features:    []suite.SupportedFeature{suite.SupportReferenceGrant},
-	Manifests:   []string{"tests/gateway-secret-reference-grant-specific.yaml"},
+	Manifests:   []string{"tests/gateway-secret-reference-grant-all-in-namespace.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "gateway-secret-reference-grant", Namespace: "gateway-conformance-infra"}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
Fixes a conformance test

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
