### PR TITLE
conformance: fix invalid `for` loop in InvalidTls test

### DIFF
--- a/conformance/tests/gateway-invalid-tls-certificateref.go
+++ b/conformance/tests/gateway-invalid-tls-certificateref.go
@@ -72,6 +72,7 @@ var GatewayInvalidTLSConfiguration = suite.ConformanceTest{
 		}
 
 		for _, tc := range testCases {
+			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, tc.gatewayNamespacedName, listeners)


### PR DESCRIPTION

/kind bug

**What this PR does / why we need it**:

Makes the test actually run all 4 tests instead of run 1 test 4 times

NOTE: Istio is actually not conformant here so I didn't test that the new tests actually work as expected

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
