### PR TITLE
docs: update Kong implementation statuses

### DIFF
--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -18,7 +18,7 @@ Implementors and integrators of Gateway API are encouraged to update this docume
 - [HAProxy Ingress][7] (alpha)
 - [HashiCorp Consul][8]
 - [Istio][9] (alpha)
-- [Kong][10] (alpha)
+- [Kong][10] (beta)
 - [Kuma][11] (alpha)
 - [NGINX Kubernetes Gateway][12]
 - [Traefik][13] (alpha)
@@ -198,7 +198,7 @@ For help and support with Kong's implementations please feel free to [create an 
 [kong]:https://konghq.com
 [kic]:https://github.com/kong/kubernetes-ingress-controller
 [kong-gw-guide]:https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/using-gateway-api/
-[kgo]:https://github.com/kong/gateway-operator
+[kgo]:https://github.com/kong/gateway-operator-docs
 [kong-issue-new]:https://github.com/Kong/kubernetes-ingress-controller/issues/new
 [kong-disc-new]:https://github.com/Kong/kubernetes-ingress-controller/discussions/new
 [kong-slack]:https://kubernetes.slack.com/archives/CDCA87FRD


### PR DESCRIPTION

**What this PR does / why we need it**:

/kind documentation


**Which issue(s) this PR fixes**:

This PR reflects that changes in kong implementations of gateway api.

- The Kong support for Gateway API (via Kong Kubernetes Ingress Controller) was moved to beta by https://github.com/Kong/kubernetes-ingress-controller/pull/2781
- The Kong Gateway Operator user facing repository was changed to https://github.com/Kong/gateway-operator-docs
 
**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
