### PR TITLE
Assert observedGeneration is incremented in Status.Conditions.

### DIFF
--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -82,9 +82,7 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			// Sanity check
 			kubernetes.GatewayMustHaveLatestConditions(t, updated)
 
-			if original.Generation == updated.Generation {
-				t.Errorf("Expected generation to change because of spec change - remained at %v", updated.Generation)
-			}
+			require.NotEqual(t, original.Generation, updated.Generation, "generation should change after an update")
 		})
 	},
 }

--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -39,7 +39,7 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 	Manifests:   []string{"tests/gateway-observed-generation-bump.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 
-		gwNN := types.NamespacedName{Name: "observed-generation-bump", Namespace: "gateway-conformance-infra"}
+		gwNN := types.NamespacedName{Name: "gateway-observed-generation-bump", Namespace: "gateway-conformance-infra"}
 
 		t.Run("observedGeneration should increment", func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)

--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -85,14 +85,6 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			if original.Generation == updated.Generation {
 				t.Errorf("Expected generation to change because of spec change - remained at %v", updated.Generation)
 			}
-
-			for _, uc := range updated.Status.Conditions {
-				for _, ec := range original.Status.Conditions {
-					if ec.Type == uc.Type && ec.ObservedGeneration == uc.ObservedGeneration {
-						t.Errorf("Expected status condition %q observedGeneration to change - remained at %v", uc.Type, uc.ObservedGeneration)
-					}
-				}
-			}
 		})
 	},
 }

--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayObservedGenerationBump)
+}
+
+var GatewayObservedGenerationBump = suite.ConformanceTest{
+	ShortName:   "GatewayObservedGenerationBump",
+	Description: "A Gateway in the gateway-conformance-infra namespace should update the observedGeneration in all of it's Status.Conditions after an update to the spec",
+	Manifests:   []string{"tests/gateway-observed-generation-bump.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+
+		gwNN := types.NamespacedName{Name: "observed-generation-bump", Namespace: "gateway-conformance-infra"}
+
+		t.Run("observedGeneration should increment", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+
+			namespaces := []string{"gateway-conformance-infra"}
+			kubernetes.NamespacesMustBeAccepted(t, s.Client, s.TimeoutConfig, namespaces)
+
+			existing := &v1beta1.Gateway{}
+			err := s.Client.Get(ctx, gwNN, existing)
+			require.NoErrorf(t, err, "error getting Gateway: %v", err)
+
+			// Sanity check
+			if kubernetes.ConditionsHaveLatestObservedGeneration(existing, existing.Status.Conditions) {
+				t.Fatal("Not all the condition's observedGeneration were updated")
+			}
+
+			all := v1beta1.NamespacesFromAll
+
+			// mutate the Gateway Spec
+			existing.Spec.Listeners = append(existing.Spec.Listeners, v1beta1.Listener{
+				Name:     "alternate",
+				Port:     80,
+				Protocol: v1beta1.HTTPProtocolType,
+				AllowedRoutes: &v1beta1.AllowedRoutes{
+					Namespaces: &v1beta1.RouteNamespaces{From: &all},
+				},
+			})
+
+			err = s.Client.Update(ctx, existing)
+			require.NoErrorf(t, err, "error updating the Gateway: %v", err)
+
+			// Ensure the generation and observedGeneration sync up
+			kubernetes.NamespacesMustBeAccepted(t, s.Client, s.TimeoutConfig, namespaces)
+
+			updated := &v1beta1.Gateway{}
+			err = s.Client.Get(ctx, gwNN, updated)
+			require.NoErrorf(t, err, "error getting Gateway: %v", err)
+
+			// Sanity check
+			if kubernetes.ConditionsHaveLatestObservedGeneration(updated, updated.Status.Conditions) {
+				t.Fatal("Not all the condition's observedGeneration were updated")
+			}
+
+			if existing.Generation == updated.Generation {
+				t.Errorf("expected generation to change because of spec change - remained at %v", updated.Generation)
+			}
+
+			for _, uc := range updated.Status.Conditions {
+				for _, ec := range existing.Status.Conditions {
+					if ec.Type == uc.Type && ec.ObservedGeneration == uc.ObservedGeneration {
+						t.Errorf("expected status condition %q observedGeneration to change - remained at %v", uc.Type, uc.ObservedGeneration)
+					}
+				}
+			}
+		})
+	},
+}

--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -53,7 +53,7 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			// Sanity check
-			if kubernetes.ConditionsHaveLatestObservedGeneration(existing, existing.Status.Conditions) {
+			if kubernetes.GatewayConditionsHaveLatestObservedGeneration(existing) {
 				t.Fatal("Not all the condition's observedGeneration were updated")
 			}
 
@@ -80,7 +80,7 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			// Sanity check
-			if kubernetes.ConditionsHaveLatestObservedGeneration(updated, updated.Status.Conditions) {
+			if kubernetes.GatewayConditionsHaveLatestObservedGeneration(updated) {
 				t.Fatal("Not all the condition's observedGeneration were updated")
 			}
 

--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -53,9 +53,7 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			// Sanity check
-			if kubernetes.GatewayConditionsHaveLatestObservedGeneration(existing) {
-				t.Fatal("Not all the condition's observedGeneration were updated")
-			}
+			kubernetes.GatewayMustHaveLatestConditions(t, existing)
 
 			all := v1beta1.NamespacesFromAll
 
@@ -80,9 +78,7 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			// Sanity check
-			if kubernetes.GatewayConditionsHaveLatestObservedGeneration(updated) {
-				t.Fatal("Not all the condition's observedGeneration were updated")
-			}
+			kubernetes.GatewayMustHaveLatestConditions(t, updated)
 
 			if existing.Generation == updated.Generation {
 				t.Errorf("Expected generation to change because of spec change - remained at %v", updated.Generation)

--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -42,7 +42,7 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 		gwNN := types.NamespacedName{Name: "observed-generation-bump", Namespace: "gateway-conformance-infra"}
 
 		t.Run("observedGeneration should increment", func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
 			namespaces := []string{"gateway-conformance-infra"}

--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -62,7 +62,7 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			// mutate the Gateway Spec
 			existing.Spec.Listeners = append(existing.Spec.Listeners, v1beta1.Listener{
 				Name:     "alternate",
-				Port:     80,
+				Port:     8080,
 				Protocol: v1beta1.HTTPProtocolType,
 				AllowedRoutes: &v1beta1.AllowedRoutes{
 					Namespaces: &v1beta1.RouteNamespaces{From: &all},

--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -85,13 +85,13 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			}
 
 			if existing.Generation == updated.Generation {
-				t.Errorf("expected generation to change because of spec change - remained at %v", updated.Generation)
+				t.Errorf("Expected generation to change because of spec change - remained at %v", updated.Generation)
 			}
 
 			for _, uc := range updated.Status.Conditions {
 				for _, ec := range existing.Status.Conditions {
 					if ec.Type == uc.Type && ec.ObservedGeneration == uc.ObservedGeneration {
-						t.Errorf("expected status condition %q observedGeneration to change - remained at %v", uc.Type, uc.ObservedGeneration)
+						t.Errorf("Expected status condition %q observedGeneration to change - remained at %v", uc.Type, uc.ObservedGeneration)
 					}
 				}
 			}

--- a/conformance/tests/gateway-observed-generation-bump.yaml
+++ b/conformance/tests/gateway-observed-generation-bump.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: gateway-observed-generation-bump
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/conformance/tests/gatewayclass-observed-generation-bump.go
+++ b/conformance/tests/gatewayclass-observed-generation-bump.go
@@ -52,7 +52,7 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error getting GatewayClass: %v", err)
 
 			// Sanity check
-			if kubernetes.ConditionsHaveLatestObservedGeneration(existing, existing.Status.Conditions) {
+			if kubernetes.GatewayClassConditionsHaveLatestObservedGeneration(existing) {
 				t.Fatal("Not all the condition's observedGeneration were updated")
 			}
 
@@ -70,7 +70,7 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error getting GatewayClass: %v", err)
 
 			// Sanity check
-			if kubernetes.ConditionsHaveLatestObservedGeneration(updated, updated.Status.Conditions) {
+			if kubernetes.GatewayClassConditionsHaveLatestObservedGeneration(updated) {
 				t.Fatal("Not all the condition's observedGeneration were updated")
 			}
 

--- a/conformance/tests/gatewayclass-observed-generation-bump.go
+++ b/conformance/tests/gatewayclass-observed-generation-bump.go
@@ -42,7 +42,7 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 		gwc := types.NamespacedName{Name: "gatewayclass-observed-generation-bump"}
 
 		t.Run("observedGeneration should increment", func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
 			kubernetes.GWCMustBeAccepted(t, s.Client, s.TimeoutConfig, gwc.Name)

--- a/conformance/tests/gatewayclass-observed-generation-bump.go
+++ b/conformance/tests/gatewayclass-observed-generation-bump.go
@@ -52,9 +52,7 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error getting GatewayClass: %v", err)
 
 			// Sanity check
-			if kubernetes.GatewayClassConditionsHaveLatestObservedGeneration(existing) {
-				t.Fatal("Not all the condition's observedGeneration were updated")
-			}
+			kubernetes.GatewayClassMustHaveLatestConditions(t, existing)
 
 			desc := "new"
 			existing.Spec.Description = &desc
@@ -70,9 +68,7 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error getting GatewayClass: %v", err)
 
 			// Sanity check
-			if kubernetes.GatewayClassConditionsHaveLatestObservedGeneration(updated) {
-				t.Fatal("Not all the condition's observedGeneration were updated")
-			}
+			kubernetes.GatewayClassMustHaveLatestConditions(t, updated)
 
 			if existing.Generation == updated.Generation {
 				t.Errorf("Expected generation to change because of spec change - remained at %v", updated.Generation)

--- a/conformance/tests/gatewayclass-observed-generation-bump.go
+++ b/conformance/tests/gatewayclass-observed-generation-bump.go
@@ -75,13 +75,13 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 			}
 
 			if existing.Generation == updated.Generation {
-				t.Errorf("expected generation to change because of spec change - remained at %v", updated.Generation)
+				t.Errorf("Expected generation to change because of spec change - remained at %v", updated.Generation)
 			}
 
 			for _, uc := range updated.Status.Conditions {
 				for _, ec := range existing.Status.Conditions {
 					if ec.Type == uc.Type && ec.ObservedGeneration == uc.ObservedGeneration {
-						t.Errorf("expected status condition %q observedGeneration to change - remained at %v", uc.Type, uc.ObservedGeneration)
+						t.Errorf("Expected status condition %q observedGeneration to change - remained at %v", uc.Type, uc.ObservedGeneration)
 					}
 				}
 			}

--- a/conformance/tests/gatewayclass-observed-generation-bump.go
+++ b/conformance/tests/gatewayclass-observed-generation-bump.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayClassObservedGenerationBump)
+}
+
+var GatewayClassObservedGenerationBump = suite.ConformanceTest{
+	ShortName:   "GatewayClassObservedGenerationBump",
+	Description: "A GatewayClass should update the observedGeneration in all of it's Status.Conditions after an update to the spec",
+	Manifests:   []string{"tests/gatewayclass-observed-generation-bump.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+
+		gwc := types.NamespacedName{Name: "gatewayclass-observed-generation-bump"}
+
+		t.Run("observedGeneration should increment", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+
+			kubernetes.GWCMustBeAccepted(t, s.Client, s.TimeoutConfig, gwc.Name)
+
+			existing := &v1beta1.GatewayClass{}
+			err := s.Client.Get(ctx, gwc, existing)
+			require.NoErrorf(t, err, "error getting GatewayClass: %v", err)
+
+			// Sanity check
+			if kubernetes.ConditionsHaveLatestObservedGeneration(existing, existing.Status.Conditions) {
+				t.Fatal("Not all the condition's observedGeneration were updated")
+			}
+
+			desc := "new"
+			existing.Spec.Description = &desc
+
+			err = s.Client.Update(ctx, existing)
+			require.NoErrorf(t, err, "error updating the GatewayClass: %v", err)
+
+			// Ensure the generation and observedGeneration sync up
+			kubernetes.GWCMustBeAccepted(t, s.Client, s.TimeoutConfig, gwc.Name)
+
+			updated := &v1beta1.GatewayClass{}
+			err = s.Client.Get(ctx, gwc, updated)
+			require.NoErrorf(t, err, "error getting GatewayClass: %v", err)
+
+			// Sanity check
+			if kubernetes.ConditionsHaveLatestObservedGeneration(updated, updated.Status.Conditions) {
+				t.Fatal("Not all the condition's observedGeneration were updated")
+			}
+
+			if existing.Generation == updated.Generation {
+				t.Errorf("expected generation to change because of spec change - remained at %v", updated.Generation)
+			}
+
+			for _, uc := range updated.Status.Conditions {
+				for _, ec := range existing.Status.Conditions {
+					if ec.Type == uc.Type && ec.ObservedGeneration == uc.ObservedGeneration {
+						t.Errorf("expected status condition %q observedGeneration to change - remained at %v", uc.Type, uc.ObservedGeneration)
+					}
+				}
+			}
+		})
+	},
+}

--- a/conformance/tests/gatewayclass-observed-generation-bump.go
+++ b/conformance/tests/gatewayclass-observed-generation-bump.go
@@ -35,6 +35,7 @@ func init() {
 
 var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 	ShortName:   "GatewayClassObservedGenerationBump",
+	Features:    []suite.SupportedFeature{suite.SupportGatewayClassObservedGenerationBump},
 	Description: "A GatewayClass should update the observedGeneration in all of it's Status.Conditions after an update to the spec",
 	Manifests:   []string{"tests/gatewayclass-observed-generation-bump.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {

--- a/conformance/tests/gatewayclass-observed-generation-bump.go
+++ b/conformance/tests/gatewayclass-observed-generation-bump.go
@@ -70,9 +70,7 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 			// Sanity check
 			kubernetes.GatewayClassMustHaveLatestConditions(t, updated)
 
-			if original.Generation == updated.Generation {
-				t.Errorf("Expected generation to change because of spec change - remained at %v", updated.Generation)
-			}
+			require.NotEqual(t, original.Generation, updated.Generation, "generation should change after an update")
 		})
 	},
 }

--- a/conformance/tests/gatewayclass-observed-generation-bump.go
+++ b/conformance/tests/gatewayclass-observed-generation-bump.go
@@ -38,7 +38,6 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 	Description: "A GatewayClass should update the observedGeneration in all of it's Status.Conditions after an update to the spec",
 	Manifests:   []string{"tests/gatewayclass-observed-generation-bump.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
-
 		gwc := types.NamespacedName{Name: "gatewayclass-observed-generation-bump"}
 
 		t.Run("observedGeneration should increment", func(t *testing.T) {
@@ -73,14 +72,6 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 
 			if original.Generation == updated.Generation {
 				t.Errorf("Expected generation to change because of spec change - remained at %v", updated.Generation)
-			}
-
-			for _, uc := range updated.Status.Conditions {
-				for _, ec := range original.Status.Conditions {
-					if ec.Type == uc.Type && ec.ObservedGeneration == uc.ObservedGeneration {
-						t.Errorf("Expected status condition %q observedGeneration to change - remained at %v", uc.Type, uc.ObservedGeneration)
-					}
-				}
 			}
 		})
 	},

--- a/conformance/tests/gatewayclass-observed-generation-bump.yaml
+++ b/conformance/tests/gatewayclass-observed-generation-bump.yaml
@@ -1,0 +1,7 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: gatewayclass-observed-generation-bump
+spec:
+  controllerName: "{GATEWAY_CONTROLLER_NAME}"
+  description: "old"

--- a/conformance/tests/httproute-observed-generation-bump.go
+++ b/conformance/tests/httproute-observed-generation-bump.go
@@ -81,20 +81,6 @@ var HTTPRouteObservedGenerationBump = suite.ConformanceTest{
 			if original.Generation == updated.Generation {
 				t.Errorf("Expected generation to change because of spec change - remained at %v", updated.Generation)
 			}
-
-			for _, up := range updated.Status.Parents {
-				originalRef := parentStatusForRef(original.Status.Parents, up.ParentRef)
-				if originalRef == nil {
-					t.Fatalf("Observed unexpected new parent ref %#v", up.ParentRef)
-				}
-				for _, uc := range up.Conditions {
-					for _, oc := range originalRef.Conditions {
-						if oc.Type == uc.Type && oc.ObservedGeneration == uc.ObservedGeneration {
-							t.Errorf("Expected status condition %q observedGeneration to change - remained at %v", uc.Type, uc.ObservedGeneration)
-						}
-					}
-				}
-			}
 		})
 	},
 }

--- a/conformance/tests/httproute-observed-generation-bump.go
+++ b/conformance/tests/httproute-observed-generation-bump.go
@@ -77,9 +77,7 @@ var HTTPRouteObservedGenerationBump = suite.ConformanceTest{
 			// Sanity check
 			kubernetes.HTTPRouteMustHaveLatestConditions(t, updated)
 
-			if original.Generation == updated.Generation {
-				t.Errorf("Expected generation to change because of spec change - remained at %v", updated.Generation)
-			}
+			require.NotEqual(t, original.Generation, updated.Generation, "generation should change after an update")
 		})
 	},
 }

--- a/conformance/tests/httproute-observed-generation-bump.go
+++ b/conformance/tests/httproute-observed-generation-bump.go
@@ -88,8 +88,7 @@ var HTTPRouteObservedGenerationBump = suite.ConformanceTest{
 			for _, up := range updated.Status.Parents {
 				existing := parentStatusForRef(existing.Status.Parents, up.ParentRef)
 				if existing == nil {
-					t.Logf("Observed unexpected new parent ref %#v", up.ParentRef)
-					continue
+					t.Fatalf("Observed unexpected new parent ref %#v", up.ParentRef)
 				}
 				for _, uc := range up.Conditions {
 					for _, ec := range existing.Conditions {

--- a/conformance/tests/httproute-observed-generation-bump.go
+++ b/conformance/tests/httproute-observed-generation-bump.go
@@ -51,7 +51,7 @@ var HTTPRouteObservedGenerationBump = suite.ConformanceTest{
 		}
 
 		t.Run("observedGeneration should increment", func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
 			namespaces := []string{"gateway-conformance-infra"}

--- a/conformance/tests/httproute-observed-generation-bump.go
+++ b/conformance/tests/httproute-observed-generation-bump.go
@@ -66,7 +66,7 @@ var HTTPRouteObservedGenerationBump = suite.ConformanceTest{
 				t.Fatal("Not all the condition's observedGeneration were updated")
 			}
 
-			existing.Spec.Rules[0].BackendRefs[0].Name = "infra-backend-new"
+			existing.Spec.Rules[0].BackendRefs[0].Name = "infra-backend-v2"
 			err = s.Client.Update(ctx, existing)
 			require.NoErrorf(t, err, "error updating the HTTPRoute: %v", err)
 

--- a/conformance/tests/httproute-observed-generation-bump.go
+++ b/conformance/tests/httproute-observed-generation-bump.go
@@ -62,9 +62,7 @@ var HTTPRouteObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error getting HTTPRoute: %v", err)
 
 			// Sanity check
-			if kubernetes.HTTPRouteConditionsHaveLatestObservedGeneration(existing) {
-				t.Fatal("Not all the condition's observedGeneration were updated")
-			}
+			kubernetes.HTTPRouteMustHaveLatestConditions(t, existing)
 
 			existing.Spec.Rules[0].BackendRefs[0].Name = "infra-backend-v2"
 			err = s.Client.Update(ctx, existing)
@@ -77,9 +75,7 @@ var HTTPRouteObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			// Sanity check
-			if kubernetes.HTTPRouteConditionsHaveLatestObservedGeneration(updated) {
-				t.Fatal("Not all the condition's observedGeneration were updated")
-			}
+			kubernetes.HTTPRouteMustHaveLatestConditions(t, updated)
 
 			if existing.Generation == updated.Generation {
 				t.Errorf("Expected generation to change because of spec change - remained at %v", updated.Generation)

--- a/conformance/tests/httproute-observed-generation-bump.go
+++ b/conformance/tests/httproute-observed-generation-bump.go
@@ -18,7 +18,6 @@ package tests
 
 import (
 	"context"
-	"reflect"
 	"testing"
 	"time"
 
@@ -83,14 +82,4 @@ var HTTPRouteObservedGenerationBump = suite.ConformanceTest{
 			}
 		})
 	},
-}
-
-func parentStatusForRef(statuses []v1beta1.RouteParentStatus, ref v1beta1.ParentReference) *v1beta1.RouteParentStatus {
-	for _, status := range statuses {
-		if reflect.DeepEqual(status.ParentRef, ref) {
-			return &status
-		}
-	}
-	return nil
-
 }

--- a/conformance/tests/httproute-observed-generation-bump.go
+++ b/conformance/tests/httproute-observed-generation-bump.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteObservedGenerationBump)
+}
+
+var HTTPRouteObservedGenerationBump = suite.ConformanceTest{
+	ShortName:   "HTTPRouteObservedGenerationBump",
+	Description: "A HTTPRoute in the gateway-conformance-infra namespace should update the observedGeneration in all of it's Status.Conditions after an update to the spec",
+	Manifests:   []string{"tests/httproute-observed-generation-bump.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+
+		routeNN := types.NamespacedName{Name: "observed-generation-bump", Namespace: "gateway-conformance-infra"}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
+
+		acceptedCondition := metav1.Condition{
+			Type:   string(v1beta1.RouteConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: "", // any reason
+		}
+
+		t.Run("observedGeneration should increment", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+
+			namespaces := []string{"gateway-conformance-infra"}
+			kubernetes.NamespacesMustBeAccepted(t, s.Client, s.TimeoutConfig, namespaces)
+
+			existing := &v1beta1.HTTPRoute{}
+			err := s.Client.Get(ctx, routeNN, existing)
+			require.NoErrorf(t, err, "error getting HTTPRoute: %v", err)
+
+			// Sanity check
+			if kubernetes.HTTPRouteConditionsHaveLatestObservedGeneration(existing) {
+				t.Fatal("Not all the condition's observedGeneration were updated")
+			}
+
+			existing.Spec.Rules[0].BackendRefs[0].Name = "infra-backend-new"
+			err = s.Client.Update(ctx, existing)
+			require.NoErrorf(t, err, "error updating the HTTPRoute: %v", err)
+
+			kubernetes.HTTPRouteMustHaveCondition(t, s.Client, s.TimeoutConfig, routeNN, gwNN, acceptedCondition)
+
+			updated := &v1beta1.HTTPRoute{}
+			err = s.Client.Get(ctx, routeNN, updated)
+			require.NoErrorf(t, err, "error getting Gateway: %v", err)
+
+			// Sanity check
+			if kubernetes.HTTPRouteConditionsHaveLatestObservedGeneration(updated) {
+				t.Fatal("Not all the condition's observedGeneration were updated")
+			}
+
+			if existing.Generation == updated.Generation {
+				t.Errorf("Expected generation to change because of spec change - remained at %v", updated.Generation)
+			}
+
+			for _, up := range updated.Status.Parents {
+				existing := parentStatusForRef(existing.Status.Parents, up.ParentRef)
+				if existing == nil {
+					t.Logf("Observed unexpected new parent ref %#v", up.ParentRef)
+					continue
+				}
+				for _, uc := range up.Conditions {
+					for _, ec := range existing.Conditions {
+						if ec.Type == uc.Type && ec.ObservedGeneration == uc.ObservedGeneration {
+							t.Errorf("Expected status condition %q observedGeneration to change - remained at %v", uc.Type, uc.ObservedGeneration)
+						}
+					}
+				}
+			}
+		})
+	},
+}
+
+func parentStatusForRef(statuses []v1beta1.RouteParentStatus, ref v1beta1.ParentReference) *v1beta1.RouteParentStatus {
+	for _, status := range statuses {
+		if reflect.DeepEqual(status.ParentRef, ref) {
+			return &status
+		}
+	}
+	return nil
+
+}

--- a/conformance/tests/httproute-observed-generation-bump.yaml
+++ b/conformance/tests/httproute-observed-generation-bump.yaml
@@ -8,5 +8,5 @@ spec:
   - name: same-namespace
   rules:
   - backendRefs:
-    - name: infra-backend-old
+    - name: infra-backend-v1
       port: 8080

--- a/conformance/tests/httproute-observed-generation-bump.yaml
+++ b/conformance/tests/httproute-observed-generation-bump.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: observed-generation-bump
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: infra-backend-old
+      port: 8080

--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -50,10 +50,10 @@ type Applier struct {
 	// If empty or nil, ports are not modified.
 	ValidUniqueListenerPorts []v1beta1.PortNumber
 
-	// GatewayClass
+	// GatewayClass will be used as the spec.gatewayClassName when applying Gateway resources
 	GatewayClass string
 
-	// ControllerName
+	// ControllerName will be used as the spec.controllerName when applying GatewayClass resources
 	ControllerName string
 }
 

--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -49,25 +49,31 @@ type Applier struct {
 	// four ValidUniqueListenerPorts.
 	// If empty or nil, ports are not modified.
 	ValidUniqueListenerPorts []v1beta1.PortNumber
+
+	// GatewayClass
+	GatewayClass string
+
+	// ControllerName
+	ControllerName string
 }
 
 // prepareGateway adjusts both listener ports and the gatewayClassName. It
 // returns an index pointing to the next valid listener port.
-func prepareGateway(t *testing.T, uObj *unstructured.Unstructured, gatewayClassName string, validListenerPorts []v1beta1.PortNumber, portIndex int) int {
-	err := unstructured.SetNestedField(uObj.Object, gatewayClassName, "spec", "gatewayClassName")
+func (a Applier) prepareGateway(t *testing.T, uObj *unstructured.Unstructured, portIndex int) int {
+	err := unstructured.SetNestedField(uObj.Object, a.GatewayClass, "spec", "gatewayClassName")
 	require.NoErrorf(t, err, "error setting `spec.gatewayClassName` on %s Gateway resource", uObj.GetName())
 
-	if len(validListenerPorts) > 0 {
+	if len(a.ValidUniqueListenerPorts) > 0 {
 		listeners, _, err := unstructured.NestedSlice(uObj.Object, "spec", "listeners")
 		require.NoErrorf(t, err, "error getting `spec.listeners` on %s Gateway resource", uObj.GetName())
 
 		for i, uListener := range listeners {
-			require.Less(t, portIndex, len(validListenerPorts), "not enough unassigned valid ports for `spec.listeners[%d]` on %s Gateway resource", i, uObj.GetName())
+			require.Less(t, portIndex, len(a.ValidUniqueListenerPorts), "not enough unassigned valid ports for `spec.listeners[%d]` on %s Gateway resource", i, uObj.GetName())
 
 			listener, ok := uListener.(map[string]interface{})
 			require.Truef(t, ok, "unexpected type at `spec.listeners[%d]` on %s Gateway resource", i, uObj.GetName())
 
-			nextPort := validListenerPorts[portIndex]
+			nextPort := a.ValidUniqueListenerPorts[portIndex]
 			err = unstructured.SetNestedField(listener, int64(nextPort), "port")
 			require.NoErrorf(t, err, "error setting `spec.listeners[%d].port` on %s Gateway resource", i, uObj.GetName())
 
@@ -80,6 +86,12 @@ func prepareGateway(t *testing.T, uObj *unstructured.Unstructured, gatewayClassN
 	}
 
 	return portIndex
+}
+
+// prepareGatewayClass adjust the spec.controllerName on the resource
+func (a Applier) prepareGatewayClass(t *testing.T, uObj *unstructured.Unstructured) {
+	err := unstructured.SetNestedField(uObj.Object, a.ControllerName, "spec", "controllerName")
+	require.NoErrorf(t, err, "error setting `spec.controllerName` on %s GatewayClass resource", uObj.GetName())
 }
 
 // prepareNamespace adjusts the Namespace labels.
@@ -104,7 +116,7 @@ func prepareNamespace(t *testing.T, uObj *unstructured.Unstructured, namespaceLa
 
 // prepareResources uses the options from an Applier to tweak resources given by
 // a set of manifests.
-func (a Applier) prepareResources(t *testing.T, decoder *yaml.YAMLOrJSONDecoder, gcName string) ([]unstructured.Unstructured, error) {
+func (a Applier) prepareResources(t *testing.T, decoder *yaml.YAMLOrJSONDecoder) ([]unstructured.Unstructured, error) {
 	var resources []unstructured.Unstructured
 
 	// portIndex is incremented for each listener we see. For a manifest file
@@ -123,8 +135,11 @@ func (a Applier) prepareResources(t *testing.T, decoder *yaml.YAMLOrJSONDecoder,
 			continue
 		}
 
+		if uObj.GetKind() == "GatewayClass" {
+			a.prepareGatewayClass(t, &uObj)
+		}
 		if uObj.GetKind() == "Gateway" {
-			portIndex = prepareGateway(t, &uObj, gcName, a.ValidUniqueListenerPorts, portIndex)
+			portIndex = a.prepareGateway(t, &uObj, portIndex)
 		}
 
 		if uObj.GetKind() == "Namespace" && uObj.GetObjectKind().GroupVersionKind().Group == "" {
@@ -168,13 +183,13 @@ func (a Applier) MustApplyObjectsWithCleanup(t *testing.T, c client.Client, time
 // MustApplyWithCleanup creates or updates Kubernetes resources defined with the
 // provided YAML file and registers a cleanup function for resources it created.
 // Note that this does not remove resources that already existed in the cluster.
-func (a Applier) MustApplyWithCleanup(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, location string, gcName string, cleanup bool) {
+func (a Applier) MustApplyWithCleanup(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, location string, cleanup bool) {
 	data, err := getContentsFromPathOrURL(location, timeoutConfig)
 	require.NoError(t, err)
 
 	decoder := yaml.NewYAMLOrJSONDecoder(data, 4096)
 
-	resources, err := a.prepareResources(t, decoder, gcName)
+	resources, err := a.prepareResources(t, decoder)
 	if err != nil {
 		t.Logf("manifest: %s", data.String())
 		require.NoErrorf(t, err, "error parsing manifest")

--- a/conformance/utils/kubernetes/apply_test.go
+++ b/conformance/utils/kubernetes/apply_test.go
@@ -259,13 +259,38 @@ spec:
 				},
 			},
 		}},
+	}, {
+		name:    "setting the controllerName for a GatewayClass",
+		applier: Applier{},
+		given: `
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind:       GatewayClass
+metadata:
+  name: test
+spec:
+  controllerName: {GATEWAY_CONTROLLER_NAME}
+`,
+		expected: []unstructured.Unstructured{{
+			Object: map[string]interface{}{
+				"apiVersion": "gateway.networking.k8s.io/v1beta1",
+				"kind":       "GatewayClass",
+				"metadata": map[string]interface{}{
+					"name": "test",
+				},
+				"spec": map[string]interface{}{
+					"controllerName": "test-controller",
+				},
+			},
+		}},
 	}}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			decoder := yaml.NewYAMLOrJSONDecoder(strings.NewReader(tc.given), 4096)
 
-			resources, err := tc.applier.prepareResources(t, decoder, "test-class")
+			tc.applier.GatewayClass = "test-class"
+			tc.applier.ControllerName = "test-controller"
+			resources, err := tc.applier.prepareResources(t, decoder)
 
 			require.NoError(t, err, "unexpected error preparing resources")
 			require.EqualValues(t, tc.expected, resources)

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -101,8 +101,7 @@ func GWCMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.Timeo
 func GatewayMustHaveLatestConditions(t *testing.T, gw *v1beta1.Gateway) {
 	t.Helper()
 
-	err := ConditionsHaveLatestObservedGeneration(gw, gw.Status.Conditions)
-	if err != nil {
+	if err := ConditionsHaveLatestObservedGeneration(gw, gw.Status.Conditions); err != nil {
 		t.Fatalf("Gateway %v", err)
 	}
 }
@@ -112,8 +111,7 @@ func GatewayMustHaveLatestConditions(t *testing.T, gw *v1beta1.Gateway) {
 func GatewayClassMustHaveLatestConditions(t *testing.T, gwc *v1beta1.GatewayClass) {
 	t.Helper()
 
-	err := ConditionsHaveLatestObservedGeneration(gwc, gwc.Status.Conditions)
-	if err != nil {
+	if err := ConditionsHaveLatestObservedGeneration(gwc, gwc.Status.Conditions); err != nil {
 		t.Fatalf("GatewayClass %v", err)
 	}
 }
@@ -124,8 +122,7 @@ func HTTPRouteMustHaveLatestConditions(t *testing.T, r *v1beta1.HTTPRoute) {
 	t.Helper()
 
 	for _, parent := range r.Status.Parents {
-		err := ConditionsHaveLatestObservedGeneration(r, parent.Conditions)
-		if err != nil {
+		if err := ConditionsHaveLatestObservedGeneration(r, parent.Conditions); err != nil {
 			t.Fatalf("HTTPRoute(controller=%v, parentRef=%#v) %v", parent.ControllerName, parent, err)
 		}
 	}
@@ -184,7 +181,7 @@ func NamespacesMustBeAccepted(t *testing.T, c client.Client, timeoutConfig confi
 			for _, gw := range gwList.Items {
 				gw := gw
 
-				if err := ConditionsHaveLatestObservedGeneration(&gw, gw.Status.Conditions); err != nil {
+				if err = ConditionsHaveLatestObservedGeneration(&gw, gw.Status.Conditions); err != nil {
 					t.Log(err)
 					return false, nil
 				}

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -140,7 +140,7 @@ func ConditionsHaveLatestObservedGeneration(obj metav1.Object, conditions []meta
 
 	var b strings.Builder
 	fmt.Fprint(&b, "expected observedGeneration to be updated for all conditions")
-	fmt.Fprintf(&b, ", only %d/%d were updated.", len(staleConditions), len(conditions))
+	fmt.Fprintf(&b, ", only %d/%d were updated.", len(conditions)-len(staleConditions), len(conditions))
 	fmt.Fprintf(&b, " stale conditions are: ")
 
 	for i, c := range staleConditions {

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -497,9 +497,9 @@ func HTTPRouteMustHaveCondition(t *testing.T, client client.Client, timeoutConfi
 		parents := route.Status.Parents
 		var conditionFound bool
 		for _, parent := range parents {
-
 			if err := ConditionsHaveLatestObservedGeneration(route, parent.Conditions); err != nil {
-				t.Logf("HTTPRoute(controller=%v,ref=%#v) %v", parent.ControllerName, parent, err)
+
+				t.Logf("HTTPRoute(parentRef=%v) %v", parentRefToString(parent.ParentRef), err)
 				return false, nil
 			}
 
@@ -514,6 +514,13 @@ func HTTPRouteMustHaveCondition(t *testing.T, client client.Client, timeoutConfi
 	})
 
 	require.NoErrorf(t, waitErr, "error waiting for HTTPRoute status to have a Condition matching expectations")
+}
+
+func parentRefToString(p v1beta1.ParentReference) string {
+	if p.Namespace != nil && *p.Namespace != "" {
+		return fmt.Sprintf("%v/%v", p.Namespace, p.Name)
+	}
+	return string(p.Name)
 }
 
 // TODO(mikemorris): this and parentsMatch could possibly be rewritten as a generic function?

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/config"
 )
 
-// GatewayRef is a tiny type for specifying an HTTP Route ParentRef withouthttps://www.cdw.ca/product/apple-airpods-pro-2nd-generation-true-wireless-earphones-with-mic/7171387?pfm=srh
+// GatewayRef is a tiny type for specifying an HTTP Route ParentRef without
 // relying on a specific api version.
 type GatewayRef struct {
 	types.NamespacedName

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -51,6 +51,9 @@ const (
 
 	// This option indicates support for Destination Port matching (extended conformance).
 	SupportRouteDestinationPortMatching SupportedFeature = "RouteDestinationPortMatching"
+
+	// This option indicates GatewayClass will update the observedGeneration in it's conditions when reconciling
+	SupportGatewayClassObservedGenerationBump SupportedFeature = "GatewayClassObservedGenerationBump"
 )
 
 // StandardCoreFeatures are the features that are required to be conformant with

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -145,8 +145,11 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 	t.Logf("Test Setup: Ensuring GatewayClass has been accepted")
 	suite.ControllerName = kubernetes.GWCMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.GatewayClassName)
 
+	suite.Applier.GatewayClass = suite.GatewayClassName
+	suite.Applier.ControllerName = suite.ControllerName
+
 	t.Logf("Test Setup: Applying base manifests")
-	suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, suite.BaseManifests, suite.GatewayClassName, suite.Cleanup)
+	suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, suite.BaseManifests, suite.Cleanup)
 
 	t.Logf("Test Setup: Applying programmatic resources")
 	secret := kubernetes.MustCreateSelfSignedCertSecret(t, "gateway-conformance-web-backend", "certificate", []string{"*"})
@@ -200,7 +203,7 @@ func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) {
 
 	for _, manifestLocation := range test.Manifests {
 		t.Logf("Applying %s", manifestLocation)
-		suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, manifestLocation, suite.GatewayClassName, true)
+		suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, manifestLocation, true)
 	}
 
 	test.Test(t, suite)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/kind api-change

**What this PR does / why we need it**:
This PR ensures Gateway Resources and their conditions update observedGeneration as described in the GEP.

Current it tests
- [x] Gateway
- [x] GatewayClass
- [x] HTTPRoute

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/kubernetes-sigs/gateway-api/issues/1584

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Conformance tests now assert observedGeneration is incremented in Status.Conditions (GatewayClass, Gateway, HTTPRoute)
```
