### PR TITLE
[WIP] conformance: require that GatewayClass controller name is immutable

### DIFF
--- a/conformance/tests/gatewayclass-admission-validation.go
+++ b/conformance/tests/gatewayclass-admission-validation.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayClassAdmissionValidation)
+}
+
+var GatewayClassAdmissionValidation = suite.ConformanceTest{
+	ShortName:   "GatewayClassAdmissionValidation",
+	Description: "GatewayClass admission validation behavior",
+	Manifests:   []string{"tests/gatewayclass-admission-validation.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		t.Run("GatewayClass.spec.controllerName is immutable", func(t *testing.T) {
+			c := suite.Client
+			timeoutConfig := suite.TimeoutConfig
+			gwcName := "gatewayclass-immutable"
+
+			ctx, cancel := context.WithTimeout(context.Background(), timeoutConfig.GetTimeout)
+			defer cancel()
+
+			gwc := &v1beta1.GatewayClass{}
+			err := c.Get(ctx, types.NamespacedName{Name: gwcName}, gwc)
+
+			require.NoErrorf(t, err, "error fetching %s GatewayClass", gwcName)
+
+			gwc.Spec.ControllerName = v1beta1.GatewayController(fmt.Sprintf("%s-modified", gwc.Spec.ControllerName))
+
+			ctx, cancel = context.WithTimeout(context.Background(), timeoutConfig.CreateTimeout)
+			defer cancel()
+
+			err = c.Update(ctx, gwc)
+
+			var e *apierrors.StatusError
+			require.ErrorAsf(t, err, &e, "updating %s GatewayClass.spec.controllerName should not be permitted", gwcName)
+			require.Equal(t, int32(400), e.ErrStatus.Code, "HTTP response code should be 400")
+		})
+	},
+}

--- a/conformance/tests/gatewayclass-admission-validation.yaml
+++ b/conformance/tests/gatewayclass-admission-validation.yaml
@@ -1,0 +1,7 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: gatewayclass-immutable
+spec:
+  controllerName: networking.k8s.io/gateway-controller
+  description: A test GatewayClass


### PR DESCRIPTION
Relates to #1514

This is a proof-of-concept conformance test that checks for the validation behavior provided by the admission webhook. In this case we're just checking that an update to a GatewayClass controller name is rejected.

We use a temporary GatewayClass rather than the one specified by the --gateway-class, to avoid messing up installations that do allow this update through.

This does raise an interesting question though - isn't it strange that we're saying an implementation is required to validate objects that it should otherwise ignore? In this case, we would would otherwise say an implementation should ingore this object because it doesn't recognize the controller name.

Failure looks like this:

```
=== RUN   TestConformance/GatewayClassAdmissionValidation/GatewayClass_controllerName_is_immutable
    gatewayclass-admission-validation.go:62:
        	Error Trace:	gatewayclass-admission-validation.go:62
        	Error:      	Should be in error chain:
        	            	expected: %!q(**errors.StatusError=0xc000014008)
        	            	in chain:
        	Test:       	TestConformance/GatewayClassAdmissionValidation/GatewayClass_controllerName_is_immutable
        	Messages:   	updating gatewayclass-immutable GatewayClass.Spec.ControllerName should not be permitted
```

