### PR TITLE
docs: mark GEP-735 as declined

### DIFF
--- a/site-src/geps/gep-735.md
+++ b/site-src/geps/gep-735.md
@@ -1,7 +1,30 @@
 # GEP-735: TCP and UDP addresses matching
 
 * Issue: [#735](https://github.com/kubernetes-sigs/gateway-api/issues/735)
-* Status: Provisional
+* Status: Declined
+
+## Notes about declined status
+
+At one point before the release of `v0.5.0` we did have an implementation
+of this GEP in `main`, but we decided to pull back on it for multiple
+reasons:
+
+- operated too much like WAF/firewall functionality, which is not in scope
+- no implementations championing the use case
+
+It should also be noted that the maintainers have at least considered the
+idea of an `IPRoute` API which would help differentiate this from firewall
+functionality, however there haven't been any strong champions for such a
+use case for this either.
+
+As such this GEP is marked as `Declined` to make it clear to readers that
+presently we don't have plans to include this in any future release. Keep
+in mind that this doesn't mean that we wouldn't consider it again as a
+future feature however: if you're interested in this functionality please
+feel free to start a new [github discussion][disc] and/or feel free to
+create a new PR updating this GEP with your use case(s) and context.
+
+[disc]:https://github.com/kubernetes-sigs/gateway-api/discussions
 
 ## TLDR
 


### PR DESCRIPTION
**What type of PR is this?**

/kind gep

**What this PR does / why we need it**:

At Kubecon 2022 in our working sessions, we decided to explicitly mark this GEP as declined so as to not cause any confusion whether we have any specific plans to implement it in an upcoming release, and to document the reasoning why it has been declined.

**Does this PR introduce a user-facing change?**:

NONE