### PR TITLE
add GatewayConditionAccepted and GatewayReasonAccepted

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -214,9 +214,7 @@ const (
 	// interoperability.
 	GatewayConditionAccepted GatewayConditionType = "Accepted"
 
-	// The "Scheduled" GatewayConditionType is deprecated and "Accepted" should
-	// be used instead.
-	// TODO: is there a need/way to add a kubebuilder annotation here?
+	// Deprecated: use "Accepted" instead.
 	GatewayConditionScheduled GatewayConditionType = "Scheduled"
 
 	// This reason is used with the "Accepted" condition when the condition is
@@ -224,9 +222,9 @@ const (
 	GatewayReasonAccepted GatewayConditionReason = "Accepted"
 
 	// This reason is used with the "Scheduled" condition when the condition is
-	// True. This reason is deprecated and GatewayReasonAccepted should be used
-	// with GatewayConditionAccepted instead.
-	// TODO: is there a need/way to add a kubebuilder annotation here?
+	// True.
+	//
+	// Deprecated: use the "Accepted" condition with reason "Accepted" instead.
 	GatewayReasonScheduled GatewayConditionReason = "Scheduled"
 
 	// This reason is used with the "Accepted" condition when no controller has

--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -202,7 +202,7 @@ const (
 	//
 	// Possible reasons for this condition to be true are:
 	//
-	// * "Scheduled"
+	// * "Accepted"
 	//
 	// Possible reasons for this condition to be False are:
 	//
@@ -212,17 +212,28 @@ const (
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
+	GatewayConditionAccepted GatewayConditionType = "Accepted"
+
+	// The "Scheduled" GatewayConditionType is deprecated and "Accepted" should
+	// be used instead.
+	// TODO: is there a need/way to add a kubebuilder annotation here?
 	GatewayConditionScheduled GatewayConditionType = "Scheduled"
 
+	// This reason is used with the "Accepted" condition when the condition is
+	// True.
+	GatewayReasonAccepted GatewayConditionReason = "Accepted"
+
 	// This reason is used with the "Scheduled" condition when the condition is
-	// true.
+	// True. This reason is deprecated and GatewayReasonAccepted should be used
+	// with GatewayConditionAccepted instead.
+	// TODO: is there a need/way to add a kubebuilder annotation here?
 	GatewayReasonScheduled GatewayConditionReason = "Scheduled"
 
-	// This reason is used with the "Scheduled" condition when no controller has
+	// This reason is used with the "Accepted" condition when no controller has
 	// reconciled the Gateway.
 	GatewayReasonNotReconciled GatewayConditionReason = "NotReconciled"
 
-	// This reason is used with the "Scheduled" condition when the
+	// This reason is used with the "Accepted" condition when the
 	// Gateway is not scheduled because insufficient infrastructure
 	// resources are available.
 	GatewayReasonNoResources GatewayConditionReason = "NoResources"

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -534,9 +534,7 @@ const (
 	// interoperability.
 	GatewayConditionAccepted GatewayConditionType = "Accepted"
 
-	// The "Scheduled" GatewayConditionType is deprecated and "Accepted" should
-	// be used instead.
-	// TODO: is there a need/way to add a kubebuilder annotation here?
+	// Deprecated: use "Accepted" instead.
 	GatewayConditionScheduled GatewayConditionType = "Scheduled"
 
 	// This reason is used with the "Accepted" condition when the condition is
@@ -544,9 +542,9 @@ const (
 	GatewayReasonAccepted GatewayConditionReason = "Accepted"
 
 	// This reason is used with the "Scheduled" condition when the condition is
-	// True. This reason is deprecated and GatewayReasonAccepted should be used
-	// with GatewayConditionAccepted instead.
-	// TODO: is there a need/way to add a kubebuilder annotation here?
+	// True.
+	//
+	// Deprecated: use the "Accepted" condition with reason "Accepted" instead.
 	GatewayReasonScheduled GatewayConditionReason = "Scheduled"
 
 	// This reason is used with the "Accepted" condition when no controller has

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -41,7 +41,7 @@ type Gateway struct {
 
 	// Status defines the current state of Gateway.
 	//
-	// +kubebuilder:default={conditions: {{type: "Scheduled", status: "Unknown", reason:"NotReconciled", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}}
+	// +kubebuilder:default={conditions: {{type: "Accepted", status: "Unknown", reason:"NotReconciled", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}}
 	Status GatewayStatus `json:"status,omitempty"`
 }
 
@@ -487,14 +487,14 @@ type GatewayStatus struct {
 	//
 	// Known condition types are:
 	//
-	// * "Scheduled"
+	// * "Accepted"
 	// * "Ready"
 	//
 	// +optional
 	// +listType=map
 	// +listMapKey=type
 	// +kubebuilder:validation:MaxItems=8
-	// +kubebuilder:default={{type: "Scheduled", status: "Unknown", reason:"NotReconciled", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
+	// +kubebuilder:default={{type: "Accepted", status: "Unknown", reason:"NotReconciled", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// Listeners provide status for each unique listener port defined in the Spec.
@@ -520,9 +520,9 @@ const (
 	// Gateway has scheduled the Gateway to the underlying network
 	// infrastructure.
 	//
-	// Possible reasons for this condition to be true are:
+	// Possible reasons for this condition to be True are:
 	//
-	// * "Scheduled"
+	// * "Accepted"
 	//
 	// Possible reasons for this condition to be False are:
 	//
@@ -532,17 +532,28 @@ const (
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
+	GatewayConditionAccepted GatewayConditionType = "Accepted"
+
+	// The "Scheduled" GatewayConditionType is deprecated and "Accepted" should
+	// be used instead.
+	// TODO: is there a need/way to add a kubebuilder annotation here?
 	GatewayConditionScheduled GatewayConditionType = "Scheduled"
 
+	// This reason is used with the "Accepted" condition when the condition is
+	// True.
+	GatewayReasonAccepted GatewayConditionReason = "Accepted"
+
 	// This reason is used with the "Scheduled" condition when the condition is
-	// true.
+	// True. This reason is deprecated and GatewayReasonAccepted should be used
+	// with GatewayConditionAccepted instead.
+	// TODO: is there a need/way to add a kubebuilder annotation here?
 	GatewayReasonScheduled GatewayConditionReason = "Scheduled"
 
-	// This reason is used with the "Scheduled" condition when no controller has
+	// This reason is used with the "Accepted" condition when no controller has
 	// reconciled the Gateway.
 	GatewayReasonNotReconciled GatewayConditionReason = "NotReconciled"
 
-	// This reason is used with the "Scheduled" condition when the
+	// This reason is used with the "Accepted" condition when the
 	// Gateway is not scheduled because insufficient infrastructure
 	// resources are available.
 	GatewayReasonNoResources GatewayConditionReason = "NoResources"

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -454,7 +454,7 @@ spec:
                 message: Waiting for controller
                 reason: NotReconciled
                 status: Unknown
-                type: Scheduled
+                type: Accepted
             description: Status defines the current state of Gateway.
             properties:
               addresses:
@@ -491,12 +491,12 @@ spec:
                   message: Waiting for controller
                   reason: NotReconciled
                   status: Unknown
-                  type: Scheduled
+                  type: Accepted
                 description: "Conditions describe the current conditions of the Gateway.
                   \n Implementations should prefer to express Gateway conditions using
                   the `GatewayConditionType` and `GatewayConditionReason` constants
                   so that operators and tools can converge on a common vocabulary
-                  to describe Gateway state. \n Known condition types are: \n * \"Scheduled\"
+                  to describe Gateway state. \n Known condition types are: \n * \"Accepted\"
                   * \"Ready\""
                 items:
                   description: "Condition contains details for one aspect of the current
@@ -1148,7 +1148,7 @@ spec:
                 message: Waiting for controller
                 reason: NotReconciled
                 status: Unknown
-                type: Scheduled
+                type: Accepted
             description: Status defines the current state of Gateway.
             properties:
               addresses:
@@ -1185,12 +1185,12 @@ spec:
                   message: Waiting for controller
                   reason: NotReconciled
                   status: Unknown
-                  type: Scheduled
+                  type: Accepted
                 description: "Conditions describe the current conditions of the Gateway.
                   \n Implementations should prefer to express Gateway conditions using
                   the `GatewayConditionType` and `GatewayConditionReason` constants
                   so that operators and tools can converge on a common vocabulary
-                  to describe Gateway state. \n Known condition types are: \n * \"Scheduled\"
+                  to describe Gateway state. \n Known condition types are: \n * \"Accepted\"
                   * \"Ready\""
                 items:
                   description: "Condition contains details for one aspect of the current

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -454,7 +454,7 @@ spec:
                 message: Waiting for controller
                 reason: NotReconciled
                 status: Unknown
-                type: Scheduled
+                type: Accepted
             description: Status defines the current state of Gateway.
             properties:
               addresses:
@@ -491,12 +491,12 @@ spec:
                   message: Waiting for controller
                   reason: NotReconciled
                   status: Unknown
-                  type: Scheduled
+                  type: Accepted
                 description: "Conditions describe the current conditions of the Gateway.
                   \n Implementations should prefer to express Gateway conditions using
                   the `GatewayConditionType` and `GatewayConditionReason` constants
                   so that operators and tools can converge on a common vocabulary
-                  to describe Gateway state. \n Known condition types are: \n * \"Scheduled\"
+                  to describe Gateway state. \n Known condition types are: \n * \"Accepted\"
                   * \"Ready\""
                 items:
                   description: "Condition contains details for one aspect of the current
@@ -1148,7 +1148,7 @@ spec:
                 message: Waiting for controller
                 reason: NotReconciled
                 status: Unknown
-                type: Scheduled
+                type: Accepted
             description: Status defines the current state of Gateway.
             properties:
               addresses:
@@ -1185,12 +1185,12 @@ spec:
                   message: Waiting for controller
                   reason: NotReconciled
                   status: Unknown
-                  type: Scheduled
+                  type: Accepted
                 description: "Conditions describe the current conditions of the Gateway.
                   \n Implementations should prefer to express Gateway conditions using
                   the `GatewayConditionType` and `GatewayConditionReason` constants
                   so that operators and tools can converge on a common vocabulary
-                  to describe Gateway state. \n Known condition types are: \n * \"Scheduled\"
+                  to describe Gateway state. \n Known condition types are: \n * \"Accepted\"
                   * \"Ready\""
                 items:
                   description: "Condition contains details for one aspect of the current


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
/kind documentation
/kind api-change
/kind deprecation

**What this PR does / why we need it**:
Implements the recommendation in [GEP-1364](https://gateway-api.sigs.k8s.io/geps/gep-1364/) to replace `GatewayConditionScheduled` with `GatewayConditionAccepted`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Refs #1111, #1364

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Adds GatewayConditionAccepted and GatewayReasonAccepted
Deprecates GatewayConditionScheduled and GatewayReasonScheduled
```

This status condition does not appear to be currently checked in conformance tests, which mostly rely on the`Ready` condition instead. We could either add checks for this condition now, or in a subsequent pull request.