### PR TITLE
Add Pending reason to GatewayClass, Gateway, Listener, and Routes

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -200,7 +200,7 @@ const (
 	// Gateway has scheduled the Gateway to the underlying network
 	// infrastructure.
 	//
-	// Possible reasons for this condition to be true are:
+	// Possible reasons for this condition to be True are:
 	//
 	// * "Accepted"
 	//
@@ -208,6 +208,10 @@ const (
 	//
 	// * "NotReconciled"
 	// * "NoResources"
+	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
 	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
@@ -229,6 +233,9 @@ const (
 
 	// This reason is used with the "Accepted" condition when no controller has
 	// reconciled the Gateway.
+	GatewayReasonPending GatewayConditionReason = "Pending"
+
+	// Deprecated: Use "Pending" instead.
 	GatewayReasonNotReconciled GatewayConditionReason = "NotReconciled"
 
 	// This reason is used with the "Accepted" condition when the
@@ -356,6 +363,10 @@ const (
 	// * "UnsupportedProtocol"
 	// * "UnsupportedAddress"
 	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
+	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
@@ -456,6 +467,10 @@ const (
 	// * "Invalid"
 	// * "Pending"
 	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
+	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
@@ -469,8 +484,8 @@ const (
 	// Listener is syntactically or semantically invalid.
 	ListenerReasonInvalid ListenerConditionReason = "Invalid"
 
-	// This reason is used with the "Ready" condition when the
-	// Listener is not yet not online and ready to accept client
-	// traffic.
+	// This reason is used with the "Accpeted" and "Ready" conditions when the
+	// Listener is either not yet reconciled or not yet not online and ready to
+	// accept client traffic.
 	ListenerReasonPending ListenerConditionReason = "Pending"
 )

--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -484,7 +484,7 @@ const (
 	// Listener is syntactically or semantically invalid.
 	ListenerReasonInvalid ListenerConditionReason = "Invalid"
 
-	// This reason is used with the "Accpeted" and "Ready" conditions when the
+	// This reason is used with the "Accepted" and "Ready" conditions when the
 	// Listener is either not yet reconciled or not yet not online and ready to
 	// accept client traffic.
 	ListenerReasonPending ListenerConditionReason = "Pending"

--- a/apis/v1alpha2/gatewayclass_types.go
+++ b/apis/v1alpha2/gatewayclass_types.go
@@ -97,7 +97,10 @@ const (
 	// Possible reasons for this condition to be False are:
 	//
 	// * "InvalidParameters"
-	// * "Waiting"
+	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
 	//
 	// Controllers should prefer to use the values of GatewayClassConditionReason
 	// for the corresponding Reason, where appropriate.
@@ -116,6 +119,9 @@ const (
 	// requested controller has not yet made a decision about whether
 	// to admit the GatewayClass. It is the default Reason on a new
 	// GatewayClass.
+	GatewayClassReasonPending GatewayClassConditionReason = "Pending"
+
+	// Deprecated: Use "Pending" instead.
 	GatewayClassReasonWaiting GatewayClassConditionReason = "Waiting"
 )
 

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -71,6 +71,10 @@ const (
 	// * "NoMatchingListenerHostname"
 	// * "UnsupportedValue"
 	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
+	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
@@ -92,6 +96,10 @@ const (
 	// This reason is used with the "Accepted" condition when a value for an Enum
 	// is not recognized.
 	RouteReasonUnsupportedValue RouteConditionReason = "UnsupportedValue"
+
+	// This reason is used with the "Accepted" when a controller has not yet
+	// reconciled the route.
+	RouteReasonPending RouteConditionReason = "Pending"
 
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the Route.

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -828,7 +828,7 @@ const (
 	// Listener is syntactically or semantically invalid.
 	ListenerReasonInvalid ListenerConditionReason = "Invalid"
 
-	// This reason is used with the "Accpeted" and "Ready" conditions when the
+	// This reason is used with the "Accepted" and "Ready" conditions when the
 	// Listener is either not yet reconciled or not yet not online and ready to
 	// accept client traffic.
 	ListenerReasonPending ListenerConditionReason = "Pending"

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -494,7 +494,7 @@ type GatewayStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	// +kubebuilder:validation:MaxItems=8
-	// +kubebuilder:default={{type: "Accepted", status: "Unknown", reason:"NotReconciled", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
+	// +kubebuilder:default={{type: "Accepted", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// Listeners provide status for each unique listener port defined in the Spec.
@@ -529,6 +529,10 @@ const (
 	// * "NotReconciled"
 	// * "NoResources"
 	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
+	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
@@ -549,6 +553,9 @@ const (
 
 	// This reason is used with the "Accepted" condition when no controller has
 	// reconciled the Gateway.
+	GatewayReasonPending GatewayConditionReason = "Pending"
+
+	// Deprecated: Use "Pending" instead.
 	GatewayReasonNotReconciled GatewayConditionReason = "NotReconciled"
 
 	// This reason is used with the "Accepted" condition when the
@@ -700,6 +707,10 @@ const (
 	// * "UnsupportedProtocol"
 	// * "UnsupportedAddress"
 	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
+	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
@@ -800,6 +811,10 @@ const (
 	// * "Invalid"
 	// * "Pending"
 	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
+	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
@@ -813,8 +828,8 @@ const (
 	// Listener is syntactically or semantically invalid.
 	ListenerReasonInvalid ListenerConditionReason = "Invalid"
 
-	// This reason is used with the "Ready" condition when the
-	// Listener is not yet not online and ready to accept client
-	// traffic.
+	// This reason is used with the "Accpeted" and "Ready" conditions when the
+	// Listener is either not yet reconciled or not yet not online and ready to
+	// accept client traffic.
 	ListenerReasonPending ListenerConditionReason = "Pending"
 )

--- a/apis/v1beta1/gatewayclass_types.go
+++ b/apis/v1beta1/gatewayclass_types.go
@@ -153,7 +153,10 @@ const (
 	// Possible reasons for this condition to be False are:
 	//
 	// * "InvalidParameters"
-	// * "Waiting"
+	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
 	//
 	// Controllers should prefer to use the values of GatewayClassConditionReason
 	// for the corresponding Reason, where appropriate.
@@ -172,6 +175,9 @@ const (
 	// requested controller has not yet made a decision about whether
 	// to admit the GatewayClass. It is the default Reason on a new
 	// GatewayClass.
+	GatewayClassReasonPending GatewayClassConditionReason = "Pending"
+
+	// Deprecated: Use "Pending" instead.
 	GatewayClassReasonWaiting GatewayClassConditionReason = "Waiting"
 )
 
@@ -187,7 +193,7 @@ type GatewayClassStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	// +kubebuilder:validation:MaxItems=8
-	// +kubebuilder:default={{type: "Accepted", status: "Unknown", message: "Waiting for controller", reason: "Waiting", lastTransitionTime: "1970-01-01T00:00:00Z"}}
+	// +kubebuilder:default={{type: "Accepted", status: "Unknown", message: "Waiting for controller", reason: "Pending", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -200,6 +200,10 @@ const (
 	// * "NoMatchingListenerHostname"
 	// * "UnsupportedValue"
 	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
+	//
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
@@ -221,6 +225,10 @@ const (
 	// This reason is used with the "Accepted" condition when a value for an Enum
 	// is not recognized.
 	RouteReasonUnsupportedValue RouteConditionReason = "UnsupportedValue"
+
+	// This reason is used with the "Accepted" when a controller has not yet
+	// reconciled the route.
+	RouteReasonPending RouteConditionReason = "Pending"
 
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the Route.
@@ -334,9 +342,9 @@ type RouteStatus struct {
 // Hostname is the fully qualified domain name of a network host. This matches
 // the RFC 1123 definition of a hostname with 2 notable exceptions:
 //
-// 1. IPs are not allowed.
-// 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
-//    label must appear by itself as the first label.
+//  1. IPs are not allowed.
+//  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+//     label must appear by itself as the first label.
 //
 // Hostname can be "precise" which is a domain name without the terminating
 // dot of a network host (e.g. "foo.example.com") or "wildcard", which is a

--- a/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -138,7 +138,7 @@ spec:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
                   message: Waiting for controller
-                  reason: Waiting
+                  reason: Pending
                   status: Unknown
                   type: Accepted
                 description: "Conditions is the current status from the controller
@@ -339,7 +339,7 @@ spec:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
                   message: Waiting for controller
-                  reason: Waiting
+                  reason: Pending
                   status: Unknown
                   type: Accepted
                 description: "Conditions is the current status from the controller

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -489,7 +489,7 @@ spec:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
                   message: Waiting for controller
-                  reason: NotReconciled
+                  reason: Pending
                   status: Unknown
                   type: Accepted
                 description: "Conditions describe the current conditions of the Gateway.
@@ -1183,7 +1183,7 @@ spec:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
                   message: Waiting for controller
-                  reason: NotReconciled
+                  reason: Pending
                   status: Unknown
                   type: Accepted
                 description: "Conditions describe the current conditions of the Gateway.

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -109,8 +109,8 @@ spec:
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
-                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
                     must appear by itself as the first label. \n Hostname can be \"precise\"
                     which is a domain name without the terminating dot of a network
                     host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -90,8 +90,8 @@ spec:
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
-                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
                     must appear by itself as the first label. \n Hostname can be \"precise\"
                     which is a domain name without the terminating dot of a network
                     host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
@@ -1924,8 +1924,8 @@ spec:
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
-                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
                     must appear by itself as the first label. \n Hostname can be \"precise\"
                     which is a domain name without the terminating dot of a network
                     host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -75,8 +75,8 @@ spec:
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
-                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
                     must appear by itself as the first label. \n Hostname can be \"precise\"
                     which is a domain name without the terminating dot of a network
                     host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain

--- a/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -138,7 +138,7 @@ spec:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
                   message: Waiting for controller
-                  reason: Waiting
+                  reason: Pending
                   status: Unknown
                   type: Accepted
                 description: "Conditions is the current status from the controller
@@ -339,7 +339,7 @@ spec:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
                   message: Waiting for controller
-                  reason: Waiting
+                  reason: Pending
                   status: Unknown
                   type: Accepted
                 description: "Conditions is the current status from the controller

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -489,7 +489,7 @@ spec:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
                   message: Waiting for controller
-                  reason: NotReconciled
+                  reason: Pending
                   status: Unknown
                   type: Accepted
                 description: "Conditions describe the current conditions of the Gateway.
@@ -1183,7 +1183,7 @@ spec:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
                   message: Waiting for controller
-                  reason: NotReconciled
+                  reason: Pending
                   status: Unknown
                   type: Accepted
                 description: "Conditions describe the current conditions of the Gateway.

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -90,8 +90,8 @@ spec:
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
-                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
                     must appear by itself as the first label. \n Hostname can be \"precise\"
                     which is a domain name without the terminating dot of a network
                     host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
@@ -1441,8 +1441,8 @@ spec:
                 items:
                   description: "Hostname is the fully qualified domain name of a network
                     host. This matches the RFC 1123 definition of a hostname with
-                    2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                    may be prefixed with a wildcard label (`*.`). The wildcard    label
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
                     must appear by itself as the first label. \n Hostname can be \"precise\"
                     which is a domain name without the terminating dot of a network
                     host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
/kind api-change

**What this PR does / why we need it**:
This adds a `Pending` Reason to:
- GatewayClass
- Gateway
- Listener
- Route

And deprecates the old Reasons associated with `Unknown` state.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1449 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
A `Pending` Reason has been added to Conditions to harmonize the unreconciled state across objects.
GatewayClass, Gateway, and Route `Accepted` Conditions have been updated.
```
