### PR TITLE
docs: fix note in GEP 709 markdown

### DIFF
--- a/site-src/geps/gep-709.md
+++ b/site-src/geps/gep-709.md
@@ -3,9 +3,8 @@
 * Issue: [#709](https://github.com/kubernetes-sigs/gateway-api/issues/709)
 * Status: Experimental
 
-!!! note
-    This resource was originally named "ReferencePolicy". It was renamed
-    to "ReferenceGrant" to avoid any confusion with policy attachment.
+> **Note**: This resource was originally named `ReferencePolicy`. It was
+> renamed to `ReferenceGrant` to avoid any confusion with policy attachment.
 
 ## TLDR
 


### PR DESCRIPTION
Github wasn't rendering the note about the renaming for ReferenceGrant properly, this patch simply updates the format to the correct syntax for a markdown note in Github.