### PR TITLE
conformance: Fix logic in HTTPRouteResponseHeaderModifier test

### DIFF
--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -94,7 +94,7 @@ spec:
       containers:
       - name: infra-backend-v1
         # From https://github.com/kubernetes-sigs/ingress-controller-conformance/tree/master/images/echoserver
-        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20220815-e21d1a4
+        image: local/echoserver:9.9
         env:
         - name: POD_NAME
           valueFrom:
@@ -140,7 +140,7 @@ spec:
     spec:
       containers:
       - name: infra-backend-v2
-        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20220815-e21d1a4
+        image: local/echoserver:9.9
         env:
         - name: POD_NAME
           valueFrom:
@@ -186,7 +186,7 @@ spec:
     spec:
       containers:
       - name: infra-backend-v3
-        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20220815-e21d1a4
+        image: local/echoserver:9.9
         env:
         - name: POD_NAME
           valueFrom:
@@ -239,7 +239,7 @@ spec:
     spec:
       containers:
       - name: app-backend-v1
-        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20220815-e21d1a4
+        image: local/echoserver:9.9
         env:
         - name: POD_NAME
           valueFrom:
@@ -285,7 +285,7 @@ spec:
     spec:
       containers:
       - name: app-backend-v2
-        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20220815-e21d1a4
+        image: local/echoserver:9.9
         env:
         - name: POD_NAME
           valueFrom:
@@ -338,7 +338,7 @@ spec:
     spec:
       containers:
       - name: web-backend
-        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20220815-e21d1a4
+        image: local/echoserver:9.9
         env:
         - name: POD_NAME
           valueFrom:

--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -94,7 +94,7 @@ spec:
       containers:
       - name: infra-backend-v1
         # From https://github.com/kubernetes-sigs/ingress-controller-conformance/tree/master/images/echoserver
-        image: local/echoserver:9.9
+        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
         env:
         - name: POD_NAME
           valueFrom:
@@ -140,7 +140,7 @@ spec:
     spec:
       containers:
       - name: infra-backend-v2
-        image: local/echoserver:9.9
+        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
         env:
         - name: POD_NAME
           valueFrom:
@@ -186,7 +186,7 @@ spec:
     spec:
       containers:
       - name: infra-backend-v3
-        image: local/echoserver:9.9
+        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
         env:
         - name: POD_NAME
           valueFrom:
@@ -239,7 +239,7 @@ spec:
     spec:
       containers:
       - name: app-backend-v1
-        image: local/echoserver:9.9
+        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
         env:
         - name: POD_NAME
           valueFrom:
@@ -285,7 +285,7 @@ spec:
     spec:
       containers:
       - name: app-backend-v2
-        image: local/echoserver:9.9
+        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
         env:
         - name: POD_NAME
           valueFrom:
@@ -338,7 +338,7 @@ spec:
     spec:
       containers:
       - name: web-backend
-        image: local/echoserver:9.9
+        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
         env:
         - name: POD_NAME
           valueFrom:

--- a/conformance/tests/httproute-cross-namespace.go
+++ b/conformance/tests/httproute-cross-namespace.go
@@ -41,10 +41,10 @@ var HTTPRouteCrossNamespace = suite.ConformanceTest{
 
 		t.Run("Simple HTTP request should reach web-backend", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
-				Request:    http.Request{Path: "/"},
-				StatusCode: 200,
-				Backend:    "web-backend",
-				Namespace:  "gateway-conformance-web-backend",
+				Request:   http.Request{Path: "/"},
+				Response:  http.Response{StatusCode: 200},
+				Backend:   "web-backend",
+				Namespace: "gateway-conformance-web-backend",
 			})
 		})
 	},

--- a/conformance/tests/httproute-exact-path-matching.go
+++ b/conformance/tests/httproute-exact-path-matching.go
@@ -50,14 +50,14 @@ var HTTPExactPathMatching = suite.ConformanceTest{
 				Backend:   "infra-backend-v2",
 				Namespace: ns,
 			}, {
-				Request:    http.Request{Path: "/"},
-				StatusCode: 404,
+				Request:  http.Request{Path: "/"},
+				Response: http.Response{StatusCode: 404},
 			}, {
-				Request:    http.Request{Path: "/one/example"},
-				StatusCode: 404,
+				Request:  http.Request{Path: "/one/example"},
+				Response: http.Response{StatusCode: 404},
 			}, {
-				Request:    http.Request{Path: "/two/"},
-				StatusCode: 404,
+				Request:  http.Request{Path: "/two/"},
+				Response: http.Response{StatusCode: 404},
 			},
 		}
 

--- a/conformance/tests/httproute-header-matching.go
+++ b/conformance/tests/httproute-header-matching.go
@@ -57,11 +57,11 @@ var HTTPRouteHeaderMatching = suite.ConformanceTest{
 			Backend:   "infra-backend-v2",
 			Namespace: ns,
 		}, {
-			Request:    http.Request{Path: "/", Headers: map[string]string{"Color": "orange"}},
-			StatusCode: 404,
+			Request:  http.Request{Path: "/", Headers: map[string]string{"Color": "orange"}},
+			Response: http.Response{StatusCode: 404},
 		}, {
-			Request:    http.Request{Path: "/", Headers: map[string]string{"Some-Other-Header": "one"}},
-			StatusCode: 404,
+			Request:  http.Request{Path: "/", Headers: map[string]string{"Some-Other-Header": "one"}},
+			Response: http.Response{StatusCode: 404},
 		}, {
 			Request:   http.Request{Path: "/", Headers: map[string]string{"Color": "blue"}},
 			Backend:   "infra-backend-v1",
@@ -79,8 +79,8 @@ var HTTPRouteHeaderMatching = suite.ConformanceTest{
 			Backend:   "infra-backend-v2",
 			Namespace: ns,
 		}, {
-			Request:    http.Request{Path: "/", Headers: map[string]string{"Color": "purple"}},
-			StatusCode: 404,
+			Request:  http.Request{Path: "/", Headers: map[string]string{"Color": "purple"}},
+			Response: http.Response{StatusCode: 404},
 		}}
 
 		for i := range testCases {

--- a/conformance/tests/httproute-hostname-intersection.go
+++ b/conformance/tests/httproute-hostname-intersection.go
@@ -63,20 +63,20 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 					Namespace: ns,
 				},
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "non.matching.com", Path: "/s1"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "non.matching.com", Path: "/s1"},
+					Response: http.Response{StatusCode: 404},
 				},
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "foo.nonmatchingwildcard.io", Path: "/s1"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "foo.nonmatchingwildcard.io", Path: "/s1"},
+					Response: http.Response{StatusCode: 404},
 				},
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "foo.wildcard.io", Path: "/s1"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "foo.wildcard.io", Path: "/s1"},
+					Response: http.Response{StatusCode: 404},
 				},
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "very.specific.com", Path: "/non-matching-prefix"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "very.specific.com", Path: "/non-matching-prefix"},
+					Response: http.Response{StatusCode: 404},
 				},
 			)
 
@@ -98,21 +98,21 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 					Namespace: ns,
 				},
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "non.matching.com", Path: "/s2"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "non.matching.com", Path: "/s2"},
+					Response: http.Response{StatusCode: 404},
 				},
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "wildcard.io", Path: "/s2"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "wildcard.io", Path: "/s2"},
+					Response: http.Response{StatusCode: 404},
 				},
 
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "very.specific.com", Path: "/s2"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "very.specific.com", Path: "/s2"},
+					Response: http.Response{StatusCode: 404},
 				},
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "foo.wildcard.io", Path: "/non-matching-prefix"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "foo.wildcard.io", Path: "/non-matching-prefix"},
+					Response: http.Response{StatusCode: 404},
 				},
 			)
 
@@ -124,20 +124,20 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 					Namespace: ns,
 				},
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "non.matching.com", Path: "/s3"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "non.matching.com", Path: "/s3"},
+					Response: http.Response{StatusCode: 404},
 				},
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "foo.specific.com", Path: "/s3"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "foo.specific.com", Path: "/s3"},
+					Response: http.Response{StatusCode: 404},
 				},
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "foo.wildcard.io", Path: "/s3"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "foo.wildcard.io", Path: "/s3"},
+					Response: http.Response{StatusCode: 404},
 				},
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "very.specific.com", Path: "/non-matching-prefix"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "very.specific.com", Path: "/non-matching-prefix"},
+					Response: http.Response{StatusCode: 404},
 				},
 			)
 
@@ -159,21 +159,21 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 					Namespace: ns,
 				},
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "anotherwildcard.io", Path: "/s4"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "anotherwildcard.io", Path: "/s4"},
+					Response: http.Response{StatusCode: 404},
 				},
 
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "foo.wildcard.io", Path: "/s4"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "foo.wildcard.io", Path: "/s4"},
+					Response: http.Response{StatusCode: 404},
 				},
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "very.specific.com", Path: "/s4"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "very.specific.com", Path: "/s4"},
+					Response: http.Response{StatusCode: 404},
 				},
 				http.ExpectedResponse{
-					Request:    http.Request{Host: "foo.anotherwildcard.io", Path: "/non-matching-prefix"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "foo.anotherwildcard.io", Path: "/non-matching-prefix"},
+					Response: http.Response{StatusCode: 404},
 				},
 			)
 
@@ -208,12 +208,12 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 
 			testCases := []http.ExpectedResponse{
 				{
-					Request:    http.Request{Host: "specific.but.wrong.com", Path: "/s5"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "specific.but.wrong.com", Path: "/s5"},
+					Response: http.Response{StatusCode: 404},
 				},
 				{
-					Request:    http.Request{Host: "wildcard.io", Path: "/s5"},
-					StatusCode: 404,
+					Request:  http.Request{Host: "wildcard.io", Path: "/s5"},
+					Response: http.Response{StatusCode: 404},
 				},
 			}
 

--- a/conformance/tests/httproute-invalid-backendref-nonexistent.go
+++ b/conformance/tests/httproute-invalid-backendref-nonexistent.go
@@ -59,7 +59,7 @@ var HTTPRouteInvalidNonExistentBackendRef = suite.ConformanceTest{
 					Method: "GET",
 					Path:   "/",
 				},
-				StatusCode: 500,
+				Response: http.Response{StatusCode: 500},
 			})
 		})
 

--- a/conformance/tests/httproute-invalid-backendref-unknown-kind.go
+++ b/conformance/tests/httproute-invalid-backendref-unknown-kind.go
@@ -60,7 +60,7 @@ var HTTPRouteInvalidBackendRefUnknownKind = suite.ConformanceTest{
 					Method: "GET",
 					Path:   "/v2",
 				},
-				StatusCode: 500,
+				Response: http.Response{StatusCode: 500},
 			})
 		})
 

--- a/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
@@ -61,7 +61,7 @@ var HTTPRouteInvalidCrossNamespaceBackendRef = suite.ConformanceTest{
 					Method: "GET",
 					Path:   "/",
 				},
-				StatusCode: 500,
+				Response: http.Response{StatusCode: 500},
 			})
 		})
 

--- a/conformance/tests/httproute-invalid-reference-grant.go
+++ b/conformance/tests/httproute-invalid-reference-grant.go
@@ -61,7 +61,7 @@ var HTTPRouteInvalidReferenceGrant = suite.ConformanceTest{
 					Method: "GET",
 					Path:   "/v2",
 				},
-				StatusCode: 500,
+				Response: http.Response{StatusCode: 500},
 			})
 		})
 
@@ -71,9 +71,9 @@ var HTTPRouteInvalidReferenceGrant = suite.ConformanceTest{
 					Method: "GET",
 					Path:   "/",
 				},
-				StatusCode: 200,
-				Backend:    "app-backend-v1",
-				Namespace:  "gateway-conformance-app-backend",
+				Response:  http.Response{StatusCode: 200},
+				Backend:   "app-backend-v1",
+				Namespace: "gateway-conformance-app-backend",
 			})
 		})
 

--- a/conformance/tests/httproute-listener-hostname-matching.go
+++ b/conformance/tests/httproute-listener-hostname-matching.go
@@ -78,11 +78,11 @@ var HTTPRouteListenerHostnameMatching = suite.ConformanceTest{
 			Backend:   "infra-backend-v3",
 			Namespace: ns,
 		}, {
-			Request:    http.Request{Host: "foo.com", Path: "/"},
-			StatusCode: 404,
+			Request:  http.Request{Host: "foo.com", Path: "/"},
+			Response: http.Response{StatusCode: 404},
 		}, {
-			Request:    http.Request{Host: "no.matching.host", Path: "/"},
-			StatusCode: 404,
+			Request:  http.Request{Host: "no.matching.host", Path: "/"},
+			Response: http.Response{StatusCode: 404},
 		}}
 
 		for i := range testCases {

--- a/conformance/tests/httproute-method-matching.go
+++ b/conformance/tests/httproute-method-matching.go
@@ -51,8 +51,8 @@ var HTTPRouteMethodMatching = suite.ConformanceTest{
 				Backend:   "infra-backend-v2",
 				Namespace: ns,
 			}, {
-				Request:    http.Request{Method: "HEAD", Path: "/"},
-				StatusCode: 404,
+				Request:  http.Request{Method: "HEAD", Path: "/"},
+				Response: http.Response{StatusCode: 404},
 			},
 		}
 

--- a/conformance/tests/httproute-query-param-matching.go
+++ b/conformance/tests/httproute-query-param-matching.go
@@ -68,17 +68,17 @@ var HTTPRouteQueryParamMatching = suite.ConformanceTest{
 			Backend:   "infra-backend-v2",
 			Namespace: ns,
 		}, {
-			Request:    http.Request{Path: "/?color=blue"},
-			StatusCode: 404,
+			Request:  http.Request{Path: "/?color=blue"},
+			Response: http.Response{StatusCode: 404},
 		}, {
-			Request:    http.Request{Path: "/?animal=dog"},
-			StatusCode: 404,
+			Request:  http.Request{Path: "/?animal=dog"},
+			Response: http.Response{StatusCode: 404},
 		}, {
-			Request:    http.Request{Path: "/?animal=whaledolphin"},
-			StatusCode: 404,
+			Request:  http.Request{Path: "/?animal=whaledolphin"},
+			Response: http.Response{StatusCode: 404},
 		}, {
-			Request:    http.Request{Path: "/"},
-			StatusCode: 404,
+			Request:  http.Request{Path: "/"},
+			Response: http.Response{StatusCode: 404},
 		}}
 
 		for i := range testCases {

--- a/conformance/tests/httproute-reference-grant.go
+++ b/conformance/tests/httproute-reference-grant.go
@@ -46,9 +46,9 @@ var HTTPRouteReferenceGrant = suite.ConformanceTest{
 					Method: "GET",
 					Path:   "/",
 				},
-				StatusCode: 200,
-				Backend:    "web-backend",
-				Namespace:  "gateway-conformance-web-backend",
+				Response:  http.Response{StatusCode: 200},
+				Backend:   "web-backend",
+				Namespace: "gateway-conformance-web-backend",
 			})
 		})
 	},

--- a/conformance/tests/httproute-request-header-modifier.go
+++ b/conformance/tests/httproute-request-header-modifier.go
@@ -171,8 +171,9 @@ var HTTPRouteRequestHeaderModifier = suite.ConformanceTest{
 				Request: http.Request{
 					Path: "/case-insensitivity",
 					Headers: map[string]string{
-						"X-Header-Set": "header-set",
-						"X-Header-Add": "original-val-add,header-add",
+						"X-Header-Set":   "header-set",
+						"X-Header-Add":   "original-val-add,header-add",
+						"Another-Header": "another-header-val",
 					},
 				},
 				AbsentHeaders: []string{"x-header-remove", "X-Header-Remove"},

--- a/conformance/tests/httproute-response-header-modifier.go
+++ b/conformance/tests/httproute-response-header-modifier.go
@@ -44,9 +44,9 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 		testCases := []http.ExpectedResponse{{
 			Request: http.Request{
 				Path: "/set",
-				Headers: map[string]string{
-					"Some-Other-Header": "val",
-				},
+			},
+			BackendSetResponseHeaders: map[string]string{
+				"Some-Other-Header": "val",
 			},
 			Response: http.Response{
 				Headers: map[string]string{
@@ -59,10 +59,10 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 		}, {
 			Request: http.Request{
 				Path: "/set",
-				Headers: map[string]string{
-					"Some-Other-Header": "val",
-					"X-Header-Set":      "some-other-value",
-				},
+			},
+			BackendSetResponseHeaders: map[string]string{
+				"Some-Other-Header": "val",
+				"X-Header-Set":      "some-other-value",
 			},
 			Response: http.Response{
 				Headers: map[string]string{
@@ -75,9 +75,9 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 		}, {
 			Request: http.Request{
 				Path: "/add",
-				Headers: map[string]string{
-					"Some-Other-Header": "val",
-				},
+			},
+			BackendSetResponseHeaders: map[string]string{
+				"Some-Other-Header": "val",
 			},
 			Response: http.Response{
 				Headers: map[string]string{
@@ -90,10 +90,10 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 		}, {
 			Request: http.Request{
 				Path: "/add",
-				Headers: map[string]string{
-					"Some-Other-Header": "val",
-					"X-Header-Add":      "some-other-value",
-				},
+			},
+			BackendSetResponseHeaders: map[string]string{
+				"Some-Other-Header": "val",
+				"X-Header-Add":      "some-other-value",
 			},
 			Response: http.Response{
 				Headers: map[string]string{
@@ -106,12 +106,11 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 		}, {
 			Request: http.Request{
 				Path: "/remove",
-				Headers: map[string]string{
-					"X-Header-Remove": "val",
-				},
+			},
+			BackendSetResponseHeaders: map[string]string{
+				"X-Header-Remove": "val",
 			},
 			Response: http.Response{
-				Headers:       map[string]string{},
 				AbsentHeaders: []string{"X-Header-Remove"},
 			},
 			Backend:   "infra-backend-v1",
@@ -119,12 +118,13 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 		}, {
 			Request: http.Request{
 				Path: "/multiple",
-				Headers: map[string]string{
-					"X-Header-Set-2":    "set-val-2",
-					"X-Header-Add-2":    "add-val-2",
-					"X-Header-Remove-2": "remove-val-2",
-					"Another-Header":    "another-header-val",
-				},
+			},
+			BackendSetResponseHeaders: map[string]string{
+				"X-Header-Set-2":    "set-val-2",
+				"X-Header-Add-2":    "add-val-2",
+				"X-Header-Remove-2": "remove-val-2",
+				"Another-Header":    "another-header-val",
+				"X-Header-Remove-1": "val",
 			},
 			Response: http.Response{
 				Headers: map[string]string{
@@ -142,20 +142,22 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 		}, {
 			Request: http.Request{
 				Path: "/case-insensitivity",
-				// The filter uses canonicalized header names,
-				// the request uses lowercase names.
-				Headers: map[string]string{
-					"x-header-set":    "original-val-set",
-					"x-header-add":    "original-val-add",
-					"x-header-remove": "original-val-remove",
-					"Another-Header":  "another-header-val",
-				},
+			},
+			BackendSetResponseHeaders: map[string]string{
+				"x-header-set":    "original-val-set",
+				"x-header-add":    "original-val-add",
+				"x-header-remove": "original-val-remove",
+				"Another-Header":  "another-header-val",
 			},
 			Response: http.Response{
 				Headers: map[string]string{
-					"X-Header-Set":   "header-set",
-					"X-Header-Add":   "original-val-add,header-add",
-					"Another-Header": "another-header-val",
+					"X-Header-Set":      "header-set",
+					"X-Header-Add":      "original-val-add,header-add",
+					"X-Lowercase-Add":   "lowercase-add",
+					"X-Mixedcase-Add-1": "mixedcase-add-1",
+					"X-Mixedcase-Add-2": "mixedcase-add-2",
+					"X-Uppercase-Add":   "uppercase-add",
+					"Another-Header":    "another-header-val",
 				},
 				AbsentHeaders: []string{"x-header-remove", "X-Header-Remove"},
 			},

--- a/conformance/tests/httproute-response-header-modifier.go
+++ b/conformance/tests/httproute-response-header-modifier.go
@@ -48,9 +48,11 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 					"Some-Other-Header": "val",
 				},
 			},
-			Headers: map[string]string{
-				"Some-Other-Header": "val",
-				"X-Header-Set":      "set-overwrites-values",
+			Response: http.Response{
+				Headers: map[string]string{
+					"Some-Other-Header": "val",
+					"X-Header-Set":      "set-overwrites-values",
+				},
 			},
 			Backend:   "infra-backend-v1",
 			Namespace: ns,
@@ -62,9 +64,11 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 					"X-Header-Set":      "some-other-value",
 				},
 			},
-			Headers: map[string]string{
-				"Some-Other-Header": "val",
-				"X-Header-Set":      "set-overwrites-values",
+			Response: http.Response{
+				Headers: map[string]string{
+					"Some-Other-Header": "val",
+					"X-Header-Set":      "set-overwrites-values",
+				},
 			},
 			Backend:   "infra-backend-v1",
 			Namespace: ns,
@@ -75,9 +79,11 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 					"Some-Other-Header": "val",
 				},
 			},
-			Headers: map[string]string{
-				"Some-Other-Header": "val",
-				"X-Header-Add":      "add-appends-values",
+			Response: http.Response{
+				Headers: map[string]string{
+					"Some-Other-Header": "val",
+					"X-Header-Add":      "add-appends-values",
+				},
 			},
 			Backend:   "infra-backend-v1",
 			Namespace: ns,
@@ -89,9 +95,11 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 					"X-Header-Add":      "some-other-value",
 				},
 			},
-			Headers: map[string]string{
-				"Some-Other-Header": "val",
-				"X-Header-Add":      "some-other-value,add-appends-values",
+			Response: http.Response{
+				Headers: map[string]string{
+					"Some-Other-Header": "val",
+					"X-Header-Add":      "some-other-value,add-appends-values",
+				},
 			},
 			Backend:   "infra-backend-v1",
 			Namespace: ns,
@@ -102,10 +110,12 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 					"X-Header-Remove": "val",
 				},
 			},
-			Headers:       map[string]string{},
-			AbsentHeaders: []string{"X-Header-Remove"},
-			Backend:       "infra-backend-v1",
-			Namespace:     ns,
+			Response: http.Response{
+				Headers:       map[string]string{},
+				AbsentHeaders: []string{"X-Header-Remove"},
+			},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
 		}, {
 			Request: http.Request{
 				Path: "/multiple",
@@ -116,17 +126,19 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 					"Another-Header":    "another-header-val",
 				},
 			},
-			Headers: map[string]string{
-				"X-Header-Set-1": "header-set-1",
-				"X-Header-Set-2": "header-set-2",
-				"X-Header-Add-1": "header-add-1",
-				"X-Header-Add-2": "add-val-2,header-add-2",
-				"X-Header-Add-3": "header-add-3",
-				"Another-Header": "another-header-val",
+			Response: http.Response{
+				Headers: map[string]string{
+					"X-Header-Set-1": "header-set-1",
+					"X-Header-Set-2": "header-set-2",
+					"X-Header-Add-1": "header-add-1",
+					"X-Header-Add-2": "add-val-2,header-add-2",
+					"X-Header-Add-3": "header-add-3",
+					"Another-Header": "another-header-val",
+				},
+				AbsentHeaders: []string{"X-Header-Remove-1", "X-Header-Remove-2"},
 			},
-			AbsentHeaders: []string{"X-Header-Remove-1", "X-Header-Remove-2"},
-			Backend:       "infra-backend-v1",
-			Namespace:     ns,
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
 		}, {
 			Request: http.Request{
 				Path: "/case-insensitivity",
@@ -139,14 +151,16 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 					"Another-Header":  "another-header-val",
 				},
 			},
-			Headers: map[string]string{
-				"X-Header-Set":   "header-set",
-				"X-Header-Add":   "original-val-add,header-add",
-				"Another-Header": "another-header-val",
+			Response: http.Response{
+				Headers: map[string]string{
+					"X-Header-Set":   "header-set",
+					"X-Header-Add":   "original-val-add,header-add",
+					"Another-Header": "another-header-val",
+				},
+				AbsentHeaders: []string{"x-header-remove", "X-Header-Remove"},
 			},
-			AbsentHeaders: []string{"x-header-remove", "X-Header-Remove"},
-			Backend:       "infra-backend-v1",
-			Namespace:     ns,
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
 		}}
 
 		for i := range testCases {

--- a/conformance/tests/httproute-response-header-modifier.yaml
+++ b/conformance/tests/httproute-response-header-modifier.yaml
@@ -83,6 +83,14 @@ spec:
         add:
         - name: X-Header-Add
           value: header-add
+        - name: x-lowercase-add
+          value: lowercase-add
+        - name: x-Mixedcase-ADD-1
+          value: mixedcase-add-1
+        - name: X-mixeDcase-add-2
+          value: mixedcase-add-2
+        - name: X-UPPERCASE-ADD
+          value: uppercase-add
         remove:
         - X-Header-Remove
     backendRefs:

--- a/conformance/tests/httproute-simple-same-namespace.go
+++ b/conformance/tests/httproute-simple-same-namespace.go
@@ -43,10 +43,10 @@ var HTTPRouteSimpleSameNamespace = suite.ConformanceTest{
 
 		t.Run("Simple HTTP request should reach infra-backend", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
-				Request:    http.Request{Path: "/"},
-				StatusCode: 200,
-				Backend:    "infra-backend-v1",
-				Namespace:  "gateway-conformance-infra",
+				Request:   http.Request{Path: "/"},
+				Response:  http.Response{StatusCode: 200},
+				Backend:   "infra-backend-v1",
+				Namespace: "gateway-conformance-infra",
 			})
 		})
 	},

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -123,7 +123,7 @@ func MakeRequestAndExpectEventuallyConsistentResponse(t *testing.T, r roundtripp
 	for name, val := range expected.BackendSetResponseHeaders {
 		backendSetHeaders = append(backendSetHeaders, name+":"+val)
 	}
-	req.Headers["X-Echo-Set-Header"] = backendSetHeaders
+	req.Headers["X-Echo-Set-Header"] = []string{strings.Join(backendSetHeaders, ",")}
 
 	WaitForConsistentResponse(t, r, req, expected, requiredConsecutiveSuccesses, timeoutConfig.MaxTimeToConsistency)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
Fixes logic in `HTTPRouteResponseHeaderModifier` conformance test.

Previously, the test conflated request and response headers.
Changes in this PR along with updated echoserver (see https://github.com/kubernetes-sigs/ingress-controller-conformance/pull/100) allow test to modify what response headers the backend app returns, to ensure modifications an implementation makes as a result of the ResponseHeaderModifier Filter are correct.

Also does some minor cleanup and changes/fixes assertions around headers.

This PR is verified with a local build of the echoserver image from https://github.com/kubernetes-sigs/ingress-controller-conformance/pull/100 as well as this spike on Contour to implement the ResponseHeaderModifier Filter: https://github.com/sunjayBhatia/contour/tree/gwapi-latest-with-resp-header-modification

Easiest to review this PR per-commit:
- first addresses #1384 to move expected response fields into their own struct
- second is the bulk of the change to fix the ResponseHeaderModifier test
- next is a little cleanup and update to changes in echoserver usage
- last is a change to the echoserver image, which will need to be updated once https://github.com/kubernetes-sigs/ingress-controller-conformance/pull/100 is merged and new echoserver image built

**Which issue(s) this PR fixes**:
Fixes #1473
Fixes #1384

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
