### PR TITLE
Mesh: define namespace boundaries for parent and backend

### DIFF
--- a/site-src/geps/gep-1426.md
+++ b/site-src/geps/gep-1426.md
@@ -115,40 +115,6 @@ An alternate pattern additionally supported by this approach would be to target 
 
 `ServiceImport` would remain a valid backend option for `xRoute` resources (but _not_ currently a requirement for core conformance), and could be specified alongside a `Service` `backendRef` to split traffic across clusters within a `ClusterSet` (as defined in the [Multi-cluster Service (MCS) APIs project](https://github.com/kubernetes-sigs/mcs-api)). This could be a way to solve the need described in [A use case for using Gateway APIs in Multi-Cluster](https://docs.google.com/document/d/1bjr0uAVMmEtTX4mpU_aGXXapQFsEz_Qt0OnDoVswEEI/edit).
 
-### Ports
-
-By default, a `Service` attachment applies to all ports in the service. Users may want to attach routes to only a *specific* port in a Service. To do so, the `parentRef.port` field should be used.
-
-If `port` is set, the implementation MUST associate the route only with that port.
-If `port` is not set, the implementation MUST associate the route with all ports defined in the Service.
-
-### `hostnames` field
-
-GAMMA implementations SHOULD NOT infer any functionality from the `hostnames` field on `xRoute`s (currently, `TLSRoute`, `HTTPRoute`, and `GRPCRoute` have this field) due to current under-specification and reserved potential for future usage or API changes.
-
-For the use case of filtering incoming traffic from selected HTTP hostnames, it is recommended to guide users toward configuring [`HTTPHeaderMatch`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPHeaderMatch) rules for the [`Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) header. Functionality to be explored in future GEPs may include supporting concurrent usage of an `xRoute` traffic configuration for multiple North/South `Gateways` and East/West mesh use cases or redirection of egress traffic to an in-cluster `Service`.
-
-### Limiting graph depth, preventing conflicts and cycles
-
-A `Service` may only be specified as a `parentRef` of an `xRoute` if it is:
-
-* NOT already specified as a `parentRef` of another `xRoute` [in the same namespace]
-    * Resolving conflicts from multiple `HTTPRoutes` attempting to target the same `Service` as a `parentRef` should follow the existing [conflict guidelines](https://gateway-api.sigs.k8s.io/concepts/guidelines/#conflicts).
-      * When an existing `xRoute` targeting the `Service` as a `parentRef` has already been accepted, any `xRoute` with a newer creation timestamp should be rejected, because the match target considered for the specificity rules (the `Service`) is identical.
-      * If creation timestamps are identical (from applying both routes simultaneously), only the `xRoute` with a `name` appearing first in alphabetical order should be accepted.
-      * Any rejected `xRoute` must set an `Accepted` condition with `status: "False"`.
-    * This requirement may be relaxed later to follow the existing [precedence rules for merging configuration](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPRouteRule), but is intended to simplify initial implementation.
-    * The namespace colocation requirement effectively forecloses using this strategy to delegate route management, but there is service mesh [user interest](https://github.com/istio/istio/issues/22997) in merging separately-defined routes together to manage large configurations, multiple versions or canary deployments for a single mesh service.
-* NOT already specified as a `backendRef` of any _other_ `xRoute` with a `Service` `parentRef`
-   * This restriction is intended to prevent route "inclusion/delegation" patterns or circular references from multiple tiers of routing rules _within mesh configuration_.
-   * A `Service` MAY still be listed as a `backendRef` on a different `xRoute` which only targets a `Gateway` as a `parentRef`. The specific behavior of how Gateways might interact with mesh routing rules will be defined in a future GEP.
-    * A `Service` MAY still be listed as a `backendRef` on the _same_ `xRoute` where it is specified as a `parentRef`, e.g. to only split off some subset of traffic from the default backend endpoints.
-    * This could be computationally expensive to validate.
-
-This should be enforced by controller validation, which should set an `Accepted: { status: False }` condition with a corresponding new `ParentRefConflict` `RouteConditionReason`.
-
-The logic described here is a bit verbose, but could be validated with conformance tests, and is intended to allow an `xRoute` configuring mesh traffic rules to additionally specify a `Gateway` `parentRef` (or `xRoute` `parentRef` if [GEP-1058: Route Inclusion and Delegation](https://github.com/kubernetes-sigs/gateway-api/pull/1085) moves forward) to apply the same routing rules when exposing a mesh service outside the cluster.
-
 ### Route types
 
 All types currently defined in the gateway-api core (`HTTP`, `GRPC`, `TCP`, `TLS`, and `UDP`) are available for use in a Mesh implementation.
@@ -166,6 +132,19 @@ Because UDP is its own protocol, it is orthogonal to these precedence order. Sin
 
 Note: these conflicts only occur when multiple *different* route types apply to the same Service+Port pair. Multiple routes of the same type are valid, and merge according to the route-specific merging semantics.
 
+### Ports
+
+By default, a `Service` attachment applies to all ports in the service. Users may want to attach routes to only a *specific* port in a Service. To do so, the `parentRef.port` field should be used.
+
+If `port` is set, the implementation MUST associate the route only with that port.
+If `port` is not set, the implementation MUST associate the route with all ports defined in the Service.
+
+### `hostnames` field
+
+GAMMA implementations SHOULD NOT infer any functionality from the `hostnames` field on `xRoute`s (currently, `TLSRoute`, `HTTPRoute`, and `GRPCRoute` have this field) due to current under-specification and reserved potential for future usage or API changes.
+
+For the use case of filtering incoming traffic from selected HTTP hostnames, it is recommended to guide users toward configuring [`HTTPHeaderMatch`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPHeaderMatch) rules for the [`Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) header. Functionality to be explored in future GEPs may include supporting concurrent usage of an `xRoute` traffic configuration for multiple North/South `Gateways` and East/West mesh use cases or redirection of egress traffic to an in-cluster `Service`.
+
 ### Namespace boundaries
 
 In a mesh, routes can be configured by two personas:
@@ -173,7 +152,7 @@ In a mesh, routes can be configured by two personas:
 * Service producers, who want to modify behavior of *inbound* requests to their services
 * Service consumers, who want to modify behavior of *outbound* requests to other services.
 
-While these concepts are not directly exposed in the API, a route is implicitly fulfilling one of these rolls and behaves differently depending on the role.
+While these concepts are not directly exposed in the API, a route is implicitly fulfilling one of these roles and behaves differently depending on the role.
 
 A route is a producer route when the `parentRef` refers to a service in the *same namespace*. This route SHOULD apply to all incoming requests to the service, including from clients in other namespaces.
 
@@ -181,7 +160,26 @@ Note: Some implementations may only be able to apply routes on client-side proxi
 
 A route is a consumer route when the `parentRef` refers to a service in *another namespace*. Unlike producer routes, consumer routes are scoped only the same namespace. This ensures that for traffic between two namespaces, another unrelated namespace cannot modify their traffic.
 
-Routes of either type can send traffic to `backendRefs` in any namespace. Unlike `Gateway` bound routes, this is allowed without a `ReferenceGrant`. In `Gateway`, routes are opt-in; by default, no Services are exposed (often to the public internet), and a service producer must explicitly opt-in by creating a route themselves, or allowing another namespace to via `ReferenceGrant`. For mesh, routes *augment* existing Services, rather than exposing them to a broader scope. As a result, a `ReferenceGrant` is not required. Access control, if desired, is handled by authorization policies.
+Routes of either type can send traffic to `backendRefs` in any namespace. Unlike `Gateway` bound routes, this is allowed without a `ReferenceGrant`. In `Gateway`-bound routes (North-South), routes are opt-in; by default, no Services are exposed (often to the public internet), and a service producer must explicitly opt-in by creating a route themselves, or allowing another namespace to via `ReferenceGrant`. For mesh, routes *augment* existing Services, rather than exposing them to a broader scope. As a result, a `ReferenceGrant` is not required in most mesh implementations. Access control, if desired, is handled by other mechanism such as `NetworkPolicy`. While uncommon, if a mesh implementation *does* expose the ability to access a broader scope than would otherwise be reachable, then `ReferenceGrant` must be used for cross namespaces references.
+
+### Multiple routes for a Service
+
+A service may be used as a `parentRef` (where we attach to the "Service Frontend") or as a `backendRef` (where we attach to the "Service Backend").
+
+In general, when a request is sent to a Service frontend (ex: `curl svc`), it should utilize a Route bound to that Service.
+However, when sent to a Service backend (ex: `curl pod-ip`), it would not.
+
+Similarly, if we have multiple "levels" of Routes defined, only the first will be used, as that is the only one that accesses the Service frontend.
+
+Consider a cluster with routes for a Service in both a Gateway, consumer namespace, and producer namespace:
+
+* Requests from the Gateway will utilize the (possibly merged) set of routes attached to the Gateway
+* Requests from a namespace with consumer routes will utilize the (possibly merged) set of routes in the consumer namespace
+* Requests from other namespaces will utilize the (possibly merged) set of routes in the producer namespace
+
+The merging of routes occurs only within groups of the same type of routes (Gateway bound, producer, or consumer), and follows the standard route merging behavior already defined.
+
+Note: a possible future extension is to allow `backendRefs` to explicitly target a "frontend" or "backend". This could allow chaining multiple routes together. However, this is out of scope for the current GEP.
 
 ### Drawbacks
 

--- a/site-src/geps/gep-1426.md
+++ b/site-src/geps/gep-1426.md
@@ -37,10 +37,6 @@ This GEP uses the [roles and personas](https://gateway-api.sigs.k8s.io/concepts/
 * MUST set a status field on `xRoute` to show if the routing configuration has been applied to the mesh.
 * MUST only be allowed to configure "producer" traffic rules for a `Service` in the same namespace as the `xRoute`.
     * Traffic routing configuration defined in this way SHOULD be respected by ALL consumer services in all namespaces in the mesh.
-* SHOULD only be allowed to direct traffic to `backendRefs` within the same namespace when used for configuration of mesh traffic.
-    * This constraint may be revisited in the future, but is intended to help simplify an initial implementation.
-    * Attempting to specify an `BackendRef` in a different namespace should set a `ResolvedRefs` status condition with `status: "False"` and reason `RefNotPermitted` on the `xRoute` if this is attempted.
-    * When a route rule contains a `BackendRef` that is invalid, requests MUST be rejected, following the existing behavior defined in each route (For example, [`HTTPRouteRule`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPRouteRule) returns a 500 status codes).
 * MAY assume that a mesh implements "transparent proxy" functionality to redirect calls to the Kubernetes DNS address for a `Service` through mesh routing rules.
 
 ## Introduction
@@ -169,6 +165,23 @@ Route type specificity is defined in the following order (first one wins):
 Because UDP is its own protocol, it is orthogonal to these precedence order. Since there is only one UDP-based route, there is currently no conflicts possible; if other UDP-based routes are added a similar ordering will be defined.
 
 Note: these conflicts only occur when multiple *different* route types apply to the same Service+Port pair. Multiple routes of the same type are valid, and merge according to the route-specific merging semantics.
+
+### Namespace boundaries
+
+In a mesh, routes can be configured by two personas:
+
+* Service producers, who want to modify behavior of *inbound* requests to their services
+* Service consumers, who want to modify behavior of *outbound* requests to other services.
+
+While these concepts are not directly exposed in the API, a route is implicitly fulfilling one of these rolls and behaves differently depending on the role.
+
+A route is a producer route when the `parentRef` refers to a service in the *same namespace*. This route SHOULD apply to all incoming requests to the service, including from clients in other namespaces.
+
+Note: Some implementations may only be able to apply routes on client-side proxies. As a result, these will likely only apply to requests from clients who are also in the mesh.
+
+A route is a consumer route when the `parentRef` refers to a service in *another namespace*. Unlike producer routes, consumer routes are scoped only the same namespace. This ensures that for traffic between two namespaces, another unrelated namespace cannot modify their traffic.
+
+Routes of either type can send traffic to `backendRefs` in any namespace. Unlike `Gateway` bound routes, this is allowed without a `ReferenceGrant`. In `Gateway`, routes are opt-in; by default, no Services are exposed (often to the public internet), and a service producer must explicitly opt-in by creating a route themselves, or allowing another namespace to via `ReferenceGrant`. For mesh, routes *augment* existing Services, rather than exposing them to a broader scope. As a result, a `ReferenceGrant` is not required. Access control, if desired, is handled by authorization policies.
 
 ### Drawbacks
 


### PR DESCRIPTION

**What type of PR is this?**

/kind gep
**What this PR does / why we need it**:
This also clarifies parentRef namespace boundries which were under-specified.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/1480

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
