### PR TITLE
conformance: listener `invalidRouteKind`

### DIFF
--- a/conformance/tests/gateway-unsupported-route-kind.go
+++ b/conformance/tests/gateway-unsupported-route-kind.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayUnsupportedRouteKind)
+}
+
+var GatewayUnsupportedRouteKind = suite.ConformanceTest{
+	ShortName:   "GatewayUnsupportedRouteKind",
+	Description: "A Gateway in the gateway-conformance-infra namespace should fail to become ready if explicitly supports any route type incompatible with the protocol type, even if there are types which are valid as well.",
+	Manifests:   []string{"tests/gateway-unsupported-route-kind.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		t.Run("Gateway listener should have a false ResolvedRefs condition with reason InvalidRouteKinds and no supportedKinds", func(t *testing.T) {
+			gwNN := types.NamespacedName{Name: "gateway-only-unsupported-route-kind", Namespace: "gateway-conformance-infra"}
+			listeners := []v1alpha2.ListenerStatus{{
+				Name:           v1alpha2.SectionName("https"),
+				SupportedKinds: []v1alpha2.RouteGroupKind{},
+				Conditions: []metav1.Condition{{
+					Type:   string(v1alpha2.ListenerConditionResolvedRefs),
+					Status: metav1.ConditionFalse,
+					Reason: string(v1alpha2.ListenerReasonInvalidRouteKinds),
+				}},
+			}}
+
+			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
+		})
+
+		t.Run("Gateway listener should have a false ResolvedRefs condition with reason InvalidRouteKinds and HTTPRoute must be put in the supportedKinds", func(t *testing.T) {
+			gwNN := types.NamespacedName{Name: "gateway-supported-and-unsupported-route-kind", Namespace: "gateway-conformance-infra"}
+			listeners := []v1alpha2.ListenerStatus{{
+				Name: v1alpha2.SectionName("https"),
+				SupportedKinds: []v1alpha2.RouteGroupKind{{
+					Group: (*v1alpha2.Group)(&v1alpha2.GroupVersion.Group),
+					Kind:  v1alpha2.Kind("HTTPRoute"),
+				}},
+				Conditions: []metav1.Condition{{
+					Type:   string(v1alpha2.ListenerConditionResolvedRefs),
+					Status: metav1.ConditionFalse,
+					Reason: string(v1alpha2.ListenerReasonInvalidRouteKinds),
+				}},
+			}}
+
+			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
+		})
+	},
+}

--- a/conformance/tests/gateway-unsupported-route-kind.yaml
+++ b/conformance/tests/gateway-unsupported-route-kind.yaml
@@ -1,0 +1,34 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  name: gateway-only-unsupported-route-kind
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: All
+        kinds:
+        - kind: UDPRoute
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  name: gateway-supported-and-unsupported-route-kind
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: All
+        kinds:
+        - kind: UDPRoute
+        - kind: HTTPRoute


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

**What this PR does / why we need it**:

A new conformance test case has been added to ensure that whenever a listener supports a Route type incompatible with the ProtocolType, the `ListenerStatus.SupportedKinds` are updated accordingly, and the `ResolvedRefs` listener condition fails with reason `InvalidRouteKinds `.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1320 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
