### PR TITLE
docs: merge 'custom' and 'implementation-specific' conformance

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -64,8 +64,8 @@ type Listener = v1beta1.Listener
 // Implementations can define their own protocols if a core ProtocolType does not
 // exist. Such definitions must use prefixed name, such as
 // `mycompany.com/my-custom-protocol`. Un-prefixed names are reserved for core
-// protocols. Any protocol defined by implementations will fall under custom
-// conformance.
+// protocols. Any protocol defined by implementations will fall under
+// implementation-specific conformance.
 //
 // Valid values include:
 //

--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -223,8 +223,8 @@ type GRPCRouteRule struct {
 	// - Implementation-specific custom filters have no API guarantees across
 	//   implementations.
 	//
-	// Specifying a core filter multiple times has unspecified or custom
-	// conformance.
+	// Specifying a core filter multiple times has unspecified or
+	// implementation-specific conformance.
 	// Support: Core
 	//
 	// +optional
@@ -256,7 +256,7 @@ type GRPCRouteRule struct {
 	//
 	// Support: Core for Kubernetes Service
 	//
-	// Support: Custom for any other resource
+	// Support: Implementation-specific for any other resource
 	//
 	// Support for weight: Core
 	//
@@ -308,9 +308,9 @@ type GRPCMethodMatch struct {
 	// Type specifies how to match against the service and/or method.
 	// Support: Core (Exact with service and method specified)
 	//
-	// Support Custom (Exact with method specified but no service specified)
+	// Support: Implementation-specific (Exact with method specified but no service specified)
 	//
-	// Support: Custom (RegularExpression)
+	// Support: Implementation-specific (RegularExpression)
 	//
 	// +optional
 	// +kubebuilder:default=Exact
@@ -402,7 +402,7 @@ type GRPCRouteFilter struct {
 	//   "Support: Extended" in this package, e.g. "RequestMirror". Implementers
 	//   are encouraged to support extended filters.
 	//
-	// - Custom: Filters that are defined and supported by specific vendors.
+	// - Implementation-specific: Filters that are defined and supported by specific vendors.
 	//   In the future, filters showing convergence in behavior across multiple
 	//   implementations will be considered for inclusion in extended or core
 	//   conformance levels. Filter-specific configuration for such filters
@@ -475,7 +475,7 @@ type GRPCBackendRef struct {
 	//
 	// Support: Core for Kubernetes Service
 	//
-	// Support: Custom for any other resource
+	// Support: Implementation-specific for any other resource
 	//
 	// Support for weight: Core
 	//
@@ -485,8 +485,8 @@ type GRPCBackendRef struct {
 	// Filters defined at this level MUST be executed if and only if the
 	// request is being forwarded to the backend defined here.
 	//
-	// Support: Custom (For broader support of filters, use the Filters field
-	// in GRPCRouteRule.)
+	// Support: Implementation-specific (For broader support of filters, use the
+	// Filters field in GRPCRouteRule.)
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=16

--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -91,8 +91,9 @@ const (
 	// Matches if the URL path matches the given regular expression with
 	// case sensitivity.
 	//
-	// Since `"RegularExpression"` has custom conformance, implementations
-	// can support POSIX, PCRE, RE2 or any other regular expression dialect.
+	// Since `"RegularExpression"` has implementation-specific conformance,
+	// implementations can support POSIX, PCRE, RE2 or any other regular expression
+	// dialect.
 	// Please read the implementation's documentation to determine the supported
 	// dialect.
 	PathMatchRegularExpression PathMatchType = "RegularExpression"
@@ -282,9 +283,9 @@ const (
 	// HTTPRouteFilterExtensionRef should be used for configuring custom
 	// HTTP filters.
 	//
-	// Support in HTTPRouteRule: Custom
+	// Support in HTTPRouteRule: Implementation-specific
 	//
-	// Support in HTTPBackendRef: Custom
+	// Support in HTTPBackendRef: Implementation-specific
 	HTTPRouteFilterExtensionRef HTTPRouteFilterType = "ExtensionRef"
 )
 

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -317,8 +317,8 @@ type AnnotationValue = v1beta1.AnnotationValue
 // The `NamedAddress` value has been deprecated in favor of implementation
 // specific domain-prefixed strings.
 //
-// All other values, including domain-prefixed values have Custom support, which
-// are used in implementation-specific behaviors. Support for additional
+// All other values, including domain-prefixed values have Implementation-specific support,
+// which are used in implementation-specific behaviors. Support for additional
 // predefined CamelCase identifiers may be added in future releases.
 //
 // +kubebuilder:validation:MinLength=1
@@ -354,6 +354,6 @@ const (
 	// The `NamedAddress` type has been deprecated in favor of implementation
 	// specific domain-prefixed strings.
 	//
-	// Support: Implementation-Specific
+	// Support: Implementation-specific
 	NamedAddressType AddressType = "NamedAddress"
 )

--- a/apis/v1alpha2/tcproute_types.go
+++ b/apis/v1alpha2/tcproute_types.go
@@ -68,7 +68,7 @@ type TCPRouteRule struct {
 	//
 	// Support: Core for Kubernetes Service
 	//
-	// Support: Custom for any other resource
+	// Support: Implementation-specific for any other resource
 	//
 	// Support for weight: Extended
 	//

--- a/apis/v1alpha2/tlsroute_types.go
+++ b/apis/v1alpha2/tlsroute_types.go
@@ -112,7 +112,7 @@ type TLSRouteRule struct {
 	//
 	// Support: Core for Kubernetes Service
 	//
-	// Support: Custom for any other resource
+	// Support: Implementation-specific for any other resource
 	//
 	// Support for weight: Extended
 	//

--- a/apis/v1alpha2/udproute_types.go
+++ b/apis/v1alpha2/udproute_types.go
@@ -67,7 +67,7 @@ type UDPRouteRule struct {
 	// the packets, then 80% of packets must be dropped instead.
 	//
 	// Support: Core for Kubernetes Service
-	// Support: Custom for any other resource
+	// Support: Implementation-specific for any other resource
 	//
 	// Support for weight: Extended
 	//

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -247,8 +247,8 @@ type Listener struct {
 // Implementations can define their own protocols if a core ProtocolType does not
 // exist. Such definitions must use prefixed name, such as
 // `mycompany.com/my-custom-protocol`. Un-prefixed names are reserved for core
-// protocols. Any protocol defined by implementations will fall under custom
-// conformance.
+// protocols. Any protocol defined by implementations will fall under
+// Implementation-specific conformance.
 //
 // Valid values include:
 //

--- a/apis/v1beta1/gatewayclass_types.go
+++ b/apis/v1beta1/gatewayclass_types.go
@@ -91,7 +91,7 @@ type GatewayClassSpec struct {
 	// If the referent cannot be found, the GatewayClass's "InvalidParameters"
 	// status condition will be true.
 	//
-	// Support: Custom
+	// Support: Implementation-specific
 	//
 	// +optional
 	ParametersRef *ParametersReference `json:"parametersRef,omitempty"`

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -192,8 +192,8 @@ type HTTPRouteRule struct {
 	// - Implementation-specific custom filters have no API guarantees across
 	//   implementations.
 	//
-	// Specifying a core filter multiple times has unspecified or custom
-	// conformance.
+	// Specifying a core filter multiple times has unspecified or
+	// implementation-specific conformance.
 	//
 	// All filters are expected to be compatible with each other except for the
 	// URLRewrite and RequestRedirect filters, which may not be combined. If an
@@ -232,7 +232,7 @@ type HTTPRouteRule struct {
 	//
 	// Support: Core for Kubernetes Service
 	//
-	// Support: Custom for any other resource
+	// Support: Implementation-specific for any other resource
 	//
 	// Support for weight: Core
 	//
@@ -282,8 +282,9 @@ const (
 	// Matches if the URL path matches the given regular expression with
 	// case sensitivity.
 	//
-	// Since `"RegularExpression"` has custom conformance, implementations
-	// can support POSIX, PCRE, RE2 or any other regular expression dialect.
+	// Since `"RegularExpression"` has implementation-specific conformance,
+	// implementations can support POSIX, PCRE, RE2 or any other regular expression
+	// dialect.
 	// Please read the implementation's documentation to determine the supported
 	// dialect.
 	PathMatchRegularExpression PathMatchType = "RegularExpression"
@@ -295,7 +296,7 @@ type HTTPPathMatch struct {
 	//
 	// Support: Core (Exact, PathPrefix)
 	//
-	// Support: Custom (RegularExpression)
+	// Support: Implementation-specific (RegularExpression)
 	//
 	// +optional
 	// +kubebuilder:default=PathPrefix
@@ -356,12 +357,12 @@ type HTTPHeaderMatch struct {
 	//
 	// Support: Core (Exact)
 	//
-	// Support: Custom (RegularExpression)
+	// Support: Implementation-specific (RegularExpression)
 	//
-	// Since RegularExpression HeaderMatchType has custom conformance,
-	// implementations can support POSIX, PCRE or any other dialects of regular
-	// expressions. Please read the implementation's documentation to determine
-	// the supported dialect.
+	// Since RegularExpression HeaderMatchType has implementation-specific
+	// conformance, implementations can support POSIX, PCRE or any other dialects
+	// of regular expressions. Please read the implementation's documentation to
+	// determine the supported dialect.
 	//
 	// +optional
 	// +kubebuilder:default=Exact
@@ -419,12 +420,12 @@ type HTTPQueryParamMatch struct {
 	//
 	// Support: Extended (Exact)
 	//
-	// Support: Custom (RegularExpression)
+	// Support: Implementation-specific (RegularExpression)
 	//
-	// Since RegularExpression QueryParamMatchType has custom conformance,
-	// implementations can support POSIX, PCRE or any other dialects of regular
-	// expressions. Please read the implementation's documentation to determine
-	// the supported dialect.
+	// Since RegularExpression QueryParamMatchType has Implementation-specific
+	// conformance, implementations can support POSIX, PCRE or any other
+	// dialects of regular expressions. Please read the implementation's
+	// documentation to determine the supported dialect.
 	//
 	// +optional
 	// +kubebuilder:default=Exact
@@ -557,7 +558,8 @@ type HTTPRouteFilter struct {
 	//   "Support: Extended" in this package, e.g. "RequestMirror". Implementers
 	//   are encouraged to support extended filters.
 	//
-	// - Custom: Filters that are defined and supported by specific vendors.
+	// - Implementation-specific: Filters that are defined and supported by
+	//   specific vendors.
 	//   In the future, filters showing convergence in behavior across multiple
 	//   implementations will be considered for inclusion in extended or core
 	//   conformance levels. Filter-specific configuration for such filters
@@ -691,9 +693,9 @@ const (
 	// HTTPRouteFilterExtensionRef should be used for configuring custom
 	// HTTP filters.
 	//
-	// Support in HTTPRouteRule: Custom
+	// Support in HTTPRouteRule: Implementation-specific
 	//
-	// Support in HTTPBackendRef: Custom
+	// Support in HTTPBackendRef: Implementation-specific
 	HTTPRouteFilterExtensionRef HTTPRouteFilterType = "ExtensionRef"
 )
 
@@ -961,7 +963,7 @@ type HTTPRequestMirrorFilter struct {
 	//
 	// Support: Extended for Kubernetes Service
 	//
-	// Support: Custom for any other resource
+	// Support: Implementation-specific for any other resource
 	BackendRef BackendObjectReference `json:"backendRef"`
 }
 
@@ -991,7 +993,7 @@ type HTTPBackendRef struct {
 	//
 	// Support: Core for Kubernetes Service
 	//
-	// Support: Custom for any other resource
+	// Support: Implementation-specific for any other resource
 	//
 	// Support for weight: Core
 	//
@@ -1001,8 +1003,8 @@ type HTTPBackendRef struct {
 	// Filters defined at this level should be executed if and only if the
 	// request is being forwarded to the backend defined here.
 	//
-	// Support: Custom (For broader support of filters, use the Filters field
-	// in HTTPRouteRule.)
+	// Support: Implementation-specific (For broader support of filters, use the
+	// Filters field in HTTPRouteRule.)
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=16

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -40,7 +40,7 @@ type ParentReference struct {
 	//
 	// Support: Core (Gateway)
 	//
-	// Support: Custom (Other Resources)
+	// Support: Implementation-specific (Other Resources)
 	//
 	// +kubebuilder:default=Gateway
 	// +optional
@@ -507,8 +507,8 @@ type AnnotationValue string
 // The `NamedAddress` value has been deprecated in favor of implementation
 // specific domain-prefixed strings.
 //
-// All other values, including domain-prefixed values have Custom support, which
-// are used in implementation-specific behaviors. Support for additional
+// All other values, including domain-prefixed values have Implementation-specific support,
+// which are used in implementation-specific behaviors. Support for additional
 // predefined CamelCase identifiers may be added in future releases.
 //
 // +kubebuilder:validation:MinLength=1
@@ -544,6 +544,6 @@ const (
 	// The `NamedAddress` type has been deprecated in favor of implementation
 	// specific domain-prefixed strings.
 	//
-	// Support: Implementation-Specific
+	// Support: Implementation-specific
 	NamedAddressType AddressType = "NamedAddress"
 )

--- a/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -90,7 +90,7 @@ spec:
                   resource, i.e. ConfigMap, or an implementation-specific custom resource.
                   The resource can be cluster-scoped or namespace-scoped. \n If the
                   referent cannot be found, the GatewayClass's \"InvalidParameters\"
-                  status condition will be true. \n Support: Custom"
+                  status condition will be true. \n Support: Implementation-specific"
                 properties:
                   group:
                     description: Group is the group of the referent.
@@ -291,7 +291,7 @@ spec:
                   resource, i.e. ConfigMap, or an implementation-specific custom resource.
                   The resource can be cluster-scoped or namespace-scoped. \n If the
                   referent cannot be found, the GatewayClass's \"InvalidParameters\"
-                  status condition will be true. \n Support: Custom"
+                  status condition will be true. \n Support: Implementation-specific"
                 properties:
                   group:
                     description: Group is the group of the referent.

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -159,7 +159,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -261,8 +261,8 @@ spec:
                         equal weights, and one is invalid, 50 percent of traffic MUST
                         receive an `UNAVAILABLE` status. Implementations may choose
                         how that 50 percent is determined. \n Support: Core for Kubernetes
-                        Service \n Support: Custom for any other resource \n Support
-                        for weight: Core"
+                        Service \n Support: Implementation-specific for any other
+                        resource \n Support for weight: Core"
                       items:
                         description: GRPCBackendRef defines how a GRPCRoute forwards
                           a gRPC request.
@@ -270,8 +270,9 @@ spec:
                           filters:
                             description: "Filters defined at this level MUST be executed
                               if and only if the request is being forwarded to the
-                              backend defined here. \n Support: Custom (For broader
-                              support of filters, use the Filters field in GRPCRouteRule.)"
+                              backend defined here. \n Support: Implementation-specific
+                              (For broader support of filters, use the Filters field
+                              in GRPCRouteRule.)"
                             items:
                               description: GRPCRouteFilter defines processing steps
                                 that must be completed during the request or response
@@ -448,7 +449,8 @@ spec:
                                         Message of the `ResolvedRefs` Condition should
                                         be used to provide more detail about the problem.
                                         \n Support: Extended for Kubernetes Service
-                                        \n Support: Custom for any other resource"
+                                        \n Support: Implementation-specific for any
+                                        other resource"
                                       properties:
                                         group:
                                           default: ""
@@ -518,21 +520,21 @@ spec:
                                     configuration defined by   \"Support: Extended\"
                                     in this package, e.g. \"RequestMirror\". Implementers
                                     \  are encouraged to support extended filters.
-                                    \n - Custom: Filters that are defined and supported
-                                    by specific vendors.   In the future, filters
-                                    showing convergence in behavior across multiple
-                                    \  implementations will be considered for inclusion
-                                    in extended or core   conformance levels. Filter-specific
-                                    configuration for such filters   is specified
-                                    using the ExtensionRef field. `Type` MUST be set
-                                    to   \"ExtensionRef\" for custom filters. \n Implementers
-                                    are encouraged to define custom implementation
-                                    types to extend the core API with implementation-specific
-                                    behavior. \n If a reference to a custom filter
-                                    type cannot be resolved, the filter MUST NOT be
-                                    skipped. Instead, requests that would have been
-                                    processed by that filter MUST receive a HTTP error
-                                    response. \n "
+                                    \n - Implementation-specific: Filters that are
+                                    defined and supported by specific vendors.   In
+                                    the future, filters showing convergence in behavior
+                                    across multiple   implementations will be considered
+                                    for inclusion in extended or core   conformance
+                                    levels. Filter-specific configuration for such
+                                    filters   is specified using the ExtensionRef
+                                    field. `Type` MUST be set to   \"ExtensionRef\"
+                                    for custom filters. \n Implementers are encouraged
+                                    to define custom implementation types to extend
+                                    the core API with implementation-specific behavior.
+                                    \n If a reference to a custom filter type cannot
+                                    be resolved, the filter MUST NOT be skipped. Instead,
+                                    requests that would have been processed by that
+                                    filter MUST receive a HTTP error response. \n "
                                   enum:
                                   - RequestHeaderModifier
                                   - RequestMirror
@@ -622,8 +624,8 @@ spec:
                         all implementations. - Implementers are encouraged to support
                         extended filters. - Implementation-specific custom filters
                         have no API guarantees across   implementations. \n Specifying
-                        a core filter multiple times has unspecified or custom conformance.
-                        Support: Core"
+                        a core filter multiple times has unspecified or implementation-specific
+                        conformance. Support: Core"
                       items:
                         description: GRPCRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -789,7 +791,8 @@ spec:
                                   In either error case, the Message of the `ResolvedRefs`
                                   Condition should be used to provide more detail
                                   about the problem. \n Support: Extended for Kubernetes
-                                  Service \n Support: Custom for any other resource"
+                                  Service \n Support: Implementation-specific for
+                                  any other resource"
                                 properties:
                                   group:
                                     default: ""
@@ -854,16 +857,16 @@ spec:
                               corresponding configuration defined by   \"Support:
                               Extended\" in this package, e.g. \"RequestMirror\".
                               Implementers   are encouraged to support extended filters.
-                              \n - Custom: Filters that are defined and supported
-                              by specific vendors.   In the future, filters showing
-                              convergence in behavior across multiple   implementations
-                              will be considered for inclusion in extended or core
-                              \  conformance levels. Filter-specific configuration
-                              for such filters   is specified using the ExtensionRef
-                              field. `Type` MUST be set to   \"ExtensionRef\" for
-                              custom filters. \n Implementers are encouraged to define
-                              custom implementation types to extend the core API with
-                              implementation-specific behavior. \n If a reference
+                              \n - Implementation-specific: Filters that are defined
+                              and supported by specific vendors.   In the future,
+                              filters showing convergence in behavior across multiple
+                              \  implementations will be considered for inclusion
+                              in extended or core   conformance levels. Filter-specific
+                              configuration for such filters   is specified using
+                              the ExtensionRef field. `Type` MUST be set to   \"ExtensionRef\"
+                              for custom filters. \n Implementers are encouraged to
+                              define custom implementation types to extend the core
+                              API with implementation-specific behavior. \n If a reference
                               to a custom filter type cannot be resolved, the filter
                               MUST NOT be skipped. Instead, requests that would have
                               been processed by that filter MUST receive a HTTP error
@@ -993,9 +996,9 @@ spec:
                                 default: Exact
                                 description: "Type specifies how to match against
                                   the service and/or method. Support: Core (Exact
-                                  with service and method specified) \n Support Custom
+                                  with service and method specified) \n Support: Implementation-specific
                                   (Exact with method specified but no service specified)
-                                  \n Support: Custom (RegularExpression)"
+                                  \n Support: Implementation-specific (RegularExpression)"
                                 enum:
                                 - Exact
                                 - RegularExpression
@@ -1151,7 +1154,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -140,7 +140,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -242,7 +242,7 @@ spec:
                         \n For example, if two backends are specified with equal weights,
                         and one is invalid, 50 percent of traffic must receive a 500.
                         Implementations may choose how that 50 percent is determined.
-                        \n Support: Core for Kubernetes Service \n Support: Custom
+                        \n Support: Core for Kubernetes Service \n Support: Implementation-specific
                         for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
@@ -251,9 +251,9 @@ spec:
                           filters:
                             description: "Filters defined at this level should be
                               executed if and only if the request is being forwarded
-                              to the backend defined here. \n Support: Custom (For
-                              broader support of filters, use the Filters field in
-                              HTTPRouteRule.)"
+                              to the backend defined here. \n Support: Implementation-specific
+                              (For broader support of filters, use the Filters field
+                              in HTTPRouteRule.)"
                             items:
                               description: HTTPRouteFilter defines processing steps
                                 that must be completed during the request or response
@@ -430,7 +430,8 @@ spec:
                                         Message of the `ResolvedRefs` Condition should
                                         be used to provide more detail about the problem.
                                         \n Support: Extended for Kubernetes Service
-                                        \n Support: Custom for any other resource"
+                                        \n Support: Implementation-specific for any
+                                        other resource"
                                       properties:
                                         group:
                                           default: ""
@@ -712,9 +713,9 @@ spec:
                                     types and their corresponding configuration defined
                                     by   \"Support: Extended\" in this package, e.g.
                                     \"RequestMirror\". Implementers   are encouraged
-                                    to support extended filters. \n - Custom: Filters
-                                    that are defined and supported by specific vendors.
-                                    \  In the future, filters showing convergence
+                                    to support extended filters. \n - Implementation-specific:
+                                    Filters that are defined and supported by   specific
+                                    vendors.   In the future, filters showing convergence
                                     in behavior across multiple   implementations
                                     will be considered for inclusion in extended or
                                     core   conformance levels. Filter-specific configuration
@@ -886,14 +887,14 @@ spec:
                         all implementations. - Implementers are encouraged to support
                         extended filters. - Implementation-specific custom filters
                         have no API guarantees across   implementations. \n Specifying
-                        a core filter multiple times has unspecified or custom conformance.
-                        \n All filters are expected to be compatible with each other
-                        except for the URLRewrite and RequestRedirect filters, which
-                        may not be combined. If an implementation can not support
-                        other combinations of filters, they must clearly document
-                        that limitation. In all cases where incompatible or unsupported
-                        filters are specified, implementations MUST add a warning
-                        condition to status. \n Support: Core"
+                        a core filter multiple times has unspecified or implementation-specific
+                        conformance. \n All filters are expected to be compatible
+                        with each other except for the URLRewrite and RequestRedirect
+                        filters, which may not be combined. If an implementation can
+                        not support other combinations of filters, they must clearly
+                        document that limitation. In all cases where incompatible
+                        or unsupported filters are specified, implementations MUST
+                        add a warning condition to status. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -1059,7 +1060,8 @@ spec:
                                   In either error case, the Message of the `ResolvedRefs`
                                   Condition should be used to provide more detail
                                   about the problem. \n Support: Extended for Kubernetes
-                                  Service \n Support: Custom for any other resource"
+                                  Service \n Support: Implementation-specific for
+                                  any other resource"
                                 properties:
                                   group:
                                     default: ""
@@ -1321,15 +1323,15 @@ spec:
                               - Extended: Filter types and their corresponding configuration
                               defined by   \"Support: Extended\" in this package,
                               e.g. \"RequestMirror\". Implementers   are encouraged
-                              to support extended filters. \n - Custom: Filters that
-                              are defined and supported by specific vendors.   In
-                              the future, filters showing convergence in behavior
-                              across multiple   implementations will be considered
-                              for inclusion in extended or core   conformance levels.
-                              Filter-specific configuration for such filters   is
-                              specified using the ExtensionRef field. `Type` should
-                              be set to   \"ExtensionRef\" for custom filters. \n
-                              Implementers are encouraged to define custom implementation
+                              to support extended filters. \n - Implementation-specific:
+                              Filters that are defined and supported by   specific
+                              vendors.   In the future, filters showing convergence
+                              in behavior across multiple   implementations will be
+                              considered for inclusion in extended or core   conformance
+                              levels. Filter-specific configuration for such filters
+                              \  is specified using the ExtensionRef field. `Type`
+                              should be set to   \"ExtensionRef\" for custom filters.
+                              \n Implementers are encouraged to define custom implementation
                               types to extend the core API with implementation-specific
                               behavior. \n If a reference to a custom filter type
                               cannot be resolved, the filter MUST NOT be skipped.
@@ -1487,12 +1489,12 @@ spec:
                                   default: Exact
                                   description: "Type specifies how to match against
                                     the value of the header. \n Support: Core (Exact)
-                                    \n Support: Custom (RegularExpression) \n Since
-                                    RegularExpression HeaderMatchType has custom conformance,
-                                    implementations can support POSIX, PCRE or any
-                                    other dialects of regular expressions. Please
-                                    read the implementation's documentation to determine
-                                    the supported dialect."
+                                    \n Support: Implementation-specific (RegularExpression)
+                                    \n Since RegularExpression HeaderMatchType has
+                                    implementation-specific conformance, implementations
+                                    can support POSIX, PCRE or any other dialects
+                                    of regular expressions. Please read the implementation's
+                                    documentation to determine the supported dialect."
                                   enum:
                                   - Exact
                                   - RegularExpression
@@ -1539,7 +1541,7 @@ spec:
                                 default: PathPrefix
                                 description: "Type specifies how to match against
                                   the path Value. \n Support: Core (Exact, PathPrefix)
-                                  \n Support: Custom (RegularExpression)"
+                                  \n Support: Implementation-specific (RegularExpression)"
                                 enum:
                                 - Exact
                                 - PathPrefix
@@ -1586,10 +1588,11 @@ spec:
                                   default: Exact
                                   description: "Type specifies how to match against
                                     the value of the query parameter. \n Support:
-                                    Extended (Exact) \n Support: Custom (RegularExpression)
-                                    \n Since RegularExpression QueryParamMatchType
-                                    has custom conformance, implementations can support
-                                    POSIX, PCRE or any other dialects of regular expressions.
+                                    Extended (Exact) \n Support: Implementation-specific
+                                    (RegularExpression) \n Since RegularExpression
+                                    QueryParamMatchType has Implementation-specific
+                                    conformance, implementations can support POSIX,
+                                    PCRE or any other dialects of regular expressions.
                                     Please read the implementation's documentation
                                     to determine the supported dialect."
                                   enum:
@@ -1761,7 +1764,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1970,7 +1974,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -2072,7 +2076,7 @@ spec:
                         \n For example, if two backends are specified with equal weights,
                         and one is invalid, 50 percent of traffic must receive a 500.
                         Implementations may choose how that 50 percent is determined.
-                        \n Support: Core for Kubernetes Service \n Support: Custom
+                        \n Support: Core for Kubernetes Service \n Support: Implementation-specific
                         for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
@@ -2081,9 +2085,9 @@ spec:
                           filters:
                             description: "Filters defined at this level should be
                               executed if and only if the request is being forwarded
-                              to the backend defined here. \n Support: Custom (For
-                              broader support of filters, use the Filters field in
-                              HTTPRouteRule.)"
+                              to the backend defined here. \n Support: Implementation-specific
+                              (For broader support of filters, use the Filters field
+                              in HTTPRouteRule.)"
                             items:
                               description: HTTPRouteFilter defines processing steps
                                 that must be completed during the request or response
@@ -2260,7 +2264,8 @@ spec:
                                         Message of the `ResolvedRefs` Condition should
                                         be used to provide more detail about the problem.
                                         \n Support: Extended for Kubernetes Service
-                                        \n Support: Custom for any other resource"
+                                        \n Support: Implementation-specific for any
+                                        other resource"
                                       properties:
                                         group:
                                           default: ""
@@ -2542,9 +2547,9 @@ spec:
                                     types and their corresponding configuration defined
                                     by   \"Support: Extended\" in this package, e.g.
                                     \"RequestMirror\". Implementers   are encouraged
-                                    to support extended filters. \n - Custom: Filters
-                                    that are defined and supported by specific vendors.
-                                    \  In the future, filters showing convergence
+                                    to support extended filters. \n - Implementation-specific:
+                                    Filters that are defined and supported by   specific
+                                    vendors.   In the future, filters showing convergence
                                     in behavior across multiple   implementations
                                     will be considered for inclusion in extended or
                                     core   conformance levels. Filter-specific configuration
@@ -2716,14 +2721,14 @@ spec:
                         all implementations. - Implementers are encouraged to support
                         extended filters. - Implementation-specific custom filters
                         have no API guarantees across   implementations. \n Specifying
-                        a core filter multiple times has unspecified or custom conformance.
-                        \n All filters are expected to be compatible with each other
-                        except for the URLRewrite and RequestRedirect filters, which
-                        may not be combined. If an implementation can not support
-                        other combinations of filters, they must clearly document
-                        that limitation. In all cases where incompatible or unsupported
-                        filters are specified, implementations MUST add a warning
-                        condition to status. \n Support: Core"
+                        a core filter multiple times has unspecified or implementation-specific
+                        conformance. \n All filters are expected to be compatible
+                        with each other except for the URLRewrite and RequestRedirect
+                        filters, which may not be combined. If an implementation can
+                        not support other combinations of filters, they must clearly
+                        document that limitation. In all cases where incompatible
+                        or unsupported filters are specified, implementations MUST
+                        add a warning condition to status. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -2889,7 +2894,8 @@ spec:
                                   In either error case, the Message of the `ResolvedRefs`
                                   Condition should be used to provide more detail
                                   about the problem. \n Support: Extended for Kubernetes
-                                  Service \n Support: Custom for any other resource"
+                                  Service \n Support: Implementation-specific for
+                                  any other resource"
                                 properties:
                                   group:
                                     default: ""
@@ -3151,15 +3157,15 @@ spec:
                               - Extended: Filter types and their corresponding configuration
                               defined by   \"Support: Extended\" in this package,
                               e.g. \"RequestMirror\". Implementers   are encouraged
-                              to support extended filters. \n - Custom: Filters that
-                              are defined and supported by specific vendors.   In
-                              the future, filters showing convergence in behavior
-                              across multiple   implementations will be considered
-                              for inclusion in extended or core   conformance levels.
-                              Filter-specific configuration for such filters   is
-                              specified using the ExtensionRef field. `Type` should
-                              be set to   \"ExtensionRef\" for custom filters. \n
-                              Implementers are encouraged to define custom implementation
+                              to support extended filters. \n - Implementation-specific:
+                              Filters that are defined and supported by   specific
+                              vendors.   In the future, filters showing convergence
+                              in behavior across multiple   implementations will be
+                              considered for inclusion in extended or core   conformance
+                              levels. Filter-specific configuration for such filters
+                              \  is specified using the ExtensionRef field. `Type`
+                              should be set to   \"ExtensionRef\" for custom filters.
+                              \n Implementers are encouraged to define custom implementation
                               types to extend the core API with implementation-specific
                               behavior. \n If a reference to a custom filter type
                               cannot be resolved, the filter MUST NOT be skipped.
@@ -3317,12 +3323,12 @@ spec:
                                   default: Exact
                                   description: "Type specifies how to match against
                                     the value of the header. \n Support: Core (Exact)
-                                    \n Support: Custom (RegularExpression) \n Since
-                                    RegularExpression HeaderMatchType has custom conformance,
-                                    implementations can support POSIX, PCRE or any
-                                    other dialects of regular expressions. Please
-                                    read the implementation's documentation to determine
-                                    the supported dialect."
+                                    \n Support: Implementation-specific (RegularExpression)
+                                    \n Since RegularExpression HeaderMatchType has
+                                    implementation-specific conformance, implementations
+                                    can support POSIX, PCRE or any other dialects
+                                    of regular expressions. Please read the implementation's
+                                    documentation to determine the supported dialect."
                                   enum:
                                   - Exact
                                   - RegularExpression
@@ -3369,7 +3375,7 @@ spec:
                                 default: PathPrefix
                                 description: "Type specifies how to match against
                                   the path Value. \n Support: Core (Exact, PathPrefix)
-                                  \n Support: Custom (RegularExpression)"
+                                  \n Support: Implementation-specific (RegularExpression)"
                                 enum:
                                 - Exact
                                 - PathPrefix
@@ -3416,10 +3422,11 @@ spec:
                                   default: Exact
                                   description: "Type specifies how to match against
                                     the value of the query parameter. \n Support:
-                                    Extended (Exact) \n Support: Custom (RegularExpression)
-                                    \n Since RegularExpression QueryParamMatchType
-                                    has custom conformance, implementations can support
-                                    POSIX, PCRE or any other dialects of regular expressions.
+                                    Extended (Exact) \n Support: Implementation-specific
+                                    (RegularExpression) \n Since RegularExpression
+                                    QueryParamMatchType has Implementation-specific
+                                    conformance, implementations can support POSIX,
+                                    PCRE or any other dialects of regular expressions.
                                     Please read the implementation's documentation
                                     to determine the supported dialect."
                                   enum:
@@ -3591,7 +3598,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -79,7 +79,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -165,7 +165,7 @@ spec:
                         attempts to this backend. Connection rejections must respect
                         weight; if an invalid backend is requested to have 80% of
                         connections, then 80% of connections must be rejected instead.
-                        \n Support: Core for Kubernetes Service \n Support: Custom
+                        \n Support: Core for Kubernetes Service \n Support: Implementation-specific
                         for any other resource \n Support for weight: Extended"
                       items:
                         description: "BackendRef defines how a Route should forward
@@ -395,7 +395,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -125,7 +125,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -214,8 +214,8 @@ spec:
                         code. Request rejections must respect weight; if an invalid
                         backend is requested to have 80% of requests, then 80% of
                         requests must be rejected instead. \n Support: Core for Kubernetes
-                        Service \n Support: Custom for any other resource \n Support
-                        for weight: Extended"
+                        Service \n Support: Implementation-specific for any other
+                        resource \n Support for weight: Extended"
                       items:
                         description: "BackendRef defines how a Route should forward
                           a request to a Kubernetes resource. \n Note that when a
@@ -444,7 +444,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -79,7 +79,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -165,8 +165,8 @@ spec:
                         attempts to this backend. Packet drops must respect weight;
                         if an invalid backend is requested to have 80% of the packets,
                         then 80% of packets must be dropped instead. \n Support: Core
-                        for Kubernetes Service Support: Custom for any other resource
-                        \n Support for weight: Extended"
+                        for Kubernetes Service Support: Implementation-specific for
+                        any other resource \n Support for weight: Extended"
                       items:
                         description: "BackendRef defines how a Route should forward
                           a request to a Kubernetes resource. \n Note that when a
@@ -395,7 +395,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -90,7 +90,7 @@ spec:
                   resource, i.e. ConfigMap, or an implementation-specific custom resource.
                   The resource can be cluster-scoped or namespace-scoped. \n If the
                   referent cannot be found, the GatewayClass's \"InvalidParameters\"
-                  status condition will be true. \n Support: Custom"
+                  status condition will be true. \n Support: Implementation-specific"
                 properties:
                   group:
                     description: Group is the group of the referent.
@@ -291,7 +291,7 @@ spec:
                   resource, i.e. ConfigMap, or an implementation-specific custom resource.
                   The resource can be cluster-scoped or namespace-scoped. \n If the
                   referent cannot be found, the GatewayClass's \"InvalidParameters\"
-                  status condition will be true. \n Support: Custom"
+                  status condition will be true. \n Support: Implementation-specific"
                 properties:
                   group:
                     description: Group is the group of the referent.

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -140,7 +140,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -216,7 +216,7 @@ spec:
                         \n For example, if two backends are specified with equal weights,
                         and one is invalid, 50 percent of traffic must receive a 500.
                         Implementations may choose how that 50 percent is determined.
-                        \n Support: Core for Kubernetes Service \n Support: Custom
+                        \n Support: Core for Kubernetes Service \n Support: Implementation-specific
                         for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
@@ -225,9 +225,9 @@ spec:
                           filters:
                             description: "Filters defined at this level should be
                               executed if and only if the request is being forwarded
-                              to the backend defined here. \n Support: Custom (For
-                              broader support of filters, use the Filters field in
-                              HTTPRouteRule.)"
+                              to the backend defined here. \n Support: Implementation-specific
+                              (For broader support of filters, use the Filters field
+                              in HTTPRouteRule.)"
                             items:
                               description: HTTPRouteFilter defines processing steps
                                 that must be completed during the request or response
@@ -404,7 +404,8 @@ spec:
                                         Message of the `ResolvedRefs` Condition should
                                         be used to provide more detail about the problem.
                                         \n Support: Extended for Kubernetes Service
-                                        \n Support: Custom for any other resource"
+                                        \n Support: Implementation-specific for any
+                                        other resource"
                                       properties:
                                         group:
                                           default: ""
@@ -526,9 +527,9 @@ spec:
                                     types and their corresponding configuration defined
                                     by   \"Support: Extended\" in this package, e.g.
                                     \"RequestMirror\". Implementers   are encouraged
-                                    to support extended filters. \n - Custom: Filters
-                                    that are defined and supported by specific vendors.
-                                    \  In the future, filters showing convergence
+                                    to support extended filters. \n - Implementation-specific:
+                                    Filters that are defined and supported by   specific
+                                    vendors.   In the future, filters showing convergence
                                     in behavior across multiple   implementations
                                     will be considered for inclusion in extended or
                                     core   conformance levels. Filter-specific configuration
@@ -637,14 +638,14 @@ spec:
                         all implementations. - Implementers are encouraged to support
                         extended filters. - Implementation-specific custom filters
                         have no API guarantees across   implementations. \n Specifying
-                        a core filter multiple times has unspecified or custom conformance.
-                        \n All filters are expected to be compatible with each other
-                        except for the URLRewrite and RequestRedirect filters, which
-                        may not be combined. If an implementation can not support
-                        other combinations of filters, they must clearly document
-                        that limitation. In all cases where incompatible or unsupported
-                        filters are specified, implementations MUST add a warning
-                        condition to status. \n Support: Core"
+                        a core filter multiple times has unspecified or implementation-specific
+                        conformance. \n All filters are expected to be compatible
+                        with each other except for the URLRewrite and RequestRedirect
+                        filters, which may not be combined. If an implementation can
+                        not support other combinations of filters, they must clearly
+                        document that limitation. In all cases where incompatible
+                        or unsupported filters are specified, implementations MUST
+                        add a warning condition to status. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -810,7 +811,8 @@ spec:
                                   In either error case, the Message of the `ResolvedRefs`
                                   Condition should be used to provide more detail
                                   about the problem. \n Support: Extended for Kubernetes
-                                  Service \n Support: Custom for any other resource"
+                                  Service \n Support: Implementation-specific for
+                                  any other resource"
                                 properties:
                                   group:
                                     default: ""
@@ -925,15 +927,15 @@ spec:
                               - Extended: Filter types and their corresponding configuration
                               defined by   \"Support: Extended\" in this package,
                               e.g. \"RequestMirror\". Implementers   are encouraged
-                              to support extended filters. \n - Custom: Filters that
-                              are defined and supported by specific vendors.   In
-                              the future, filters showing convergence in behavior
-                              across multiple   implementations will be considered
-                              for inclusion in extended or core   conformance levels.
-                              Filter-specific configuration for such filters   is
-                              specified using the ExtensionRef field. `Type` should
-                              be set to   \"ExtensionRef\" for custom filters. \n
-                              Implementers are encouraged to define custom implementation
+                              to support extended filters. \n - Implementation-specific:
+                              Filters that are defined and supported by   specific
+                              vendors.   In the future, filters showing convergence
+                              in behavior across multiple   implementations will be
+                              considered for inclusion in extended or core   conformance
+                              levels. Filter-specific configuration for such filters
+                              \  is specified using the ExtensionRef field. `Type`
+                              should be set to   \"ExtensionRef\" for custom filters.
+                              \n Implementers are encouraged to define custom implementation
                               types to extend the core API with implementation-specific
                               behavior. \n If a reference to a custom filter type
                               cannot be resolved, the filter MUST NOT be skipped.
@@ -1032,12 +1034,12 @@ spec:
                                   default: Exact
                                   description: "Type specifies how to match against
                                     the value of the header. \n Support: Core (Exact)
-                                    \n Support: Custom (RegularExpression) \n Since
-                                    RegularExpression HeaderMatchType has custom conformance,
-                                    implementations can support POSIX, PCRE or any
-                                    other dialects of regular expressions. Please
-                                    read the implementation's documentation to determine
-                                    the supported dialect."
+                                    \n Support: Implementation-specific (RegularExpression)
+                                    \n Since RegularExpression HeaderMatchType has
+                                    implementation-specific conformance, implementations
+                                    can support POSIX, PCRE or any other dialects
+                                    of regular expressions. Please read the implementation's
+                                    documentation to determine the supported dialect."
                                   enum:
                                   - Exact
                                   - RegularExpression
@@ -1084,7 +1086,7 @@ spec:
                                 default: PathPrefix
                                 description: "Type specifies how to match against
                                   the path Value. \n Support: Core (Exact, PathPrefix)
-                                  \n Support: Custom (RegularExpression)"
+                                  \n Support: Implementation-specific (RegularExpression)"
                                 enum:
                                 - Exact
                                 - PathPrefix
@@ -1131,10 +1133,11 @@ spec:
                                   default: Exact
                                   description: "Type specifies how to match against
                                     the value of the query parameter. \n Support:
-                                    Extended (Exact) \n Support: Custom (RegularExpression)
-                                    \n Since RegularExpression QueryParamMatchType
-                                    has custom conformance, implementations can support
-                                    POSIX, PCRE or any other dialects of regular expressions.
+                                    Extended (Exact) \n Support: Implementation-specific
+                                    (RegularExpression) \n Since RegularExpression
+                                    QueryParamMatchType has Implementation-specific
+                                    conformance, implementations can support POSIX,
+                                    PCRE or any other dialects of regular expressions.
                                     Please read the implementation's documentation
                                     to determine the supported dialect."
                                   enum:
@@ -1306,7 +1309,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1487,7 +1491,7 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Custom (Other Resources)"
+                        (Gateway) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1563,7 +1567,7 @@ spec:
                         \n For example, if two backends are specified with equal weights,
                         and one is invalid, 50 percent of traffic must receive a 500.
                         Implementations may choose how that 50 percent is determined.
-                        \n Support: Core for Kubernetes Service \n Support: Custom
+                        \n Support: Core for Kubernetes Service \n Support: Implementation-specific
                         for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
@@ -1572,9 +1576,9 @@ spec:
                           filters:
                             description: "Filters defined at this level should be
                               executed if and only if the request is being forwarded
-                              to the backend defined here. \n Support: Custom (For
-                              broader support of filters, use the Filters field in
-                              HTTPRouteRule.)"
+                              to the backend defined here. \n Support: Implementation-specific
+                              (For broader support of filters, use the Filters field
+                              in HTTPRouteRule.)"
                             items:
                               description: HTTPRouteFilter defines processing steps
                                 that must be completed during the request or response
@@ -1751,7 +1755,8 @@ spec:
                                         Message of the `ResolvedRefs` Condition should
                                         be used to provide more detail about the problem.
                                         \n Support: Extended for Kubernetes Service
-                                        \n Support: Custom for any other resource"
+                                        \n Support: Implementation-specific for any
+                                        other resource"
                                       properties:
                                         group:
                                           default: ""
@@ -1873,9 +1878,9 @@ spec:
                                     types and their corresponding configuration defined
                                     by   \"Support: Extended\" in this package, e.g.
                                     \"RequestMirror\". Implementers   are encouraged
-                                    to support extended filters. \n - Custom: Filters
-                                    that are defined and supported by specific vendors.
-                                    \  In the future, filters showing convergence
+                                    to support extended filters. \n - Implementation-specific:
+                                    Filters that are defined and supported by   specific
+                                    vendors.   In the future, filters showing convergence
                                     in behavior across multiple   implementations
                                     will be considered for inclusion in extended or
                                     core   conformance levels. Filter-specific configuration
@@ -1984,14 +1989,14 @@ spec:
                         all implementations. - Implementers are encouraged to support
                         extended filters. - Implementation-specific custom filters
                         have no API guarantees across   implementations. \n Specifying
-                        a core filter multiple times has unspecified or custom conformance.
-                        \n All filters are expected to be compatible with each other
-                        except for the URLRewrite and RequestRedirect filters, which
-                        may not be combined. If an implementation can not support
-                        other combinations of filters, they must clearly document
-                        that limitation. In all cases where incompatible or unsupported
-                        filters are specified, implementations MUST add a warning
-                        condition to status. \n Support: Core"
+                        a core filter multiple times has unspecified or implementation-specific
+                        conformance. \n All filters are expected to be compatible
+                        with each other except for the URLRewrite and RequestRedirect
+                        filters, which may not be combined. If an implementation can
+                        not support other combinations of filters, they must clearly
+                        document that limitation. In all cases where incompatible
+                        or unsupported filters are specified, implementations MUST
+                        add a warning condition to status. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -2157,7 +2162,8 @@ spec:
                                   In either error case, the Message of the `ResolvedRefs`
                                   Condition should be used to provide more detail
                                   about the problem. \n Support: Extended for Kubernetes
-                                  Service \n Support: Custom for any other resource"
+                                  Service \n Support: Implementation-specific for
+                                  any other resource"
                                 properties:
                                   group:
                                     default: ""
@@ -2272,15 +2278,15 @@ spec:
                               - Extended: Filter types and their corresponding configuration
                               defined by   \"Support: Extended\" in this package,
                               e.g. \"RequestMirror\". Implementers   are encouraged
-                              to support extended filters. \n - Custom: Filters that
-                              are defined and supported by specific vendors.   In
-                              the future, filters showing convergence in behavior
-                              across multiple   implementations will be considered
-                              for inclusion in extended or core   conformance levels.
-                              Filter-specific configuration for such filters   is
-                              specified using the ExtensionRef field. `Type` should
-                              be set to   \"ExtensionRef\" for custom filters. \n
-                              Implementers are encouraged to define custom implementation
+                              to support extended filters. \n - Implementation-specific:
+                              Filters that are defined and supported by   specific
+                              vendors.   In the future, filters showing convergence
+                              in behavior across multiple   implementations will be
+                              considered for inclusion in extended or core   conformance
+                              levels. Filter-specific configuration for such filters
+                              \  is specified using the ExtensionRef field. `Type`
+                              should be set to   \"ExtensionRef\" for custom filters.
+                              \n Implementers are encouraged to define custom implementation
                               types to extend the core API with implementation-specific
                               behavior. \n If a reference to a custom filter type
                               cannot be resolved, the filter MUST NOT be skipped.
@@ -2379,12 +2385,12 @@ spec:
                                   default: Exact
                                   description: "Type specifies how to match against
                                     the value of the header. \n Support: Core (Exact)
-                                    \n Support: Custom (RegularExpression) \n Since
-                                    RegularExpression HeaderMatchType has custom conformance,
-                                    implementations can support POSIX, PCRE or any
-                                    other dialects of regular expressions. Please
-                                    read the implementation's documentation to determine
-                                    the supported dialect."
+                                    \n Support: Implementation-specific (RegularExpression)
+                                    \n Since RegularExpression HeaderMatchType has
+                                    implementation-specific conformance, implementations
+                                    can support POSIX, PCRE or any other dialects
+                                    of regular expressions. Please read the implementation's
+                                    documentation to determine the supported dialect."
                                   enum:
                                   - Exact
                                   - RegularExpression
@@ -2431,7 +2437,7 @@ spec:
                                 default: PathPrefix
                                 description: "Type specifies how to match against
                                   the path Value. \n Support: Core (Exact, PathPrefix)
-                                  \n Support: Custom (RegularExpression)"
+                                  \n Support: Implementation-specific (RegularExpression)"
                                 enum:
                                 - Exact
                                 - PathPrefix
@@ -2478,10 +2484,11 @@ spec:
                                   default: Exact
                                   description: "Type specifies how to match against
                                     the value of the query parameter. \n Support:
-                                    Extended (Exact) \n Support: Custom (RegularExpression)
-                                    \n Since RegularExpression QueryParamMatchType
-                                    has custom conformance, implementations can support
-                                    POSIX, PCRE or any other dialects of regular expressions.
+                                    Extended (Exact) \n Support: Implementation-specific
+                                    (RegularExpression) \n Since RegularExpression
+                                    QueryParamMatchType has Implementation-specific
+                                    conformance, implementations can support POSIX,
+                                    PCRE or any other dialects of regular expressions.
                                     Please read the implementation's documentation
                                     to determine the supported dialect."
                                   enum:
@@ -2653,7 +2660,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Custom (Other Resources)"
+                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Resources)"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -124,7 +124,8 @@ Conformance levels are defined by the filter type:
  - Implementers are encouraged to support "extended" filters.
  - "Custom" filters have no API guarantees across implementations.
 
-Specifying a core filter multiple times has unspecified or custom conformance.
+Specifying a core filter multiple times has unspecified or 
+implementation-specific conformance.
 
 All filters are expected to be compatible with each other except for the
 URLRewrite and RequestRedirect filters, which may not be combined. If an

--- a/site-src/concepts/conformance.md
+++ b/site-src/concepts/conformance.md
@@ -30,13 +30,13 @@ support level for each feature:
   feature will have the same behavior and semantics. It is expected that some
   number of roadmap features will eventually migrate into the Core. Extended
   features will be part of the API types and schema.
-* **Custom** features are those that are not portable and are vendor-specific.
-  Custom features will not have API types and schema except via generic
-  extension points.
+* **Implementation-specific** features are those that are not portable and are
+  vendor-specific. Implementation-specific features will not have API types and
+  schema except via generic extension points.
 
 Behavior and feature in the Core and Extended set will be defined and validated
-via behavior-driven conformance tests. Custom features will not be covered by
-conformance tests.
+via behavior-driven conformance tests. Implementation-specific features will not
+be covered by conformance tests.
 
 By including and standardizing Extended features in the API spec, we expect to
 be able to converge on portable subsets of the API among implementations without

--- a/site-src/concepts/guidelines.md
+++ b/site-src/concepts/guidelines.md
@@ -102,10 +102,6 @@ still vary (and that's ok).
 These cases will be specified as defining delimited parts of the API
 "implementation-specific".
 
-The "implementation-specific" designation allows a CORE or EXTENDED feature to
-be well-defined taking into account the realities of some features that are
-mostly but not entirely portable.
-
 
 ## Kind vs. Resource
 

--- a/site-src/geps/gep-1016.md
+++ b/site-src/geps/gep-1016.md
@@ -215,10 +215,10 @@ In the table above, `Service` unspecified and `Method` specified with type Exact
 is listed as being equivalent to a path matcher with type suffix or type regex.
 We imagine that many GRPCRoute implementations will be done using translation to
 `HTTPRoute`s. `HTTPRoute` does not support a Suffix matcher and its Regex
-matcher is specified as "Custom" support. In order to accommodate `GRPCRoute`
-implementations built on top of `HTTPRoute` implementations without regex
-support, we list this particular case as having custom support within the
-context of `GRPCRoute`.
+matcher is specified as "Implementation-specific" support. In order to accommodate
+`GRPCRoute` implementations built on top of `HTTPRoute` implementations without
+regex support, we list this particular case as having implementation-specific 
+support within the context of `GRPCRoute`.
 
 #### Transport
 
@@ -411,8 +411,8 @@ type GRPCRouteRule struct {
 	// - Implementation-specific custom filters have no API guarantees across
 	//   implementations.
 	//
-	// Specifying a core filter multiple times has unspecified or custom
-	// conformance.
+	// Specifying a core filter multiple times has unspecified or 
+	// implementation-specific conformance.
 	// Support: Core
 	//
 	// +optional
@@ -429,7 +429,7 @@ type GRPCRouteRule struct {
 	// weight is respected; if an invalid backend is requested to have 80% of
 	// requests, then 80% of requests must get a `UNAVAILABLE` instead.
 	// Support: Core for Kubernetes Service
-	// Support: Custom for any other resource
+	// Support: Implementation-specific for any other resource
 	//
 	// Support for weight: Core
 	//
@@ -481,9 +481,10 @@ type GRPCMethodMatch struct {
 	// Type specifies how to match against the service and/or method.
 	// Support: Core (Exact with service and method specified)
 	//
-	// Support Custom (Exact with method specified but no service specified)
+	// Support Implementation-specific (Exact with method specified but no 
+	// service specified)
 	//
-	// Support: Custom (RegularExpression)
+	// Support: Implementation-specific (RegularExpression)
 	//
 	// +optional
 	// +kubebuilder:default=Exact
@@ -588,7 +589,7 @@ type GRPCBackendRef struct {
 	// In either error case, the Message of the `ResolvedRefs` Condition
 	// should be used to provide more detail about the problem.
 	//
-	// Support: Custom
+	// Support: Implementation-specific
 	//
 	// +optional
 	BackendRef `json:",inline"`
@@ -596,7 +597,7 @@ type GRPCBackendRef struct {
 	// Filters defined at this level should be executed if and only if the
 	// request is being forwarded to the backend defined here.
 	//
-	// Support: Custom (For broader support of filters, use the Filters field
+	// Support: Implementation-specific (For broader support of filters, use the Filters field
 	// in GRPCRouteRule.)
 	//
 	// +optional

--- a/site-src/geps/gep-718.md
+++ b/site-src/geps/gep-718.md
@@ -87,7 +87,7 @@ type BackendRef struct {
 	// Kind is kind of the backend resource.
 	//
 	// Support: Core (Kubernetes Service)
-	// Support: Custom (any other resource)
+	// Support: Implementation-specific (any other resource)
 	//
 	// +optional
 	// +kubebuilder:validation:MinLength=1

--- a/site-src/geps/gep-735.md
+++ b/site-src/geps/gep-735.md
@@ -53,7 +53,7 @@ type AddressMatch struct {
 	// For IPAddress the implementor may expect either IPv4 or IPv6.
 	//
 	// Support: Core (IPAddress)
-	// Support: Custom (NamedAddress)
+	// Support: Implementation-specific (NamedAddress)
 	//
 	// +optional
 	// +kubebuilder:validation:Enum=IPAddress;NamedAddress


### PR DESCRIPTION
Signed-off-by: Lucas Caparelli <lucas.caparelli@gympass.com>

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

This PR merges the concepts of `custom` and `implementation-specific` conformance into `implementation-specific` only in order to simplify the spec. All `custom` conformance mentions were replaced by `implementation-specific`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #640 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Changes "custom" conformance level to "implementation-specific"
```