### PR TITLE
Add buildx support in docker build image

### DIFF
--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -66,6 +66,7 @@ fi
 # Note that an image will *always* be built tagged with the GIT_TAG, so we know when it was built.
 # And, we add an extra version tag - either :latest or semver.
 # The buildx integrate build and push in one line.
+docker buildx create --use
 docker buildx build \
     -t ${REGISTRY}/admission-server:${GIT_TAG} \
     -t ${REGISTRY}/admission-server:${VERSION_TAG} \


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
For my experience, add this command can solve the driver problem of buildx.
<img width="1352" alt="image" src="https://user-images.githubusercontent.com/1269496/203000228-a1c0365e-de38-4823-9ba0-4f0044640948.png">

**Which issue(s) this PR fixes**:
Fixes #1545 

