### PR TITLE
webhook: validates that if ParentRefs includes 2 or more references to the same parent, parentRefs must specify unique sectionName values

### DIFF
--- a/apis/v1beta1/util/validation/http_route.go
+++ b/apis/v1beta1/util/validation/http_route.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import gatewayv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+// containsInSectionNameSlice checks whether the provided SectionName
+// is in the target SectionName slice.
+func ContainsInSectionNameSlice(items []gatewayv1b1.SectionName, item *gatewayv1b1.SectionName) bool {
+	for _, eachItem := range items {
+		if eachItem == *item {
+			return true
+		}
+	}
+	return false
+}

--- a/apis/v1beta1/util/validation/http_route_test.go
+++ b/apis/v1beta1/util/validation/http_route_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation_test
+
+import (
+	"testing"
+
+	gatewayv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	validationtutils "sigs.k8s.io/gateway-api/apis/v1beta1/util/validation"
+)
+
+func TestContainsInSectionNameSlice(t *testing.T) {
+	targetSectionSlice := []gatewayv1b1.SectionName{
+		gatewayv1b1.SectionName("Section A"),
+		gatewayv1b1.SectionName("Section B"),
+	}
+	testCases := []struct {
+		name        string
+		sectionName gatewayv1b1.SectionName
+		isvalid     bool
+	}{
+		{
+			name:        "Section found in slice",
+			sectionName: "Section A",
+			isvalid:     true,
+		},
+		{
+			name:        "SectionName not found in slice",
+			sectionName: "Section C",
+			isvalid:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			isValid := validationtutils.ContainsInSectionNameSlice(targetSectionSlice, &tc.sectionName)
+			if isValid != tc.isvalid {
+				t.Errorf("Expected validity %t, got %t", tc.isvalid, isValid)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

**What this PR does / why we need it**:

This PR add a validation to validate that if ParentRefs includes 2 or more references to the same parent, parentRefs must specify unique sectionName values

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1481

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
