### PR TITLE
Mesh: allow non-HTTP types

### DIFF
--- a/site-src/geps/gep-1426.md
+++ b/site-src/geps/gep-1426.md
@@ -133,7 +133,7 @@ A `Service` may only be specified as a `parentRef` of an `xRoute` if it is:
     * Resolving conflicts from multiple `HTTPRoutes` attempting to target the same `Service` as a `parentRef` should follow the existing [conflict guidelines](https://gateway-api.sigs.k8s.io/concepts/guidelines/#conflicts).
       * When an existing `xRoute` targeting the `Service` as a `parentRef` has already been accepted, any `xRoute` with a newer creation timestamp should be rejected, because the match target considered for the specificity rules (the `Service`) is identical.
       * If creation timestamps are identical (from applying both routes simultaneously), only the `xRoute` with a `name` appearing first in alphabetical order should be accepted.
-      * Any rejected `xRoute` should set an `Accepted` condition with `status: "False"`.
+      * Any rejected `xRoute` must set an `Accepted` condition with `status: "False"`.
     * This requirement may be relaxed later to follow the existing [precedence rules for merging configuration](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPRouteRule), but is intended to simplify initial implementation.
     * The namespace colocation requirement effectively forecloses using this strategy to delegate route management, but there is service mesh [user interest](https://github.com/istio/istio/issues/22997) in merging separately-defined routes together to manage large configurations, multiple versions or canary deployments for a single mesh service.
 * NOT already specified as a `backendRef` of any _other_ `xRoute` with a `Service` `parentRef`

--- a/site-src/geps/gep-1426.md
+++ b/site-src/geps/gep-1426.md
@@ -150,13 +150,14 @@ The logic described here is a bit verbose, but could be validated with conforman
 
 All types currently defined in the gateway-api core (`HTTP`, `GRPC`, `TCP`, `TLS`, and `UDP`) are available for use in a Mesh implementation.
 
-If multiple routes with of different type both bind to the same Service and Port pair, only a single route type should be applied. The rejected routes should be ignored and have the `RouteConditionAccepted` status set to the (new) reason `RouteReasonConflicted`.
+If multiple routes with different types both bind to the same Service and Port pair, only a single route type should be applied. The rejected routes should be ignored and have the `RouteConditionAccepted` status set to the (new) reason `RouteReasonConflicted`.
 
 Route type specificity is defined in the following order (first one wins):
 
-1. HTTPRoute
-2. TLSRoute
-3. TCPRoute
+1. GRPCRoute
+2. HTTPRoute
+3. TLSRoute
+4. TCPRoute
 
 Because UDP is its own protocol, it is orthogonal to these precedence order. Since there is only one UDP-based route, there is currently no conflicts possible; if other UDP-based routes are added a similar ordering will be defined.
 

--- a/site-src/geps/gep-1426.md
+++ b/site-src/geps/gep-1426.md
@@ -1,11 +1,11 @@
-# GEP-1426: Routes Mesh Binding
+# GEP-1426: xRoutes Mesh Binding
 
 * Issue: [#1294](https://github.com/kubernetes-sigs/gateway-api/issues/1294)
 * Status: Provisional
 
 ## Overview
 
-Similar to how `Routes` bind to `Gateways` and manage North/South traffic flows in Gateway API’s ingress use-case, it would be natural to adopt a similar model for traffic routing concerns in service mesh deployments. The purpose of this GEP is to add a mechanism to the Gateway API spec for the purpose of associating the various `Route` types to a service mesh and offering a model for service owners to manage traffic splitting configurations.
+Similar to how `xRoutes` bind to `Gateways` and manage North/South traffic flows in Gateway API’s ingress use-case, it would be natural to adopt a similar model for traffic routing concerns in service mesh deployments. The purpose of this GEP is to add a mechanism to the Gateway API spec for the purpose of associating the various `xRoute` types to a service mesh and offering a model for service owners to manage traffic splitting configurations.
 	
 This GEP is intended to establish an implementable, but experimental, baseline for supporting basic service mesh traffic routing functionality through the Gateway API spec.
 
@@ -15,10 +15,10 @@ This GEP uses the [roles and personas](https://gateway-api.sigs.k8s.io/concepts/
 
 ## Goals
 
-* MUST allow `Route` traffic rules to be configurable for a mesh service by the application owner/producer.
-* SHOULD allow control by the cluster operator (mesh administrator) to grant permission for whether `Route` resources in a given namespace are allowed to configure mesh traffic routing.
+* MUST allow `xRoute` traffic rules to be configurable for a mesh service by the application owner/producer.
+* SHOULD allow control by the cluster operator (mesh administrator) to grant permission for whether `xRoute` resources in a given namespace are allowed to configure mesh traffic routing.
 * SHOULD NOT require downstream "consumer" services to update configuration or DNS addresses for traffic to follow "producer" mesh routing rules configured by upstream services.
-* SHOULD NOT require reconfiguring existing `Route` resources for North/South Gateway configuration.
+* SHOULD NOT require reconfiguring existing `xRoute` resources for North/South Gateway configuration.
 
 ## Non-Goals
 
@@ -27,27 +27,27 @@ This GEP uses the [roles and personas](https://gateway-api.sigs.k8s.io/concepts/
     * Redirecting calls from arbitrary custom domains to an in-cluster service.
 * Defining how multiple `Services` or `EndpointSlices` representing instances of a single "logical" service should present an identity for AuthN/AuthZ or be associated with each other beyond routing rules.
 * Defining how AuthZ should be implemented to secure East/West traffic between services.
-* Defining how [Policy Attachment](https://gateway-api.sigs.k8s.io/references/policy-attachment/) would bind to `Route`, services or a mesh.
+* Defining how [Policy Attachment](https://gateway-api.sigs.k8s.io/references/policy-attachment/) would bind to `xRoute`, services or a mesh.
 * Defining how `Routes` configured for East/West service mesh traffic management might integrate with North/South `Gateways`.
     * This is a bit tricky in that it's effectively a form of delegation as described in [GEP-1058: Route Inclusion and Delegation](https://github.com/kubernetes-sigs/gateway-api/pull/1085), and is planned to be explored in a future GEP.
 * Handling East/West traffic outside the cluster (VMs, etc).
 
 ## Implementation Details and Constraints
 
-* MUST set a status field on `Route` to show if the routing configuration has been applied to the mesh.
-* MUST only be allowed to configure "producer" traffic rules for a `Service` in the same namespace as the `Route`.
+* MUST set a status field on `xRoute` to show if the routing configuration has been applied to the mesh.
+* MUST only be allowed to configure "producer" traffic rules for a `Service` in the same namespace as the `xRoute`.
     * Traffic routing configuration defined in this way SHOULD be respected by ALL consumer services in all namespaces in the mesh.
 * SHOULD only be allowed to direct traffic to `backendRefs` within the same namespace when used for configuration of mesh traffic.
     * This constraint may be revisited in the future, but is intended to help simplify an initial implementation.
-    * Attempting to specify an `BackendRef` in a different namespace should set a `ResolvedRefs` status condition with `status: "False"` and reason `RefNotPermitted` on the `Route` if this is attempted.
+    * Attempting to specify an `BackendRef` in a different namespace should set a `ResolvedRefs` status condition with `status: "False"` and reason `RefNotPermitted` on the `xRoute` if this is attempted.
     * When a route rule contains a `BackendRef` that is invalid, requests MUST be rejected, following the existing behavior defined in each route (For example, [`HTTPRouteRule`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPRouteRule) returns a 500 status codes).
 * MAY assume that a mesh implements "transparent proxy" functionality to redirect calls to the Kubernetes DNS address for a `Service` through mesh routing rules.
 
 ## Introduction
 
-It is proposed that an application owner should configure traffic rules for a mesh service by configuring an `Route` with a Kubernetes `Service` resource as a `parentRef`.
+It is proposed that an application owner should configure traffic rules for a mesh service by configuring an `xRoute` with a Kubernetes `Service` resource as a `parentRef`.
 
-This approach is dependent on both the "frontend" role of the Kubernetes `Service` resource as defined in [GEP-1324: Service Mesh in Gateway API](https://gateway-api.sigs.k8s.io/geps/gep-1324/#service) when used as a `parentRef` and the "backend" role of `Service` when used as a `backendRef`. It would use the Kubernetes service name to match traffic for meshes implementing "transparent proxy" functionality, but the `backendRef` endpoints would ultimately be used for the canonical IP address(es) to which traffic should be redirected by rules defined in this `Route`. This approach leverages the existing points of extensibility within the Gateway API spec, and would not require introducing any API changes or new resources, only defining expected behavior.
+This approach is dependent on both the "frontend" role of the Kubernetes `Service` resource as defined in [GEP-1324: Service Mesh in Gateway API](https://gateway-api.sigs.k8s.io/geps/gep-1324/#service) when used as a `parentRef` and the "backend" role of `Service` when used as a `backendRef`. It would use the Kubernetes service name to match traffic for meshes implementing "transparent proxy" functionality, but the `backendRef` endpoints would ultimately be used for the canonical IP address(es) to which traffic should be redirected by rules defined in this `xRoute`. This approach leverages the existing points of extensibility within the Gateway API spec, and would not require introducing any API changes or new resources, only defining expected behavior.
 
 ## API
 
@@ -75,7 +75,7 @@ In the example above, routing rules have been configured to direct 90% of traffi
 
 Implementations SHOULD support a terse syntax which allows omitting `backendRefs` to avoid unnecessary redundancy for simple configurations. If no `backendRefs` are specified, implementations should direct traffic to the default endpoints of the `parentRef` service. The behavior should be exactly the same as if the `parentRef` service was explicitly defined as the only `backendRef`, so if the `parentRef` does not have any endpoints, implementations MUST return an HTTP 503 response code (see discussion in [#1210](https://github.com/kubernetes-sigs/gateway-api/pull/1210)).
 
-This syntax has limited utility currently, but could become more relevant if additional functionality beyond traffic splitting is added to the `Route` resource. `Routes` configured in this way MAY be used to manually enroll services into a mesh (which could trigger behavior like injecting a sidecar proxy) if they have not already been enrolled by some other mechanism (as proposed in [GEP-1291: Mesh Representation](https://docs.google.com/document/d/1oyA9uUH7pNNxxwy3WZGSWx-edHDBLrujcezr8q3el70/edit) or similar).
+This syntax has limited utility currently, but could become more relevant if additional functionality beyond traffic splitting is added to the `xRoute` resource. `Routes` configured in this way MAY be used to manually enroll services into a mesh (which could trigger behavior like injecting a sidecar proxy) if they have not already been enrolled by some other mechanism (as proposed in [GEP-1291: Mesh Representation](https://docs.google.com/document/d/1oyA9uUH7pNNxxwy3WZGSWx-edHDBLrujcezr8q3el70/edit) or similar).
 
 ```
 metadata:
@@ -117,34 +117,34 @@ An alternate pattern additionally supported by this approach would be to target 
 
 `ServiceImport` resources allocate a virtual IP in the cluster, so MAY be allowed as a `parentRef`.
 
-`ServiceImport` would remain a valid backend option for `Route` resources (but _not_ currently a requirement for core conformance), and could be specified alongside a `Service` `backendRef` to split traffic across clusters within a `ClusterSet` (as defined in the [Multi-cluster Service (MCS) APIs project](https://github.com/kubernetes-sigs/mcs-api)). This could be a way to solve the need described in [A use case for using Gateway APIs in Multi-Cluster](https://docs.google.com/document/d/1bjr0uAVMmEtTX4mpU_aGXXapQFsEz_Qt0OnDoVswEEI/edit).
+`ServiceImport` would remain a valid backend option for `xRoute` resources (but _not_ currently a requirement for core conformance), and could be specified alongside a `Service` `backendRef` to split traffic across clusters within a `ClusterSet` (as defined in the [Multi-cluster Service (MCS) APIs project](https://github.com/kubernetes-sigs/mcs-api)). This could be a way to solve the need described in [A use case for using Gateway APIs in Multi-Cluster](https://docs.google.com/document/d/1bjr0uAVMmEtTX4mpU_aGXXapQFsEz_Qt0OnDoVswEEI/edit).
 
 ### `hostnames` field
 
-GAMMA implementations SHOULD NOT infer any functionality from the `hostnames` field on `Route`s (currently, `TLSRoute`, `HTTPRoute`, and `GRPCRoute` have this field) due to current under-specification and reserved potential for future usage or API changes.
+GAMMA implementations SHOULD NOT infer any functionality from the `hostnames` field on `xRoute`s (currently, `TLSRoute`, `HTTPRoute`, and `GRPCRoute` have this field) due to current under-specification and reserved potential for future usage or API changes.
 
-For the use case of filtering incoming traffic from selected HTTP hostnames, it is recommended to guide users toward configuring [`HTTPHeaderMatch`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPHeaderMatch) rules for the [`Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) header. Functionality to be explored in future GEPs may include supporting concurrent usage of an `Route` traffic configuration for multiple North/South `Gateways` and East/West mesh use cases or redirection of egress traffic to an in-cluster `Service`.
+For the use case of filtering incoming traffic from selected HTTP hostnames, it is recommended to guide users toward configuring [`HTTPHeaderMatch`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPHeaderMatch) rules for the [`Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) header. Functionality to be explored in future GEPs may include supporting concurrent usage of an `xRoute` traffic configuration for multiple North/South `Gateways` and East/West mesh use cases or redirection of egress traffic to an in-cluster `Service`.
 
 ### Limiting graph depth, preventing conflicts and cycles
 
-A `Service` may only be specified as a `parentRef` of an `Route` if it is:
+A `Service` may only be specified as a `parentRef` of an `xRoute` if it is:
 
-* NOT already specified as a `parentRef` of another `Route` [in the same namespace]
+* NOT already specified as a `parentRef` of another `xRoute` [in the same namespace]
     * Resolving conflicts from multiple `HTTPRoutes` attempting to target the same `Service` as a `parentRef` should follow the existing [conflict guidelines](https://gateway-api.sigs.k8s.io/concepts/guidelines/#conflicts).
-      * When an existing `Route` targeting the `Service` as a `parentRef` has already been accepted, any `Route` with a newer creation timestamp should be rejected, because the match target considered for the specificity rules (the `Service`) is identical.
-      * If creation timestamps are identical (from applying both routes simultaneously), only the `Route` with a `name` appearing first in alphabetical order should be accepted.
-      * Any rejected `Route` should set an `Accepted` condition with `status: "False"`.
+      * When an existing `xRoute` targeting the `Service` as a `parentRef` has already been accepted, any `xRoute` with a newer creation timestamp should be rejected, because the match target considered for the specificity rules (the `Service`) is identical.
+      * If creation timestamps are identical (from applying both routes simultaneously), only the `xRoute` with a `name` appearing first in alphabetical order should be accepted.
+      * Any rejected `xRoute` should set an `Accepted` condition with `status: "False"`.
     * This requirement may be relaxed later to follow the existing [precedence rules for merging configuration](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPRouteRule), but is intended to simplify initial implementation.
     * The namespace colocation requirement effectively forecloses using this strategy to delegate route management, but there is service mesh [user interest](https://github.com/istio/istio/issues/22997) in merging separately-defined routes together to manage large configurations, multiple versions or canary deployments for a single mesh service.
-* NOT already specified as a `backendRef` of any _other_ `Route` with a `Service` `parentRef`
+* NOT already specified as a `backendRef` of any _other_ `xRoute` with a `Service` `parentRef`
    * This restriction is intended to prevent route "inclusion/delegation" patterns or circular references from multiple tiers of routing rules _within mesh configuration_.
-   * A `Service` MAY still be listed as a `backendRef` on a different `Route` which only targets a `Gateway` as a `parentRef`. The specific behavior of how Gateways might interact with mesh routing rules will be defined in a future GEP.
-    * A `Service` MAY still be listed as a `backendRef` on the _same_ `Route` where it is specified as a `parentRef`, e.g. to only split off some subset of traffic from the default backend endpoints.
+   * A `Service` MAY still be listed as a `backendRef` on a different `xRoute` which only targets a `Gateway` as a `parentRef`. The specific behavior of how Gateways might interact with mesh routing rules will be defined in a future GEP.
+    * A `Service` MAY still be listed as a `backendRef` on the _same_ `xRoute` where it is specified as a `parentRef`, e.g. to only split off some subset of traffic from the default backend endpoints.
     * This could be computationally expensive to validate.
 
 This should be enforced by controller validation, which should set an `Accepted: { status: False }` condition with a corresponding new `ParentRefConflict` `RouteConditionReason`.
 
-The logic described here is a bit verbose, but could be validated with conformance tests, and is intended to allow an `Route` configuring mesh traffic rules to additionally specify a `Gateway` `parentRef` (or `Route` `parentRef` if [GEP-1058: Route Inclusion and Delegation](https://github.com/kubernetes-sigs/gateway-api/pull/1085) moves forward) to apply the same routing rules when exposing a mesh service outside the cluster.
+The logic described here is a bit verbose, but could be validated with conformance tests, and is intended to allow an `xRoute` configuring mesh traffic rules to additionally specify a `Gateway` `parentRef` (or `xRoute` `parentRef` if [GEP-1058: Route Inclusion and Delegation](https://github.com/kubernetes-sigs/gateway-api/pull/1085) moves forward) to apply the same routing rules when exposing a mesh service outside the cluster.
 
 ### Route types
 

--- a/site-src/geps/gep-1426.md
+++ b/site-src/geps/gep-1426.md
@@ -150,7 +150,17 @@ The logic described here is a bit verbose, but could be validated with conforman
 
 All types currently defined in the gateway-api core (`HTTP`, `GRPC`, `TCP`, `TLS`, and `UDP`) are available for use in a Mesh implementation.
 
-If multiple routes with of different type both bind to the same Service and Port pair, the same resolution rules as defined in [`listener.allowedRoutes`](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.AllowedRoutes) apply.
+If multiple routes with of different type both bind to the same Service and Port pair, only a single route type should be applied. The rejected routes should be ignored and have the `RouteConditionAccepted` status set to the (new) reason `RouteReasonConflicted`.
+
+Route type specificity is defined in the following order (first one wins):
+
+1. HTTPRoute
+2. TLSRoute
+3. TCPRoute
+
+Because UDP is its own protocol, it is orthogonal to these precedence order. Since there is only one UDP-based route, there is currently no conflicts possible; if other UDP-based routes are added a similar ordering will be defined.
+
+Note: these conflicts only occur when multiple *different* route types apply to the same Service+Port pair. Multiple routes of the same type are valid, and merge according to the route-specific merging semantics.
 
 ### Drawbacks
 

--- a/site-src/geps/gep-1426.md
+++ b/site-src/geps/gep-1426.md
@@ -1,11 +1,11 @@
-# GEP-1426: HTTPRoute Mesh Binding
+# GEP-1426: Routes Mesh Binding
 
 * Issue: [#1294](https://github.com/kubernetes-sigs/gateway-api/issues/1294)
 * Status: Provisional
 
 ## Overview
 
-Similar to how `HTTPRoutes` bind to `Gateways` and manage North/South traffic flows in Gateway API’s ingress use-case, it would be natural to adopt a similar model for traffic routing concerns in service mesh deployments. The purpose of this GEP is to add a mechanism to the Gateway API spec for the purpose of associating `HTTPRoutes` to a service mesh and offering a model for service owners to manage traffic splitting configurations.
+Similar to how `Routes` bind to `Gateways` and manage North/South traffic flows in Gateway API’s ingress use-case, it would be natural to adopt a similar model for traffic routing concerns in service mesh deployments. The purpose of this GEP is to add a mechanism to the Gateway API spec for the purpose of associating the various `Route` types to a service mesh and offering a model for service owners to manage traffic splitting configurations.
 	
 This GEP is intended to establish an implementable, but experimental, baseline for supporting basic service mesh traffic routing functionality through the Gateway API spec.
 
@@ -15,10 +15,10 @@ This GEP uses the [roles and personas](https://gateway-api.sigs.k8s.io/concepts/
 
 ## Goals
 
-* MUST allow `HTTPRoute` traffic rules to be configurable for a mesh service by the application owner/producer.
-* SHOULD allow control by the cluster operator (mesh administrator) to grant permission for whether `HTTPRoute` resources in a given namespace are allowed to configure mesh traffic routing.
+* MUST allow `Route` traffic rules to be configurable for a mesh service by the application owner/producer.
+* SHOULD allow control by the cluster operator (mesh administrator) to grant permission for whether `Route` resources in a given namespace are allowed to configure mesh traffic routing.
 * SHOULD NOT require downstream "consumer" services to update configuration or DNS addresses for traffic to follow "producer" mesh routing rules configured by upstream services.
-* SHOULD NOT require reconfiguring existing `HTTPRoute` resources for North/South Gateway configuration.
+* SHOULD NOT require reconfiguring existing `Route` resources for North/South Gateway configuration.
 
 ## Non-Goals
 
@@ -27,34 +27,33 @@ This GEP uses the [roles and personas](https://gateway-api.sigs.k8s.io/concepts/
     * Redirecting calls from arbitrary custom domains to an in-cluster service.
 * Defining how multiple `Services` or `EndpointSlices` representing instances of a single "logical" service should present an identity for AuthN/AuthZ or be associated with each other beyond routing rules.
 * Defining how AuthZ should be implemented to secure East/West traffic between services.
-* Defining how [Policy Attachment](https://gateway-api.sigs.k8s.io/references/policy-attachment/) would bind to `HTTPRoute`, services or a mesh.
-* Defining how `HTTPRoutes` configured for East/West service mesh traffic management might integrate with North/South `Gateways`.
+* Defining how [Policy Attachment](https://gateway-api.sigs.k8s.io/references/policy-attachment/) would bind to `Route`, services or a mesh.
+* Defining how `Routes` configured for East/West service mesh traffic management might integrate with North/South `Gateways`.
     * This is a bit tricky in that it's effectively a form of delegation as described in [GEP-1058: Route Inclusion and Delegation](https://github.com/kubernetes-sigs/gateway-api/pull/1085), and is planned to be explored in a future GEP.
 * Handling East/West traffic outside the cluster (VMs, etc).
 
 ## Implementation Details and Constraints
 
-* MUST set a status field on `HTTPRoute` to show if the routing configuration has been applied to the mesh.
-* MUST only be allowed to configure "producer" traffic rules for a `Service` in the same namespace as the `HTTPRoute`.
+* MUST set a status field on `Route` to show if the routing configuration has been applied to the mesh.
+* MUST only be allowed to configure "producer" traffic rules for a `Service` in the same namespace as the `Route`.
     * Traffic routing configuration defined in this way SHOULD be respected by ALL consumer services in all namespaces in the mesh.
 * SHOULD only be allowed to direct traffic to `backendRefs` within the same namespace when used for configuration of mesh traffic.
     * This constraint may be revisited in the future, but is intended to help simplify an initial implementation.
-    * Attempting to specify an `HTTPBackendRef` in a different namespace should set a `ResolvedRefs` status condition with `status: "False"` and reason `RefNotPermitted` on the `HTTPRoute` if this is attempted.
-    * When a route rule contains a `HTTPBackendRef` that is invalid, 500 status codes MUST be returned for requests that would match that route rule.
-        * This matches existing behavior as defined in [`HTTPRouteRule`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPRouteRule).
+    * Attempting to specify an `BackendRef` in a different namespace should set a `ResolvedRefs` status condition with `status: "False"` and reason `RefNotPermitted` on the `Route` if this is attempted.
+    * When a route rule contains a `BackendRef` that is invalid, requests MUST be rejected, following the existing behavior defined in each route (For example, [`HTTPRouteRule`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPRouteRule) returns a 500 status codes).
 * MAY assume that a mesh implements "transparent proxy" functionality to redirect calls to the Kubernetes DNS address for a `Service` through mesh routing rules.
 
 ## Introduction
 
-It is proposed that an application owner should configure traffic rules for a mesh service by configuring an `HTTPRoute` with a Kubernetes `Service` resource as a `parentRef`.
+It is proposed that an application owner should configure traffic rules for a mesh service by configuring an `Route` with a Kubernetes `Service` resource as a `parentRef`.
 
-This approach is dependent on both the "frontend" role of the Kubernetes `Service` resource as defined in [GEP-1324: Service Mesh in Gateway API](https://gateway-api.sigs.k8s.io/geps/gep-1324/#service) when used as a `parentRef` and the "backend" role of `Service` when used as a `backendRef`. It would use the Kubernetes service name to match traffic for meshes implementing "transparent proxy" functionality, but the `backendRef` endpoints would ultimately be used for the canonical IP address(es) to which traffic should be redirected by rules defined in this HTTPRoute. This approach leverages the existing points of extensibility within the Gateway API spec, and would not require introducing any API changes or new resources, only defining expected behavior.
+This approach is dependent on both the "frontend" role of the Kubernetes `Service` resource as defined in [GEP-1324: Service Mesh in Gateway API](https://gateway-api.sigs.k8s.io/geps/gep-1324/#service) when used as a `parentRef` and the "backend" role of `Service` when used as a `backendRef`. It would use the Kubernetes service name to match traffic for meshes implementing "transparent proxy" functionality, but the `backendRef` endpoints would ultimately be used for the canonical IP address(es) to which traffic should be redirected by rules defined in this `Route`. This approach leverages the existing points of extensibility within the Gateway API spec, and would not require introducing any API changes or new resources, only defining expected behavior.
 
 ## API
 
 ```
 metadata:
-  name: foo_route
+  name: foo-route
   namespace: store
 spec:
   parentRefs:
@@ -66,21 +65,21 @@ spec:
       name: foo
       weight: 90
     - kind: Service
-      name: foo_v2
+      name: foo-v2
       weight: 10
 ```
 
-In the example above, routing rules have been configured to direct 90% of traffic for the `foo` `Service` to the default "backend" endpoints specified by the `foo` `Service` [`selector`](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) field, and 10% to the `foo_v2` `Service`. This is determined based on the `ClusterIP` (for `Service`) and `ClusterSetIP` (for `ServiceImport`) matching, and for "transparent proxy" mesh implementations would match all requests to `foo.svc.cluster.local` (or arbitrary custom suffix, as the hostname is not specified manually) from within the same namespace, all requests to `foo.store.svc.cluster.local` from other namespaces, and all requests to `foo.store.svc.clusterset.local` for multicluster services, within the scope of the service mesh.
+In the example above, routing rules have been configured to direct 90% of traffic for the `foo` `Service` to the default "backend" endpoints specified by the `foo` `Service` [`selector`](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) field, and 10% to the `foo-v2` `Service`. This is determined based on the `ClusterIP` (for `Service`) and `ClusterSetIP` (for `ServiceImport`) matching, and for "transparent proxy" mesh implementations would match all requests to `foo.svc.cluster.local` (or arbitrary custom suffix, as the hostname is not specified manually) from within the same namespace, all requests to `foo.store.svc.cluster.local` from other namespaces, and all requests to `foo.store.svc.clusterset.local` for multicluster services, within the scope of the service mesh.
 
 ### Omitting `backendRefs`
 
 Implementations SHOULD support a terse syntax which allows omitting `backendRefs` to avoid unnecessary redundancy for simple configurations. If no `backendRefs` are specified, implementations should direct traffic to the default endpoints of the `parentRef` service. The behavior should be exactly the same as if the `parentRef` service was explicitly defined as the only `backendRef`, so if the `parentRef` does not have any endpoints, implementations MUST return an HTTP 503 response code (see discussion in [#1210](https://github.com/kubernetes-sigs/gateway-api/pull/1210)).
 
-This syntax has limited utility currently, but could become more relevant if additional functionality beyond traffic splitting is added to the `HTTPRoute` resource. `HTTPRoutes` configured in this way MAY be used to manually enroll services into a mesh (which could trigger behavior like injecting a sidecar proxy) if they have not already been enrolled by some other mechanism (as proposed in [GEP-1291: Mesh Representation](https://docs.google.com/document/d/1oyA9uUH7pNNxxwy3WZGSWx-edHDBLrujcezr8q3el70/edit) or similar).
+This syntax has limited utility currently, but could become more relevant if additional functionality beyond traffic splitting is added to the `Route` resource. `Routes` configured in this way MAY be used to manually enroll services into a mesh (which could trigger behavior like injecting a sidecar proxy) if they have not already been enrolled by some other mechanism (as proposed in [GEP-1291: Mesh Representation](https://docs.google.com/document/d/1oyA9uUH7pNNxxwy3WZGSWx-edHDBLrujcezr8q3el70/edit) or similar).
 
 ```
 metadata:
-  name: foo_route
+  name: foo-route
   namespace: store
 spec:
   parentRefs:
@@ -98,7 +97,7 @@ When no `HTTPRoute` resources or AuthZ configuration are defined, all traffic sh
 
 ### Allowed service types
 
-Services valid to be selected as a `parentRef` SHOULD have a way to identify traffic to them - typically by one or more virtual IP(s), DNS hostname(s) or name(s).
+Services valid to be selected as a `parentRef` SHOULD have a way to identify traffic to them - typically by one or more virtual IP(s), DNS hostname(s), or name(s).
 
 Implementations SHOULD support the default [`ClusterIP`](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) `Service` type as a `parentRef`, with or without selectors.
 
@@ -114,37 +113,44 @@ Services supported as `backendRefs` SHOULD be consistent with expectations for N
 
 An alternate pattern additionally supported by this approach would be to target a `Service` without selectors as the `parentRef`. This could be a clean way to create a pure routing construct and abstract a logical frontend, as traffic would resolve to a `backendRef` `Service` with selectors defined on the `HTTPRoute`, or receive a 4xx/5xx error response if no matching path or valid backend was found.
 
-
 #### Multicluster support with `ServiceImport`
 
 `ServiceImport` resources allocate a virtual IP in the cluster, so MAY be allowed as a `parentRef`.
 
-`ServiceImport` would remain a valid backend option for `HTTPRoute` resources (but _not_ currently a requirement for core conformance), and could be specified alongside a `Service` `backendRef` to split traffic across clusters within a `ClusterSet` (as defined in the [Multi-cluster Service (MCS) APIs project](https://github.com/kubernetes-sigs/mcs-api)). This could be a way to solve the need described in [A use case for using Gateway APIs in Multi-Cluster](https://docs.google.com/document/d/1bjr0uAVMmEtTX4mpU_aGXXapQFsEz_Qt0OnDoVswEEI/edit).
+`ServiceImport` would remain a valid backend option for `Route` resources (but _not_ currently a requirement for core conformance), and could be specified alongside a `Service` `backendRef` to split traffic across clusters within a `ClusterSet` (as defined in the [Multi-cluster Service (MCS) APIs project](https://github.com/kubernetes-sigs/mcs-api)). This could be a way to solve the need described in [A use case for using Gateway APIs in Multi-Cluster](https://docs.google.com/document/d/1bjr0uAVMmEtTX4mpU_aGXXapQFsEz_Qt0OnDoVswEEI/edit).
 
 ### `hostnames` field
 
-GAMMA implementations SHOULD NOT infer any functionality from the `hostnames` field on `HTTPRoute` due to current under-specification and reserved potential for future usage or API changes. For the use case of filtering incoming traffic from selected hostnames, it is recommended to guide users toward configuring [`HTTPHeaderMatch`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPHeaderMatch) rules for the [`Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) header. Functionality to be explored in future GEPs may include supporting concurrent usage of an `HTTPRoute` traffic configuration for multiple North/South `Gateways` and East/West mesh use cases or redirection of egress traffic to an in-cluster `Service`.
+GAMMA implementations SHOULD NOT infer any functionality from the `hostnames` field on `Route`s (currently, `TLSRoute`, `HTTPRoute`, and `GRPCRoute` have this field) due to current under-specification and reserved potential for future usage or API changes.
+
+For the use case of filtering incoming traffic from selected HTTP hostnames, it is recommended to guide users toward configuring [`HTTPHeaderMatch`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPHeaderMatch) rules for the [`Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) header. Functionality to be explored in future GEPs may include supporting concurrent usage of an `Route` traffic configuration for multiple North/South `Gateways` and East/West mesh use cases or redirection of egress traffic to an in-cluster `Service`.
 
 ### Limiting graph depth, preventing conflicts and cycles
 
-A `Service` may only be specified as a `parentRef` of an `HTTPRoute` if it is:
+A `Service` may only be specified as a `parentRef` of an `Route` if it is:
 
-* NOT already specified as a `parentRef` of another `HTTPRoute` [in the same namespace]
+* NOT already specified as a `parentRef` of another `Route` [in the same namespace]
     * Resolving conflicts from multiple `HTTPRoutes` attempting to target the same `Service` as a `parentRef` should follow the existing [conflict guidelines](https://gateway-api.sigs.k8s.io/concepts/guidelines/#conflicts).
-      * When an existing `HTTPRoute` targeting the `Service` as a `parentRef` has already been accepted, any `HTTPRoute` with a newer creation timestamp should be rejected, because the match target considered for the specificity rules (the `Service`) is identical.
-      * If creation timestamps are identical (from applying both routes simultaneously), only the `HTTPRoute` with a `name` appearing first in alphabetical order should be accepted.
-      * Any rejected `HTTPRoute` should set an `Accepted` condition with `status: "False"`.
+      * When an existing `Route` targeting the `Service` as a `parentRef` has already been accepted, any `Route` with a newer creation timestamp should be rejected, because the match target considered for the specificity rules (the `Service`) is identical.
+      * If creation timestamps are identical (from applying both routes simultaneously), only the `Route` with a `name` appearing first in alphabetical order should be accepted.
+      * Any rejected `Route` should set an `Accepted` condition with `status: "False"`.
     * This requirement may be relaxed later to follow the existing [precedence rules for merging configuration](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPRouteRule), but is intended to simplify initial implementation.
     * The namespace colocation requirement effectively forecloses using this strategy to delegate route management, but there is service mesh [user interest](https://github.com/istio/istio/issues/22997) in merging separately-defined routes together to manage large configurations, multiple versions or canary deployments for a single mesh service.
-* NOT already specified as a `backendRef` of any _other_ `HTTPRoute` with a `Service` `parentRef`
+* NOT already specified as a `backendRef` of any _other_ `Route` with a `Service` `parentRef`
    * This restriction is intended to prevent route "inclusion/delegation" patterns or circular references from multiple tiers of routing rules _within mesh configuration_.
-   * A `Service` MAY still be listed as a `backendRef` on a different `HTTPRoute` which only targets a `Gateway` as a `parentRef`. The specific behavior of how Gateways might interact with mesh routing rules will be defined in a future GEP.
-    * A `Service` MAY still be listed as a `backendRef` on the _same_ `HTTPRoute` where it is specified as a `parentRef`, e.g. to only split off some subset of traffic from the default backend endpoints.
+   * A `Service` MAY still be listed as a `backendRef` on a different `Route` which only targets a `Gateway` as a `parentRef`. The specific behavior of how Gateways might interact with mesh routing rules will be defined in a future GEP.
+    * A `Service` MAY still be listed as a `backendRef` on the _same_ `Route` where it is specified as a `parentRef`, e.g. to only split off some subset of traffic from the default backend endpoints.
     * This could be computationally expensive to validate.
 
 This should be enforced by controller validation, which should set an `Accepted: { status: False }` condition with a corresponding new `ParentRefConflict` `RouteConditionReason`.
 
-The logic described here is a bit verbose, but could be validated with conformance tests, and is intended to allow an `HTTPRoute` configuring mesh traffic rules to additionally specify a `Gateway` `parentRef` (or `HTTPRoute` `parentRef` if [GEP-1058: Route Inclusion and Delegation](https://github.com/kubernetes-sigs/gateway-api/pull/1085) moves forward) to apply the same routing rules when exposing a mesh service outside the cluster.
+The logic described here is a bit verbose, but could be validated with conformance tests, and is intended to allow an `Route` configuring mesh traffic rules to additionally specify a `Gateway` `parentRef` (or `Route` `parentRef` if [GEP-1058: Route Inclusion and Delegation](https://github.com/kubernetes-sigs/gateway-api/pull/1085) moves forward) to apply the same routing rules when exposing a mesh service outside the cluster.
+
+### Route types
+
+All types currently defined in the gateway-api core (`HTTP`, `GRPC`, `TCP`, `TLS`, and `UDP`) are available for use in a Mesh implementation.
+
+If multiple routes with of different type both bind to the same Service and Port pair, the same resolution rules as defined in [`listener.allowedRoutes`](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.AllowedRoutes) apply.
 
 ### Drawbacks
 


### PR DESCRIPTION


**What type of PR is this?**

/kind gep

**What this PR does / why we need it**:

This expands the GEP to cover non-HTTP types

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/1483

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
