### PR TITLE
Update remaining v1alpha2 references in conformance tests

### DIFF
--- a/conformance/tests/gateway-unsupported-route-kind.yaml
+++ b/conformance/tests/gateway-unsupported-route-kind.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   name: gateway-only-unsupported-route-kind
@@ -15,7 +15,7 @@ spec:
         kinds:
         - kind: UDPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   name: gateway-supported-and-unsupported-route-kind

--- a/conformance/tests/httproute-hostname-intersection.yaml
+++ b/conformance/tests/httproute-hostname-intersection.yaml
@@ -28,7 +28,7 @@ spec:
         from: Same
     hostname: "*.anotherwildcard.io"
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: specific-host-matches-listener-specific-host
@@ -50,7 +50,7 @@ spec:
     - name: infra-backend-v1
       port: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: specific-host-matches-listener-wildcard-host
@@ -74,7 +74,7 @@ spec:
     - name: infra-backend-v2
       port: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: wildcard-host-matches-listener-specific-host
@@ -95,7 +95,7 @@ spec:
     - name: infra-backend-v3
       port: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: wildcard-host-matches-listener-wildcard-host
@@ -115,7 +115,7 @@ spec:
     - name: infra-backend-v1
       port: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: no-intersecting-hosts

--- a/conformance/tests/httproute-method-matching.yaml
+++ b/conformance/tests/httproute-method-matching.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: method-matching


### PR DESCRIPTION

**What type of PR is this?**
/kind bug



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
