### PR TITLE
Typo in ReferenceGrant documentation.

### DIFF
--- a/site-src/api-types/referencegrant.md
+++ b/site-src/api-types/referencegrant.md
@@ -63,7 +63,7 @@ metadata:
   namespace: bar
 spec:
   from:
-  - group: networking.gateway.k8s.io
+  - group: gateway.networking.k8s.io
     kind: HTTPRoute
     namespace: foo
   to:


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

<!--
Add one of the following kinds:
-->

**What this PR does / why we need it**:
There is a typo in the documentation for ReferenceGrant. Using the example does not work unless you change networking.gateway.k8s.io -> gateway.networking.k8s.io in the from.group field.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
