### PR TITLE
Webhook: validate TLS config must be set when protocol is HTTPS or TLS.

### DIFF
--- a/apis/v1alpha2/validation/gateway_test.go
+++ b/apis/v1alpha2/validation/gateway_test.go
@@ -46,26 +46,11 @@ func TestValidateGateway(t *testing.T) {
 			Addresses:        addresses,
 		},
 	}
-	tlsConfig := gatewayv1a2.GatewayTLSConfig{}
 
 	testCases := map[string]struct {
 		mutate             func(gw *gatewayv1a2.Gateway)
 		expectErrsOnFields []string
 	}{
-		"tls config present with http protocol": {
-			mutate: func(gw *gatewayv1a2.Gateway) {
-				gw.Spec.Listeners[0].Protocol = gatewayv1a2.HTTPProtocolType
-				gw.Spec.Listeners[0].TLS = &tlsConfig
-			},
-			expectErrsOnFields: []string{"spec.listeners[0].tls"},
-		},
-		"tls config present with tcp protocol": {
-			mutate: func(gw *gatewayv1a2.Gateway) {
-				gw.Spec.Listeners[0].Protocol = gatewayv1a2.TCPProtocolType
-				gw.Spec.Listeners[0].TLS = &tlsConfig
-			},
-			expectErrsOnFields: []string{"spec.listeners[0].tls"},
-		},
 		"hostname present with tcp protocol": {
 			mutate: func(gw *gatewayv1a2.Gateway) {
 				hostname := gatewayv1a2.Hostname("foo.bar.com")

--- a/apis/v1beta1/validation/gateway_test.go
+++ b/apis/v1beta1/validation/gateway_test.go
@@ -66,6 +66,18 @@ func TestValidateGateway(t *testing.T) {
 			},
 			expectErrsOnFields: []string{"spec.listeners[0].tls"},
 		},
+		"tls config not set with https protocol": {
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1b1.HTTPSProtocolType
+			},
+			expectErrsOnFields: []string{"spec.listeners[0].tls"},
+		},
+		"tls config not set with tls protocol": {
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1b1.TLSProtocolType
+			},
+			expectErrsOnFields: []string{"spec.listeners[0].tls"},
+		},
 		"hostname present with tcp protocol": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
 				hostname := gatewayv1b1.Hostname("foo.bar.com")

--- a/apis/v1beta1/validation/gateway_test.go
+++ b/apis/v1beta1/validation/gateway_test.go
@@ -78,6 +78,24 @@ func TestValidateGateway(t *testing.T) {
 			},
 			expectErrsOnFields: []string{"spec.listeners[0].tls"},
 		},
+		"tls config not set with http protocol": {
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1b1.HTTPProtocolType
+			},
+			expectErrsOnFields: nil,
+		},
+		"tls config not set with tcp protocol": {
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1b1.TCPProtocolType
+			},
+			expectErrsOnFields: nil,
+		},
+		"tls config not set with udp protocol": {
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners[0].Protocol = gatewayv1b1.UDPProtocolType
+			},
+			expectErrsOnFields: nil,
+		},
 		"hostname present with tcp protocol": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
 				hostname := gatewayv1b1.Hostname("foo.bar.com")
@@ -94,11 +112,22 @@ func TestValidateGateway(t *testing.T) {
 			},
 			expectErrsOnFields: []string{"spec.listeners[0].hostname"},
 		},
-		"certificatedRefs not set with TLS terminate mode": {
+		"certificatedRefs not set with https protocol and TLS terminate mode": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
 				hostname := gatewayv1b1.Hostname("foo.bar.com")
 				tlsMode := gatewayv1b1.TLSModeType("Terminate")
 				gw.Spec.Listeners[0].Protocol = gatewayv1b1.HTTPSProtocolType
+				gw.Spec.Listeners[0].Hostname = &hostname
+				gw.Spec.Listeners[0].TLS = &tlsConfig
+				gw.Spec.Listeners[0].TLS.Mode = &tlsMode
+			},
+			expectErrsOnFields: []string{"spec.listeners[0].tls.certificateRefs"},
+		},
+		"certificatedRefs not set with tls protocol and TLS terminate mode": {
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				hostname := gatewayv1b1.Hostname("foo.bar.com")
+				tlsMode := gatewayv1b1.TLSModeType("Terminate")
+				gw.Spec.Listeners[0].Protocol = gatewayv1b1.TLSProtocolType
 				gw.Spec.Listeners[0].Hostname = &hostname
 				gw.Spec.Listeners[0].TLS = &tlsConfig
 				gw.Spec.Listeners[0].TLS.Mode = &tlsMode


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

**What this PR does / why we need it**:

- Add a validation to validate TLS config must be set when protocol is HTTPS or TLS.
- Remove TLS validate duplicate code and tests in v1alpha1 and include that from v1beta1.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1467 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
