### PR TITLE
Webhook: validate at least one of GRPCRoute.Rules.Matches.{Method,Service} is supplied

### DIFF
--- a/apis/v1alpha2/validation/grpcroute.go
+++ b/apis/v1alpha2/validation/grpcroute.go
@@ -47,13 +47,13 @@ func validateGRPCRouteRules(rules []gatewayv1a2.GRPCRouteRule, path *field.Path)
 	return errs
 }
 
-// validateRuleMatches validates that at least one of the fields Service and Method of
+// validateRuleMatches validates that at least one of the fields Service or Method of
 // GRPCMethodMatch to be specified
 func validateRuleMatches(matches []gatewayv1a2.GRPCRouteMatch, path *field.Path) field.ErrorList {
 	var errs field.ErrorList
 	for i, m := range matches {
 		if m.Method != nil && m.Method.Service == nil && m.Method.Method == nil {
-			errs = append(errs, field.Required(path.Index(i).Child("methods"), "should have at least one of fields Service and Method"))
+			errs = append(errs, field.Required(path.Index(i).Child("methods"), "should have at least one of fields Service or Method"))
 			return errs
 		}
 	}

--- a/apis/v1alpha2/validation/grpcroute.go
+++ b/apis/v1alpha2/validation/grpcroute.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// ValidateGRPCRoute validates GRPCRoute according to the Gateway API specification.
+// For additional details of the GRPCRoute spec, refer to:
+// https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRoute
+func ValidateGRPCRoute(route *gatewayv1a2.GRPCRoute) field.ErrorList {
+	return validateGRPCRouteSpec(&route.Spec, field.NewPath("spec"))
+}
+
+// validateRouteSpec validates that required fields of spec are set according to the
+// Gateway API specification.
+func validateGRPCRouteSpec(spec *gatewayv1a2.GRPCRouteSpec, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	errs = append(errs, validateGRPCRouteRules(spec.Rules, path.Child("rules"))...)
+	return errs
+}
+
+// validateGRPCRouteRules validates whether required fields of rules are set according
+// to the Gateway API specification.
+func validateGRPCRouteRules(rules []gatewayv1a2.GRPCRouteRule, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	for i, rule := range rules {
+		errs = append(errs, validateRuleMatches(rule.Matches, path.Index(i).Child("matches"))...)
+	}
+	return errs
+}
+
+// validateRuleMatches validates that at least one of the fields Service and Method of
+// GRPCMethodMatch to be specified
+func validateRuleMatches(matches []gatewayv1a2.GRPCRouteMatch, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	for i, m := range matches {
+		if m.Method != nil && m.Method.Service == nil && m.Method.Method == nil {
+			errs = append(errs, field.Required(path.Index(i).Child("methods"), "should have at least one of fields Service and Method"))
+			return errs
+		}
+	}
+	return errs
+}

--- a/apis/v1alpha2/validation/grpcroute_test.go
+++ b/apis/v1alpha2/validation/grpcroute_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	gatewayv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestValidateGRPCRoute(t *testing.T) {
+	t.Parallel()
+
+	service := "foo"
+	method := "login"
+
+	tests := []struct {
+		name  string
+		rules []gatewayv1a2.GRPCRouteRule
+		errs  field.ErrorList
+	}{
+		{
+			name: "valid GRPCRoute with 1 service in GRPCMethodMatch field",
+			rules: []gatewayv1a2.GRPCRouteRule{
+				{
+					Matches: []gatewayv1a2.GRPCRouteMatch{
+						{
+							Method: &gatewayv1a2.GRPCMethodMatch{
+								Service: &service,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "valid GRPCRoute with 1 method in GRPCMethodMatch field",
+			rules: []gatewayv1a2.GRPCRouteRule{
+				{
+					Matches: []gatewayv1a2.GRPCRouteMatch{
+						{
+							Method: &gatewayv1a2.GRPCMethodMatch{
+								Method: &method,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid GRPCRoute missing service or method in GRPCMethodMatch field",
+			rules: []gatewayv1a2.GRPCRouteRule{
+				{
+					Matches: []gatewayv1a2.GRPCRouteMatch{
+						{
+							Method: &gatewayv1a2.GRPCMethodMatch{
+								Service: nil,
+								Method: nil,
+							},
+						},
+					},
+				},
+			},
+			errs: field.ErrorList{
+				{
+					Type:	field.ErrorTypeRequired,
+					Field:	"spec.rules[0].matches[0].methods",
+					Detail: "should have at least one of fields Service and Method",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			route := gatewayv1a2.GRPCRoute{Spec: gatewayv1a2.GRPCRouteSpec{Rules: tc.rules}}
+			errs := ValidateGRPCRoute(&route)
+			if len(errs) != len(tc.errs) {
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), len(tc.errs), errs)
+				t.FailNow()
+			}
+			for i := 0; i < len(errs); i++ {
+				realErr := errs[i].Error()
+				expectedErr := tc.errs[i].Error()
+				if realErr != expectedErr {
+					t.Errorf("expect error message: %s, but got: %s", expectedErr, realErr)
+					t.FailNow()
+				}
+			}
+		})
+	}
+}

--- a/apis/v1alpha2/validation/grpcroute_test.go
+++ b/apis/v1alpha2/validation/grpcroute_test.go
@@ -81,7 +81,7 @@ func TestValidateGRPCRoute(t *testing.T) {
 				{
 					Type:	field.ErrorTypeRequired,
 					Field:	"spec.rules[0].matches[0].methods",
-					Detail: "should have at least one of fields Service and Method",
+					Detail: "should have at least one of fields Service or Method",
 				},
 			},
 		},

--- a/apis/v1alpha2/validation/grpcroute_test.go
+++ b/apis/v1alpha2/validation/grpcroute_test.go
@@ -71,7 +71,7 @@ func TestValidateGRPCRoute(t *testing.T) {
 						{
 							Method: &gatewayv1a2.GRPCMethodMatch{
 								Service: nil,
-								Method: nil,
+								Method:  nil,
 							},
 						},
 					},
@@ -79,8 +79,8 @@ func TestValidateGRPCRoute(t *testing.T) {
 			},
 			errs: field.ErrorList{
 				{
-					Type:	field.ErrorTypeRequired,
-					Field:	"spec.rules[0].matches[0].methods",
+					Type:   field.ErrorTypeRequired,
+					Field:  "spec.rules[0].matches[0].methods",
 					Detail: "should have at least one of fields Service or Method",
 				},
 			},

--- a/pkg/admission/server.go
+++ b/pkg/admission/server.go
@@ -61,6 +61,11 @@ var (
 		Version:  v1alpha2.SchemeGroupVersion.Version,
 		Resource: "httproutes",
 	}
+	v1a2GRPCRouteGVR = meta.GroupVersionResource{
+		Group:    v1alpha2.SchemeGroupVersion.Group,
+		Version:  v1alpha2.SchemeGroupVersion.Version,
+		Resource: "grpcroutes",
+	}
 	v1a2GatewayGVR = meta.GroupVersionResource{
 		Group:    v1alpha2.SchemeGroupVersion.Group,
 		Version:  v1alpha2.SchemeGroupVersion.Version,
@@ -207,6 +212,14 @@ func handleValidation(request admission.AdmissionRequest) (*admission.AdmissionR
 		}
 
 		fieldErr = v1a2Validation.ValidateHTTPRoute(&hRoute)
+	case v1a2GRPCRouteGVR:
+		var gRoute v1alpha2.GRPCRoute
+		_, _, err := deserializer.Decode(request.Object.Raw, nil, &gRoute)
+		if err != nil {
+			return nil, err
+		}
+
+		fieldErr = v1a2Validation.ValidateGRPCRoute(&gRoute)
 	case v1b1HTTPRouteGVR:
 		var hRoute v1beta1.HTTPRoute
 		_, _, err := deserializer.Decode(request.Object.Raw, nil, &hRoute)


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
**What this PR does / why we need it**:
- Initial GRPCRoute apis validations
- Add a validation to validate that at least one of the fields Service and Method of GRPCMethodMatch to be specified

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1098 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
