### PR TITLE
Fixing webhook config to watch v1beta1

### DIFF
--- a/config/webhook/admission_webhook.yaml
+++ b/config/webhook/admission_webhook.yaml
@@ -13,7 +13,7 @@ webhooks:
     rules:
       - operations: [ "CREATE" , "UPDATE" ]
         apiGroups: [ "gateway.networking.k8s.io" ]
-        apiVersions: [ "v1alpha2" ]
+        apiVersions: [ "v1alpha2", "v1beta1" ]
         resources: [ "gateways", "gatewayclasses", "httproutes" ]
     failurePolicy: Fail
     sideEffects: None


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As pointed out by @markmc, we missed updating the webhook config to include v1beta1 when we released v0.5.0. 

Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
