### PR TITLE
conformance: fix GatewayUnsupportedRouteKind HTTPS listeners without TLS config

### DIFF
--- a/conformance/tests/gateway-unsupported-route-kind.go
+++ b/conformance/tests/gateway-unsupported-route-kind.go
@@ -39,7 +39,7 @@ var GatewayUnsupportedRouteKind = suite.ConformanceTest{
 		t.Run("Gateway listener should have a false ResolvedRefs condition with reason InvalidRouteKinds and no supportedKinds", func(t *testing.T) {
 			gwNN := types.NamespacedName{Name: "gateway-only-unsupported-route-kind", Namespace: "gateway-conformance-infra"}
 			listeners := []v1beta1.ListenerStatus{{
-				Name:           v1beta1.SectionName("https"),
+				Name:           v1beta1.SectionName("http"),
 				SupportedKinds: []v1beta1.RouteGroupKind{},
 				Conditions: []metav1.Condition{{
 					Type:   string(v1beta1.ListenerConditionResolvedRefs),
@@ -54,7 +54,7 @@ var GatewayUnsupportedRouteKind = suite.ConformanceTest{
 		t.Run("Gateway listener should have a false ResolvedRefs condition with reason InvalidRouteKinds and HTTPRoute must be put in the supportedKinds", func(t *testing.T) {
 			gwNN := types.NamespacedName{Name: "gateway-supported-and-unsupported-route-kind", Namespace: "gateway-conformance-infra"}
 			listeners := []v1beta1.ListenerStatus{{
-				Name: v1beta1.SectionName("https"),
+				Name: v1beta1.SectionName("http"),
 				SupportedKinds: []v1beta1.RouteGroupKind{{
 					Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
 					Kind:  v1beta1.Kind("HTTPRoute"),

--- a/conformance/tests/gateway-unsupported-route-kind.yaml
+++ b/conformance/tests/gateway-unsupported-route-kind.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
   listeners:
-    - name: https
-      port: 443
-      protocol: HTTPS
+    - name: http
+      port: 80
+      protocol: HTTP
       allowedRoutes:
         namespaces:
           from: All
@@ -23,9 +23,9 @@ metadata:
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
   listeners:
-    - name: https
-      port: 443
-      protocol: HTTPS
+    - name: http
+      port: 80
+      protocol: HTTP
       allowedRoutes:
         namespaces:
           from: All


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
The resources created by the `GatewayUnsupportedRouteKind` test aren't valid because if protocol is HTTPS, the TLS field must be set. I think #1460 would have caught this.

They don't need to be HTTPS for this test however.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
