### PR TITLE
replace Attached condition with Accepted in HTTPRoute docs

### DIFF
--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -65,7 +65,7 @@ type HTTPRouteRule = v1beta1.HTTPRouteRule
 // must ensure that unknown values will not cause a crash.
 //
 // Unknown values here must result in the implementation setting the
-// Attached Condition for the Route to `status: False`, with a
+// Accepted Condition for the Route to `status: False`, with a
 // Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=Exact;PathPrefix;RegularExpression
@@ -112,7 +112,7 @@ type HTTPPathMatch = v1beta1.HTTPPathMatch
 // must ensure that unknown values will not cause a crash.
 //
 // Unknown values here must result in the implementation setting the
-// Attached Condition for the Route to `status: False`, with a
+// Accepted Condition for the Route to `status: False`, with a
 // Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=Exact;RegularExpression
@@ -159,7 +159,7 @@ type HTTPHeaderMatch = v1beta1.HTTPHeaderMatch
 // must ensure that unknown values will not cause a crash.
 //
 // Unknown values here must result in the implementation setting the
-// Attached Condition for the Route to `status: False`, with a
+// Accepted Condition for the Route to `status: False`, with a
 // Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=Exact;RegularExpression
@@ -187,7 +187,7 @@ type HTTPQueryParamMatch = v1beta1.HTTPQueryParamMatch
 // must ensure that unknown values will not cause a crash.
 //
 // Unknown values here must result in the implementation setting the
-// Attached Condition for the Route to `status: False`, with a
+// Accepted Condition for the Route to `status: False`, with a
 // Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=GET;HEAD;POST;PUT;DELETE;CONNECT;OPTIONS;TRACE;PATCH

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -257,7 +257,7 @@ type HTTPRouteRule struct {
 // must ensure that unknown values will not cause a crash.
 //
 // Unknown values here must result in the implementation setting the
-// Attached Condition for the Route to `status: False`, with a
+// Accepted Condition for the Route to `status: False`, with a
 // Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=Exact;PathPrefix;RegularExpression
@@ -319,7 +319,7 @@ type HTTPPathMatch struct {
 // must ensure that unknown values will not cause a crash.
 //
 // Unknown values here must result in the implementation setting the
-// Attached Condition for the Route to `status: False`, with a
+// Accepted Condition for the Route to `status: False`, with a
 // Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=Exact;RegularExpression
@@ -400,7 +400,7 @@ type HTTPHeaderMatch struct {
 // must ensure that unknown values will not cause a crash.
 //
 // Unknown values here must result in the implementation setting the
-// Attached Condition for the Route to `status: False`, with a
+// Accepted Condition for the Route to `status: False`, with a
 // Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=Exact;RegularExpression
@@ -468,7 +468,7 @@ type HTTPQueryParamMatch struct {
 // must ensure that unknown values will not cause a crash.
 //
 // Unknown values here must result in the implementation setting the
-// Attached Condition for the Route to `status: False`, with a
+// Accepted Condition for the Route to `status: False`, with a
 // Reason of `UnsupportedValue`.
 //
 // +kubebuilder:validation:Enum=GET;HEAD;POST;PUT;DELETE;CONNECT;OPTIONS;TRACE;PATCH
@@ -575,7 +575,7 @@ type HTTPRouteFilter struct {
 	// must ensure that unknown values will not cause a crash.
 	//
 	// Unknown values here must result in the implementation setting the
-	// Attached Condition for the Route to `status: False`, with a
+	// Accepted Condition for the Route to `status: False`, with a
 	// Reason of `UnsupportedValue`.
 	//
 	// +unionDiscriminator
@@ -819,7 +819,7 @@ type HTTPPathModifier struct {
 	// must ensure that unknown values will not cause a crash.
 	//
 	// Unknown values here must result in the implementation setting the
-	// Attached Condition for the Route to `status: False`, with a
+	// Accepted Condition for the Route to `status: False`, with a
 	// Reason of `UnsupportedValue`.
 	//
 	// <gateway:experimental>
@@ -863,7 +863,7 @@ type HTTPRequestRedirectFilter struct {
 	// must ensure that unknown values will not cause a crash.
 	//
 	// Unknown values here must result in the implementation setting the
-	// Attached Condition for the Route to `status: False`, with a
+	// Accepted Condition for the Route to `status: False`, with a
 	// Reason of `UnsupportedValue`.
 	//
 	// +optional
@@ -906,7 +906,7 @@ type HTTPRequestRedirectFilter struct {
 	// must ensure that unknown values will not cause a crash.
 	//
 	// Unknown values here must result in the implementation setting the
-	// Attached Condition for the Route to `status: False`, with a
+	// Accepted Condition for the Route to `status: False`, with a
 	// Reason of `UnsupportedValue`.
 	//
 	// +optional

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -543,7 +543,7 @@ spec:
                                             implementations must ensure that unknown
                                             values will not cause a crash. \n Unknown
                                             values here must result in the implementation
-                                            setting the Attached Condition for the
+                                            setting the Accepted Condition for the
                                             Route to `status: False`, with a Reason
                                             of `UnsupportedValue`. \n <gateway:experimental>"
                                           enum:
@@ -570,7 +570,7 @@ spec:
                                         values may be added to this enum, implementations
                                         must ensure that unknown values will not cause
                                         a crash. \n Unknown values here must result
-                                        in the implementation setting the Attached
+                                        in the implementation setting the Accepted
                                         Condition for the Route to `status: False`,
                                         with a Reason of `UnsupportedValue`."
                                       enum:
@@ -585,7 +585,7 @@ spec:
                                         implementations must ensure that unknown values
                                         will not cause a crash. \n Unknown values
                                         here must result in the implementation setting
-                                        the Attached Condition for the Route to `status:
+                                        the Accepted Condition for the Route to `status:
                                         False`, with a Reason of `UnsupportedValue`."
                                       enum:
                                       - 301
@@ -730,7 +730,7 @@ spec:
                                     Note that values may be added to this enum, implementations
                                     must ensure that unknown values will not cause
                                     a crash. \n Unknown values here must result in
-                                    the implementation setting the Attached Condition
+                                    the implementation setting the Accepted Condition
                                     for the Route to `status: False`, with a Reason
                                     of `UnsupportedValue`. \n "
                                   enum:
@@ -791,7 +791,7 @@ spec:
                                             implementations must ensure that unknown
                                             values will not cause a crash. \n Unknown
                                             values here must result in the implementation
-                                            setting the Attached Condition for the
+                                            setting the Accepted Condition for the
                                             Route to `status: False`, with a Reason
                                             of `UnsupportedValue`. \n <gateway:experimental>"
                                           enum:
@@ -1163,7 +1163,7 @@ spec:
                                       to this enum, implementations must ensure that
                                       unknown values will not cause a crash. \n Unknown
                                       values here must result in the implementation
-                                      setting the Attached Condition for the Route
+                                      setting the Accepted Condition for the Route
                                       to `status: False`, with a Reason of `UnsupportedValue`.
                                       \n <gateway:experimental>"
                                     enum:
@@ -1190,7 +1190,7 @@ spec:
                                   to this enum, implementations must ensure that unknown
                                   values will not cause a crash. \n Unknown values
                                   here must result in the implementation setting the
-                                  Attached Condition for the Route to `status: False`,
+                                  Accepted Condition for the Route to `status: False`,
                                   with a Reason of `UnsupportedValue`."
                                 enum:
                                 - http
@@ -1203,7 +1203,7 @@ spec:
                                   values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a
                                   crash. \n Unknown values here must result in the
-                                  implementation setting the Attached Condition for
+                                  implementation setting the Accepted Condition for
                                   the Route to `status: False`, with a Reason of `UnsupportedValue`."
                                 enum:
                                 - 301
@@ -1338,7 +1338,7 @@ spec:
                               that values may be added to this enum, implementations
                               must ensure that unknown values will not cause a crash.
                               \n Unknown values here must result in the implementation
-                              setting the Attached Condition for the Route to `status:
+                              setting the Accepted Condition for the Route to `status:
                               False`, with a Reason of `UnsupportedValue`. \n "
                             enum:
                             - RequestHeaderModifier
@@ -1394,7 +1394,7 @@ spec:
                                       to this enum, implementations must ensure that
                                       unknown values will not cause a crash. \n Unknown
                                       values here must result in the implementation
-                                      setting the Attached Condition for the Route
+                                      setting the Accepted Condition for the Route
                                       to `status: False`, with a Reason of `UnsupportedValue`.
                                       \n <gateway:experimental>"
                                     enum:
@@ -2373,7 +2373,7 @@ spec:
                                             implementations must ensure that unknown
                                             values will not cause a crash. \n Unknown
                                             values here must result in the implementation
-                                            setting the Attached Condition for the
+                                            setting the Accepted Condition for the
                                             Route to `status: False`, with a Reason
                                             of `UnsupportedValue`. \n <gateway:experimental>"
                                           enum:
@@ -2400,7 +2400,7 @@ spec:
                                         values may be added to this enum, implementations
                                         must ensure that unknown values will not cause
                                         a crash. \n Unknown values here must result
-                                        in the implementation setting the Attached
+                                        in the implementation setting the Accepted
                                         Condition for the Route to `status: False`,
                                         with a Reason of `UnsupportedValue`."
                                       enum:
@@ -2415,7 +2415,7 @@ spec:
                                         implementations must ensure that unknown values
                                         will not cause a crash. \n Unknown values
                                         here must result in the implementation setting
-                                        the Attached Condition for the Route to `status:
+                                        the Accepted Condition for the Route to `status:
                                         False`, with a Reason of `UnsupportedValue`."
                                       enum:
                                       - 301
@@ -2560,7 +2560,7 @@ spec:
                                     Note that values may be added to this enum, implementations
                                     must ensure that unknown values will not cause
                                     a crash. \n Unknown values here must result in
-                                    the implementation setting the Attached Condition
+                                    the implementation setting the Accepted Condition
                                     for the Route to `status: False`, with a Reason
                                     of `UnsupportedValue`. \n "
                                   enum:
@@ -2621,7 +2621,7 @@ spec:
                                             implementations must ensure that unknown
                                             values will not cause a crash. \n Unknown
                                             values here must result in the implementation
-                                            setting the Attached Condition for the
+                                            setting the Accepted Condition for the
                                             Route to `status: False`, with a Reason
                                             of `UnsupportedValue`. \n <gateway:experimental>"
                                           enum:
@@ -2993,7 +2993,7 @@ spec:
                                       to this enum, implementations must ensure that
                                       unknown values will not cause a crash. \n Unknown
                                       values here must result in the implementation
-                                      setting the Attached Condition for the Route
+                                      setting the Accepted Condition for the Route
                                       to `status: False`, with a Reason of `UnsupportedValue`.
                                       \n <gateway:experimental>"
                                     enum:
@@ -3020,7 +3020,7 @@ spec:
                                   to this enum, implementations must ensure that unknown
                                   values will not cause a crash. \n Unknown values
                                   here must result in the implementation setting the
-                                  Attached Condition for the Route to `status: False`,
+                                  Accepted Condition for the Route to `status: False`,
                                   with a Reason of `UnsupportedValue`."
                                 enum:
                                 - http
@@ -3033,7 +3033,7 @@ spec:
                                   values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a
                                   crash. \n Unknown values here must result in the
-                                  implementation setting the Attached Condition for
+                                  implementation setting the Accepted Condition for
                                   the Route to `status: False`, with a Reason of `UnsupportedValue`."
                                 enum:
                                 - 301
@@ -3168,7 +3168,7 @@ spec:
                               that values may be added to this enum, implementations
                               must ensure that unknown values will not cause a crash.
                               \n Unknown values here must result in the implementation
-                              setting the Attached Condition for the Route to `status:
+                              setting the Accepted Condition for the Route to `status:
                               False`, with a Reason of `UnsupportedValue`. \n "
                             enum:
                             - RequestHeaderModifier
@@ -3224,7 +3224,7 @@ spec:
                                       to this enum, implementations must ensure that
                                       unknown values will not cause a crash. \n Unknown
                                       values here must result in the implementation
-                                      setting the Attached Condition for the Route
+                                      setting the Accepted Condition for the Route
                                       to `status: False`, with a Reason of `UnsupportedValue`.
                                       \n <gateway:experimental>"
                                     enum:

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -493,7 +493,7 @@ spec:
                                         values may be added to this enum, implementations
                                         must ensure that unknown values will not cause
                                         a crash. \n Unknown values here must result
-                                        in the implementation setting the Attached
+                                        in the implementation setting the Accepted
                                         Condition for the Route to `status: False`,
                                         with a Reason of `UnsupportedValue`."
                                       enum:
@@ -508,7 +508,7 @@ spec:
                                         implementations must ensure that unknown values
                                         will not cause a crash. \n Unknown values
                                         here must result in the implementation setting
-                                        the Attached Condition for the Route to `status:
+                                        the Accepted Condition for the Route to `status:
                                         False`, with a Reason of `UnsupportedValue`."
                                       enum:
                                       - 301
@@ -544,7 +544,7 @@ spec:
                                     Note that values may be added to this enum, implementations
                                     must ensure that unknown values will not cause
                                     a crash. \n Unknown values here must result in
-                                    the implementation setting the Attached Condition
+                                    the implementation setting the Accepted Condition
                                     for the Route to `status: False`, with a Reason
                                     of `UnsupportedValue`. \n "
                                   enum:
@@ -895,7 +895,7 @@ spec:
                                   to this enum, implementations must ensure that unknown
                                   values will not cause a crash. \n Unknown values
                                   here must result in the implementation setting the
-                                  Attached Condition for the Route to `status: False`,
+                                  Accepted Condition for the Route to `status: False`,
                                   with a Reason of `UnsupportedValue`."
                                 enum:
                                 - http
@@ -908,7 +908,7 @@ spec:
                                   values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a
                                   crash. \n Unknown values here must result in the
-                                  implementation setting the Attached Condition for
+                                  implementation setting the Accepted Condition for
                                   the Route to `status: False`, with a Reason of `UnsupportedValue`."
                                 enum:
                                 - 301
@@ -942,7 +942,7 @@ spec:
                               that values may be added to this enum, implementations
                               must ensure that unknown values will not cause a crash.
                               \n Unknown values here must result in the implementation
-                              setting the Attached Condition for the Route to `status:
+                              setting the Accepted Condition for the Route to `status:
                               False`, with a Reason of `UnsupportedValue`. \n "
                             enum:
                             - RequestHeaderModifier
@@ -1840,7 +1840,7 @@ spec:
                                         values may be added to this enum, implementations
                                         must ensure that unknown values will not cause
                                         a crash. \n Unknown values here must result
-                                        in the implementation setting the Attached
+                                        in the implementation setting the Accepted
                                         Condition for the Route to `status: False`,
                                         with a Reason of `UnsupportedValue`."
                                       enum:
@@ -1855,7 +1855,7 @@ spec:
                                         implementations must ensure that unknown values
                                         will not cause a crash. \n Unknown values
                                         here must result in the implementation setting
-                                        the Attached Condition for the Route to `status:
+                                        the Accepted Condition for the Route to `status:
                                         False`, with a Reason of `UnsupportedValue`."
                                       enum:
                                       - 301
@@ -1891,7 +1891,7 @@ spec:
                                     Note that values may be added to this enum, implementations
                                     must ensure that unknown values will not cause
                                     a crash. \n Unknown values here must result in
-                                    the implementation setting the Attached Condition
+                                    the implementation setting the Accepted Condition
                                     for the Route to `status: False`, with a Reason
                                     of `UnsupportedValue`. \n "
                                   enum:
@@ -2242,7 +2242,7 @@ spec:
                                   to this enum, implementations must ensure that unknown
                                   values will not cause a crash. \n Unknown values
                                   here must result in the implementation setting the
-                                  Attached Condition for the Route to `status: False`,
+                                  Accepted Condition for the Route to `status: False`,
                                   with a Reason of `UnsupportedValue`."
                                 enum:
                                 - http
@@ -2255,7 +2255,7 @@ spec:
                                   values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a
                                   crash. \n Unknown values here must result in the
-                                  implementation setting the Attached Condition for
+                                  implementation setting the Accepted Condition for
                                   the Route to `status: False`, with a Reason of `UnsupportedValue`."
                                 enum:
                                 - 301
@@ -2289,7 +2289,7 @@ spec:
                               that values may be added to this enum, implementations
                               must ensure that unknown values will not cause a crash.
                               \n Unknown values here must result in the implementation
-                              setting the Attached Condition for the Route to `status:
+                              setting the Accepted Condition for the Route to `status:
                               False`, with a Reason of `UnsupportedValue`. \n "
                             enum:
                             - RequestHeaderModifier


### PR DESCRIPTION
The HTTPRoute docs have several references to
an "Attached" condition, however this condition
does not exist for routes. Replaces these
references with the appropriate "Accepted"
condition.

Signed-off-by: Steve Kriss <krisss@vmware.com>



**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

The HTTPRoute docs have several references to
an "Attached" condition, however this condition
does not exist for routes. Replaces these
references with the appropriate "Accepted"
condition.

See https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.RouteConditionType for the list of valid Route condition types and reasons.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
