### PR TITLE
Merging Gateway API Admins and Maintainers, Moving Harry to Emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,6 @@
 
 approvers:
   - sig-network-leads
-  - gateway-api-admins
   - gateway-api-maintainers
 
 reviewers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,13 +9,8 @@ aliases:
     - thockin
 
   # Reference: https://github.com/kubernetes/org/blob/main/config/kubernetes-sigs/sig-network/teams.yaml
-  gateway-api-admins:
-    - bowei
-    - thockin
-
   gateway-api-maintainers:
     - bowei
-    - hbagdi
     - robscott
     - shaneutt
     - youngnick
@@ -27,4 +22,5 @@ aliases:
 
   emeritus-gateway-api-maintainers:
     - danehans
+    - hbagdi
     - jpeach

--- a/README.md
+++ b/README.md
@@ -49,11 +49,6 @@ Community meeting schedule, notes and developer guide can be found on the
 [community page][cm].
 Our Kubernetes Slack channel is [#sig-network-gateway-api][slack].
 
-## Technical Leads
-
-- @bowei
-- @thockin
-
 ### Code of conduct
 
 Participation in the Kubernetes community is governed by the


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR does 2 things:

- Merges Gateway API Admins and Maintainers: This will not have any real effect until we make the same change in k/org. At that point, Gateway API maintainers will get slightly more GitHub access.
- Moves @hbagdi to emeritus: A huge thanks for all his contributions over the years, unfortunately he doesn't have the same level of bandwidth to contribute to the project anymore.

I've checked in with everyone that would be affected by these changes, and they're all onboard.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @bowei @hbagdi @shaneutt @thockin @youngnick 