### PR TITLE
Minor GRPCRoute implementation fixes

### DIFF
--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -323,7 +323,6 @@ type GRPCMethodMatch struct {
 	//
 	// At least one of Service and Method MUST be a non-empty string.
 	// +optional
-	// +kubebuilder:default=""
 	// +kubebuilder:validation:MaxLength=1024
 	// +kubebuilder:validation:Pattern=`^[^\/]*$`
 	Service *string `json:"service,omitempty"`
@@ -333,7 +332,6 @@ type GRPCMethodMatch struct {
 	//
 	// At least one of Service and Method MUST be a non-empty string.
 	// +optional
-	// +kubebuilder:default=""
 	// +kubebuilder:validation:MaxLength=1024
 	// +kubebuilder:validation:Pattern=`^[^\/]*$`
 	Method *string `json:"method,omitempty"`
@@ -349,9 +347,23 @@ type GRPCMethodMatch struct {
 //
 // - Must not contain `/` character
 //
-// +kubebuilder:validation:Enum=Exact;PathPrefix;RegularExpression
 // +kubebuilder:validation:Enum=Exact;RegularExpression
 type GRPCMethodMatchType string
+
+const (
+	// Matches the method or service exactly and with case sensitivity.
+	PathMatchExact GRPCMethodMatchType = "Exact"
+
+	// Matches if the method or service matches the given regular expression with
+	// case sensitivity.
+	//
+	// Since `"RegularExpression"` has implementation-specific conformance,
+	// implementations can support POSIX, PCRE, RE2 or any other regular expression
+	// dialect.
+	// Please read the implementation's documentation to determine the supported
+	// dialect.
+	PathMatchRegularExpression GRPCMethodMatchType = "RegularExpression"
+)
 
 // GRPCHeaderMatch describes how to select a gRPC route by matching gRPC request
 // headers.
@@ -394,6 +406,14 @@ const (
 	//
 	// Support in GRPCBackendRef: Extended
 	GRPCRouteFilterRequestHeaderModifier GRPCRouteFilterType = "RequestHeaderModifier"
+
+	// GRPCRouteFilterRequestHeaderModifier can be used to add or remove a gRPC
+	// header from a gRPC response before it is sent to the client.
+	//
+	// Support in GRPCRouteRule: Core
+	//
+	// Support in GRPCBackendRef: Extended
+	GRPCRouteFilterResponseHeaderModifier GRPCRouteFilterType = "ResponseHeaderModifier"
 
 	// GRPCRouteFilterRequestMirror can be used to mirror gRPC requests to a
 	// different backend. The responses from this backend MUST be ignored by
@@ -446,8 +466,8 @@ type GRPCRouteFilter struct {
 	// that filter MUST receive a HTTP error response.
 	//
 	// +unionDiscriminator
-	// +kubebuilder:validation:Enum=RequestHeaderModifier;RequestMirror;ExtensionRef
-	// <gateway:experimental:validation:Enum=RequestHeaderModifier;RequestMirror;ExtensionRef>
+	// +kubebuilder:validation:Enum=ResponseHeaderModifier;RequestHeaderModifier;RequestMirror;ExtensionRef
+	// <gateway:experimental:validation:Enum=ResponseHeaderModifier;RequestHeaderModifier;RequestMirror;ExtensionRef>
 	Type GRPCRouteFilterType `json:"type"`
 
 	// RequestHeaderModifier defines a schema for a filter that modifies request
@@ -457,6 +477,15 @@ type GRPCRouteFilter struct {
 	//
 	// +optional
 	RequestHeaderModifier *HTTPHeaderFilter `json:"requestHeaderModifier,omitempty"`
+
+	// ResponseHeaderModifier defines a schema for a filter that modifies response
+	// headers.
+	//
+	// Support: Extended
+	//
+	// +optional
+	// <gateway:experimental>
+	ResponseHeaderModifier *HTTPHeaderFilter `json:"responseHeaderModifier,omitempty"`
 
 	// RequestMirror defines a schema for a filter that mirrors requests.
 	// Requests are sent to the specified destination, but responses from

--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -352,7 +352,7 @@ type GRPCMethodMatchType string
 
 const (
 	// Matches the method or service exactly and with case sensitivity.
-	PathMatchExact GRPCMethodMatchType = "Exact"
+	GRPCMethodMatchExact GRPCMethodMatchType = "Exact"
 
 	// Matches if the method or service matches the given regular expression with
 	// case sensitivity.
@@ -362,7 +362,7 @@ const (
 	// dialect.
 	// Please read the implementation's documentation to determine the supported
 	// dialect.
-	PathMatchRegularExpression GRPCMethodMatchType = "RegularExpression"
+	GRPCMethodMatchRegularExpression GRPCMethodMatchType = "RegularExpression"
 )
 
 // GRPCHeaderMatch describes how to select a gRPC route by matching gRPC request

--- a/apis/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/v1alpha2/zz_generated.deepcopy.go
@@ -134,6 +134,11 @@ func (in *GRPCRouteFilter) DeepCopyInto(out *GRPCRouteFilter) {
 		*out = new(v1beta1.HTTPHeaderFilter)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ResponseHeaderModifier != nil {
+		in, out := &in.ResponseHeaderModifier, &out.ResponseHeaderModifier
+		*out = new(v1beta1.HTTPHeaderFilter)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.RequestMirror != nil {
 		in, out := &in.RequestMirror, &out.RequestMirror
 		*out = new(v1beta1.HTTPRequestMirrorFilter)

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -512,6 +512,115 @@ spec:
                                   required:
                                   - backendRef
                                   type: object
+                                responseHeaderModifier:
+                                  description: "ResponseHeaderModifier defines a schema
+                                    for a filter that modifies response headers. \n
+                                    Support: Extended \n <gateway:experimental>"
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,
+                                        value) to the request before the action. It
+                                        appends to any existing values associated
+                                        with the header name. \n Input:   GET /foo
+                                        HTTP/1.1   my-header: foo \n Config:   add:
+                                        \  - name: \"my-header\"     value: \"bar,baz\"
+                                        \n Output:   GET /foo HTTP/1.1   my-header:
+                                        foo,bar,baz"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from
+                                        the HTTP request before the action. The value
+                                        of Remove is a list of HTTP header names.
+                                        Note that the header names are case-insensitive
+                                        (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                        \n Input:   GET /foo HTTP/1.1   my-header1:
+                                        foo   my-header2: bar   my-header3: baz \n
+                                        Config:   remove: [\"my-header1\", \"my-header3\"]
+                                        \n Output:   GET /foo HTTP/1.1   my-header2:
+                                        bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                    set:
+                                      description: "Set overwrites the request with
+                                        the given header (name, value) before the
+                                        action. \n Input:   GET /foo HTTP/1.1   my-header:
+                                        foo \n Config:   set:   - name: \"my-header\"
+                                        \    value: \"bar\" \n Output:   GET /foo
+                                        HTTP/1.1   my-header: bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
                                 type:
                                   description: "Type identifies the type of filter
                                     to apply. As with other API fields, types are
@@ -540,6 +649,7 @@ spec:
                                     requests that would have been processed by that
                                     filter MUST receive a HTTP error response. \n "
                                   enum:
+                                  - ResponseHeaderModifier
                                   - RequestHeaderModifier
                                   - RequestMirror
                                   - ExtensionRef
@@ -851,6 +961,107 @@ spec:
                             required:
                             - backendRef
                             type: object
+                          responseHeaderModifier:
+                            description: "ResponseHeaderModifier defines a schema
+                              for a filter that modifies response headers. \n Support:
+                              Extended \n <gateway:experimental>"
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,
+                                  value) to the request before the action. It appends
+                                  to any existing values associated with the header
+                                  name. \n Input:   GET /foo HTTP/1.1   my-header:
+                                  foo \n Config:   add:   - name: \"my-header\"     value:
+                                  \"bar,baz\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo,bar,baz"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the
+                                  HTTP request before the action. The value of Remove
+                                  is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                  \n Input:   GET /foo HTTP/1.1   my-header1: foo
+                                  \  my-header2: bar   my-header3: baz \n Config:
+                                  \  remove: [\"my-header1\", \"my-header3\"] \n Output:
+                                  \  GET /foo HTTP/1.1   my-header2: bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                              set:
+                                description: "Set overwrites the request with the
+                                  given header (name, value) before the action. \n
+                                  Input:   GET /foo HTTP/1.1   my-header: foo \n Config:
+                                  \  set:   - name: \"my-header\"     value: \"bar\"
+                                  \n Output:   GET /foo HTTP/1.1   my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
                           type:
                             description: "Type identifies the type of filter to apply.
                               As with other API fields, types are classified into
@@ -877,6 +1088,7 @@ spec:
                               been processed by that filter MUST receive a HTTP error
                               response. \n "
                             enum:
+                            - ResponseHeaderModifier
                             - RequestHeaderModifier
                             - RequestMirror
                             - ExtensionRef
@@ -980,7 +1192,6 @@ spec:
                               and methods will match.
                             properties:
                               method:
-                                default: ""
                                 description: "Value of the method to match against.
                                   If left empty or omitted, will match all services.
                                   \n At least one of Service and Method MUST be a
@@ -989,7 +1200,6 @@ spec:
                                 pattern: ^[^\/]*$
                                 type: string
                               service:
-                                default: ""
                                 description: "Value of the service to match against.
                                   If left empty or omitted, will match all services.
                                   \n At least one of Service and Method MUST be a


### PR DESCRIPTION
/kind bug

This PR fixes some minor issues in the `GRPCRoute` GEP, namely:

- Includes const values for `GRPCRouteMethodMatchType`
- Correctly interprets unsupplied `Service` and `Method` fields
- Adds support for `ResponseHeaderModifierFilter`, which was recently added to `HTTPRoute`

```release-note
NONE
```
