### PR TITLE
Revert "broken_site_src"

### DIFF
--- a/site-src/api-types/gatewayclass.md
+++ b/site-src/api-types/gatewayclass.md
@@ -135,5 +135,5 @@ example.net/gateway/v2.1 // Use version 2.1
 example.net/gateway      // Use the default version
 ```
 
-[gatewayclass]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.GatewayClass
+[gatewayclass]: /references/spec/#gateway.networking.k8s.io/v1beta1.GatewayClass
 [ingress-class-api]: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class

--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -197,12 +197,12 @@ only one Route rule may match each request. For more information on how conflict
 resolution applies to merging, refer to the [API specification][httprouterule].
 
 
-[httproute]:https://gateway-api.sigs.k8s.io/api-types/httproute/
-[httprouterule]:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteRule
-[hostname]:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.Hostname
-[rfc-3986]:https://tools.ietf.org/html/rfc3986
-[matches]:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteMatch
-[filters]:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteFilter
-[backendRef]:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPBackendRef
-[parentRef]:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.ParentRef
+[httproute]: /references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute
+[httprouterule]: /references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteRule
+[hostname]: /references/spec/#gateway.networking.k8s.io/v1beta1.Hostname
+[rfc-3986]: https://tools.ietf.org/html/rfc3986
+[matches]: /references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteMatch
+[filters]: /references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteFilter
+[backendRef]: /references/spec/#gateway.networking.k8s.io/v1beta1.HTTPBackendRef
+[parentRef]: /references/spec/#gateway.networking.k8s.io/v1beta1.ParentRef
 

--- a/site-src/api-types/referencegrant.md
+++ b/site-src/api-types/referencegrant.md
@@ -87,7 +87,7 @@ While the API is simplistic in nature, it comes with a few notable decisions:
    other. This makes it impossible for them to conflict with each other.
 
 Please see the [API
-Specification](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.ReferenceGrant)
+Specification](/references/spec#gateway.networking.k8s.io/v1alpha2.ReferenceGrant)
 for more details on how specific ReferenceGrant fields are interpreted.
 
 ## Exceptions

--- a/site-src/blog/2021/introducing-v1alpha2.md
+++ b/site-src/blog/2021/introducing-v1alpha2.md
@@ -25,7 +25,7 @@ an experimental API group (`networking.x-k8s.io`) to the new
 is concerned, this version is wholly distinct from v1alpha1, and automatic
 conversion is not possible.
 
-![New API group for v1alpha2](/site-src/images/v1alpha2-group.png)
+![New API group for v1alpha2](/images/v1alpha2-group.png)
 
 ### Simpler Route-Gateway Binding
 In v1alpha1 we provided many ways to connect Gateways and Routes. This was a bit
@@ -104,7 +104,7 @@ This is intended to allow things like:
 As a simple example, a TimeoutPolicy may be attached to a Gateway. The effects
 of that policy would cascade down to Routes attached to that policy:
 
-![Simple Ingress Example](/site-src/images/policy/ingress-simple.png)
+![Simple Ingress Example](/images/policy/ingress-simple.png)
 
 This is covered in more detail in [GEP 713](https://gateway-api.sigs.k8s.io/geps/gep-713/).
 
@@ -113,7 +113,7 @@ There are a lot of changes in v1alpha2 that we haven't covered here. For the
 full changelog, refer to our [v0.4.0 release
 notes](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.4.0). 
 
-Many of our [implementations](/site-src/implementations) are planning to release support
+Many of our [implementations](/implementations) are planning to release support
 for the v1alpha2 API in the coming weeks. We'll update our documentation as
 v1alpha2 implementations become available.
 
@@ -125,4 +125,4 @@ We still have lots more to work on. Some of our next items to discuss include:
 * L4 Route matching
 
 If these kinds of topics interest you, we'd love to have your input. Refer to
-our [community page](/site-src/contributing/community) to see how you can get involved.
+our [community page](/contributing/community) to see how you can get involved.

--- a/site-src/blog/index.md
+++ b/site-src/blog/index.md
@@ -15,7 +15,7 @@ rewrites.
 
 [:octicons-arrow-right-24: Continue reading][Gateway API Graduates to Beta]
 
-[Gateway API Graduates to Beta]:/site-src/blog/2022/graduating-to-beta
+[Gateway API Graduates to Beta]:/blog/2022/graduating-to-beta
 
 ## [Introducing Gateway API v1alpha2]
 
@@ -30,4 +30,4 @@ the highlights.
 
 [:octicons-arrow-right-24: Continue reading][Introducing Gateway API v1alpha2]
 
-[Introducing Gateway API v1alpha2]: /site-src/blog/2021/introducing-v1alpha2
+[Introducing Gateway API v1alpha2]: /blog/2021/introducing-v1alpha2


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
As pointed out by @markmc when reviewing #1357, we probably want to roll back all of #1319. I think this was caused by a common point of confusion. When browsing links in site-src within the repo, they will be broken, that is intentional. The goal of site-src is to build https://gateway-api.sigs.k8s.io/, not to be useful independently of that. I'm not sure how/where to document that because I know it's confusing, suggestions welcome.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
