### PR TITLE
Update GEP-1364 to Standard implementation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,7 +75,6 @@ nav:
         - geps/gep-1324.md
         - geps/gep-1282.md
       - Implementable:
-        - geps/gep-1364.md
       - Experimental:
         - geps/gep-1323.md
         - geps/gep-1016.md
@@ -83,6 +82,7 @@ nav:
         - geps/gep-726.md
         - geps/gep-713.md
       - Standard:
+        - geps/gep-1364.md
         - geps/gep-922.md
         - geps/gep-917.md
         - geps/gep-851.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
         - geps/gep-1324.md
         - geps/gep-1282.md
       - Implementable:
+        - Nothing
       - Experimental:
         - geps/gep-1323.md
         - geps/gep-1016.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,7 +75,7 @@ nav:
         - geps/gep-1324.md
         - geps/gep-1282.md
       - Implementable:
-        - Nothing
+        - DummyEntry
       - Experimental:
         - geps/gep-1323.md
         - geps/gep-1016.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,8 +74,6 @@ nav:
         - geps/gep-1426.md
         - geps/gep-1324.md
         - geps/gep-1282.md
-      - Implementable:
-        - DummyEntry
       - Experimental:
         - geps/gep-1323.md
         - geps/gep-1016.md

--- a/site-src/geps/gep-1364.md
+++ b/site-src/geps/gep-1364.md
@@ -1,7 +1,7 @@
 # GEP-1364: Status and Conditions Update
 
 * Issue: [#1364](https://github.com/kubernetes-sigs/gateway-api/issues/1364)
-* Status: Implementable
+* Status: Standard
 
 ## TLDR
 

--- a/site-src/geps/gep-1364.md
+++ b/site-src/geps/gep-1364.md
@@ -419,7 +419,7 @@ an Extended condition.
 It will have the following behavior:
 
 * `Ready` is an optional Condition that has Extended support, with conformance
-tests to verify the behvaior.
+tests to verify the behavior.
 * When it's set, the condition indicates that traffic is ready to flow through
 the data plane _immediately_, not at some eventual point in the future.
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/kind gep

**What this PR does / why we need it**:
Updates GEP-1364 (#1364) to implemented in the Standard channel.

Fixes #1364.
