### PR TITLE
website: render approved GEPs in chronological order

### DIFF
--- a/site-src/geps/.pages
+++ b/site-src/geps/.pages
@@ -1,1 +1,20 @@
 title: Approved GEPs
+nav:
+    - gep-696.md
+    - gep-709.md
+    - gep-713.md
+    - gep-718.md
+    - gep-724.md
+    - gep-726.md
+    - gep-735.md
+    - gep-746.md
+    - gep-820.md
+    - gep-851.md
+    - gep-917.md
+    - gep-922.md
+    - gep-957.md
+    - gep-1016.md
+    - gep-1282.md
+    - gep-1323.md
+    - gep-1324.md
+    - gep-1364.md


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation

**What this PR does / why we need it**:
This will order the navigation menu for approved GEPs.

Fix is using the support from the already installed `mkdocs-awesome-pages-plugin`
configured as it is given here:  https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin#customize-navigation

Now it order the nav items in chronological order:

![Screenshot 2022-10-06 at 19 48 56](https://user-images.githubusercontent.com/22471342/194338478-b0212f81-df0c-49e9-96a0-ac3d721d1dac.png)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/1428
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
