### PR TITLE
Updating our versioning guidelines to allow additional types of changes

### DIFF
--- a/site-src/concepts/versioning.md
+++ b/site-src/concepts/versioning.md
@@ -73,16 +73,19 @@ change across API versions.
 * Clarifications to godocs
 * Updates to CRDs and/or code to fix a bug
 * Conformance test fixes
+* Additional conformance test coverage for existing features
 * Fixes to typos
 
 ### Minor version (e.g. v0.4.0 -> v0.5.0)
 * Everything that is valid in a patch release
 * New experimental API fields or resources
+* Changes to recommended conditions or reasons in status
 * Loosened validation
 * Making required fields optional
 * Removal of experimental fields
 * Removal of experimental resources
 * Graduation of fields or resources from experimental to standard track
+* Changes to conformance tests to match spec updates
 * Introduction of a new **API version**, which may also include:
   * Renamed fields
   * Anything else that is valid in a new Kubernetes API version


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This updates our versioning guidelines to allow the following types of changes:

1. Patch versions now formally allow expanding conformance test coverage 
This is very important as we're in active development and conformance test coverage of existing features  has still not reached 100%. We should not wait to add better conformance tests until we have another minor release.

2. Minor versions now allow for changes to recommended status conditions 
Importantly this does not include changes to the structure of the API, just the values we recommend that implementations set. This also includes a corresponding allowance for conformance test changes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/hold for consensus
