### PR TITLE
Add "Programmed" Gateway condition, move "Ready" to extended conformance

### DIFF
--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -493,7 +493,7 @@ const (
 )
 
 const (
-	// This condition indicates whether a Listener have generated some
+	// This condition indicates whether a Listener has generated some
 	// configuration that will soon be ready in the underlying data plane.
 	//
 	// It is a positive-polarity summary condition, and so should always be

--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -196,6 +196,44 @@ type GatewayConditionType = v1beta1.GatewayConditionType
 type GatewayConditionReason = v1beta1.GatewayConditionReason
 
 const (
+	// This condition indicates whether a Gateway have generated some
+	// configuration that will soon be ready in the underlying data plane.
+	//
+	// It is a positive-polarity summary condition, and so should always be
+	// present on the resource.
+	//
+	// It should be set to Unknown if the controller performs updates to the
+	// status before it has all the information it needs to be able to determine
+	// if the condition is true.
+	//
+	// Possible reasons for this condition to be True are:
+	//
+	// * "Programmed"
+	//
+	// Possible reasons for this condition to be False are:
+	//
+	// * "Invalid"
+	// * "Pending"
+	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
+	//
+	// Controllers may raise this condition with other reasons,
+	// but should prefer to use the reasons listed above to improve
+	// interoperability.
+	GatewayConditionProgrammed GatewayConditionType = "Programmed"
+
+	// This reason is used with the "Programmed" condition when the condition is
+	// true.
+	GatewayReasonProgrammed GatewayConditionReason = "Programmed"
+
+	// This reason is used with the "Programmed" condition when the Listener is
+	// syntactically or semantically invalid.
+	GatewayReasonInvalid GatewayConditionReason = "Invalid"
+)
+
+const (
 	// This condition is true when the controller managing the Gateway is
 	// syntactically and semantically valid enough to produce some configuration
 	// in the underlying data plane, though it has not yet produced such
@@ -232,8 +270,8 @@ const (
 	// Deprecated: use the "Accepted" condition with reason "Accepted" instead.
 	GatewayReasonScheduled GatewayConditionReason = "Scheduled"
 
-	// This reason is used with the "Accepted" condition when no controller has
-	// reconciled the Gateway.
+	// This reason is used with the "Accepted", "Programmed" and "Ready"
+	// conditions when no controller has reconciled the Gateway.
 	GatewayReasonPending GatewayConditionReason = "Pending"
 
 	// Deprecated: Use "Pending" instead.
@@ -246,11 +284,9 @@ const (
 )
 
 const (
-	// This condition is true when the Gateway is expected to be able
-	// to serve traffic. Note that this does not indicate that the
-	// Gateway configuration is current or even complete (e.g. the
-	// controller may still not have reconciled the latest version,
-	// or some parts of the configuration could be missing).
+	// Ready is an optional Condition that has Extended support. When it's set,
+	// the condition indicates whether the Gateway has been completely configured
+	// and traffic is ready to flow through the data plane immediately.
 	//
 	// If both the "ListenersNotValid" and "ListenersNotReady"
 	// reasons are true, the Gateway controller should prefer the
@@ -456,10 +492,45 @@ const (
 )
 
 const (
-	// This condition indicates whether the Listener has been
-	// configured on the Gateway.
+	// This condition indicates whether a Listener have generated some
+	// configuration that will soon be ready in the underlying data plane.
 	//
-	// Possible reasons for this condition to be true are:
+	// It is a positive-polarity summary condition, and so should always be
+	// present on the resource.
+	//
+	// It should be set to Unknown if the controller performs updates to the
+	// status before it has all the information it needs to be able to determine
+	// if the condition is true.
+	//
+	// Possible reasons for this condition to be True are:
+	//
+	// * "Programmed"
+	//
+	// Possible reasons for this condition to be False are:
+	//
+	// * "Invalid"
+	// * "Pending"
+	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
+	//
+	// Controllers may raise this condition with other reasons,
+	// but should prefer to use the reasons listed above to improve
+	// interoperability.
+	ListenerConditionProgrammed ListenerConditionType = "Programmed"
+
+	// This reason is used with the "Programmed" condition when the condition is
+	// true.
+	ListenerReasonProgrammed ListenerConditionReason = "Programmed"
+)
+
+const (
+	// Ready is an optional Condition that has Extended support. When it's set,
+	// the condition indicates whether the Listener has been configured on the
+	// Gateway and traffic is ready to flow through the data plane immediately.
+	//
+	// Possible reasons for this condition to be True are:
 	//
 	// * "Ready"
 	//
@@ -481,12 +552,12 @@ const (
 	// true.
 	ListenerReasonReady ListenerConditionReason = "Ready"
 
-	// This reason is used with the "Ready" condition when the
+	// This reason is used with the "Ready" and "Programmed" conditions when the
 	// Listener is syntactically or semantically invalid.
 	ListenerReasonInvalid ListenerConditionReason = "Invalid"
 
-	// This reason is used with the "Accepted" and "Ready" conditions when the
-	// Listener is either not yet reconciled or not yet not online and ready to
-	// accept client traffic.
+	// This reason is used with the "Accepted", "Ready" and "Programmed"
+	// conditions when the Listener is either not yet reconciled or not yet not
+	// online and ready to accept client traffic.
 	ListenerReasonPending ListenerConditionReason = "Pending"
 )

--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -236,8 +236,7 @@ const (
 const (
 	// This condition is true when the controller managing the Gateway is
 	// syntactically and semantically valid enough to produce some configuration
-	// in the underlying data plane, though it has not yet produced such
-	// configuration.
+	// in the underlying data plane, though it has not necessarily configured it yet.
 	//
 	// Possible reasons for this condition to be True are:
 	//

--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -200,7 +200,7 @@ const (
 	// configuration that will soon be ready in the underlying data plane.
 	//
 	// It is a positive-polarity summary condition, and so should always be
-	// present on the resource.
+	// present on the resource with ObservedGeneration set.
 	//
 	// It should be set to Unknown if the controller performs updates to the
 	// status before it has all the information it needs to be able to determine
@@ -271,7 +271,8 @@ const (
 	GatewayReasonScheduled GatewayConditionReason = "Scheduled"
 
 	// This reason is used with the "Accepted", "Programmed" and "Ready"
-	// conditions when no controller has reconciled the Gateway.
+	// conditions when the status is "Unknown" and no controller has reconciled
+	// the Gateway.
 	GatewayReasonPending GatewayConditionReason = "Pending"
 
 	// Deprecated: Use "Pending" instead.
@@ -496,7 +497,7 @@ const (
 	// configuration that will soon be ready in the underlying data plane.
 	//
 	// It is a positive-polarity summary condition, and so should always be
-	// present on the resource.
+	// present on the resource with ObservedGeneration set.
 	//
 	// It should be set to Unknown if the controller performs updates to the
 	// status before it has all the information it needs to be able to determine

--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -196,9 +196,10 @@ type GatewayConditionType = v1beta1.GatewayConditionType
 type GatewayConditionReason = v1beta1.GatewayConditionReason
 
 const (
-	// This condition is true when the controller managing the
-	// Gateway has scheduled the Gateway to the underlying network
-	// infrastructure.
+	// This condition is true when the controller managing the Gateway is
+	// syntactically and semantically valid enough to produce some configuration
+	// in the underlying data plane, though it has not yet produced such
+	// configuration.
 	//
 	// Possible reasons for this condition to be True are:
 	//

--- a/apis/v1alpha2/gateway_types.go
+++ b/apis/v1alpha2/gateway_types.go
@@ -196,7 +196,7 @@ type GatewayConditionType = v1beta1.GatewayConditionType
 type GatewayConditionReason = v1beta1.GatewayConditionReason
 
 const (
-	// This condition indicates whether a Gateway have generated some
+	// This condition indicates whether a Gateway has generated some
 	// configuration that will soon be ready in the underlying data plane.
 	//
 	// It is a positive-polarity summary condition, and so should always be

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -516,7 +516,7 @@ type GatewayConditionType string
 type GatewayConditionReason string
 
 const (
-	// This condition indicates whether a Gateway have generated some
+	// This condition indicates whether a Gateway has generated some
 	// configuration that will soon be ready in the underlying data plane.
 	//
 	// It is a positive-polarity summary condition, and so should always be

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -516,9 +516,10 @@ type GatewayConditionType string
 type GatewayConditionReason string
 
 const (
-	// This condition is true when the controller managing the
-	// Gateway has scheduled the Gateway to the underlying network
-	// infrastructure.
+	// This condition is true when the controller managing the Gateway is
+	// syntactically and semantically valid enough to produce some configuration
+	// in the underlying data plane, though it has not yet produced such
+	// configuration.
 	//
 	// Possible reasons for this condition to be True are:
 	//

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -837,7 +837,7 @@ const (
 )
 
 const (
-	// This condition indicates whether a Listener have generated some
+	// This condition indicates whether a Listener has generated some
 	// configuration that will soon be ready in the underlying data plane.
 	//
 	// It is a positive-polarity summary condition, and so should always be

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -516,6 +516,44 @@ type GatewayConditionType string
 type GatewayConditionReason string
 
 const (
+	// This condition indicates whether a Gateway have generated some
+	// configuration that will soon be ready in the underlying data plane.
+	//
+	// It is a positive-polarity summary condition, and so should always be
+	// present on the resource.
+	//
+	// It should be set to Unknown if the controller performs updates to the
+	// status before it has all the information it needs to be able to determine
+	// if the condition is true.
+	//
+	// Possible reasons for this condition to be True are:
+	//
+	// * "Programmed"
+	//
+	// Possible reasons for this condition to be False are:
+	//
+	// * "Invalid"
+	// * "Pending"
+	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
+	//
+	// Controllers may raise this condition with other reasons,
+	// but should prefer to use the reasons listed above to improve
+	// interoperability.
+	GatewayConditionProgrammed GatewayConditionType = "Programmed"
+
+	// This reason is used with the "Programmed" condition when the condition is
+	// true.
+	GatewayReasonProgrammed GatewayConditionReason = "Programmed"
+
+	// This reason is used with the "Programmed" condition when the Listener is
+	// syntactically or semantically invalid.
+	GatewayReasonInvalid GatewayConditionReason = "Invalid"
+)
+
+const (
 	// This condition is true when the controller managing the Gateway is
 	// syntactically and semantically valid enough to produce some configuration
 	// in the underlying data plane, though it has not yet produced such
@@ -552,8 +590,8 @@ const (
 	// Deprecated: use the "Accepted" condition with reason "Accepted" instead.
 	GatewayReasonScheduled GatewayConditionReason = "Scheduled"
 
-	// This reason is used with the "Accepted" condition when no controller has
-	// reconciled the Gateway.
+	// This reason is used with the "Accepted", "Programmed" and "Ready"
+	// conditions when no controller has reconciled the Gateway.
 	GatewayReasonPending GatewayConditionReason = "Pending"
 
 	// Deprecated: Use "Pending" instead.
@@ -566,11 +604,9 @@ const (
 )
 
 const (
-	// This condition is true when the Gateway is expected to be able
-	// to serve traffic. Note that this does not indicate that the
-	// Gateway configuration is current or even complete (e.g. the
-	// controller may still not have reconciled the latest version,
-	// or some parts of the configuration could be missing).
+	// Ready is an optional Condition that has Extended support. When it's set,
+	// the condition indicates whether the Gateway has been completely configured
+	// and traffic is ready to flow through the data plane immediately.
 	//
 	// If both the "ListenersNotValid" and "ListenersNotReady"
 	// reasons are true, the Gateway controller should prefer the
@@ -800,10 +836,45 @@ const (
 )
 
 const (
-	// This condition indicates whether the Listener has been
-	// configured on the Gateway.
+	// This condition indicates whether a Listener have generated some
+	// configuration that will soon be ready in the underlying data plane.
 	//
-	// Possible reasons for this condition to be true are:
+	// It is a positive-polarity summary condition, and so should always be
+	// present on the resource.
+	//
+	// It should be set to Unknown if the controller performs updates to the
+	// status before it has all the information it needs to be able to determine
+	// if the condition is true.
+	//
+	// Possible reasons for this condition to be True are:
+	//
+	// * "Programmed"
+	//
+	// Possible reasons for this condition to be False are:
+	//
+	// * "Invalid"
+	// * "Pending"
+	//
+	// Possible reasons for this condition to be Unknown are:
+	//
+	// * "Pending"
+	//
+	// Controllers may raise this condition with other reasons,
+	// but should prefer to use the reasons listed above to improve
+	// interoperability.
+	ListenerConditionProgrammed ListenerConditionType = "Programmed"
+
+	// This reason is used with the "Programmed" condition when the condition is
+	// true.
+	ListenerReasonProgrammed ListenerConditionReason = "Programmed"
+)
+
+const (
+	// Ready is an optional Condition that has Extended support. When it's set,
+	// the condition indicates whether the Listener has been configured on the
+	// Gateway and traffic is ready to flow through the data plane immediately.
+	//
+	// Possible reasons for this condition to be True are:
 	//
 	// * "Ready"
 	//
@@ -825,12 +896,12 @@ const (
 	// true.
 	ListenerReasonReady ListenerConditionReason = "Ready"
 
-	// This reason is used with the "Ready" condition when the
+	// This reason is used with the "Ready" and "Programmed" conditions when the
 	// Listener is syntactically or semantically invalid.
 	ListenerReasonInvalid ListenerConditionReason = "Invalid"
 
-	// This reason is used with the "Accepted" and "Ready" conditions when the
-	// Listener is either not yet reconciled or not yet not online and ready to
-	// accept client traffic.
+	// This reason is used with the "Accepted", "Ready" and "Programmed"
+	// conditions when the Listener is either not yet reconciled or not yet not
+	// online and ready to accept client traffic.
 	ListenerReasonPending ListenerConditionReason = "Pending"
 )

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -520,7 +520,7 @@ const (
 	// configuration that will soon be ready in the underlying data plane.
 	//
 	// It is a positive-polarity summary condition, and so should always be
-	// present on the resource.
+	// present on the resource with ObservedGeneration set.
 	//
 	// It should be set to Unknown if the controller performs updates to the
 	// status before it has all the information it needs to be able to determine
@@ -591,7 +591,8 @@ const (
 	GatewayReasonScheduled GatewayConditionReason = "Scheduled"
 
 	// This reason is used with the "Accepted", "Programmed" and "Ready"
-	// conditions when no controller has reconciled the Gateway.
+	// conditions when the status is "Unknown" and no controller has reconciled
+	// the Gateway.
 	GatewayReasonPending GatewayConditionReason = "Pending"
 
 	// Deprecated: Use "Pending" instead.
@@ -840,7 +841,7 @@ const (
 	// configuration that will soon be ready in the underlying data plane.
 	//
 	// It is a positive-polarity summary condition, and so should always be
-	// present on the resource.
+	// present on the resource with ObservedGeneration set.
 	//
 	// It should be set to Unknown if the controller performs updates to the
 	// status before it has all the information it needs to be able to determine

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -556,8 +556,7 @@ const (
 const (
 	// This condition is true when the controller managing the Gateway is
 	// syntactically and semantically valid enough to produce some configuration
-	// in the underlying data plane, though it has not yet produced such
-	// configuration.
+	// in the underlying data plane, though it has not necessarily configured it yet.
 	//
 	// Possible reasons for this condition to be True are:
 	//

--- a/conformance/tests/gateway-secret-missing-reference-grant.go
+++ b/conformance/tests/gateway-secret-missing-reference-grant.go
@@ -33,7 +33,7 @@ func init() {
 
 var GatewaySecretMissingReferenceGrant = suite.ConformanceTest{
 	ShortName:   "GatewaySecretMissingReferenceGrant",
-	Description: "A Gateway in the gateway-conformance-infra namespace should fail to become ready if the Gateway has a certificateRef for a Secret in the gateway-conformance-web-backend namespace and a ReferenceGrant granting permission to the Secret does not exist",
+	Description: "A Gateway in the gateway-conformance-infra namespace should fail to become programmed if the Gateway has a certificateRef for a Secret in the gateway-conformance-web-backend namespace and a ReferenceGrant granting permission to the Secret does not exist",
 	Features:    []suite.SupportedFeature{suite.SupportReferenceGrant},
 	Manifests:   []string{"tests/gateway-secret-missing-reference-grant.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {

--- a/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go
+++ b/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go
@@ -33,13 +33,13 @@ func init() {
 
 var GatewaySecretReferenceGrantAllInNamespace = suite.ConformanceTest{
 	ShortName:   "GatewaySecretReferenceGrantAllInNamespace",
-	Description: "A Gateway in the gateway-conformance-infra namespace should become ready if the Gateway has a certificateRef for a Secret in the gateway-conformance-web-backend namespace and a ReferenceGrant granting permission to all Secrets in the namespace exists",
+	Description: "A Gateway in the gateway-conformance-infra namespace should become programmed if the Gateway has a certificateRef for a Secret in the gateway-conformance-web-backend namespace and a ReferenceGrant granting permission to all Secrets in the namespace exists",
 	Features:    []suite.SupportedFeature{suite.SupportReferenceGrant},
 	Manifests:   []string{"tests/gateway-secret-reference-grant-all-in-namespace.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "gateway-secret-reference-grant", Namespace: "gateway-conformance-infra"}
 
-		t.Run("Gateway listener should have a true ResolvedRefs condition and a true Ready condition", func(t *testing.T) {
+		t.Run("Gateway listener should have a true ResolvedRefs condition and a true Programmed condition", func(t *testing.T) {
 			listeners := []v1beta1.ListenerStatus{{
 				Name: v1beta1.SectionName("https"),
 				SupportedKinds: []v1beta1.RouteGroupKind{{
@@ -48,9 +48,9 @@ var GatewaySecretReferenceGrantAllInNamespace = suite.ConformanceTest{
 				}},
 				Conditions: []metav1.Condition{
 					{
-						Type:   string(v1beta1.ListenerConditionReady),
+						Type:   string(v1beta1.ListenerConditionProgrammed),
 						Status: metav1.ConditionTrue,
-						Reason: string(v1beta1.ListenerReasonReady),
+						Reason: string(v1beta1.ListenerConditionProgrammed),
 					},
 				},
 			}}

--- a/conformance/tests/gateway-secret-reference-grant-specific.go
+++ b/conformance/tests/gateway-secret-reference-grant-specific.go
@@ -33,13 +33,13 @@ func init() {
 
 var GatewaySecretReferenceGrantSpecific = suite.ConformanceTest{
 	ShortName:   "GatewaySecretReferenceGrantSpecific",
-	Description: "A Gateway in the gateway-conformance-infra namespace should become ready if the Gateway has a certificateRef for a Secret in the gateway-conformance-web-backend namespace and a ReferenceGrant granting permission to the specific Secret exists",
+	Description: "A Gateway in the gateway-conformance-infra namespace should become programmed if the Gateway has a certificateRef for a Secret in the gateway-conformance-web-backend namespace and a ReferenceGrant granting permission to the specific Secret exists",
 	Features:    []suite.SupportedFeature{suite.SupportReferenceGrant},
 	Manifests:   []string{"tests/gateway-secret-reference-grant-specific.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "gateway-secret-reference-grant", Namespace: "gateway-conformance-infra"}
 
-		t.Run("Gateway listener should have a true ResolvedRefs condition and a true Ready condition", func(t *testing.T) {
+		t.Run("Gateway listener should have a true ResolvedRefs condition and a true Programmed condition", func(t *testing.T) {
 			listeners := []v1beta1.ListenerStatus{{
 				Name: v1beta1.SectionName("https"),
 				SupportedKinds: []v1beta1.RouteGroupKind{{
@@ -48,9 +48,9 @@ var GatewaySecretReferenceGrantSpecific = suite.ConformanceTest{
 				}},
 				Conditions: []metav1.Condition{
 					{
-						Type:   string(v1beta1.ListenerConditionReady),
+						Type:   string(v1beta1.ListenerConditionProgrammed),
 						Status: metav1.ConditionTrue,
-						Reason: string(v1beta1.ListenerReasonReady),
+						Reason: string(v1beta1.ListenerReasonProgrammed),
 					},
 				},
 			}}

--- a/conformance/tests/httproute-cross-namespace.go
+++ b/conformance/tests/httproute-cross-namespace.go
@@ -37,7 +37,7 @@ var HTTPRouteCrossNamespace = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "cross-namespace", Namespace: "gateway-conformance-web-backend"}
 		gwNN := types.NamespacedName{Name: "backend-namespaces", Namespace: "gateway-conformance-infra"}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		t.Run("Simple HTTP request should reach web-backend", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{

--- a/conformance/tests/httproute-disallowed-kind.go
+++ b/conformance/tests/httproute-disallowed-kind.go
@@ -37,7 +37,7 @@ var HTTPRouteDisallowedKind = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		// This test creates an additional Gateway in the gateway-conformance-infra
 		// namespace so we have to wait for it to be ready.
-		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{"gateway-conformance-infra"})
+		kubernetes.NamespacesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, []string{"gateway-conformance-infra"})
 
 		routeName := types.NamespacedName{Name: "disallowed-kind", Namespace: "gateway-conformance-infra"}
 		gwName := types.NamespacedName{Name: "tlsroutes-only", Namespace: "gateway-conformance-infra"}

--- a/conformance/tests/httproute-exact-path-matching.go
+++ b/conformance/tests/httproute-exact-path-matching.go
@@ -38,7 +38,7 @@ var HTTPExactPathMatching = suite.ConformanceTest{
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "exact-matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		testCases := []http.ExpectedResponse{
 			{

--- a/conformance/tests/httproute-header-matching.go
+++ b/conformance/tests/httproute-header-matching.go
@@ -38,7 +38,7 @@ var HTTPRouteHeaderMatching = suite.ConformanceTest{
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "header-matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request:   http.Request{Path: "/", Headers: map[string]string{"Version": "one"}},

--- a/conformance/tests/httproute-hostname-intersection.go
+++ b/conformance/tests/httproute-hostname-intersection.go
@@ -42,7 +42,7 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 
 		// This test creates an additional Gateway in the gateway-conformance-infra
 		// namespace so we have to wait for it to be ready.
-		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+		kubernetes.NamespacesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, []string{ns})
 
 		t.Run("HTTPRoutes that do intersect with listener hostnames", func(t *testing.T) {
 			routes := []types.NamespacedName{
@@ -51,7 +51,7 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 				{Namespace: ns, Name: "wildcard-host-matches-listener-specific-host"},
 				{Namespace: ns, Name: "wildcard-host-matches-listener-wildcard-host"},
 			}
-			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routes...)
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routes...)
 
 			var testCases []http.ExpectedResponse
 
@@ -189,7 +189,7 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 		})
 
 		t.Run("HTTPRoutes that do not intersect with listener hostnames", func(t *testing.T) {
-			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN))
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN))
 
 			routeName := types.NamespacedName{Namespace: ns, Name: "no-intersecting-hosts"}
 			parents := []v1beta1.RouteParentStatus{{

--- a/conformance/tests/httproute-invalid-backendref-nonexistent.go
+++ b/conformance/tests/httproute-invalid-backendref-nonexistent.go
@@ -41,7 +41,7 @@ var HTTPRouteInvalidNonExistentBackendRef = suite.ConformanceTest{
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 
 		// Gateway and Route must be Accepted.
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		t.Run("HTTPRoute with only a nonexistent BackendRef has a ResolvedRefs Condition with status False and Reason BackendNotFound", func(t *testing.T) {
 			resolvedRefsCond := metav1.Condition{

--- a/conformance/tests/httproute-invalid-backendref-unknown-kind.go
+++ b/conformance/tests/httproute-invalid-backendref-unknown-kind.go
@@ -41,7 +41,7 @@ var HTTPRouteInvalidBackendRefUnknownKind = suite.ConformanceTest{
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 
 		// Both the Gateway and the Route are Accepted.
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		// The Route must have a ResolvedRefs Condition with a InvalidKind Reason.
 		t.Run("HTTPRoute with Invalid Kind has a ResolvedRefs Condition with status False and Reason InvalidKind", func(t *testing.T) {

--- a/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
@@ -42,7 +42,7 @@ var HTTPRouteInvalidCrossNamespaceBackendRef = suite.ConformanceTest{
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 
 		// The Route must be Attached.
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		t.Run("HTTPRoute with a cross-namespace BackendRef and no ReferenceGrant has a ResolvedRefs Condition with status False and Reason RefNotPermitted", func(t *testing.T) {
 

--- a/conformance/tests/httproute-invalid-reference-grant.go
+++ b/conformance/tests/httproute-invalid-reference-grant.go
@@ -42,7 +42,7 @@ var HTTPRouteInvalidReferenceGrant = suite.ConformanceTest{
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 
 		// Route and Gateway must be Attached.
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, s.Client, s.TimeoutConfig, s.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, s.Client, s.TimeoutConfig, s.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		t.Run("HTTPRoute with BackendRef in another namespace and no ReferenceGrant covering the Service has a ResolvedRefs Condition with status False and Reason RefNotPermitted", func(t *testing.T) {
 

--- a/conformance/tests/httproute-listener-hostname-matching.go
+++ b/conformance/tests/httproute-listener-hostname-matching.go
@@ -39,17 +39,17 @@ var HTTPRouteListenerHostnameMatching = suite.ConformanceTest{
 
 		// This test creates an additional Gateway in the gateway-conformance-infra
 		// namespace so we have to wait for it to be ready.
-		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+		kubernetes.NamespacesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, []string{ns})
 
 		gwNN := types.NamespacedName{Name: "httproute-listener-hostname-matching", Namespace: ns}
 
-		_ = kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-1"),
+		_ = kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-1"),
 			types.NamespacedName{Namespace: ns, Name: "backend-v1"},
 		)
-		_ = kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-2"),
+		_ = kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-2"),
 			types.NamespacedName{Namespace: ns, Name: "backend-v2"},
 		)
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-3", "listener-4"),
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-3", "listener-4"),
 			types.NamespacedName{Namespace: ns, Name: "backend-v3"},
 		)
 

--- a/conformance/tests/httproute-matching-across-routes.go
+++ b/conformance/tests/httproute-matching-across-routes.go
@@ -39,7 +39,7 @@ var HTTPRouteMatchingAcrossRoutes = suite.ConformanceTest{
 		routeNN1 := types.NamespacedName{Name: "matching-part1", Namespace: ns}
 		routeNN2 := types.NamespacedName{Name: "matching-part2", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN1, routeNN2)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN1, routeNN2)
 
 		testCases := []http.ExpectedResponse{{
 			Request: http.Request{

--- a/conformance/tests/httproute-matching.go
+++ b/conformance/tests/httproute-matching.go
@@ -38,7 +38,7 @@ var HTTPRouteMatching = suite.ConformanceTest{
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request:   http.Request{Path: "/"},

--- a/conformance/tests/httproute-method-matching.go
+++ b/conformance/tests/httproute-method-matching.go
@@ -39,7 +39,7 @@ var HTTPRouteMethodMatching = suite.ConformanceTest{
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "method-matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		testCases := []http.ExpectedResponse{
 			{

--- a/conformance/tests/httproute-query-param-matching.go
+++ b/conformance/tests/httproute-query-param-matching.go
@@ -40,7 +40,7 @@ var HTTPRouteQueryParamMatching = suite.ConformanceTest{
 			ns      = "gateway-conformance-infra"
 			routeNN = types.NamespacedName{Namespace: ns, Name: "query-param-matching"}
 			gwNN    = types.NamespacedName{Namespace: ns, Name: "same-namespace"}
-			gwAddr  = kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+			gwAddr  = kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 		)
 
 		testCases := []http.ExpectedResponse{{

--- a/conformance/tests/httproute-reference-grant.go
+++ b/conformance/tests/httproute-reference-grant.go
@@ -38,7 +38,7 @@ var HTTPRouteReferenceGrant = suite.ConformanceTest{
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "reference-grant", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, s.Client, s.TimeoutConfig, s.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, s.Client, s.TimeoutConfig, s.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		t.Run("Simple HTTP request should reach web-backend", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, s.TimeoutConfig, gwAddr, http.ExpectedResponse{

--- a/conformance/tests/httproute-request-header-modifier.go
+++ b/conformance/tests/httproute-request-header-modifier.go
@@ -38,7 +38,7 @@ var HTTPRouteRequestHeaderModifier = suite.ConformanceTest{
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "request-header-modifier", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request: http.Request{

--- a/conformance/tests/httproute-response-header-modifier.go
+++ b/conformance/tests/httproute-response-header-modifier.go
@@ -39,7 +39,7 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "response-header-modifier", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request: http.Request{

--- a/conformance/tests/httproute-simple-same-namespace.go
+++ b/conformance/tests/httproute-simple-same-namespace.go
@@ -39,7 +39,7 @@ var HTTPRouteSimpleSameNamespace = suite.ConformanceTest{
 		ns := v1beta1.Namespace("gateway-conformance-infra")
 		routeNN := types.NamespacedName{Name: "gateway-conformance-infra-test", Namespace: string(ns)}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: string(ns)}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeReady(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		t.Run("Simple HTTP request should reach infra-backend", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -89,10 +89,10 @@ func GWCMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.Timeo
 	return controllerName
 }
 
-// NamespacesMustBeReady waits until all Pods and Gateways in the provided
-// namespaces are marked as ready. This will cause the test to halt if the
-// specified timeout is exceeded.
-func NamespacesMustBeReady(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, namespaces []string) {
+// NamespacesMustBeAccepted waits until all Pods are marked ready and all Gateways
+// are marked accepted in the provided namespaces. This will cause the test to
+// halt if the specified timeout is exceeded.
+func NamespacesMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, namespaces []string) {
 	t.Helper()
 
 	waitErr := wait.PollImmediate(1*time.Second, timeoutConfig.NamespacesMustBeReady, func() (bool, error) {
@@ -107,7 +107,7 @@ func NamespacesMustBeReady(t *testing.T, c client.Client, timeoutConfig config.T
 			}
 			for _, gw := range gwList.Items {
 				// Passing an empty string as the Reason means that any Reason will do.
-				if !findConditionInList(t, gw.Status.Conditions, "Ready", "True", "") {
+				if !findConditionInList(t, gw.Status.Conditions, string(v1beta1.GatewayConditionAccepted), "True", "") {
 					t.Logf("%s/%s Gateway not ready yet", ns, gw.Name)
 					return false, nil
 				}
@@ -132,11 +132,11 @@ func NamespacesMustBeReady(t *testing.T, c client.Client, timeoutConfig config.T
 	require.NoErrorf(t, waitErr, "error waiting for %s namespaces to be ready", strings.Join(namespaces, ", "))
 }
 
-// GatewayAndHTTPRoutesMustBeReady waits until the specified Gateway has an IP
+// GatewayAndHTTPRoutesMustBeAccepted waits until the specified Gateway has an IP
 // address assigned to it and the Route has a ParentRef referring to the
 // Gateway. The test will fail if these conditions are not met before the
 // timeouts.
-func GatewayAndHTTPRoutesMustBeReady(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, controllerName string, gw GatewayRef, routeNNs ...types.NamespacedName) string {
+func GatewayAndHTTPRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, controllerName string, gw GatewayRef, routeNNs ...types.NamespacedName) string {
 	t.Helper()
 
 	gwAddr, err := WaitForGatewayAddress(t, c, timeoutConfig, gw.NamespacedName)

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -157,7 +157,7 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 		"gateway-conformance-app-backend",
 		"gateway-conformance-web-backend",
 	}
-	kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, namespaces)
+	kubernetes.NamespacesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, namespaces)
 }
 
 // Run runs the provided set of conformance tests.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
/kind api-change
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**: Make necessary changes to Gateway and Listener conditions in order to implement [GEP-1364](https://gateway-api.sigs.k8s.io/geps/gep-1364/).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1454 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Added "Programmed" Gateway and Listener conditions, moved "Ready" to extended conformance
```
