### PR TITLE
Update types to fix API review feedback

### DIFF
--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -336,10 +336,10 @@ type GRPCMethodMatch struct {
 }
 
 // MethodMatchType specifies the semantics of how gRPC methods and services are compared.
-// Valid MethodMatchType values are:
+// Valid MethodMatchType values, along with their conformance levels, are:
 //
-// * "Exact"
-// * "RegularExpression"
+// * "Exact" - Core
+// * "RegularExpression" - Implementation Specific
 //
 // Exact methods MUST be syntactically valid:
 //
@@ -389,10 +389,11 @@ type GRPCHeaderMatch struct {
 }
 
 // GRPCHeaderMatchType specifies the semantics of how GRPC header values should
-// be compared. Valid GRPCHeaderMatchType values are:
+// be compared. Valid GRPCHeaderMatchType values, along with their conformance
+// levels, are:
 //
-// * "Exact"
-// * "RegularExpression"
+// * "Exact" - Core
+// * "RegularExpression" - Implementation Specific
 //
 // Note that new values may be added to this enum in future releases of the API,
 // implementations MUST ensure that unknown values will not cause a crash.

--- a/apis/v1alpha2/httproute_types.go
+++ b/apis/v1alpha2/httproute_types.go
@@ -56,11 +56,11 @@ type HTTPRouteSpec = v1beta1.HTTPRouteSpec
 type HTTPRouteRule = v1beta1.HTTPRouteRule
 
 // PathMatchType specifies the semantics of how HTTP paths should be compared.
-// Valid PathMatchType values are:
+// Valid PathMatchType values, along with their conformance level, are:
 //
-// * "Exact"
-// * "PathPrefix"
-// * "RegularExpression"
+// * "Exact" - Core
+// * "PathPrefix" - Core
+// * "RegularExpression" - Implementation Specific
 //
 // PathPrefix and Exact paths must be syntactically valid:
 //
@@ -83,10 +83,10 @@ type PathMatchType = v1beta1.PathMatchType
 type HTTPPathMatch = v1beta1.HTTPPathMatch
 
 // HeaderMatchType specifies the semantics of how HTTP header values should be
-// compared. Valid HeaderMatchType values are:
+// compared. Valid HeaderMatchType values, along with their conformance levels, are:
 //
-// * "Exact"
-// * "RegularExpression"
+// * "Exact" - Core
+// * "RegularExpression" - Implementation Specific
 //
 // Note that values may be added to this enum, implementations
 // must ensure that unknown values will not cause a crash.
@@ -124,10 +124,11 @@ type HTTPHeaderName = v1beta1.HTTPHeaderName
 type HTTPHeaderMatch = v1beta1.HTTPHeaderMatch
 
 // QueryParamMatchType specifies the semantics of how HTTP query parameter
-// values should be compared. Valid QueryParamMatchType values are:
+// values should be compared. Valid QueryParamMatchType values, along with their
+// conformance levels, are:
 //
-// * "Exact"
-// * "RegularExpression"
+// * "Exact" - Core
+// * "RegularExpression" - Implementation Specific
 //
 // Note that values may be added to this enum, implementations
 // must ensure that unknown values will not cause a crash.

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -494,7 +494,7 @@ type GatewayStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	// +kubebuilder:validation:MaxItems=8
-	// +kubebuilder:default={{type: "Accepted", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
+	// +kubebuilder:default={{type: "Accepted", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"},{type: "Programmed", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// Listeners provide status for each unique listener port defined in the Spec.

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -242,11 +242,11 @@ type HTTPRouteRule struct {
 }
 
 // PathMatchType specifies the semantics of how HTTP paths should be compared.
-// Valid PathMatchType values are:
+// Valid PathMatchType values, along with their support levels, are:
 //
-// * "Exact"
-// * "PathPrefix"
-// * "RegularExpression"
+// * "Exact" - Core
+// * "PathPrefix" - Core
+// * "RegularExpression" - Implementation Specific
 //
 // PathPrefix and Exact paths must be syntactically valid:
 //
@@ -311,10 +311,10 @@ type HTTPPathMatch struct {
 }
 
 // HeaderMatchType specifies the semantics of how HTTP header values should be
-// compared. Valid HeaderMatchType values are:
+// compared. Valid HeaderMatchType values, along with their conformance levels, are:
 //
-// * "Exact"
-// * "RegularExpression"
+// * "Exact" - Core
+// * "RegularExpression" - Implementation Specific
 //
 // Note that values may be added to this enum, implementations
 // must ensure that unknown values will not cause a crash.
@@ -392,10 +392,11 @@ type HTTPHeaderMatch struct {
 }
 
 // QueryParamMatchType specifies the semantics of how HTTP query parameter
-// values should be compared. Valid QueryParamMatchType values are:
+// values should be compared. Valid QueryParamMatchType values, along with their
+// conformance levels, are:
 //
-// * "Exact"
-// * "RegularExpression"
+// * "Exact" - Core
+// * "RegularExpression" - Implementation Specific
 //
 // Note that values may be added to this enum, implementations
 // must ensure that unknown values will not cause a crash.

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -492,6 +492,11 @@ spec:
                   reason: Pending
                   status: Unknown
                   type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
                 description: "Conditions describe the current conditions of the Gateway.
                   \n Implementations should prefer to express Gateway conditions using
                   the `GatewayConditionType` and `GatewayConditionReason` constants
@@ -1188,6 +1193,11 @@ spec:
                   reason: Pending
                   status: Unknown
                   type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
                 description: "Conditions describe the current conditions of the Gateway.
                   \n Implementations should prefer to express Gateway conditions using
                   the `GatewayConditionType` and `GatewayConditionReason` constants

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -492,6 +492,11 @@ spec:
                   reason: Pending
                   status: Unknown
                   type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
                 description: "Conditions describe the current conditions of the Gateway.
                   \n Implementations should prefer to express Gateway conditions using
                   the `GatewayConditionType` and `GatewayConditionReason` constants
@@ -1188,6 +1193,11 @@ spec:
                   reason: Pending
                   status: Unknown
                   type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
                 description: "Conditions describe the current conditions of the Gateway.
                   \n Implementations should prefer to express Gateway conditions using
                   the `GatewayConditionType` and `GatewayConditionReason` constants


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
- Adds the `Programmed` Condition to the Gateway default condition list. (https://github.com/kubernetes-sigs/gateway-api/pull/1538#discussion_r1024619384)
- Adds conformance information to all the type selectors that have values like `Exact` and `RegularExpression` to ensure that `RegularExpression` is clearly `ImplementationSpecific` conformance. (#1581)

**Which issue(s) this PR fixes**:
Fixes #1581 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
- The Gateway default conditions list now includes the Programmed condition.
- `RegularExpression` type selectors have been clarified to all be `ImplementationSpecific` conformance.
```
