### PR TITLE
Add help info to NGINX Kubernetes Gateway implementation section

### DIFF
--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -19,7 +19,7 @@ Implementors and integrators of Gateway API are encouraged to update this docume
 - [Istio][9] (alpha)
 - [Kong][10] (alpha)
 - [Kuma][11] (alpha)
-- [NGINX Kubernetes Gateway][12] (pre-alpha)
+- [NGINX Kubernetes Gateway][12]
 - [Traefik][13] (alpha)
 
 ## Integration Status
@@ -205,8 +205,13 @@ Kuma is actively working on an implementation of Gateway API specification for t
 
 [NGINX Kubernetes Gateway][nginx-kubernetes-gateway] is an open-source project that provides an implementation of the Gateway API using [NGINX][nginx] as the data plane. The goal of this project is to implement the core Gateway API -- Gateway, GatewayClass, HTTPRoute, TCPRoute, TLSRoute, and UDPRoute -- to configure an HTTP or TCP/UDP load balancer, reverse-proxy, or API gateway for applications running on Kubernetes. NGINX Kubernetes Gateway is currently under development and supports a subset of the Gateway API.
 
+If you have any suggestions or experience issues with NGINX Kubernetes Gateway, please [create an issue][nginx-issue-new] or a [discussion][nginx-disc-new] on GitHub. You can also ask for help in the [#nginx-kubernetes-gateway channel on NGINX slack][nginx-slack].
+
 [nginx-kubernetes-gateway]:https://github.com/nginxinc/nginx-kubernetes-gateway
 [nginx]:https://nginx.org/
+[nginx-issue-new]:https://github.com/nginxinc/nginx-kubernetes-gateway/issues/new
+[nginx-disc-new]:https://github.com/nginxinc/nginx-kubernetes-gateway/discussions/new
+[nginx-slack]:https://nginxcommunity.slack.com/channels/nginx-kubernetes-gateway
 
 ### Traefik
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

This PR adds help information to the NGINX Kubernetes Gateway implementation section. It also removes the `pre-alpha` qualifier from the NGINX Kubernetes Gateway implementation status. 

**Which issue(s) this PR fixes**:

NONE

**Does this PR introduce a user-facing change?**:

NONE