### PR TITLE
Fix last round of feedback on GEP-1364

### DIFF
--- a/site-src/geps/gep-1364.md
+++ b/site-src/geps/gep-1364.md
@@ -283,9 +283,7 @@ less positive Conditions for now.
 #### `Accepted`
 
 This GEP proposes replacing all conditions that indicate syntactic and semantic
-validity with one, `Accepted` condition type, with the exception of the
-GatewayClass resource (because it's the root of the resource tree and doesn't
-attach to anything).
+validity with one, `Accepted` condition type.
 
 That is, the proposal is to replace:
 * `Scheduled` on Gateway
@@ -355,9 +353,9 @@ Examples of Conditions:
 * HTTPRoute with one match with one backend that is valid. `Accepted` is true,
 `ResolvedRefs` is true.
 * HTTPRoute with one match with one backend that is a non-existent Service backend.
-The `Accepted` Condition is true, the `ResolvedRefs` condition is false. `Accepted`
-is true in this case because the data path must respond to requests that would be
-sent to that backend with a 500 response.
+The `Accepted` Condition is true, the `ResolvedRefs` condition is false, with
+a reason of `BackendNotFound`. `Accepted` is true in this case because the data
+path must respond to requests that would be sent to that backend with a 500 response.
 * HTTPRoute with one match with two backends, one of which is a non-existent Service
 backend. The `Accepted` Condition is true, the `ResolvedRefs` condition is false.
 `Accepted` is true in this case because the data path must respond to a percentage
@@ -365,8 +363,9 @@ of the requests matching the rule corresponding to the weighting of the non-exis
 backend (which would be fifty percent unless weights are applied).
 * HTTPRoute with one match with one backend that is in a different namespace, and
 does _not_ have a ReferenceGrant permitting that access. The `Accepted` condition
-is true, and the `ResolvedRefs` Condition is false. As before, `Accepted` is true
-because in this case, the data path must be programmed with 500s for the match.
+is true, and the `ResolvedRefs` Condition is false, with a reason of `RefNotPermitted`.
+As before, `Accepted` is true because in this case, the data path must be
+programmed with 500s for the match.
 * TCPRoute with one match with a backend that is a non-existent Service. `Accepted`
 is false, and `ResolvedRefs` is false. `Accepted` is false in this case because
 there is not enough information to program any rules to handle the traffic in the
@@ -379,7 +378,8 @@ setting of the ExtensionRef field to the name, group, version, and kind of a
 custom resource that describes the filter. If that custom resource is not supported,
 it seems reasonable to say that this should be a reference failure, and be treated
 like other reference failures (`Accepted` will be set to true, `ResolvedRefs` to
-false, and traffic that would have matched the filter should receive a 500 error.)
+false with a `InvalidKind` Reason, and traffic that would have matched the filter
+should receive a 500 error.)
 * A HTTPRoute with one rule that specifies a HTTPRequestRedirect filter _and_ a
 HTTPURLRewrite filter. `Accepted` must be false, because there's only one rule,
 and this configuration for the rule is invalid (see [reference][httpreqredirect])
@@ -448,3 +448,4 @@ needs updating.)
 [1362]: https://github.com/kubernetes-sigs/gateway-api/issues/1362
 
 [typstatus]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+[httpreqredirect]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPRequestRedirectFilter


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
/kind gep

**What this PR does / why we need it**:
Fixes the last round of feedback on GEP-1364 (from #1383). Thanks @mikemorris for the review.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Updates #1364

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
