### PR TITLE
Rework GRPCRoute API docs.

### DIFF
--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -29,9 +29,9 @@ import (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // GRPCRoute provides a way to route gRPC requests. This includes the capability
-// to match requests by hostname, gRPC service, gRPC method, or HTTP/2 header. Filters can be
-// used to specify additional processing steps. Backends specify where matching
-// requests will be routed.
+// to match requests by hostname, gRPC service, gRPC method, or HTTP/2 header.
+// Filters can be used to specify additional processing steps. Backends specify
+// where matching requests will be routed.
 //
 // GRPCRoute falls under extended support within the Gateway API. Within the
 // following specification, the word "MUST" indicates that an implementation
@@ -39,26 +39,22 @@ import (
 // implementation not supporting this route type need not follow the requirement
 // unless explicitly indicated.
 //
-// Virtually all existing gRPC connections happen directly over HTTP/2 without
-// first upgrading from HTTP/1. Nearly no server implementations support the
-// upgrade and next to no clients start with HTTP/1. As such, certain
-// restrictions are placed on implementations that claim support for GRPCRoute.
-//
 // Implementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST
 // accept HTTP/2 connections without an initial upgrade from HTTP/1.1, i.e. via
-// ALPN. If the implementation does not support this, then it MUST set the "Accepted"
-// condition to "False" for the affected listener with a reason of
-// "UnsupportedProtocol".
-// Note that a compliant implementation MAY also accept HTTP/2 connections with an
-// upgrade from HTTP/1.
+// ALPN. If the implementation does not support this, then it MUST set the
+// "Accepted" condition to "False" for the affected listener with a reason of
+// "UnsupportedProtocol".  Implementations MAY also accept HTTP/2 connections
+// with an upgrade from HTTP/1.
 //
 // Implementations supporting `GRPCRoute` with the `HTTP` `ProtocolType` MUST
-// support cleartext HTTP/2 without an initial upgrade from HTTP/1.1. If the
-// implementation does not support this, then it MUST set the "Accepted"
-// condition to "False" for the affected listener with a reason of
-// "UnsupportedProtocol".
-// Note that a compliant implementation MAY also accept HTTP/2 connections with an
-// upgrade from HTTP/1.
+// support HTTP/2 over cleartext TCP (h2c,
+// https://www.rfc-editor.org/rfc/rfc7540#section-3.1) without an initial
+// upgrade from HTTP/1.1, i.e. with prior knowledge
+// (https://www.rfc-editor.org/rfc/rfc7540#section-3.4). If the implementation
+// does not support this, then it MUST set the "Accepted" condition to "False"
+// for the affected listener with a reason of "UnsupportedProtocol".
+// Implementations MAY also accept HTTP/2 connections with an upgrade from
+// HTTP/1, i.e. without prior knowledge.
 //
 // Support: Extended
 type GRPCRoute struct {

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -36,22 +36,19 @@ spec:
           the word \"MUST\" indicates that an implementation supporting GRPCRoute
           must conform to the indicated requirement, but an implementation not supporting
           this route type need not follow the requirement unless explicitly indicated.
-          \n Virtually all existing gRPC connections happen directly over HTTP/2 without
-          first upgrading from HTTP/1. Nearly no server implementations support the
-          upgrade and next to no clients start with HTTP/1. As such, certain restrictions
-          are placed on implementations that claim support for GRPCRoute. \n Implementations
-          supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST accept HTTP/2
-          connections without an initial upgrade from HTTP/1.1, i.e. via ALPN. If
-          the implementation does not support this, then it MUST set the \"Accepted\"
+          \n Implementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType`
+          MUST accept HTTP/2 connections without an initial upgrade from HTTP/1.1,
+          i.e. via ALPN. If the implementation does not support this, then it MUST
+          set the \"Accepted\" condition to \"False\" for the affected listener with
+          a reason of \"UnsupportedProtocol\".  Implementations MAY also accept HTTP/2
+          connections with an upgrade from HTTP/1. \n Implementations supporting `GRPCRoute`
+          with the `HTTP` `ProtocolType` MUST support HTTP/2 over cleartext TCP (h2c,
+          https://www.rfc-editor.org/rfc/rfc7540#section-3.1) without an initial upgrade
+          from HTTP/1.1, i.e. with prior knowledge (https://www.rfc-editor.org/rfc/rfc7540#section-3.4).
+          If the implementation does not support this, then it MUST set the \"Accepted\"
           condition to \"False\" for the affected listener with a reason of \"UnsupportedProtocol\".
-          Note that a compliant implementation MAY also accept HTTP/2 connections
-          with an upgrade from HTTP/1. \n Implementations supporting `GRPCRoute` with
-          the `HTTP` `ProtocolType` MUST support cleartext HTTP/2 without an initial
-          upgrade from HTTP/1.1. If the implementation does not support this, then
-          it MUST set the \"Accepted\" condition to \"False\" for the affected listener
-          with a reason of \"UnsupportedProtocol\". Note that a compliant implementation
-          MAY also accept HTTP/2 connections with an upgrade from HTTP/1. \n Support:
-          Extended"
+          Implementations MAY also accept HTTP/2 connections with an upgrade from
+          HTTP/1, i.e. without prior knowledge. \n Support: Extended"
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation


### PR DESCRIPTION
- Remove rationales
- Be more explicit about h2, h2c, prior knowledge, and ALPN.

**What type of PR is this?**

/kind cleanup


```release-note
NONE
```
