### PR TITLE
docs: add v0.6.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,119 @@
 - [v0.1.0-rc2](#v010-rc2)
 - [v0.1.0-rc1](#v010-rc1)
 
+# v0.6.0
+
+## Major Changes
+
+### ReferenceGrant moves to `v1beta1`, ReferencePolicy removed
+
+With more implementations now supporting ReferenceGrant (and more conformance coverage of the resource), we've moved ReferenceGrant to `v1beta1` in this release. **Note** that moving to beta also moves the object to the Standard channel (it was Experimental previously).
+
+We've also removed the already-deprecated ReferencePolicy resource, so please move over to the shiny new ReferenceGrant, which has all the same features.
+
+- Promotes ReferenceGrant to the v1beta1 API and the standard release channel
+  (#1455, @nathancoleman)
+- ReferencePolicy has been removed from the API in favor of ReferenceGrant.
+  (#1406, @robscott)
+
+### Introduce GRPCRoute
+
+The `GRPCRoute` resource has been introduced in order to simplify the routing of GRPC requests.
+Its design is described in [GEP-1016](https://gateway-api.sigs.k8s.io/geps/gep-1016/).
+As it is a new resource, it is introduced in the experimental channel.
+
+Thanks to @gnossen for pushing this ahead.
+
+- Introduce GRPCRoute resource. (#1115, @gnossen)
+
+### Status updates
+
+As described in [GEP-1364](https://gateway-api.sigs.k8s.io/geps/gep-1364/), status conditions have been updated within the Gateway resource to make it more consistent with the rest of the API. These changes, along with some other status changes, are detailed below.
+
+Gateway:
+
+* New `Accepted` and `Programmed` conditions introduced.
+* `Scheduled` condition deprecated.
+* Core Conditions now `Accepted` and `Programmed`.
+* Moves to Extended: `Ready`.
+
+Gateway Listener:
+
+* New `Accepted` and `Programmed` conditions introduced.
+* `Detached` condition deprecated.
+* Core Conditions now `Accepted`, `Programmed`, `ResolvedRefs`, and `Conflicted`.
+* Moves to Extended: `Ready`.
+
+All Resources:
+
+* The `Accepted` Condition now has a `Pending` reason, which is the default until
+  the condition is updated by a controller.
+
+Route resources:
+
+* The `Accepted` Condition now has a `NoMatchingParent` reason, to be set on routes
+  when no matching parent can be found.
+
+The purpose of these changes is to make the status flows more consistent across objects, and to provide a clear pattern for new objects as we evolve the API.
+
+> **Note**: This change will require updates for implementations to be able to pass conformance tests. Implementations may choose to publish both new and old conditions, or only new conditions.
+
+- Adds `Accepted` and deprecates `Detached` Listener conditions and reasons (#1446, @mikemorris)
+- Adds `Accepted` and deprecates `Scheduled` Gateway conditions and reasons (#1447, @mikemorris)
+- Adds `Pending` reason for use with all `Accepted` conditions throughout the API (#1453, @youngnick)
+- Adds `Programmed` Gateway and Listener conditions, moves `Ready` to extended
+  conformance (#1499, @LCaparelli)
+- Add `RouteReasonNoMatchingParent` reason for `Accepted` condition. (#1516, @pmalek)
+
+## Other Changes by type
+
+### Deprecations
+
+- GatewayClass, Gateway, and HTTPRoute are now only supported with the v1beta1
+  version of the API. The v1alpha2 API versions of these resources will be fully
+  removed in a future release. Additionally, v1alpha2 is marked as deprecated
+  everywhere. (#1348 and #1405, @robscott)
+
+### API Changes
+
+- A new field `responseHeaderModifier` is added to `.spec.rules.filters`, which
+  allows for modification of HTTP response headers (#1373, @aryan9600)
+- Display the Programmed condition instead of the Ready condition in the output
+- HTTPRoute: Validating webhook now ensures that Exact and Prefix path match
+  values can now only include valid path values per RFC-3986. (RegularExpression
+  path matches are not affected by this change). (#1599, @robscott)
+- `RegularExpression` type selectors have been clarified to all be
+  `ImplementationSpecific` conformance. (#1604, @youngnick)
+
+### Documentation
+
+- Clarify that BackendObjectReference's Port field specifies a service port, not
+  a target port, for Kubernetes Service backends. (#1332, @Miciah)
+- HTTPRequestHeaderFilter and HTTPResponseHeaderFilter forbid configuring
+  multiple actions for the same header. (#1497, @rainest)
+- Changes "custom" conformance level to "implementation-specific" (#1436,
+  @LCaparelli)
+- Clarification that changes to ReferenceGrants MUST be reconciled (#1429,
+  @robscott)
+
+### Conformance Tests
+
+- ExemptFeatures have been merged into SupportedFeatures providing implementations
+  a uniform way to specify the features they support.
+  (#1507, @robscott) (#1394, @gyohuangxin)
+- To be conformant with the API, if there is no ReferenceGrant that grants a
+  listener to reference a secret in another namespace, the
+  ListenerConditionReason for the condition ResolvedRefs must be set to
+  RefNotPermitted instead of InvalidCertificateRef. (#1305, @mlavacca)
+- A new test has been added to cover HTTP Redirects (#1556, @LiorLieberman)
+- Fix Gateway reference in HTTPRouteInvalidParentRefNotMatchingListenerPort
+  (#1591, @sayboras)
+
+### Developer Notes
+
+- Deprecated `v1alpha2` Go types are now aliases to their `v1beta1` versions
+  (#1390, @howardjohn)
+
 # v0.6.0-rc2
 
 We expect this to be our final release candidate before launching v0.6.0. This


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds the `CHANGELOG` entry for the `v0.6.0` release.

**Which issue(s) this PR fixes**:

Fixes #1613 