### PR TITLE
gateway.listeners: make optional

### DIFF
--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -109,7 +109,7 @@ type GatewaySpec struct {
 	//
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MinItems=1
+	// +optional
 	// +kubebuilder:validation:MaxItems=64
 	Listeners []Listener `json:"listeners"`
 

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -438,14 +438,12 @@ spec:
                   - protocol
                   type: object
                 maxItems: 64
-                minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
             required:
             - gatewayClassName
-            - listeners
             type: object
           status:
             default:
@@ -1132,14 +1130,12 @@ spec:
                   - protocol
                   type: object
                 maxItems: 64
-                minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
             required:
             - gatewayClassName
-            - listeners
             type: object
           status:
             default:

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -438,14 +438,12 @@ spec:
                   - protocol
                   type: object
                 maxItems: 64
-                minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
             required:
             - gatewayClassName
-            - listeners
             type: object
           status:
             default:
@@ -1132,14 +1130,12 @@ spec:
                   - protocol
                   type: object
                 maxItems: 64
-                minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
             required:
             - gatewayClassName
-            - listeners
             type: object
           status:
             default:


### PR DESCRIPTION

**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
This changes `listeners` field to be optional (i.e. allow 0 length list).

The motivation here is that a Gateway actually provisions underlying infrastructure. This can take a long time, too, depending on the set.
 It may be useful to initially provision a Gateway with
*zero* listeners, and then later add them.

This PR loosens validation to allow not configuring any listeners, with the expectation that underlying infra would be provisioned, then a user would add specific listeners.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Gateway.Spec.Listeners field is now optional
```
