### PR TITLE
chore: remove workaround logics in verify-examples-kind.sh

### DIFF
--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,7 +1,0 @@
-resources:
-  - 0-namespace.yaml
-  - certificate_config.yaml
-  - admission_webhook.yaml
-images:
-  - name: gcr.io/k8s-staging-gateway-api/admission-server:v0.5.0
-    newTag: latest

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - 0-namespace.yaml
+  - certificate_config.yaml
+  - admission_webhook.yaml
+images:
+  - name: gcr.io/k8s-staging-gateway-api/admission-server:v0.5.0
+    newTag: latest

--- a/hack/verify-examples-kind.sh
+++ b/hack/verify-examples-kind.sh
@@ -22,6 +22,7 @@ readonly GO111MODULE="on"
 readonly GOFLAGS="-mod=readonly"
 readonly GOPATH="$(mktemp -d)"
 readonly CLUSTER_NAME="verify-gateway-api"
+readonly ADMISSION_WEBHOOK_VERSION="v0.5.1"
 
 export KUBECONFIG="${GOPATH}/.kubeconfig"
 export GOFLAGS GO111MODULE GOPATH
@@ -60,7 +61,7 @@ resources:
   - certificate_config.yaml
   - admission_webhook.yaml
 images:
-  - name: gcr.io/k8s-staging-gateway-api/admission-server:v0.5.0
+  - name: gcr.io/k8s-staging-gateway-api/admission-server:${ADMISSION_WEBHOOK_VERSION}
     newTag: latest
 EOF
 


### PR DESCRIPTION
Signed-off-by: Chao Zhang <tokers@apache.org>

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature
/kind cleanup

**What this PR does / why we need it**:

Previously, we have some workaround logics in the `hack/verify-examples-kind.sh`, it modifies the image tag in `config/webhook/admission_webhook.yaml`, so that the latest commit of admission webhook can be used.

This PR removed the hack logic by using the customization feature in Kustomize, see https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#customizing for the details. We create the `config/webhook/kustomization.yaml` file temporarily (and remove it when cleanup), which replaces the webhook image tag from `v0.5.0` (or others in the future) to `latest`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1366

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->

NONE
