### PR TITLE
Fix Broken Links in Docs Causing Rendering Failures

### DIFF
--- a/examples/standard/reference-grant.yaml
+++ b/examples/standard/reference-grant.yaml
@@ -1,6 +1,5 @@
 #$ Used in:
 #$ - site-src/concepts/security-model.md
-#$ - site-src/blog/2021/introducing-v1alpha2.md
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:

--- a/site-src/blog/2021/introducing-v1alpha2.md
+++ b/site-src/blog/2021/introducing-v1alpha2.md
@@ -83,7 +83,18 @@ namespace to forward traffic to Services wherever this ReferenceGrant was
 installed:
 
 ```yaml
-{% include 'experimental/reference-grant.yaml' %}
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: ReferenceGrant
+metadata:
+  name: allow-prod-traffic
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: prod
+  to:
+  - group: ""
+    kind: Service
 ```
 
 This is covered in more detail in [GEP 709](https://gateway-api.sigs.k8s.io/geps/gep-709/).

--- a/site-src/concepts/security-model.md
+++ b/site-src/concepts/security-model.md
@@ -118,7 +118,7 @@ the "prod" namespace to HTTPRoutes that are deployed in the same namespace as
 the ReferenceGrant.
 
 ```yaml
-{% include 'experimental/reference-grant.yaml' %}
+{% include 'standard/reference-grant.yaml' %}
 ```
 
 For more information on ReferenceGrant, refer to our [detailed documentation

--- a/site-src/guides/tls.md
+++ b/site-src/guides/tls.md
@@ -98,7 +98,7 @@ target namespace. Without that ReferenceGrant, the cross-namespace reference
 would be invalid.
 
 ```yaml
-{% include 'experimental/tls-cert-cross-namespace.yaml' %}
+{% include 'standard/tls-cert-cross-namespace.yaml' %}
 ```
 
 ## Extensions


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

* These broken links are causing rendering issues on the published docs and also show up when runnning `make docs`.
* For everything except the v1alpha2 blog I simply updated the link
* For the v1alpha2 blog I copied the actual yaml from when the blog was posted.
* Example of https://gateway-api.sigs.k8s.io/blog/2021/introducing-v1alpha2/ right now:
![Screenshot 2022-11-07 7 16 31 PM](https://user-images.githubusercontent.com/9636457/200466805-d1690e3a-9a7e-45af-b174-8dfd4c826e8b.png)
* `make docs` now reports no errors when I run it locally.



**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
