### PR TITLE
Update golangci-lint (1.46.2->1.50.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,17 @@ uninstall:
 verify:
 	hack/verify-all.sh -v
 
+# Run Go linter
+.PHONY: lint
+lint:
+	hack/verify-golint.sh
+
+# Run Go linter auto-fixers if supported
+.PHONY: lint-fix
+lint-fix:
+	hack/verify-golint.sh --fix
+
+
 # Build the documentation.
 .PHONY: docs
 docs:

--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -272,15 +272,15 @@ type GRPCRouteRule struct {
 // For example, the match below will match a gRPC request only if its service
 // is `foo` AND it contains the `version: v1` header:
 //
-// ```
-// matches:
-// - method:
-//    type: Exact
-//    service: "foo"
-//   headers:
-//   - name: "version"
-//     value "v1"
-// ```
+//	```
+//	matches:
+//	- method:
+//	   type: Exact
+//	   service: "foo"
+//	  headers:
+//	  - name: "version"
+//	    value "v1"
+//	```
 type GRPCRouteMatch struct {
 	// Path specifies a gRPC request service/method matcher. If this field is not
 	// specified, all services and methods will match.

--- a/apis/v1alpha2/referencegrant_types.go
+++ b/apis/v1alpha2/referencegrant_types.go
@@ -40,7 +40,6 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // grant allowed.
 //
 // Support: Core
-//
 type ReferenceGrant struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha2/validation/gateway.go
+++ b/apis/v1alpha2/validation/gateway.go
@@ -40,7 +40,7 @@ var (
 
 // ValidateGateway validates gw according to the Gateway API specification.
 // For additional details of the Gateway spec, refer to:
-//  https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.Gateway
+// https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.Gateway
 //
 // Validation that is not possible with CRD annotations may be added here in the future.
 // See https://github.com/kubernetes-sigs/gateway-api/issues/868 for more information.

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -340,9 +340,9 @@ const (
 //
 // Invalid values include:
 //
-// * ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-//   headers are not currently supported by this type.
-// * "/invalid" - "/" is an invalid character
+//   - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+//     headers are not currently supported by this type.
+//   - "/invalid" - "/" is an invalid character
 //
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=256
@@ -495,11 +495,13 @@ const (
 //
 // ```
 // match:
-//   path:
-//     value: "/foo"
-//   headers:
-//   - name: "version"
-//     value "v1"
+//
+//	path:
+//	  value: "/foo"
+//	headers:
+//	- name: "version"
+//	  value "v1"
+//
 // ```
 type HTTPRouteMatch struct {
 	// Path specifies a HTTP request path matcher. If this field is not

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -334,9 +334,9 @@ type RouteStatus struct {
 // Hostname is the fully qualified domain name of a network host. This matches
 // the RFC 1123 definition of a hostname with 2 notable exceptions:
 //
-// 1. IPs are not allowed.
-// 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
-//    label must appear by itself as the first label.
+//  1. IPs are not allowed.
+//  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+//     label must appear by itself as the first label.
 //
 // Hostname can be "precise" which is a domain name without the terminating
 // dot of a network host (e.g. "foo.example.com") or "wildcard", which is a

--- a/apis/v1beta1/validation/gateway.go
+++ b/apis/v1beta1/validation/gateway.go
@@ -40,7 +40,7 @@ var (
 
 // ValidateGateway validates gw according to the Gateway API specification.
 // For additional details of the Gateway spec, refer to:
-//  https://gateway-api.sigs.k8s.io/v1beta1/references/spec/#gateway.networking.k8s.io/v1beta1.Gateway
+// https://gateway-api.sigs.k8s.io/v1beta1/references/spec/#gateway.networking.k8s.io/v1beta1.Gateway
 //
 // Validation that is not possible with CRD annotations may be added here in the future.
 // See https://github.com/kubernetes-sigs/gateway-api/issues/868 for more information.

--- a/cmd/admission/main.go
+++ b/cmd/admission/main.go
@@ -27,6 +27,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -72,7 +73,8 @@ func main() {
 	server := &http.Server{
 		Addr: ":8443",
 		// Require at least TLS12 to satisfy golint G402.
-		TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{certs}},
+		TLSConfig:         &tls.Config{MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{certs}},
+		ReadHeaderTimeout: 16 * time.Second,
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/validate", admission.ServeHTTP)

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -109,8 +109,8 @@ spec:
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
-                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
                     must appear by itself as the first label. \n Hostname can be \"precise\"
                     which is a domain name without the terminating dot of a network
                     host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
@@ -915,9 +915,9 @@ spec:
                           ANDed together, i.e. the match will evaluate to true only
                           if all conditions are satisfied. \n For example, the match
                           below will match a gRPC request only if its service is `foo`
-                          AND it contains the `version: v1` header: \n ``` matches:
-                          - method:    type: Exact    service: \"foo\"   headers:
-                          \  - name: \"version\"     value \"v1\" ```"
+                          AND it contains the `version: v1` header: \n \t``` \tmatches:
+                          \t- method: \t   type: Exact \t   service: \"foo\" \t  headers:
+                          \t  - name: \"version\" \t    value \"v1\" \t```"
                         properties:
                           headers:
                             description: Headers specifies gRPC request header matchers.

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -90,8 +90,8 @@ spec:
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
-                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
                     must appear by itself as the first label. \n Hostname can be \"precise\"
                     which is a domain name without the terminating dot of a network
                     host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
@@ -1451,8 +1451,8 @@ spec:
                           if all conditions are satisfied. \n For example, the match
                           below will match a HTTP request only if its path starts
                           with `/foo` AND it contains the `version: v1` header: \n
-                          ``` match:   path:     value: \"/foo\"   headers:   - name:
-                          \"version\"     value \"v1\" ```"
+                          ``` match: \n \tpath: \t  value: \"/foo\" \theaders: \t-
+                          name: \"version\" \t  value \"v1\" \n ```"
                         properties:
                           headers:
                             description: Headers specifies HTTP request header matchers.
@@ -1920,8 +1920,8 @@ spec:
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
-                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
                     must appear by itself as the first label. \n Hostname can be \"precise\"
                     which is a domain name without the terminating dot of a network
                     host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
@@ -3281,8 +3281,8 @@ spec:
                           if all conditions are satisfied. \n For example, the match
                           below will match a HTTP request only if its path starts
                           with `/foo` AND it contains the `version: v1` header: \n
-                          ``` match:   path:     value: \"/foo\"   headers:   - name:
-                          \"version\"     value \"v1\" ```"
+                          ``` match: \n \tpath: \t  value: \"/foo\" \theaders: \t-
+                          name: \"version\" \t  value \"v1\" \n ```"
                         properties:
                           headers:
                             description: Headers specifies HTTP request header matchers.

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -75,8 +75,8 @@ spec:
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
-                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
                     must appear by itself as the first label. \n Hostname can be \"precise\"
                     which is a domain name without the terminating dot of a network
                     host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -90,8 +90,8 @@ spec:
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
-                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
                     must appear by itself as the first label. \n Hostname can be \"precise\"
                     which is a domain name without the terminating dot of a network
                     host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
@@ -996,8 +996,8 @@ spec:
                           if all conditions are satisfied. \n For example, the match
                           below will match a HTTP request only if its path starts
                           with `/foo` AND it contains the `version: v1` header: \n
-                          ``` match:   path:     value: \"/foo\"   headers:   - name:
-                          \"version\"     value \"v1\" ```"
+                          ``` match: \n \tpath: \t  value: \"/foo\" \theaders: \t-
+                          name: \"version\" \t  value \"v1\" \n ```"
                         properties:
                           headers:
                             description: Headers specifies HTTP request header matchers.
@@ -1437,8 +1437,8 @@ spec:
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
-                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
                     must appear by itself as the first label. \n Hostname can be \"precise\"
                     which is a domain name without the terminating dot of a network
                     host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
@@ -2343,8 +2343,8 @@ spec:
                           if all conditions are satisfied. \n For example, the match
                           below will match a HTTP request only if its path starts
                           with `/foo` AND it contains the `version: v1` header: \n
-                          ``` match:   path:     value: \"/foo\"   headers:   - name:
-                          \"version\"     value \"v1\" ```"
+                          ``` match: \n \tpath: \t  value: \"/foo\" \theaders: \t-
+                          name: \"version\" \t  value \"v1\" \n ```"
                         properties:
                           headers:
                             description: Headers specifies HTTP request header matchers.

--- a/conformance/utils/roundtripper/roundtripper.go
+++ b/conformance/utils/roundtripper/roundtripper.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -127,7 +127,7 @@ func (d *DefaultRoundTripper) CaptureRoundTrip(request Request) (*CapturedReques
 		fmt.Printf("Received Response:\n%s\n\n", formatDump(dump, "< "))
 	}
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 
 	// we cannot assume the response is JSON
 	if resp.Header.Get("Content-type") == "application/json" {

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -18,7 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly VERSION="v1.46.2"
+GOLANGCI_LINT_ARGS=${1:-''}
+
+readonly VERSION="v1.50.0"
 readonly KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 cd "${KUBE_ROOT}"
@@ -26,6 +28,6 @@ cd "${KUBE_ROOT}"
 # See configuration file in ${KUBE_ROOT}/.golangci.yml.
 mkdir -p cache
 
-docker run --rm -v $(pwd)/cache:/cache -v $(pwd):/app --security-opt="label=disable" -e GOLANGCI_LINT_CACHE=/cache -w /app "golangci/golangci-lint:$VERSION" golangci-lint run
+docker run --rm -v $(pwd)/cache:/cache -v $(pwd):/app --security-opt="label=disable" -e GOLANGCI_LINT_CACHE=/cache -w /app "golangci/golangci-lint:$VERSION" golangci-lint run ${GOLANGCI_LINT_ARGS}
 
 # ex: ts=2 sw=2 et filetype=sh

--- a/pkg/admission/server.go
+++ b/pkg/admission/server.go
@@ -19,7 +19,7 @@ package admission
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	admission "k8s.io/api/admission/v1"
@@ -126,7 +126,7 @@ func ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.StatusBadRequest)
 		return
 	}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		log500(w, err)
 		return


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

Updates the golangci-lint version from 1.46.2 -> 1.49.0 and fixes all the findings. This is needed due to linters being disabled currently. Also adds `make lint` target which just makes it easier for developers. 

Here is the current main branch linter output:
```
hack/verify-golint.sh
level=warning msg="[linters context] bodyclose is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
level=warning msg="[linters context] contextcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
level=warning msg="[linters context] nilerr is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
level=warning msg="[linters context] noctx is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
level=warning msg="[linters context] rowserrcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
level=warning msg="[linters context] sqlclosecheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
level=warning msg="[linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
level=warning msg="[linters context] unparam is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
```


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
