### PR TITLE
Add configurable timeout conformance test.

### DIFF
--- a/conformance/tests/httproute-disallowed-kind.go
+++ b/conformance/tests/httproute-disallowed-kind.go
@@ -17,13 +17,10 @@ limitations under the License.
 package tests
 
 import (
-	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 )
@@ -47,21 +44,8 @@ var HTTPRouteDisallowedKind = suite.ConformanceTest{
 		t.Run("Route should not have Parents set in status", func(t *testing.T) {
 			kubernetes.HTTPRouteMustHaveNoAcceptedParents(t, suite.Client, suite.TimeoutConfig, routeName)
 		})
-
 		t.Run("Gateway should have 0 Routes attached", func(t *testing.T) {
-			gw := &v1beta1.Gateway{}
-			err := suite.Client.Get(context.TODO(), gwName, gw)
-			require.NoError(t, err, "error fetching Gateway")
-			// There are two valid ways to represent this:
-			// 1. No listeners in status
-			// 2. One listener in status with 0 attached routes
-			if len(gw.Status.Listeners) == 0 {
-				// No listeners in status.
-			} else if len(gw.Status.Listeners) == 1 {
-				require.Equal(t, int32(0), gw.Status.Listeners[0].AttachedRoutes)
-			} else {
-				t.Errorf("Expected no more than 1 listener in status, got %d", len(gw.Status.Listeners))
-			}
+			kubernetes.GatewayMustHaveZeroRoutes(t, suite.Client, suite.TimeoutConfig, gwName)
 		})
 	},
 }

--- a/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go
@@ -17,14 +17,10 @@ limitations under the License.
 package tests
 
 import (
-	"context"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 )
@@ -46,25 +42,7 @@ var HTTPRouteInvalidCrossNamespaceParentRef = suite.ConformanceTest{
 		})
 
 		t.Run("Gateway should have 0 Routes attached", func(t *testing.T) {
-			require.Eventually(t, func() bool {
-				gw := &v1beta1.Gateway{}
-				if err := suite.Client.Get(context.TODO(), gwName, gw); err != nil {
-					t.Logf("error fetching gateway: %v", err)
-					return false
-				}
-
-				// There are two valid ways to represent this:
-				// 1. No listeners in status
-				// 2. One listener in status with 0 attached routes
-				if len(gw.Status.Listeners) == 0 {
-					// No listeners in status.
-					return true
-				} else if len(gw.Status.Listeners) == 1 {
-					// Listener with no attached routes
-					return gw.Status.Listeners[0].AttachedRoutes == 0
-				}
-				return false
-			}, time.Second*15, time.Second, "Expected no attached routes")
+			kubernetes.GatewayMustHaveZeroRoutes(t, suite.Client, suite.TimeoutConfig, gwName)
 		})
 	},
 }

--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -27,6 +27,10 @@ type TimeoutConfig struct {
 	// Max value for conformant implementation: None
 	DeleteTimeout time.Duration
 
+	// GetTimeout represents the maximum time to get a Kubernetes object.
+	// Max value for conformant implementation: None
+	GetTimeout time.Duration
+
 	// GatewayMustHaveAddress represents the maximum time for at least one IP Address has been set in the status of a Gateway.
 	// Max value for conformant implementation: None
 	GatewayMustHaveAddress time.Duration
@@ -73,6 +77,7 @@ func DefaultTimeoutConfig() TimeoutConfig {
 	return TimeoutConfig{
 		CreateTimeout:                  60 * time.Second,
 		DeleteTimeout:                  10 * time.Second,
+		GetTimeout:                     10 * time.Second,
 		GatewayMustHaveAddress:         180 * time.Second,
 		GatewayStatusMustHaveListeners: 60 * time.Second,
 		GWCMustBeAccepted:              180 * time.Second,
@@ -93,6 +98,9 @@ func SetupTimeoutConfig(timeoutConfig *TimeoutConfig) {
 	}
 	if timeoutConfig.DeleteTimeout == 0 {
 		timeoutConfig.DeleteTimeout = defaultTimeoutConfig.DeleteTimeout
+	}
+	if timeoutConfig.GetTimeout == 0 {
+		timeoutConfig.GetTimeout = defaultTimeoutConfig.GetTimeout
 	}
 	if timeoutConfig.GatewayMustHaveAddress == 0 {
 		timeoutConfig.GatewayMustHaveAddress = defaultTimeoutConfig.GatewayMustHaveAddress

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -210,6 +210,35 @@ func WaitForGatewayAddress(t *testing.T, client client.Client, timeoutConfig con
 	return net.JoinHostPort(ipAddr, port), waitErr
 }
 
+// GatewayMustHaveZeroRoutes validates that the gateway has zero routes attached.  The status
+// may indicate a single listener with zero attached routes or no listeners.
+func GatewayMustHaveZeroRoutes(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, gwName types.NamespacedName) {
+	var gotStatus *v1beta1.GatewayStatus
+	waitErr := wait.PollImmediate(1*time.Second, timeoutConfig.GatewayStatusMustHaveListeners, func() (bool, error) {
+		gw := &v1beta1.Gateway{}
+		ctx, cancel := context.WithTimeout(context.Background(), timeoutConfig.GetTimeout)
+		defer cancel()
+		err := client.Get(ctx, gwName, gw)
+		require.NoError(t, err, "error fetching Gateway")
+		// There are two valid ways to represent this:
+		// 1. No listeners in status
+		// 2. One listener in status with 0 attached routes
+		if len(gw.Status.Listeners) == 0 {
+			// No listeners in status.
+			return true, nil
+		}
+		if len(gw.Status.Listeners) == 1 && gw.Status.Listeners[0].AttachedRoutes == 0 {
+			// One listener with zero attached routes.
+			return true, nil
+		}
+		gotStatus = &gw.Status
+		return false, nil
+	})
+	if waitErr != nil {
+		t.Errorf("Error waiting for gateway, got Gateway Status %v, want zero listeners or exactly 1 listener with zero routes", gotStatus)
+	}
+}
+
 // HTTPRouteMustHaveNoAcceptedParents waits for the specified HTTPRoute to have either no parents
 // or a single parent that is not accepted. This is used to validate HTTPRoute errors.
 func HTTPRouteMustHaveNoAcceptedParents(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, routeName types.NamespacedName) {


### PR DESCRIPTION
HTTPRouteInvalidCrossNamespaceParentRef hardcodes a 15 second timeout. Utilize suite.TimeoutConfig for specifying the timeout instead.

**What type of PR is this?**
/kind cleanup
/kind flake

**What this PR does / why we need it**:

The test hardcodes 15 seconds for a status condition to appear which can cause flakiness for slower controllers.  Use a configurable timeout to allow for separation of function and performance.

#1397 
