### PR TITLE
Webhook: validate the combination of port, protocol, and hostname are unique for each listener.

### DIFF
--- a/apis/v1beta1/validation/gateway.go
+++ b/apis/v1beta1/validation/gateway.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/apis/v1beta1/validation/gateway.go
+++ b/apis/v1beta1/validation/gateway.go
@@ -140,7 +140,7 @@ func ValidateListenerNames(listeners []gatewayv1b1.Listener, path *field.Path) f
 // unique for each listener.
 func validateHostnameProtocolPort(listeners []gatewayv1b1.Listener, path *field.Path) field.ErrorList {
 	var errs field.ErrorList
-	hostnameProtocolPortSets:= sets.Set[string]{}
+	hostnameProtocolPortSets := sets.Set[string]{}
 	for i, listener := range listeners {
 		hostname := new(gatewayv1b1.Hostname)
 		if listener.Hostname != nil {

--- a/apis/v1beta1/validation/gateway.go
+++ b/apis/v1beta1/validation/gateway.go
@@ -148,12 +148,11 @@ func validateHostnameProtocolPort(listeners []gatewayv1b1.Listener, path *field.
 		}
 		protocol := listener.Protocol
 		port := listener.Port
-		
 		hostnameProtocolPort := fmt.Sprintf("%s:%s:%d", *hostname, protocol, port)
 		if hostnameProtocolPortSets.Has(hostnameProtocolPort) {
 			errs = append(errs, field.Forbidden(path.Index(i), fmt.Sprintln("combination of port, protocol, and name must be unique for each listener")))
 		}
 		hostnameProtocolPortSets.Insert(hostnameProtocolPort)
-	} 
+	}
 	return errs
 }

--- a/apis/v1beta1/validation/gateway.go
+++ b/apis/v1beta1/validation/gateway.go
@@ -136,7 +136,7 @@ func ValidateListenerNames(listeners []gatewayv1b1.Listener, path *field.Path) f
 	return errs
 }
 
-// validateHostnameProtocolPort validates that the combination of port, protocol, and name are
+// validateHostnameProtocolPort validates that the combination of port, protocol, and hostname are
 // unique for each listener.
 func validateHostnameProtocolPort(listeners []gatewayv1b1.Listener, path *field.Path) field.ErrorList {
 	var errs field.ErrorList
@@ -150,7 +150,7 @@ func validateHostnameProtocolPort(listeners []gatewayv1b1.Listener, path *field.
 		port := listener.Port
 		hostnameProtocolPort := fmt.Sprintf("%s:%s:%d", *hostname, protocol, port)
 		if hostnameProtocolPortSets.Has(hostnameProtocolPort) {
-			errs = append(errs, field.Forbidden(path.Index(i), fmt.Sprintln("combination of port, protocol, and name must be unique for each listener")))
+			errs = append(errs, field.Forbidden(path.Index(i), fmt.Sprintln("combination of port, protocol, and hostname must be unique for each listener")))
 		} else {
 			hostnameProtocolPortSets.Insert(hostnameProtocolPort)
 		}

--- a/apis/v1beta1/validation/gateway.go
+++ b/apis/v1beta1/validation/gateway.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package validation
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	gatewayv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -70,6 +71,7 @@ func validateGatewayListeners(listeners []gatewayv1b1.Listener, path *field.Path
 	errs = append(errs, validateListenerHostname(listeners, path)...)
 	errs = append(errs, ValidateTLSCertificateRefs(listeners, path)...)
 	errs = append(errs, ValidateListenerNames(listeners, path)...)
+	errs = append(errs, validateHostnameProtocolPort(listeners, path)...)
 	return errs
 }
 
@@ -131,5 +133,27 @@ func ValidateListenerNames(listeners []gatewayv1b1.Listener, path *field.Path) f
 		}
 		nameMap[c.Name] = struct{}{}
 	}
+	return errs
+}
+
+// validateHostnameProtocolPort validates that the combination of port, protocol, and name are
+// unique for each listener.
+func validateHostnameProtocolPort(listeners []gatewayv1b1.Listener, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	hostnameProtocolPortSets:= sets.Set[string]{}
+	for i, listener := range listeners {
+		hostname := new(gatewayv1b1.Hostname)
+		if listener.Hostname != nil {
+			hostname = listener.Hostname
+		}
+		protocol := listener.Protocol
+		port := listener.Port
+		
+		hostnameProtocolPort := fmt.Sprintf("%s:%s:%d", *hostname, protocol, port)
+		if hostnameProtocolPortSets.Has(hostnameProtocolPort) {
+			errs = append(errs, field.Forbidden(path.Index(i), fmt.Sprintln("combination of port, protocol, and name must be unique for each listener")))
+		}
+		hostnameProtocolPortSets.Insert(hostnameProtocolPort)
+	} 
 	return errs
 }

--- a/apis/v1beta1/validation/gateway.go
+++ b/apis/v1beta1/validation/gateway.go
@@ -151,8 +151,9 @@ func validateHostnameProtocolPort(listeners []gatewayv1b1.Listener, path *field.
 		hostnameProtocolPort := fmt.Sprintf("%s:%s:%d", *hostname, protocol, port)
 		if hostnameProtocolPortSets.Has(hostnameProtocolPort) {
 			errs = append(errs, field.Forbidden(path.Index(i), fmt.Sprintln("combination of port, protocol, and name must be unique for each listener")))
+		} else {
+			hostnameProtocolPortSets.Insert(hostnameProtocolPort)
 		}
-		hostnameProtocolPortSets.Insert(hostnameProtocolPort)
 	}
 	return errs
 }

--- a/apis/v1beta1/validation/gateway_test.go
+++ b/apis/v1beta1/validation/gateway_test.go
@@ -149,7 +149,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			expectErrsOnFields: []string{"spec.listeners[1].name"},
 		},
-		"combination of port, protocol, and name are not unique for each listener": {
+		"combination of port, protocol, and hostname are not unique for each listener": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
 				hostnameFoo := gatewayv1b1.Hostname("foo.com")
 				gw.Spec.Listeners[0].Name = "foo"
@@ -166,6 +166,86 @@ func TestValidateGateway(t *testing.T) {
 				)
 			},
 			expectErrsOnFields: []string{"spec.listeners[1]"},
+		},
+		"combination of port and protocol are not unique for each listenr when hostnames not set": {
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners[0].Name = "foo"
+				gw.Spec.Listeners[0].Protocol = gatewayv1b1.HTTPProtocolType
+				gw.Spec.Listeners[0].Port = 80
+				gw.Spec.Listeners = append(gw.Spec.Listeners,
+					gatewayv1b1.Listener{
+						Name:     "bar",
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     80,
+					},
+				)
+			},
+			expectErrsOnFields: []string{"spec.listeners[1]"},
+		},
+		"port is unique when protocol and hostname are the same": {
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				hostnameFoo := gatewayv1b1.Hostname("foo.com")
+				gw.Spec.Listeners[0].Name = "foo"
+				gw.Spec.Listeners[0].Hostname = &hostnameFoo
+				gw.Spec.Listeners[0].Protocol = gatewayv1b1.HTTPProtocolType
+				gw.Spec.Listeners[0].Port = 80
+				gw.Spec.Listeners = append(gw.Spec.Listeners,
+					gatewayv1b1.Listener{
+						Name:     "bar",
+						Hostname: &hostnameFoo,
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     8080,
+					},
+				)
+			},
+			expectErrsOnFields: nil,
+		},
+		"hostname is unique when protoco and port are the same": {
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				hostnameFoo := gatewayv1b1.Hostname("foo.com")
+				hostnameBar := gatewayv1b1.Hostname("bar.com")
+				gw.Spec.Listeners[0].Name = "foo"
+				gw.Spec.Listeners[0].Hostname = &hostnameFoo
+				gw.Spec.Listeners[0].Protocol = gatewayv1b1.HTTPProtocolType
+				gw.Spec.Listeners[0].Port = 80
+				gw.Spec.Listeners = append(gw.Spec.Listeners,
+					gatewayv1b1.Listener{
+						Name:     "bar",
+						Hostname: &hostnameBar,
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     80,
+					},
+				)
+			},
+			expectErrsOnFields: nil,
+		},
+		"protocol is unique when port and hostname are the same": {
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				hostnameFoo := gatewayv1b1.Hostname("foo.com")
+				tlsConfigFoo := tlsConfig
+				tlsModeFoo := gatewayv1b1.TLSModeType("Terminate")
+				tlsConfigFoo.Mode = &tlsModeFoo
+				tlsConfigFoo.CertificateRefs = []gatewayv1b1.SecretObjectReference{
+					{
+						Name: "FooCertificateRefs",
+					},
+				}
+				gw.Spec.Listeners[0].Name = "foo"
+				gw.Spec.Listeners[0].Hostname = &hostnameFoo
+				gw.Spec.Listeners[0].Protocol = gatewayv1b1.HTTPSProtocolType
+				gw.Spec.Listeners[0].Port = 8000
+				gw.Spec.Listeners[0].TLS = &tlsConfigFoo
+				gw.Spec.Listeners = append(gw.Spec.Listeners,
+					gatewayv1b1.Listener{
+						Name:     "bar",
+						Hostname: &hostnameFoo,
+						Protocol: gatewayv1b1.TLSProtocolType,
+						Port:     8000,
+						TLS:      &tlsConfigFoo,
+					},
+				)
+			},
+			expectErrsOnFields: nil,
 		},
 	}
 

--- a/apis/v1beta1/validation/gateway_test.go
+++ b/apis/v1beta1/validation/gateway_test.go
@@ -200,7 +200,7 @@ func TestValidateGateway(t *testing.T) {
 			},
 			expectErrsOnFields: nil,
 		},
-		"hostname is unique when protoco and port are the same": {
+		"hostname is unique when protocol and port are the same": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
 				hostnameFoo := gatewayv1b1.Hostname("foo.com")
 				hostnameBar := gatewayv1b1.Hostname("bar.com")

--- a/apis/v1beta1/validation/gateway_test.go
+++ b/apis/v1beta1/validation/gateway_test.go
@@ -136,13 +136,34 @@ func TestValidateGateway(t *testing.T) {
 		},
 		"names are not unique within the Gateway": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
+				hostnameFoo := gatewayv1b1.Hostname("foo.com")
+				hostnameBar := gatewayv1b1.Hostname("bar.com")
 				gw.Spec.Listeners[0].Name = "foo"
+				gw.Spec.Listeners[0].Hostname = &hostnameFoo
 				gw.Spec.Listeners = append(gw.Spec.Listeners, gatewayv1b1.Listener{
 					Name: "foo",
+					Hostname: &hostnameBar,
 				},
 				)
 			},
 			expectErrsOnFields: []string{"spec.listeners[1].name"},
+		},
+		"combination of port, protocol, and name are not unique for each listener": {
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				hostnameFoo := gatewayv1b1.Hostname("foo.com")
+				gw.Spec.Listeners[0].Name = "foo"
+				gw.Spec.Listeners[0].Hostname = &hostnameFoo
+				gw.Spec.Listeners[0].Protocol = gatewayv1b1.HTTPProtocolType
+				gw.Spec.Listeners[0].Port = 80
+				gw.Spec.Listeners = append(gw.Spec.Listeners, gatewayv1b1.Listener{
+					Name: "bar",
+					Hostname: &hostnameFoo,
+					Protocol: gatewayv1b1.HTTPProtocolType,
+					Port: 80,
+				},
+				)
+			},
+			expectErrsOnFields: []string{"spec.listeners[1]"},
 		},
 	}
 

--- a/apis/v1beta1/validation/gateway_test.go
+++ b/apis/v1beta1/validation/gateway_test.go
@@ -140,10 +140,11 @@ func TestValidateGateway(t *testing.T) {
 				hostnameBar := gatewayv1b1.Hostname("bar.com")
 				gw.Spec.Listeners[0].Name = "foo"
 				gw.Spec.Listeners[0].Hostname = &hostnameFoo
-				gw.Spec.Listeners = append(gw.Spec.Listeners, gatewayv1b1.Listener{
-					Name: "foo",
-					Hostname: &hostnameBar,
-				},
+				gw.Spec.Listeners = append(gw.Spec.Listeners,
+					gatewayv1b1.Listener{
+						Name:     "foo",
+						Hostname: &hostnameBar,
+					},
 				)
 			},
 			expectErrsOnFields: []string{"spec.listeners[1].name"},
@@ -155,12 +156,13 @@ func TestValidateGateway(t *testing.T) {
 				gw.Spec.Listeners[0].Hostname = &hostnameFoo
 				gw.Spec.Listeners[0].Protocol = gatewayv1b1.HTTPProtocolType
 				gw.Spec.Listeners[0].Port = 80
-				gw.Spec.Listeners = append(gw.Spec.Listeners, gatewayv1b1.Listener{
-					Name: "bar",
-					Hostname: &hostnameFoo,
-					Protocol: gatewayv1b1.HTTPProtocolType,
-					Port: 80,
-				},
+				gw.Spec.Listeners = append(gw.Spec.Listeners,
+					gatewayv1b1.Listener{
+						Name:     "bar",
+						Hostname: &hostnameFoo,
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     80,
+					},
 				)
 			},
 			expectErrsOnFields: []string{"spec.listeners[1]"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

**What this PR does / why we need it**:

Add validation to validate the combination of port, protocol, and hostname are unique for each listener.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #847

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
