### PR TITLE
Use correct reason in docs when no ReferenceGrant for cert ref

### DIFF
--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -317,7 +317,7 @@ type GatewayTLSConfig struct {
 	// is a ReferenceGrant in the target namespace that allows the certificate
 	// to be attached. If a ReferenceGrant does not allow this reference, the
 	// "ResolvedRefs" condition MUST be set to False for this listener with the
-	// "InvalidCertificateRef" reason.
+	// "RefNotPermitted" reason.
 	//
 	// This field is required to have at least one element when the mode is set
 	// to "Terminate" (default) and is optional otherwise.

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -337,9 +337,9 @@ spec:
                             namespace that allows the certificate to be attached.
                             If a ReferenceGrant does not allow this reference, the
                             \"ResolvedRefs\" condition MUST be set to False for this
-                            listener with the \"InvalidCertificateRef\" reason. \n
-                            This field is required to have at least one element when
-                            the mode is set to \"Terminate\" (default) and is optional
+                            listener with the \"RefNotPermitted\" reason. \n This
+                            field is required to have at least one element when the
+                            mode is set to \"Terminate\" (default) and is optional
                             otherwise. \n CertificateRefs can reference to standard
                             Kubernetes resources, i.e. Secret, or implementation-specific
                             custom resources. \n Support: Core - A single reference
@@ -1031,9 +1031,9 @@ spec:
                             namespace that allows the certificate to be attached.
                             If a ReferenceGrant does not allow this reference, the
                             \"ResolvedRefs\" condition MUST be set to False for this
-                            listener with the \"InvalidCertificateRef\" reason. \n
-                            This field is required to have at least one element when
-                            the mode is set to \"Terminate\" (default) and is optional
+                            listener with the \"RefNotPermitted\" reason. \n This
+                            field is required to have at least one element when the
+                            mode is set to \"Terminate\" (default) and is optional
                             otherwise. \n CertificateRefs can reference to standard
                             Kubernetes resources, i.e. Secret, or implementation-specific
                             custom resources. \n Support: Core - A single reference

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -337,9 +337,9 @@ spec:
                             namespace that allows the certificate to be attached.
                             If a ReferenceGrant does not allow this reference, the
                             \"ResolvedRefs\" condition MUST be set to False for this
-                            listener with the \"InvalidCertificateRef\" reason. \n
-                            This field is required to have at least one element when
-                            the mode is set to \"Terminate\" (default) and is optional
+                            listener with the \"RefNotPermitted\" reason. \n This
+                            field is required to have at least one element when the
+                            mode is set to \"Terminate\" (default) and is optional
                             otherwise. \n CertificateRefs can reference to standard
                             Kubernetes resources, i.e. Secret, or implementation-specific
                             custom resources. \n Support: Core - A single reference
@@ -1031,9 +1031,9 @@ spec:
                             namespace that allows the certificate to be attached.
                             If a ReferenceGrant does not allow this reference, the
                             \"ResolvedRefs\" condition MUST be set to False for this
-                            listener with the \"InvalidCertificateRef\" reason. \n
-                            This field is required to have at least one element when
-                            the mode is set to \"Terminate\" (default) and is optional
+                            listener with the \"RefNotPermitted\" reason. \n This
+                            field is required to have at least one element when the
+                            mode is set to \"Terminate\" (default) and is optional
                             otherwise. \n CertificateRefs can reference to standard
                             Kubernetes resources, i.e. Secret, or implementation-specific
                             custom resources. \n Support: Core - A single reference


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation

**What this PR does / why we need it**:
#1297 and #1362 have clarified that a cross-namespace certificate reference without a `ReferenceGrant` permitting it should use `RefNotPermitted` instead of `InvalidCertificateRef`; however, there is one remaining reference to `InvalidCertificateRef` for this purpose in the docs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
