### PR TITLE
Mark multiple `GatewayTLSConfig.CertificateRefs` as Extended support

### DIFF
--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -327,7 +327,7 @@ type GatewayTLSConfig struct {
 	//
 	// Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
 	//
-	// Support: Implementation-specific (More than one reference or other resource types)
+	// Support: Extended (More than one reference or other resource types)
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=64

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -344,8 +344,7 @@ spec:
                             Kubernetes resources, i.e. Secret, or implementation-specific
                             custom resources. \n Support: Core - A single reference
                             to a Kubernetes Secret of type kubernetes.io/tls \n Support:
-                            Implementation-specific (More than one reference or other
-                            resource types)"
+                            Extended (More than one reference or other resource types)"
                           items:
                             description: "SecretObjectReference identifies an API
                               object including its namespace, defaulting to Secret.
@@ -1038,8 +1037,7 @@ spec:
                             Kubernetes resources, i.e. Secret, or implementation-specific
                             custom resources. \n Support: Core - A single reference
                             to a Kubernetes Secret of type kubernetes.io/tls \n Support:
-                            Implementation-specific (More than one reference or other
-                            resource types)"
+                            Extended (More than one reference or other resource types)"
                           items:
                             description: "SecretObjectReference identifies an API
                               object including its namespace, defaulting to Secret.

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -344,8 +344,7 @@ spec:
                             Kubernetes resources, i.e. Secret, or implementation-specific
                             custom resources. \n Support: Core - A single reference
                             to a Kubernetes Secret of type kubernetes.io/tls \n Support:
-                            Implementation-specific (More than one reference or other
-                            resource types)"
+                            Extended (More than one reference or other resource types)"
                           items:
                             description: "SecretObjectReference identifies an API
                               object including its namespace, defaulting to Secret.
@@ -1038,8 +1037,7 @@ spec:
                             Kubernetes resources, i.e. Secret, or implementation-specific
                             custom resources. \n Support: Core - A single reference
                             to a Kubernetes Secret of type kubernetes.io/tls \n Support:
-                            Implementation-specific (More than one reference or other
-                            resource types)"
+                            Extended (More than one reference or other resource types)"
                           items:
                             description: "SecretObjectReference identifies an API
                               object including its namespace, defaulting to Secret.


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
As per the https://github.com/kubernetes-sigs/gateway-api/issues/1330#issuecomment-1306430866 , the multiple certificates field has to be marked as "Extended Support"

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1330

cc : @youngnick 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
