### PR TITLE
Mark `HTTPRouteMatch.QueryParam` as extended

### DIFF
--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -524,6 +524,8 @@ type HTTPRouteMatch struct {
 	// values are ANDed together, meaning, a request must match all the
 	// specified query parameters to select the route.
 	//
+	// Support: Extended
+	//
 	// +listType=map
 	// +listMapKey=name
 	// +optional

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -1554,10 +1554,10 @@ spec:
                                 type: string
                             type: object
                           queryParams:
-                            description: QueryParams specifies HTTP query parameter
+                            description: "QueryParams specifies HTTP query parameter
                               matchers. Multiple match values are ANDed together,
                               meaning, a request must match all the specified query
-                              parameters to select the route.
+                              parameters to select the route. \n Support: Extended"
                             items:
                               description: HTTPQueryParamMatch describes how to select
                                 a HTTP route by matching HTTP query parameters.
@@ -3388,10 +3388,10 @@ spec:
                                 type: string
                             type: object
                           queryParams:
-                            description: QueryParams specifies HTTP query parameter
+                            description: "QueryParams specifies HTTP query parameter
                               matchers. Multiple match values are ANDed together,
                               meaning, a request must match all the specified query
-                              parameters to select the route.
+                              parameters to select the route. \n Support: Extended"
                             items:
                               description: HTTPQueryParamMatch describes how to select
                                 a HTTP route by matching HTTP query parameters.

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -1099,10 +1099,10 @@ spec:
                                 type: string
                             type: object
                           queryParams:
-                            description: QueryParams specifies HTTP query parameter
+                            description: "QueryParams specifies HTTP query parameter
                               matchers. Multiple match values are ANDed together,
                               meaning, a request must match all the specified query
-                              parameters to select the route.
+                              parameters to select the route. \n Support: Extended"
                             items:
                               description: HTTPQueryParamMatch describes how to select
                                 a HTTP route by matching HTTP query parameters.
@@ -2450,10 +2450,10 @@ spec:
                                 type: string
                             type: object
                           queryParams:
-                            description: QueryParams specifies HTTP query parameter
+                            description: "QueryParams specifies HTTP query parameter
                               matchers. Multiple match values are ANDed together,
                               meaning, a request must match all the specified query
-                              parameters to select the route.
+                              parameters to select the route. \n Support: Extended"
                             items:
                               description: HTTPQueryParamMatch describes how to select
                                 a HTTP route by matching HTTP query parameters.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind documentation

**What this PR does / why we need it**:

Add `Support: Extended` comment for `HTTPRouteMatch.QueryParam`, so the documentation is less confusing. As it is now, the  `HTTPRouteMatch.QueryParam` is a list of `HTTPQueryParamMatch`, that has a `Type` field that can be Exact (Support: Extended, default value) or  RegularExpression (Support: Implementation-specific). The gateway implementation does not need to implement RegularExpression type to be conformant. As such, it seems `HTTPRouteMatch.QueryParam` should be marked as extended support.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1466


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
