### PR TITLE
release-0.5: Cherry pick #1365 - Fixing webhook config to watch v1beta1

### DIFF
--- a/config/webhook/admission_webhook.yaml
+++ b/config/webhook/admission_webhook.yaml
@@ -13,7 +13,7 @@ webhooks:
     rules:
       - operations: [ "CREATE" , "UPDATE" ]
         apiGroups: [ "gateway.networking.k8s.io" ]
-        apiVersions: [ "v1alpha2" ]
+        apiVersions: [ "v1alpha2", "v1beta1" ]
         resources: [ "gateways", "gatewayclasses", "httproutes" ]
     failurePolicy: Fail
     sideEffects: None


### PR DESCRIPTION
**What type of PR is this?**

Add one of the following kinds:
/kind bug

**What this PR does / why we need it**:

Cherry-pick https://github.com/kubernetes-sigs/gateway-api/pull/1365 to 0.5.x release branch

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
