### PR TITLE
Bumping version to v0.5.1 throughout docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- [v0.5.1](#v051)
 - [v0.5.0](#v050)
 - [v0.5.0-rc2](#v050-rc2)
 - [v0.5.0-rc1](#v050-rc1)
@@ -16,6 +17,39 @@
 - [v0.1.0](#v010)
 - [v0.1.0-rc2](#v010-rc2)
 - [v0.1.0-rc1](#v010-rc1)
+
+## v0.5.1
+
+API versions: v1beta1, v1alpha2
+
+This release includes a number of bug fixes and clarifications:
+
+### API Spec
+
+* The spec has been clarified to state that the port specified in BackendRef
+  refers to the Service port number, not the target port, when a Service is
+  referenced. [#1332](https://github.com/kubernetes-sigs/gateway-api/pull/1332)
+* The spec has been clarified to state that "Accepted" should be used instead of
+  "Attached" on HTTPRoute.
+  [#1382](https://github.com/kubernetes-sigs/gateway-api/pull/1382)
+
+### Webhook:
+
+* The duplicate gateway-system namespace definitions have been removed.
+  [#1387](https://github.com/kubernetes-sigs/gateway-api/pull/1387)
+* The webhook has been updated to watch v1beta1.
+  [#1365](https://github.com/kubernetes-sigs/gateway-api/pull/1368)
+
+### Conformance:
+
+* The expected condition for a cross-namespace certificate reference that has
+  not been allowed by a ReferenceGrant has been changed from
+  "InvalidCertificateRef" to "RefNotPermitted" to more closely match the spec.
+  [#1351](https://github.com/kubernetes-sigs/gateway-api/pull/1351)
+* A new test has been added to cover when a Gateway references a Secret that
+  does not exist
+  [#1334](https://github.com/kubernetes-sigs/gateway-api/pull/1334)
+
 
 ## v0.5.0
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ the specification and Custom Resource Definitions (CRDs).
 
 ## Status
 
-The latest supported version is `v1beta1` as released by the [v0.5.0
-release](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.5.0) of
+The latest supported version is `v1beta1` as released by the [v0.5.1
+release](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.5.1) of
 this project.
 
 This version of the API is has beta level support for the following resources:

--- a/config/webhook/admission_webhook.yaml
+++ b/config/webhook/admission_webhook.yaml
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: gcr.io/k8s-staging-gateway-api/admission-server:v0.5.0
+          image: gcr.io/k8s-staging-gateway-api/admission-server:v0.5.1
           imagePullPolicy: Always
           args:
             - -logtostderr

--- a/hack/verify-examples-kind.sh
+++ b/hack/verify-examples-kind.sh
@@ -54,7 +54,7 @@ kind create cluster --name "${CLUSTER_NAME}" || res=$?
 # Install webhook
 docker build -t gcr.io/k8s-staging-gateway-api/admission-server:latest .
 # Temporary workaround for release
-sed -i 's/v0.5.0/latest/g' config/webhook/admission_webhook.yaml
+sed -i 's/v0.5.1/latest/g' config/webhook/admission_webhook.yaml
 kubectl apply -f config/webhook/
 
 # Wait for webhook to be ready
@@ -106,7 +106,7 @@ for CHANNEL in experimental standard; do
 done
 
 # Undo workaround from earlier
-sed -i 's/latest/v0.5.0/g' config/webhook/admission_webhook.yaml
+sed -i 's/latest/v0.5.1/g' config/webhook/admission_webhook.yaml
 
 # Clean up and exit
 cleanup || res=$?

--- a/site-src/guides/getting-started.md
+++ b/site-src/guides/getting-started.md
@@ -38,7 +38,7 @@ including GatewayClass, Gateway, and HTTPRoute. To install this channel, run the
 following kubectl command:
 
 ```
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.5.0/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.5.1/standard-install.yaml
 ```
 
 ### Install Experimental Channel
@@ -56,7 +56,7 @@ documentation](https://gateway-api.sigs.k8s.io/concepts/versioning/).
 To install the experimental channel, run the following kubectl command:
 
 ```
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.5.0/experimental-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.5.1/experimental-install.yaml
 ```
 
 ### Cleanup


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This updates our documentation to account for the recent [v0.5.1 release](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.5.1).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
