### PR TITLE
Fixing docs links that incorrectly had site-src/ prefix

### DIFF
--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -17,7 +17,7 @@ The specification of an HTTPRoute consists of:
   fields.
 
 The following illustrates an HTTPRoute that sends all traffic to one Service:
-![httproute-basic-example](/site-src/images/httproute-basic-example.svg)
+![httproute-basic-example](/images/httproute-basic-example.svg)
 
 ### Attaching to Gateways
 

--- a/site-src/api-types/referencegrant.md
+++ b/site-src/api-types/referencegrant.md
@@ -94,7 +94,7 @@ for more details on how specific ReferenceGrant fields are interpreted.
 Cross namespace Route -> Gateway binding follows a slightly different pattern
 where the handshake mechanism is built into the Gateway resource. For more
 information on that approach, refer to the relevant [Security Model
-documentation](/site-src/concepts/security-model). Although conceptually similar to
+documentation](/concepts/security-model). Although conceptually similar to
 ReferenceGrant, this configuration is built directly into Gateway Listeners,
 and allows for fine-grained per Listener configuration that would not be
 possible with ReferenceGrant.

--- a/site-src/contributing/enhancement-requests.md
+++ b/site-src/contributing/enhancement-requests.md
@@ -19,7 +19,7 @@ enhancement into the project.
    (GEP)][gep]
 
 [issue]: https://github.com/kubernetes-sigs/gateway-api/issues/new/choose
-[gep]: /site-src/contributing/gep
+[gep]: /contributing/gep
 
 ## What is Considered an Enhancement?
 

--- a/site-src/contributing/gamma.md
+++ b/site-src/contributing/gamma.md
@@ -9,7 +9,7 @@ service mesh projects, regardless of their technology stack or proxy.
 
 ## Deliverables
 
-This group will deliver [Gateway Enhancement Proposals](/site-src/contributing/gep)
+This group will deliver [Gateway Enhancement Proposals](/contributing/gep)
 consisting of resources, additions, and modifications to the Gateway API
 specification for mesh and mesh-adjacent use-cases. Governance of the Gateway
 API specification remains solely with the maintainers of the Gateway API
@@ -23,6 +23,6 @@ PT and 8am PT slots to try to be as time-zone inclusive as possible. Meetings
 will be moderated by the [GAMMA
 leads](https://github.com/kubernetes-sigs/gateway-api/blob/main/OWNERS_ALIASES#L23)
 with notes taken by a volunteer. Meeting occurences can be found on the
-[sig-network calendar](/site-src/contributing/community/#meetings). Community members
+[sig-network calendar](/contributing/community/#meetings). Community members
 should feel free to attend both GAMMA and Gateway API meetings, but are by no
 means obligated to do so.

--- a/site-src/contributing/gep.md
+++ b/site-src/contributing/gep.md
@@ -46,7 +46,7 @@ can easily find previous discussions and alternatives considered.
 
 ## Format
 
-GEPs should match the format of the template found in [GEP-696](/site-src/geps/gep-696).
+GEPs should match the format of the template found in [GEP-696](/geps/gep-696).
 
 ## Out of scope
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
As caught by @plgingembre, some of our docs links incorrectly had the "/site-src" prefix, this fixes that.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
