### PR TITLE
feat: conformance tests opt-out option

### DIFF
--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -91,7 +91,7 @@ type ConformanceTestSuite struct {
 	Applier           kubernetes.Applier
 	SupportedFeatures map[SupportedFeature]bool
 	TimeoutConfig     config.TimeoutConfig
-	SkipTests         []string
+	SkipTests         sets.Set[string]
 }
 
 // Options can be used to initialize a ConformanceTestSuite.
@@ -152,7 +152,7 @@ func New(s Options) *ConformanceTestSuite {
 		},
 		SupportedFeatures: s.SupportedFeatures,
 		TimeoutConfig:     s.TimeoutConfig,
-		SkipTests:         s.SkipTests,
+		SkipTests:         sets.New(s.SkipTests...),
 	}
 
 	// apply defaults
@@ -226,7 +226,7 @@ func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) {
 	}
 
 	// check that the test should not be skipped
-	if sets.New(suite.SkipTests...).Has(test.ShortName) {
+	if suite.SkipTests.Has(test.ShortName) {
 		t.Logf("Skipping %s", test.ShortName)
 		return
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

**What this PR does / why we need it**:

A new "SkipTests" field has been added to the conformance test options to opt out of specific tests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1525 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
A new SkipTests field has been added to the conformance test options to opt-out of specific tests.
```
