### PR TITLE
add ListenerConditionAccepted, update docs from "Detached"

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -352,9 +352,7 @@ const (
 	// interoperability.
 	ListenerConditionAccepted ListenerConditionType = "Accepted"
 
-	// The "Detached" ListenerConditionType is deprecated and "Accepted" should
-	// be used instead.
-	// TODO: is there a need/way to add a kubebuilder annotation here?
+	// Deprecated: use "Accepted" instead.
 	ListenerConditionDetached ListenerConditionType = "Detached"
 
 	// This reason is used with the "Accepted" condition when the condition is
@@ -362,9 +360,9 @@ const (
 	ListenerReasonAccepted ListenerConditionReason = "Accepted"
 
 	// This reason is used with the "Detached" condition when the condition is
-	// False. This reason is deprecated and ListenerReasonAccepted should be used
-	// with ListenerConditionAccepted instead.
-	// TODO: is there a need/way to add a kubebuilder annotation here?
+	// False.
+	//
+	// Deprecated: use the "Accepted" condition with reason "Accepted" instead.
 	ListenerReasonAttached ListenerConditionReason = "Attached"
 
 	// This reason is used with the "Accepted" condition when the Listener

--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -62,7 +62,7 @@ type Listener = v1beta1.Listener
 // ProtocolType defines the application protocol accepted by a Listener.
 // Implementations are not required to accept all the defined protocols.
 // If an implementation does not support a specified protocol, it
-// should raise a "Detached" condition for the affected Listener with
+// should set the "Accepted" condition to "False" for the affected Listener with
 // a reason of "UnsupportedProtocol".
 //
 // Core ProtocolType values are listed in the table below.
@@ -337,22 +337,37 @@ const (
 	// if it specifies an unsupported requirement, or prerequisite
 	// resources are not available.
 	//
-	// Possible reasons for this condition to be true are:
+	// Possible reasons for this condition to be True are:
+	//
+	// * "Accepted"
+	//
+	// Possible reasons for this condition to be False are:
 	//
 	// * "PortUnavailable"
 	// * "UnsupportedProtocol"
 	// * "UnsupportedAddress"
 	//
-	// Possible reasons for this condition to be False are:
-	//
-	// * "Attached"
-	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
+	ListenerConditionAccepted ListenerConditionType = "Accepted"
+
+	// The "Detached" ListenerConditionType is deprecated and "Accepted" should
+	// be used instead.
+	// TODO: is there a need/way to add a kubebuilder annotation here?
 	ListenerConditionDetached ListenerConditionType = "Detached"
 
-	// This reason is used with the "Detached" condition when the Listener
+	// This reason is used with the "Accepted" condition when the condition is
+	// True.
+	ListenerReasonAccepted ListenerConditionReason = "Accepted"
+
+	// This reason is used with the "Detached" condition when the condition is
+	// False. This reason is deprecated and ListenerReasonAccepted should be used
+	// with ListenerConditionAccepted instead.
+	// TODO: is there a need/way to add a kubebuilder annotation here?
+	ListenerReasonAttached ListenerConditionReason = "Attached"
+
+	// This reason is used with the "Accepted" condition when the Listener
 	// requests a port that cannot be used on the Gateway. This reason could be
 	// used in a number of instances, including:
 	//
@@ -360,22 +375,18 @@ const (
 	// * The port is not supported by the implementation.
 	ListenerReasonPortUnavailable ListenerConditionReason = "PortUnavailable"
 
-	// This reason is used with the "Detached" condition when the
+	// This reason is used with the "Accepted" condition when the
 	// Listener could not be attached to be Gateway because its
 	// protocol type is not supported.
 	ListenerReasonUnsupportedProtocol ListenerConditionReason = "UnsupportedProtocol"
 
-	// This reason is used with the "Detached" condition when the Listener could
+	// This reason is used with the "Accepted" condition when the Listener could
 	// not be attached to the Gateway because the requested address is not
 	// supported. This reason could be used in a number of instances, including:
 	//
 	// * The address is already in use.
 	// * The type of address is not supported by the implementation.
 	ListenerReasonUnsupportedAddress ListenerConditionReason = "UnsupportedAddress"
-
-	// This reason is used with the "Detached" condition when the condition is
-	// False.
-	ListenerReasonAttached ListenerConditionReason = "Attached"
 )
 
 const (

--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -46,15 +46,17 @@ import (
 //
 // Implementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST
 // accept HTTP/2 connections without an initial upgrade from HTTP/1.1, i.e. via
-// ALPN. If the implementation does not support this, then it MUST raise a "Detached"
-// condition for the affected listener with a reason of "UnsupportedProtocol".
+// ALPN. If the implementation does not support this, then it MUST set the "Accepted"
+// condition to "False" for the affected listener with a reason of
+// "UnsupportedProtocol".
 // Note that a compliant implementation MAY also accept HTTP/2 connections with an
 // upgrade from HTTP/1.
 //
 // Implementations supporting `GRPCRoute` with the `HTTP` `ProtocolType` MUST
 // support cleartext HTTP/2 without an initial upgrade from HTTP/1.1. If the
-// implementation does not support this, then it MUST raise a "Detached"
-// condition for the affected listener with a reason of "UnsupportedProtocol".
+// implementation does not support this, then it MUST set the "Accepted"
+// condition to "False" for the affected listener with a reason of
+// "UnsupportedProtocol".
 // Note that a compliant implementation MAY also accept HTTP/2 connections with an
 // upgrade from HTTP/1.
 //

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -696,9 +696,7 @@ const (
 	// interoperability.
 	ListenerConditionAccepted ListenerConditionType = "Accepted"
 
-	// The "Detached" ListenerConditionType is deprecated and "Accepted" should
-	// be used instead.
-	// TODO: is there a need/way to add a kubebuilder annotation here?
+	// Deprecated: use "Accepted" instead.
 	ListenerConditionDetached ListenerConditionType = "Detached"
 
 	// This reason is used with the "Accepted" condition when the condition is
@@ -706,9 +704,9 @@ const (
 	ListenerReasonAccepted ListenerConditionReason = "Accepted"
 
 	// This reason is used with the "Detached" condition when the condition is
-	// False. This reason is deprecated and ListenerReasonAccepted should be used
-	// with ListenerConditionAccepted instead.
-	// TODO: is there a need/way to add a kubebuilder annotation here?
+	// False.
+	//
+	// Deprecated: use the "Accepted" condition with reason "Accepted" instead.
 	ListenerReasonAttached ListenerConditionReason = "Attached"
 
 	// This reason is used with the "Accepted" condition when the Listener

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -239,7 +239,7 @@ type Listener struct {
 // ProtocolType defines the application protocol accepted by a Listener.
 // Implementations are not required to accept all the defined protocols.
 // If an implementation does not support a specified protocol, it
-// should raise a "Detached" condition for the affected Listener with
+// should set the "Accepted" condition for the affected Listener with
 // a reason of "UnsupportedProtocol".
 //
 // Core ProtocolType values are listed in the table below.
@@ -681,22 +681,37 @@ const (
 	// if it specifies an unsupported requirement, or prerequisite
 	// resources are not available.
 	//
-	// Possible reasons for this condition to be true are:
+	// Possible reasons for this condition to be True are:
+	//
+	// * "Accepted"
+	//
+	// Possible reasons for this condition to be False are:
 	//
 	// * "PortUnavailable"
 	// * "UnsupportedProtocol"
 	// * "UnsupportedAddress"
 	//
-	// Possible reasons for this condition to be False are:
-	//
-	// * "Attached"
-	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
+	ListenerConditionAccepted ListenerConditionType = "Accepted"
+
+	// The "Detached" ListenerConditionType is deprecated and "Accepted" should
+	// be used instead.
+	// TODO: is there a need/way to add a kubebuilder annotation here?
 	ListenerConditionDetached ListenerConditionType = "Detached"
 
-	// This reason is used with the "Detached" condition when the Listener
+	// This reason is used with the "Accepted" condition when the condition is
+	// True.
+	ListenerReasonAccepted ListenerConditionReason = "Accepted"
+
+	// This reason is used with the "Detached" condition when the condition is
+	// False. This reason is deprecated and ListenerReasonAccepted should be used
+	// with ListenerConditionAccepted instead.
+	// TODO: is there a need/way to add a kubebuilder annotation here?
+	ListenerReasonAttached ListenerConditionReason = "Attached"
+
+	// This reason is used with the "Accepted" condition when the Listener
 	// requests a port that cannot be used on the Gateway. This reason could be
 	// used in a number of instances, including:
 	//
@@ -704,22 +719,18 @@ const (
 	// * The port is not supported by the implementation.
 	ListenerReasonPortUnavailable ListenerConditionReason = "PortUnavailable"
 
-	// This reason is used with the "Detached" condition when the
+	// This reason is used with the "Accepted" condition when the
 	// Listener could not be attached to be Gateway because its
 	// protocol type is not supported.
 	ListenerReasonUnsupportedProtocol ListenerConditionReason = "UnsupportedProtocol"
 
-	// This reason is used with the "Detached" condition when the Listener could
+	// This reason is used with the "Accepted" condition when the Listener could
 	// not be attached to the Gateway because the requested address is not
 	// supported. This reason could be used in a number of instances, including:
 	//
 	// * The address is already in use.
 	// * The type of address is not supported by the implementation.
 	ListenerReasonUnsupportedAddress ListenerConditionReason = "UnsupportedAddress"
-
-	// This reason is used with the "Detached" condition when the condition is
-	// False.
-	ListenerReasonAttached ListenerConditionReason = "Attached"
 )
 
 const (

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -48,8 +48,8 @@ spec:
           with an upgrade from HTTP/1. \n Implementations supporting `GRPCRoute` with
           the `HTTP` `ProtocolType` MUST support cleartext HTTP/2 without an initial
           upgrade from HTTP/1.1. If the implementation does not support this, then
-          it MUST set the \"Accepted\" condition to \"False\" for the affected listener with a
-          reason of \"UnsupportedProtocol\". Note that a compliant implementation
+          it MUST set the \"Accepted\" condition to \"False\" for the affected listener
+          with a reason of \"UnsupportedProtocol\". Note that a compliant implementation
           MAY also accept HTTP/2 connections with an upgrade from HTTP/1. \n Support:
           Extended"
         properties:

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -42,13 +42,13 @@ spec:
           are placed on implementations that claim support for GRPCRoute. \n Implementations
           supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST accept HTTP/2
           connections without an initial upgrade from HTTP/1.1, i.e. via ALPN. If
-          the implementation does not support this, then it MUST raise a \"Detached\"
-          condition for the affected listener with a reason of \"UnsupportedProtocol\".
+          the implementation does not support this, then it MUST set the \"Accepted\"
+          condition to \"False\" for the affected listener with a reason of \"UnsupportedProtocol\".
           Note that a compliant implementation MAY also accept HTTP/2 connections
           with an upgrade from HTTP/1. \n Implementations supporting `GRPCRoute` with
           the `HTTP` `ProtocolType` MUST support cleartext HTTP/2 without an initial
           upgrade from HTTP/1.1. If the implementation does not support this, then
-          it MUST raise a \"Detached\" condition for the affected listener with a
+          it MUST set the \"Accepted\" condition to \"False\" for the affected listener with a
           reason of \"UnsupportedProtocol\". Note that a compliant implementation
           MAY also accept HTTP/2 connections with an upgrade from HTTP/1. \n Support:
           Extended"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
/kind documentation
/kind api-change
/kind deprecation

**What this PR does / why we need it**:
Implements the switch from `ListenerConditionDetached` to a new `ListenerConditionAttached`, as recommended in [GEP-1364](https://gateway-api.sigs.k8s.io/geps/gep-1364/).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1110, refs #1364 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Adds `ListenerConditionAccepted` and `ListenerReasonAccepted`
Deprecates `ListenerConditionDetached` and `ListenerReasonAttached`
```

Now that we've settled on the expected behavior, these expectations should likely be added to relevant conformance tests.