### PR TITLE
Remove -f to use default value for docker build job fix

### DIFF
--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -67,7 +67,6 @@ fi
 # And, we add an extra version tag - either :latest or semver.
 # The buildx integrate build and push in one line.
 docker buildx build \
-    -f Dockerfile \
     -t ${REGISTRY}/admission-server:${GIT_TAG} \
     -t ${REGISTRY}/admission-server:${VERSION_TAG} \
     --build-arg "COMMIT=${COMMIT}" \


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Build job failed, not sure what compatibility problem for this, after changed and tested successful now in local:
<img width="1515" alt="image" src="https://user-images.githubusercontent.com/1269496/202344057-177c23b2-4b93-41a2-8c13-6bf292bf4f65.png">

