### PR TITLE
Add PartiallyInvalid Route condition

### DIFF
--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -205,8 +205,14 @@ type HTTPRouteRule struct {
 	// All filters are expected to be compatible with each other except for the
 	// URLRewrite and RequestRedirect filters, which may not be combined. If an
 	// implementation can not support other combinations of filters, they must clearly
-	// document that limitation. In all cases where incompatible or unsupported
-	// filters are specified, implementations MUST add a warning condition to status.
+	// document that limitation. A Route containing a single rule with incompatible
+	// filters must result in the implementation setting the Accepted Condition for
+	// the Route to `status: False`, with a Reason of `UnsupportedValue`. A Route
+	// containing multiple rules with a subset of them containing incompatible
+	// filters must result in the implementation setting the Accepted Contition for
+	// the Route to `status: True`. In all cases where incompatible or unsupported
+	// filters are specified, implementations MUST add the `IncompatibleFilters`
+	// condition to status.
 	//
 	// Support: Core
 	//

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -205,14 +205,9 @@ type HTTPRouteRule struct {
 	// All filters are expected to be compatible with each other except for the
 	// URLRewrite and RequestRedirect filters, which may not be combined. If an
 	// implementation can not support other combinations of filters, they must clearly
-	// document that limitation. A Route containing a single rule with incompatible
-	// filters must result in the implementation setting the Accepted Condition for
-	// the Route to `status: False`, with a Reason of `UnsupportedValue`. A Route
-	// containing multiple rules with a subset of them containing incompatible
-	// filters must result in the implementation setting the Accepted Contition for
-	// the Route to `status: True`. In all cases where incompatible or unsupported
-	// filters are specified, implementations MUST add the `IncompatibleFilters`
-	// condition to status.
+	// document that limitation. In all cases where incompatible or unsupported
+	// filters are specified, implementations MUST add the `PartiallyInvalid` error
+	// condition with status `True` and reason `IncompatibleFilters`.
 	//
 	// Support: Core
 	//

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -205,9 +205,10 @@ type HTTPRouteRule struct {
 	// All filters are expected to be compatible with each other except for the
 	// URLRewrite and RequestRedirect filters, which may not be combined. If an
 	// implementation can not support other combinations of filters, they must clearly
-	// document that limitation. In all cases where incompatible or unsupported
-	// filters are specified, implementations MUST add the `PartiallyInvalid` error
-	// condition with status `True` and reason `IncompatibleFilters`.
+	// document that limitation. In cases where incompatible or unsupported
+	// filters are specified on subset of the rules on a route, implementations
+	// MUST add the `PartiallyInvalid` error condition with status `True` and
+	// reason `IncompatibleFilters`.
 	//
 	// Support: Core
 	//

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -290,10 +290,15 @@ const (
 	RouteReasonBackendNotFound RouteConditionReason = "BackendNotFound"
 
 	// This condition indicates whether configuration present in a Route is
-	// partially invalid. This may occur in the form of a combination of
-	// incompatible filters present in an individual route rule that an
-	// implementation wishes to call out. Controllers should only add this
-	// condition with status true when such an error is present.
+	// partially invalid. This may occur when matches or filters in a routing
+	// rule has any of the following errors:
+	//
+	// * an unsupported value;
+	// * an incompatible set of filters;
+	// * an unpermitted reference in an ExtensionRef filter.
+	//
+	// Controllers should only add this condition with status true when
+	// such an error is present.
 	//
 	// Possible reasons for this condition to be true are:
 	//
@@ -348,7 +353,16 @@ type RouteParentStatus struct {
 	// Gateway, and why.
 	//
 	// A Route MUST be considered "Accepted" if at least one of the Route's
-	// rules is implemented by the Gateway.
+	// rules is implemented by the Gateway. An "Accepted" Route may include some
+	// rules that are invalid (e.g. include unsupported configuration values,
+	// unsupported combinations of Filters, etc.) and MUST have the "PartiallyInvalid"
+	// error condition set to "True" to reflect this.
+	//
+	// If no Route rules are implementable by the Gateway, the "Accepted" condition
+	// MUST be set with status "False". The reason accompanying this condition may
+	// vary depending on the source of the configuration invalidity. For example if
+	// caused by an unsupported value the controller MUST set the "Accepted" condition
+	// with status "False" and reason "UnsupportedValue".
 	//
 	// There are a number of cases where the "Accepted" condition may not be set
 	// due to lack of controller visibility, that includes when:

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -292,6 +292,17 @@ const (
 	// This condition indicates whether incompatible filters are present on
 	// a Route. Controllers should only add this condition with status true
 	// when an incompatible combination is present.
+	//
+	// Possible reasons for this condition to be true are:
+	//
+	// * "IncompatibleFilters"
+	//
+	// This condition is an error condition and should not be set with status
+	// false.
+	//
+	// Controllers may raise this condition with other reasons,
+	// but should prefer to use the reasons listed above to improve
+	// interoperability.
 	RouteConditionIncompatibleFilters RouteConditionType = "IncompatibleFilters"
 
 	// This reason is used with the "IncompatibleFilters" condition when the

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -298,6 +298,8 @@ const (
 	// Possible reasons for this condition to be true are:
 	//
 	// * "IncompatibleFilters"
+	// * "RefNotPermitted"
+	// * "UnsupportedValue"
 	//
 	// This condition is an error condition and should not be set with status
 	// false.

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -289,9 +289,11 @@ const (
 	// Route's rules has a reference to a resource that does not exist.
 	RouteReasonBackendNotFound RouteConditionReason = "BackendNotFound"
 
-	// This condition indicates whether incompatible filters are present on
-	// a Route. Controllers should only add this condition with status true
-	// when an incompatible combination is present.
+	// This condition indicates whether configuration present in a Route is
+	// partially invalid. This may occur in the form of a combination of
+	// incompatible filters present in an individual route rule that an
+	// implementation wishes to call out. Controllers should only add this
+	// condition with status true when such an error is present.
 	//
 	// Possible reasons for this condition to be true are:
 	//
@@ -303,10 +305,11 @@ const (
 	// Controllers may raise this condition with other reasons,
 	// but should prefer to use the reasons listed above to improve
 	// interoperability.
-	RouteConditionIncompatibleFilters RouteConditionType = "IncompatibleFilters"
+	RouteConditionPartiallyInvalid RouteConditionType = "PartiallyInvalid"
 
-	// This reason is used with the "IncompatibleFilters" condition when the
-	// condition is true.
+	// This reason is used with the "PartiallyInvalid" condition when the
+	// there are incompatible filters present on a route rule (for example if
+	// the URLRewrite and RequestRedirect are both present on an HTTPRoute).
 	RouteReasonIncompatibleFilters RouteConditionReason = "IncompatibleFilters"
 )
 

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -288,6 +288,15 @@ const (
 	// This reason is used with the "ResolvedRefs" condition when one of the
 	// Route's rules has a reference to a resource that does not exist.
 	RouteReasonBackendNotFound RouteConditionReason = "BackendNotFound"
+
+	// This condition indicates whether incompatible filters are present on
+	// a Route. Controllers should only add this condition with status true
+	// when an incompatible combination is present.
+	RouteConditionIncompatibleFilters RouteConditionType = "IncompatibleFilters"
+
+	// This reason is used with the "IncompatibleFilters" condition when the
+	// condition is true.
+	RouteReasonIncompatibleFilters RouteConditionReason = "IncompatibleFilters"
 )
 
 // RouteParentStatus describes the status of a route with respect to an

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -1281,11 +1281,21 @@ spec:
                         to indicate whether the route has been accepted or rejected
                         by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
                         if at least one of the Route's rules is implemented by the
-                        Gateway. \n There are a number of cases where the \"Accepted\"
-                        condition may not be set due to lack of controller visibility,
-                        that includes when: \n * The Route refers to a non-existent
-                        parent. * The Route is of a type that the controller does
-                        not support. * The Route is in a namespace the controller
+                        Gateway. An \"Accepted\" Route may include some rules that
+                        are invalid (e.g. include unsupported configuration values,
+                        unsupported combinations of Filters, etc.) and MUST have the
+                        \"PartiallyInvalid\" error condition set to \"True\" to reflect
+                        this. \n If no Route rules are implementable by the Gateway,
+                        the \"Accepted\" condition MUST be set with status \"False\".
+                        The reason accompanying this condition may vary depending
+                        on the source of the configuration invalidity. For example
+                        if caused by an unsupported value the controller MUST set
+                        the \"Accepted\" condition with status \"False\" and reason
+                        \"UnsupportedValue\". \n There are a number of cases where
+                        the \"Accepted\" condition may not be set due to lack of controller
+                        visibility, that includes when: \n * The Route refers to a
+                        non-existent parent. * The Route is of a type that the controller
+                        does not support. * The Route is in a namespace the controller
                         does not have access to."
                       items:
                         description: "Condition contains details for one aspect of

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -943,10 +943,10 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. In all cases where incompatible
-                        or unsupported filters are specified, implementations MUST
-                        add the `PartiallyInvalid` error condition with status `True`
-                        and reason `IncompatibleFilters`. \n Support: Core"
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified on subset of the rules on a route, implementations
+                        MUST add the `PartiallyInvalid` error condition with status
+                        `True` and reason `IncompatibleFilters`. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -2866,10 +2866,10 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. In all cases where incompatible
-                        or unsupported filters are specified, implementations MUST
-                        add the `PartiallyInvalid` error condition with status `True`
-                        and reason `IncompatibleFilters`. \n Support: Core"
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified on subset of the rules on a route, implementations
+                        MUST add the `PartiallyInvalid` error condition with status
+                        `True` and reason `IncompatibleFilters`. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -943,9 +943,16 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. In all cases where incompatible
+                        document that limitation. A Route containing a single rule
+                        with incompatible filters must result in the implementation
+                        setting the Accepted Condition for the Route to `status: False`,
+                        with a Reason of `UnsupportedValue`. A Route containing multiple
+                        rules with a subset of them containing incompatible filters
+                        must result in the implementation setting the Accepted Contition
+                        for the Route to `status: True`. In all cases where incompatible
                         or unsupported filters are specified, implementations MUST
-                        add a warning condition to status. \n Support: Core"
+                        add the `IncompatibleFilters` condition to status. \n Support:
+                        Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -2865,9 +2872,16 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. In all cases where incompatible
+                        document that limitation. A Route containing a single rule
+                        with incompatible filters must result in the implementation
+                        setting the Accepted Condition for the Route to `status: False`,
+                        with a Reason of `UnsupportedValue`. A Route containing multiple
+                        rules with a subset of them containing incompatible filters
+                        must result in the implementation setting the Accepted Contition
+                        for the Route to `status: True`. In all cases where incompatible
                         or unsupported filters are specified, implementations MUST
-                        add a warning condition to status. \n Support: Core"
+                        add the `IncompatibleFilters` condition to status. \n Support:
+                        Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -943,16 +943,10 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. A Route containing a single rule
-                        with incompatible filters must result in the implementation
-                        setting the Accepted Condition for the Route to `status: False`,
-                        with a Reason of `UnsupportedValue`. A Route containing multiple
-                        rules with a subset of them containing incompatible filters
-                        must result in the implementation setting the Accepted Contition
-                        for the Route to `status: True`. In all cases where incompatible
+                        document that limitation. In all cases where incompatible
                         or unsupported filters are specified, implementations MUST
-                        add the `IncompatibleFilters` condition to status. \n Support:
-                        Core"
+                        add the `PartiallyInvalid` error condition with status `True`
+                        and reason `IncompatibleFilters`. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -2872,16 +2866,10 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. A Route containing a single rule
-                        with incompatible filters must result in the implementation
-                        setting the Accepted Condition for the Route to `status: False`,
-                        with a Reason of `UnsupportedValue`. A Route containing multiple
-                        rules with a subset of them containing incompatible filters
-                        must result in the implementation setting the Accepted Contition
-                        for the Route to `status: True`. In all cases where incompatible
+                        document that limitation. In all cases where incompatible
                         or unsupported filters are specified, implementations MUST
-                        add the `IncompatibleFilters` condition to status. \n Support:
-                        Core"
+                        add the `PartiallyInvalid` error condition with status `True`
+                        and reason `IncompatibleFilters`. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -1732,11 +1732,21 @@ spec:
                         to indicate whether the route has been accepted or rejected
                         by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
                         if at least one of the Route's rules is implemented by the
-                        Gateway. \n There are a number of cases where the \"Accepted\"
-                        condition may not be set due to lack of controller visibility,
-                        that includes when: \n * The Route refers to a non-existent
-                        parent. * The Route is of a type that the controller does
-                        not support. * The Route is in a namespace the controller
+                        Gateway. An \"Accepted\" Route may include some rules that
+                        are invalid (e.g. include unsupported configuration values,
+                        unsupported combinations of Filters, etc.) and MUST have the
+                        \"PartiallyInvalid\" error condition set to \"True\" to reflect
+                        this. \n If no Route rules are implementable by the Gateway,
+                        the \"Accepted\" condition MUST be set with status \"False\".
+                        The reason accompanying this condition may vary depending
+                        on the source of the configuration invalidity. For example
+                        if caused by an unsupported value the controller MUST set
+                        the \"Accepted\" condition with status \"False\" and reason
+                        \"UnsupportedValue\". \n There are a number of cases where
+                        the \"Accepted\" condition may not be set due to lack of controller
+                        visibility, that includes when: \n * The Route refers to a
+                        non-existent parent. * The Route is of a type that the controller
+                        does not support. * The Route is in a namespace the controller
                         does not have access to."
                       items:
                         description: "Condition contains details for one aspect of
@@ -3655,11 +3665,21 @@ spec:
                         to indicate whether the route has been accepted or rejected
                         by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
                         if at least one of the Route's rules is implemented by the
-                        Gateway. \n There are a number of cases where the \"Accepted\"
-                        condition may not be set due to lack of controller visibility,
-                        that includes when: \n * The Route refers to a non-existent
-                        parent. * The Route is of a type that the controller does
-                        not support. * The Route is in a namespace the controller
+                        Gateway. An \"Accepted\" Route may include some rules that
+                        are invalid (e.g. include unsupported configuration values,
+                        unsupported combinations of Filters, etc.) and MUST have the
+                        \"PartiallyInvalid\" error condition set to \"True\" to reflect
+                        this. \n If no Route rules are implementable by the Gateway,
+                        the \"Accepted\" condition MUST be set with status \"False\".
+                        The reason accompanying this condition may vary depending
+                        on the source of the configuration invalidity. For example
+                        if caused by an unsupported value the controller MUST set
+                        the \"Accepted\" condition with status \"False\" and reason
+                        \"UnsupportedValue\". \n There are a number of cases where
+                        the \"Accepted\" condition may not be set due to lack of controller
+                        visibility, that includes when: \n * The Route refers to a
+                        non-existent parent. * The Route is of a type that the controller
+                        does not support. * The Route is in a namespace the controller
                         does not have access to."
                       items:
                         description: "Condition contains details for one aspect of

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -306,11 +306,21 @@ spec:
                         to indicate whether the route has been accepted or rejected
                         by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
                         if at least one of the Route's rules is implemented by the
-                        Gateway. \n There are a number of cases where the \"Accepted\"
-                        condition may not be set due to lack of controller visibility,
-                        that includes when: \n * The Route refers to a non-existent
-                        parent. * The Route is of a type that the controller does
-                        not support. * The Route is in a namespace the controller
+                        Gateway. An \"Accepted\" Route may include some rules that
+                        are invalid (e.g. include unsupported configuration values,
+                        unsupported combinations of Filters, etc.) and MUST have the
+                        \"PartiallyInvalid\" error condition set to \"True\" to reflect
+                        this. \n If no Route rules are implementable by the Gateway,
+                        the \"Accepted\" condition MUST be set with status \"False\".
+                        The reason accompanying this condition may vary depending
+                        on the source of the configuration invalidity. For example
+                        if caused by an unsupported value the controller MUST set
+                        the \"Accepted\" condition with status \"False\" and reason
+                        \"UnsupportedValue\". \n There are a number of cases where
+                        the \"Accepted\" condition may not be set due to lack of controller
+                        visibility, that includes when: \n * The Route refers to a
+                        non-existent parent. * The Route is of a type that the controller
+                        does not support. * The Route is in a namespace the controller
                         does not have access to."
                       items:
                         description: "Condition contains details for one aspect of

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -355,11 +355,21 @@ spec:
                         to indicate whether the route has been accepted or rejected
                         by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
                         if at least one of the Route's rules is implemented by the
-                        Gateway. \n There are a number of cases where the \"Accepted\"
-                        condition may not be set due to lack of controller visibility,
-                        that includes when: \n * The Route refers to a non-existent
-                        parent. * The Route is of a type that the controller does
-                        not support. * The Route is in a namespace the controller
+                        Gateway. An \"Accepted\" Route may include some rules that
+                        are invalid (e.g. include unsupported configuration values,
+                        unsupported combinations of Filters, etc.) and MUST have the
+                        \"PartiallyInvalid\" error condition set to \"True\" to reflect
+                        this. \n If no Route rules are implementable by the Gateway,
+                        the \"Accepted\" condition MUST be set with status \"False\".
+                        The reason accompanying this condition may vary depending
+                        on the source of the configuration invalidity. For example
+                        if caused by an unsupported value the controller MUST set
+                        the \"Accepted\" condition with status \"False\" and reason
+                        \"UnsupportedValue\". \n There are a number of cases where
+                        the \"Accepted\" condition may not be set due to lack of controller
+                        visibility, that includes when: \n * The Route refers to a
+                        non-existent parent. * The Route is of a type that the controller
+                        does not support. * The Route is in a namespace the controller
                         does not have access to."
                       items:
                         description: "Condition contains details for one aspect of

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -306,11 +306,21 @@ spec:
                         to indicate whether the route has been accepted or rejected
                         by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
                         if at least one of the Route's rules is implemented by the
-                        Gateway. \n There are a number of cases where the \"Accepted\"
-                        condition may not be set due to lack of controller visibility,
-                        that includes when: \n * The Route refers to a non-existent
-                        parent. * The Route is of a type that the controller does
-                        not support. * The Route is in a namespace the controller
+                        Gateway. An \"Accepted\" Route may include some rules that
+                        are invalid (e.g. include unsupported configuration values,
+                        unsupported combinations of Filters, etc.) and MUST have the
+                        \"PartiallyInvalid\" error condition set to \"True\" to reflect
+                        this. \n If no Route rules are implementable by the Gateway,
+                        the \"Accepted\" condition MUST be set with status \"False\".
+                        The reason accompanying this condition may vary depending
+                        on the source of the configuration invalidity. For example
+                        if caused by an unsupported value the controller MUST set
+                        the \"Accepted\" condition with status \"False\" and reason
+                        \"UnsupportedValue\". \n There are a number of cases where
+                        the \"Accepted\" condition may not be set due to lack of controller
+                        visibility, that includes when: \n * The Route refers to a
+                        non-existent parent. * The Route is of a type that the controller
+                        does not support. * The Route is in a namespace the controller
                         does not have access to."
                       items:
                         description: "Condition contains details for one aspect of

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -1706,11 +1706,21 @@ spec:
                         to indicate whether the route has been accepted or rejected
                         by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
                         if at least one of the Route's rules is implemented by the
-                        Gateway. \n There are a number of cases where the \"Accepted\"
-                        condition may not be set due to lack of controller visibility,
-                        that includes when: \n * The Route refers to a non-existent
-                        parent. * The Route is of a type that the controller does
-                        not support. * The Route is in a namespace the controller
+                        Gateway. An \"Accepted\" Route may include some rules that
+                        are invalid (e.g. include unsupported configuration values,
+                        unsupported combinations of Filters, etc.) and MUST have the
+                        \"PartiallyInvalid\" error condition set to \"True\" to reflect
+                        this. \n If no Route rules are implementable by the Gateway,
+                        the \"Accepted\" condition MUST be set with status \"False\".
+                        The reason accompanying this condition may vary depending
+                        on the source of the configuration invalidity. For example
+                        if caused by an unsupported value the controller MUST set
+                        the \"Accepted\" condition with status \"False\" and reason
+                        \"UnsupportedValue\". \n There are a number of cases where
+                        the \"Accepted\" condition may not be set due to lack of controller
+                        visibility, that includes when: \n * The Route refers to a
+                        non-existent parent. * The Route is of a type that the controller
+                        does not support. * The Route is in a namespace the controller
                         does not have access to."
                       items:
                         description: "Condition contains details for one aspect of
@@ -3575,11 +3585,21 @@ spec:
                         to indicate whether the route has been accepted or rejected
                         by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
                         if at least one of the Route's rules is implemented by the
-                        Gateway. \n There are a number of cases where the \"Accepted\"
-                        condition may not be set due to lack of controller visibility,
-                        that includes when: \n * The Route refers to a non-existent
-                        parent. * The Route is of a type that the controller does
-                        not support. * The Route is in a namespace the controller
+                        Gateway. An \"Accepted\" Route may include some rules that
+                        are invalid (e.g. include unsupported configuration values,
+                        unsupported combinations of Filters, etc.) and MUST have the
+                        \"PartiallyInvalid\" error condition set to \"True\" to reflect
+                        this. \n If no Route rules are implementable by the Gateway,
+                        the \"Accepted\" condition MUST be set with status \"False\".
+                        The reason accompanying this condition may vary depending
+                        on the source of the configuration invalidity. For example
+                        if caused by an unsupported value the controller MUST set
+                        the \"Accepted\" condition with status \"False\" and reason
+                        \"UnsupportedValue\". \n There are a number of cases where
+                        the \"Accepted\" condition may not be set due to lack of controller
+                        visibility, that includes when: \n * The Route refers to a
+                        non-existent parent. * The Route is of a type that the controller
+                        does not support. * The Route is in a namespace the controller
                         does not have access to."
                       items:
                         description: "Condition contains details for one aspect of

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -917,9 +917,16 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. In all cases where incompatible
+                        document that limitation. A Route containing a single rule
+                        with incompatible filters must result in the implementation
+                        setting the Accepted Condition for the Route to `status: False`,
+                        with a Reason of `UnsupportedValue`. A Route containing multiple
+                        rules with a subset of them containing incompatible filters
+                        must result in the implementation setting the Accepted Contition
+                        for the Route to `status: True`. In all cases where incompatible
                         or unsupported filters are specified, implementations MUST
-                        add a warning condition to status. \n Support: Core"
+                        add the `IncompatibleFilters` condition to status. \n Support:
+                        Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -2785,9 +2792,16 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. In all cases where incompatible
+                        document that limitation. A Route containing a single rule
+                        with incompatible filters must result in the implementation
+                        setting the Accepted Condition for the Route to `status: False`,
+                        with a Reason of `UnsupportedValue`. A Route containing multiple
+                        rules with a subset of them containing incompatible filters
+                        must result in the implementation setting the Accepted Contition
+                        for the Route to `status: True`. In all cases where incompatible
                         or unsupported filters are specified, implementations MUST
-                        add a warning condition to status. \n Support: Core"
+                        add the `IncompatibleFilters` condition to status. \n Support:
+                        Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -917,10 +917,10 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. In all cases where incompatible
-                        or unsupported filters are specified, implementations MUST
-                        add the `PartiallyInvalid` error condition with status `True`
-                        and reason `IncompatibleFilters`. \n Support: Core"
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified on subset of the rules on a route, implementations
+                        MUST add the `PartiallyInvalid` error condition with status
+                        `True` and reason `IncompatibleFilters`. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -2786,10 +2786,10 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. In all cases where incompatible
-                        or unsupported filters are specified, implementations MUST
-                        add the `PartiallyInvalid` error condition with status `True`
-                        and reason `IncompatibleFilters`. \n Support: Core"
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified on subset of the rules on a route, implementations
+                        MUST add the `PartiallyInvalid` error condition with status
+                        `True` and reason `IncompatibleFilters`. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -917,16 +917,10 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. A Route containing a single rule
-                        with incompatible filters must result in the implementation
-                        setting the Accepted Condition for the Route to `status: False`,
-                        with a Reason of `UnsupportedValue`. A Route containing multiple
-                        rules with a subset of them containing incompatible filters
-                        must result in the implementation setting the Accepted Contition
-                        for the Route to `status: True`. In all cases where incompatible
+                        document that limitation. In all cases where incompatible
                         or unsupported filters are specified, implementations MUST
-                        add the `IncompatibleFilters` condition to status. \n Support:
-                        Core"
+                        add the `PartiallyInvalid` error condition with status `True`
+                        and reason `IncompatibleFilters`. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -2792,16 +2786,10 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. A Route containing a single rule
-                        with incompatible filters must result in the implementation
-                        setting the Accepted Condition for the Route to `status: False`,
-                        with a Reason of `UnsupportedValue`. A Route containing multiple
-                        rules with a subset of them containing incompatible filters
-                        must result in the implementation setting the Accepted Contition
-                        for the Route to `status: True`. In all cases where incompatible
+                        document that limitation. In all cases where incompatible
                         or unsupported filters are specified, implementations MUST
-                        add the `IncompatibleFilters` condition to status. \n Support:
-                        Core"
+                        add the `PartiallyInvalid` error condition with status `True`
+                        and reason `IncompatibleFilters`. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.

--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -130,8 +130,14 @@ implementation-specific conformance.
 All filters are expected to be compatible with each other except for the
 URLRewrite and RequestRedirect filters, which may not be combined. If an
 implementation can not support other combinations of filters, they must clearly
-document that limitation. In all cases where incompatible or unsupported
-filters are specified, implementations MUST add a warning condition to status.
+document that limitation. A Route containing a single rule with incompatible
+filters must result in the implementation setting the Accepted Condition for
+the Route to `status: False`, with a Reason of `UnsupportedValue`. A Route
+containing multiple rules with a subset of them containing incompatible
+filters must result in the implementation setting the Accepted Contition for
+the Route to `status: True`. In all cases where incompatible or unsupported
+filters are specified, implementations MUST add the `IncompatibleFilters`
+condition to status.
 
 #### BackendRefs (optional)
 

--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -130,14 +130,9 @@ implementation-specific conformance.
 All filters are expected to be compatible with each other except for the
 URLRewrite and RequestRedirect filters, which may not be combined. If an
 implementation can not support other combinations of filters, they must clearly
-document that limitation. A Route containing a single rule with incompatible
-filters must result in the implementation setting the Accepted Condition for
-the Route to `status: False`, with a Reason of `UnsupportedValue`. A Route
-containing multiple rules with a subset of them containing incompatible
-filters must result in the implementation setting the Accepted Contition for
-the Route to `status: True`. In all cases where incompatible or unsupported
-filters are specified, implementations MUST add the `IncompatibleFilters`
-condition to status.
+document that limitation. In all cases where incompatible or unsupported
+filters are specified, implementations MUST add the `PartiallyInvalid` error
+condition with status `True` and reason `IncompatibleFilters`.
 
 #### BackendRefs (optional)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
~~Fixes documentation on HTTPRoute filters for when incompatible filters are present.~~

Adds PartiallyInvalid Route condition with one example Reason, "IncompatibleFilters"

This condition can be used in cases where cases where some configuration is valid but some is not (so Accepted=True, but not everything is valid/supported)

**Which issue(s) this PR fixes**:
Fixes #1521
Fixes #1696 

**Does this PR introduce a user-facing change?**:
```release-note
Add PartiallyInvalid Route condition to reflect Route status that is partially unsupported or invalid for an implementation.
```
