### PR TITLE
Add and test single filter action per header restriction

### DIFF
--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -722,9 +722,10 @@ type HTTPHeader struct {
 
 // HTTPHeaderFilter defines a filter that modifies the headers of an HTTP
 // request or response. Only one action for a given header name is permitted.
-// Filters MUST NOT specify multiple actions of the same or different type for
-// any one header name. Configuration to set or add multiple values for a
-// header MUST use RFC 7230 header value formatting, separating each value with
+// Filters specifying multiple actions of the same or different type for
+// any one header name are invalid and will be rejected by the webhook if
+// installed. Configuration to set or add multiple values for a
+// header must use RFC 7230 header value formatting, separating each value with
 // a comma.
 type HTTPHeaderFilter struct {
 	// Set overwrites the request with the given header (name, value)

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -720,8 +720,12 @@ type HTTPHeader struct {
 	Value string `json:"value"`
 }
 
-// HTTPHeaderFilter defines a filter that modifies the headers of an HTTP request
-// or response.
+// HTTPHeaderFilter defines a filter that modifies the headers of an HTTP
+// request or response. Only one action for a given header name is permitted.
+// Filters MUST NOT specify multiple actions of the same or different type for
+// any one header name. Configuration to set or add multiple values for a
+// header MUST use RFC 7230 header value formatting, separating each value with
+// a comma.
 type HTTPHeaderFilter struct {
 	// Set overwrites the request with the given header (name, value)
 	// before the action.
@@ -756,12 +760,11 @@ type HTTPHeaderFilter struct {
 	// Config:
 	//   add:
 	//   - name: "my-header"
-	//     value: "bar"
+	//     value: "bar,baz"
 	//
 	// Output:
 	//   GET /foo HTTP/1.1
-	//   my-header: foo
-	//   my-header: bar
+	//   my-header: foo,bar,baz
 	//
 	// +optional
 	// +listType=map

--- a/apis/v1beta1/validation/httproute.go
+++ b/apis/v1beta1/validation/httproute.go
@@ -286,33 +286,33 @@ func validateHTTPHeaderModifier(filter gatewayv1b1.HTTPHeaderFilter, path *field
 	var errs field.ErrorList
 	singleAction := make(map[string]bool)
 	for i, action := range filter.Add {
-		if needsErr, ok := singleAction[string(action.Name)]; ok {
+		if needsErr, ok := singleAction[strings.ToLower(string(action.Name))]; ok {
 			if needsErr {
 				errs = append(errs, field.Invalid(path.Child("add"), filter.Add[i], "cannot specify multiple actions for header"))
 			}
-			singleAction[string(action.Name)] = false
+			singleAction[strings.ToLower(string(action.Name))] = false
 		} else {
-			singleAction[string(action.Name)] = true
+			singleAction[strings.ToLower(string(action.Name))] = true
 		}
 	}
 	for i, action := range filter.Set {
-		if needsErr, ok := singleAction[string(action.Name)]; ok {
+		if needsErr, ok := singleAction[strings.ToLower(string(action.Name))]; ok {
 			if needsErr {
 				errs = append(errs, field.Invalid(path.Child("set"), filter.Set[i], "cannot specify multiple actions for header"))
 			}
-			singleAction[string(action.Name)] = false
+			singleAction[strings.ToLower(string(action.Name))] = false
 		} else {
-			singleAction[string(action.Name)] = true
+			singleAction[strings.ToLower(string(action.Name))] = true
 		}
 	}
 	for i, action := range filter.Remove {
-		if needsErr, ok := singleAction[action]; ok {
+		if needsErr, ok := singleAction[strings.ToLower(action)]; ok {
 			if needsErr {
 				errs = append(errs, field.Invalid(path.Child("remove"), filter.Remove[i], "cannot specify multiple actions for header"))
 			}
-			singleAction[action] = false
+			singleAction[strings.ToLower(action)] = false
 		} else {
-			singleAction[action] = true
+			singleAction[strings.ToLower(action)] = true
 		}
 	}
 	return errs

--- a/apis/v1beta1/validation/httproute.go
+++ b/apis/v1beta1/validation/httproute.go
@@ -111,6 +111,12 @@ func validateHTTPRouteFilters(filters []gatewayv1b1.HTTPRouteFilter, matches []g
 		if filter.URLRewrite != nil && filter.URLRewrite.Path != nil {
 			errs = append(errs, validateHTTPPathModifier(*filter.URLRewrite.Path, matches, path.Index(i).Child("urlRewrite", "path"))...)
 		}
+		if filter.RequestHeaderModifier != nil {
+			errs = append(errs, validateHTTPHeaderModifier(*filter.RequestHeaderModifier, path.Index(i).Child("requestHeaderModifier"))...)
+		}
+		if filter.ResponseHeaderModifier != nil {
+			errs = append(errs, validateHTTPHeaderModifier(*filter.ResponseHeaderModifier, path.Index(i).Child("responseHeaderModifier"))...)
+		}
 		errs = append(errs, validateHTTPRouteFilterTypeMatchesValue(filter, path.Index(i))...)
 	}
 	// custom filters don't have any validation
@@ -271,6 +277,42 @@ func validateHTTPPathModifier(modifier gatewayv1b1.HTTPPathModifier, matches []g
 	if modifier.Type == gatewayv1b1.PrefixMatchHTTPPathModifier && modifier.ReplacePrefixMatch != nil {
 		if !hasExactlyOnePrefixMatch(matches) {
 			errs = append(errs, field.Invalid(path, modifier.ReplacePrefixMatch, "exactly one PathPrefix match must be specified to use this path modifier"))
+		}
+	}
+	return errs
+}
+
+func validateHTTPHeaderModifier(filter gatewayv1b1.HTTPHeaderFilter, path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	singleAction := make(map[string]bool)
+	for i, action := range filter.Add {
+		if needsErr, ok := singleAction[string(action.Name)]; ok {
+			if needsErr {
+				errs = append(errs, field.Invalid(path.Child("add"), filter.Add[i], "cannot specify multiple actions for header"))
+			}
+			singleAction[string(action.Name)] = false
+		} else {
+			singleAction[string(action.Name)] = true
+		}
+	}
+	for i, action := range filter.Set {
+		if needsErr, ok := singleAction[string(action.Name)]; ok {
+			if needsErr {
+				errs = append(errs, field.Invalid(path.Child("set"), filter.Set[i], "cannot specify multiple actions for header"))
+			}
+			singleAction[string(action.Name)] = false
+		} else {
+			singleAction[string(action.Name)] = true
+		}
+	}
+	for i, action := range filter.Remove {
+		if needsErr, ok := singleAction[action]; ok {
+			if needsErr {
+				errs = append(errs, field.Invalid(path.Child("remove"), filter.Remove[i], "cannot specify multiple actions for header"))
+			}
+			singleAction[action] = false
+		} else {
+			singleAction[action] = true
 		}
 	}
 	return errs

--- a/apis/v1beta1/validation/httproute_test.go
+++ b/apis/v1beta1/validation/httproute_test.go
@@ -475,6 +475,82 @@ func TestValidateHTTPRoute(t *testing.T) {
 							Name:  gatewayv1b1.HTTPHeaderName("x-grain"),
 							Value: "wheat",
 						},
+						{
+							Name:  gatewayv1b1.HTTPHeaderName("x-spice"),
+							Value: "coriander",
+						},
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "multiple actions for the same request header with inconsistent case (invalid)",
+		errCount: 1,
+		rules: []gatewayv1b1.HTTPRouteRule{{
+			Filters: []gatewayv1b1.HTTPRouteFilter{{
+				Type: gatewayv1b1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1b1.HTTPHeaderFilter{
+					Add: []gatewayv1b1.HTTPHeader{
+						{
+							Name:  gatewayv1b1.HTTPHeaderName("x-fruit"),
+							Value: "apple",
+						},
+					},
+					Set: []gatewayv1b1.HTTPHeader{
+						{
+							Name:  gatewayv1b1.HTTPHeaderName("X-Fruit"),
+							Value: "watermelon",
+						},
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "multiple of the same action for the same request header (invalid)",
+		errCount: 1,
+		rules: []gatewayv1b1.HTTPRouteRule{{
+			Filters: []gatewayv1b1.HTTPRouteFilter{{
+				Type: gatewayv1b1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1b1.HTTPHeaderFilter{
+					Add: []gatewayv1b1.HTTPHeader{
+						{
+							Name:  gatewayv1b1.HTTPHeaderName("x-fruit"),
+							Value: "apple",
+						},
+						{
+							Name:  gatewayv1b1.HTTPHeaderName("x-fruit"),
+							Value: "plum",
+						},
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "multiple actions for different request headers",
+		errCount: 0,
+		rules: []gatewayv1b1.HTTPRouteRule{{
+			Filters: []gatewayv1b1.HTTPRouteFilter{{
+				Type: gatewayv1b1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1b1.HTTPHeaderFilter{
+					Add: []gatewayv1b1.HTTPHeader{
+						{
+							Name:  gatewayv1b1.HTTPHeaderName("x-vegetable"),
+							Value: "carrot",
+						},
+						{
+							Name:  gatewayv1b1.HTTPHeaderName("x-grain"),
+							Value: "rye",
+						},
+					},
+					Set: []gatewayv1b1.HTTPHeader{
+						{
+							Name:  gatewayv1b1.HTTPHeaderName("x-fruit"),
+							Value: "watermelon",
+						},
+						{
+							Name:  gatewayv1b1.HTTPHeaderName("x-spice"),
+							Value: "coriander",
+						},
 					},
 				},
 			}},
@@ -492,6 +568,24 @@ func TestValidateHTTPRoute(t *testing.T) {
 					}},
 					Set: []gatewayv1b1.HTTPHeader{{
 						Name:  gatewayv1b1.HTTPHeaderName("x-example"),
+						Value: "turnip",
+					}},
+				},
+			}},
+		}},
+	}, {
+		name:     "multiple actions for different response headers",
+		errCount: 0,
+		rules: []gatewayv1b1.HTTPRouteRule{{
+			Filters: []gatewayv1b1.HTTPRouteFilter{{
+				Type: gatewayv1b1.HTTPRouteFilterResponseHeaderModifier,
+				ResponseHeaderModifier: &gatewayv1b1.HTTPHeaderFilter{
+					Add: []gatewayv1b1.HTTPHeader{{
+						Name:  gatewayv1b1.HTTPHeaderName("x-example"),
+						Value: "blueberry",
+					}},
+					Set: []gatewayv1b1.HTTPHeader{{
+						Name:  gatewayv1b1.HTTPHeaderName("x-different"),
 						Value: "turnip",
 					}},
 				},

--- a/apis/v1beta1/validation/httproute_test.go
+++ b/apis/v1beta1/validation/httproute_test.go
@@ -445,6 +445,58 @@ func TestValidateHTTPRoute(t *testing.T) {
 				},
 			}},
 		}},
+	}, {
+		name:     "multiple actions for the same request header (invalid)",
+		errCount: 2,
+		rules: []gatewayv1b1.HTTPRouteRule{{
+			Filters: []gatewayv1b1.HTTPRouteFilter{{
+				Type: gatewayv1b1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1b1.HTTPHeaderFilter{
+					Add: []gatewayv1b1.HTTPHeader{
+						{
+							Name:  gatewayv1b1.HTTPHeaderName("x-fruit"),
+							Value: "apple",
+						},
+						{
+							Name:  gatewayv1b1.HTTPHeaderName("x-vegetable"),
+							Value: "carrot",
+						},
+						{
+							Name:  gatewayv1b1.HTTPHeaderName("x-grain"),
+							Value: "rye",
+						},
+					},
+					Set: []gatewayv1b1.HTTPHeader{
+						{
+							Name:  gatewayv1b1.HTTPHeaderName("x-fruit"),
+							Value: "watermelon",
+						},
+						{
+							Name:  gatewayv1b1.HTTPHeaderName("x-grain"),
+							Value: "wheat",
+						},
+					},
+				},
+			}},
+		}},
+	}, {
+		name:     "multiple actions for the same response header (invalid)",
+		errCount: 1,
+		rules: []gatewayv1b1.HTTPRouteRule{{
+			Filters: []gatewayv1b1.HTTPRouteFilter{{
+				Type: gatewayv1b1.HTTPRouteFilterResponseHeaderModifier,
+				ResponseHeaderModifier: &gatewayv1b1.HTTPHeaderFilter{
+					Add: []gatewayv1b1.HTTPHeader{{
+						Name:  gatewayv1b1.HTTPHeaderName("x-example"),
+						Value: "blueberry",
+					}},
+					Set: []gatewayv1b1.HTTPHeader{{
+						Name:  gatewayv1b1.HTTPHeaderName("x-example"),
+						Value: "turnip",
+					}},
+				},
+			}},
+		}},
 	}}
 
 	for _, tc := range tests {

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -326,9 +326,9 @@ spec:
                                         appends to any existing values associated
                                         with the header name. \n Input:   GET /foo
                                         HTTP/1.1   my-header: foo \n Config:   add:
-                                        \  - name: \"my-header\"     value: \"bar\"
+                                        \  - name: \"my-header\"     value: \"bar,baz\"
                                         \n Output:   GET /foo HTTP/1.1   my-header:
-                                        foo   my-header: bar"
+                                        foo,bar,baz"
                                       items:
                                         description: HTTPHeader represents an HTTP
                                           Header name and value as defined by RFC
@@ -678,8 +678,8 @@ spec:
                                   to any existing values associated with the header
                                   name. \n Input:   GET /foo HTTP/1.1   my-header:
                                   foo \n Config:   add:   - name: \"my-header\"     value:
-                                  \"bar\" \n Output:   GET /foo HTTP/1.1   my-header:
-                                  foo   my-header: bar"
+                                  \"bar,baz\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo,bar,baz"
                                 items:
                                   description: HTTPHeader represents an HTTP Header
                                     name and value as defined by RFC 7230.

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -307,9 +307,9 @@ spec:
                                         appends to any existing values associated
                                         with the header name. \n Input:   GET /foo
                                         HTTP/1.1   my-header: foo \n Config:   add:
-                                        \  - name: \"my-header\"     value: \"bar\"
+                                        \  - name: \"my-header\"     value: \"bar,baz\"
                                         \n Output:   GET /foo HTTP/1.1   my-header:
-                                        foo   my-header: bar"
+                                        foo,bar,baz"
                                       items:
                                         description: HTTPHeader represents an HTTP
                                           Header name and value as defined by RFC
@@ -604,9 +604,9 @@ spec:
                                         appends to any existing values associated
                                         with the header name. \n Input:   GET /foo
                                         HTTP/1.1   my-header: foo \n Config:   add:
-                                        \  - name: \"my-header\"     value: \"bar\"
+                                        \  - name: \"my-header\"     value: \"bar,baz\"
                                         \n Output:   GET /foo HTTP/1.1   my-header:
-                                        foo   my-header: bar"
+                                        foo,bar,baz"
                                       items:
                                         description: HTTPHeader represents an HTTP
                                           Header name and value as defined by RFC
@@ -947,8 +947,8 @@ spec:
                                   to any existing values associated with the header
                                   name. \n Input:   GET /foo HTTP/1.1   my-header:
                                   foo \n Config:   add:   - name: \"my-header\"     value:
-                                  \"bar\" \n Output:   GET /foo HTTP/1.1   my-header:
-                                  foo   my-header: bar"
+                                  \"bar,baz\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo,bar,baz"
                                 items:
                                   description: HTTPHeader represents an HTTP Header
                                     name and value as defined by RFC 7230.
@@ -1223,8 +1223,8 @@ spec:
                                   to any existing values associated with the header
                                   name. \n Input:   GET /foo HTTP/1.1   my-header:
                                   foo \n Config:   add:   - name: \"my-header\"     value:
-                                  \"bar\" \n Output:   GET /foo HTTP/1.1   my-header:
-                                  foo   my-header: bar"
+                                  \"bar,baz\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo,bar,baz"
                                 items:
                                   description: HTTPHeader represents an HTTP Header
                                     name and value as defined by RFC 7230.
@@ -2141,9 +2141,9 @@ spec:
                                         appends to any existing values associated
                                         with the header name. \n Input:   GET /foo
                                         HTTP/1.1   my-header: foo \n Config:   add:
-                                        \  - name: \"my-header\"     value: \"bar\"
+                                        \  - name: \"my-header\"     value: \"bar,baz\"
                                         \n Output:   GET /foo HTTP/1.1   my-header:
-                                        foo   my-header: bar"
+                                        foo,bar,baz"
                                       items:
                                         description: HTTPHeader represents an HTTP
                                           Header name and value as defined by RFC
@@ -2438,9 +2438,9 @@ spec:
                                         appends to any existing values associated
                                         with the header name. \n Input:   GET /foo
                                         HTTP/1.1   my-header: foo \n Config:   add:
-                                        \  - name: \"my-header\"     value: \"bar\"
+                                        \  - name: \"my-header\"     value: \"bar,baz\"
                                         \n Output:   GET /foo HTTP/1.1   my-header:
-                                        foo   my-header: bar"
+                                        foo,bar,baz"
                                       items:
                                         description: HTTPHeader represents an HTTP
                                           Header name and value as defined by RFC
@@ -2781,8 +2781,8 @@ spec:
                                   to any existing values associated with the header
                                   name. \n Input:   GET /foo HTTP/1.1   my-header:
                                   foo \n Config:   add:   - name: \"my-header\"     value:
-                                  \"bar\" \n Output:   GET /foo HTTP/1.1   my-header:
-                                  foo   my-header: bar"
+                                  \"bar,baz\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo,bar,baz"
                                 items:
                                   description: HTTPHeader represents an HTTP Header
                                     name and value as defined by RFC 7230.
@@ -3057,8 +3057,8 @@ spec:
                                   to any existing values associated with the header
                                   name. \n Input:   GET /foo HTTP/1.1   my-header:
                                   foo \n Config:   add:   - name: \"my-header\"     value:
-                                  \"bar\" \n Output:   GET /foo HTTP/1.1   my-header:
-                                  foo   my-header: bar"
+                                  \"bar,baz\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo,bar,baz"
                                 items:
                                   description: HTTPHeader represents an HTTP Header
                                     name and value as defined by RFC 7230.

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -281,9 +281,9 @@ spec:
                                         appends to any existing values associated
                                         with the header name. \n Input:   GET /foo
                                         HTTP/1.1   my-header: foo \n Config:   add:
-                                        \  - name: \"my-header\"     value: \"bar\"
+                                        \  - name: \"my-header\"     value: \"bar,baz\"
                                         \n Output:   GET /foo HTTP/1.1   my-header:
-                                        foo   my-header: bar"
+                                        foo,bar,baz"
                                       items:
                                         description: HTTPHeader represents an HTTP
                                           Header name and value as defined by RFC
@@ -698,8 +698,8 @@ spec:
                                   to any existing values associated with the header
                                   name. \n Input:   GET /foo HTTP/1.1   my-header:
                                   foo \n Config:   add:   - name: \"my-header\"     value:
-                                  \"bar\" \n Output:   GET /foo HTTP/1.1   my-header:
-                                  foo   my-header: bar"
+                                  \"bar,baz\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo,bar,baz"
                                 items:
                                   description: HTTPHeader represents an HTTP Header
                                     name and value as defined by RFC 7230.
@@ -1632,9 +1632,9 @@ spec:
                                         appends to any existing values associated
                                         with the header name. \n Input:   GET /foo
                                         HTTP/1.1   my-header: foo \n Config:   add:
-                                        \  - name: \"my-header\"     value: \"bar\"
+                                        \  - name: \"my-header\"     value: \"bar,baz\"
                                         \n Output:   GET /foo HTTP/1.1   my-header:
-                                        foo   my-header: bar"
+                                        foo,bar,baz"
                                       items:
                                         description: HTTPHeader represents an HTTP
                                           Header name and value as defined by RFC
@@ -2049,8 +2049,8 @@ spec:
                                   to any existing values associated with the header
                                   name. \n Input:   GET /foo HTTP/1.1   my-header:
                                   foo \n Config:   add:   - name: \"my-header\"     value:
-                                  \"bar\" \n Output:   GET /foo HTTP/1.1   my-header:
-                                  foo   my-header: bar"
+                                  \"bar,baz\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo,bar,baz"
                                 items:
                                   description: HTTPHeader represents an HTTP Header
                                     name and value as defined by RFC 7230.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Documents restrictions on header filters and how implementations should handle invalid filters. Header filters cannot modify the same header twice. When users require multiple values for the same header, they must specify the comma-separated values in configuration.

~Adds a conformance test confirming that invalid headers result in a false `Accepted` Condition with reason `RouteReasonUnsupportedValue`.~

Adds a webhook rule that rejects header filters that violate the single action per header rule.

**Which issue(s) this PR fixes**:

Fix #480. Order of operations is a moot point if there is only one action for a given header, and there are no outcomes that actually require multiple actions.

**Does this PR introduce a user-facing change?**:
```release-note
HTTPRequestHeaderFilter and HTTPResponseHeaderFilter forbid configuring multiple actions for the same header.
```
