### PR TITLE
conformance: do not use (and mutate) DefaultClient

### DIFF
--- a/conformance/utils/roundtripper/roundtripper.go
+++ b/conformance/utils/roundtripper/roundtripper.go
@@ -88,7 +88,7 @@ type DefaultRoundTripper struct {
 // is received.
 func (d *DefaultRoundTripper) CaptureRoundTrip(request Request) (*CapturedRequest, *CapturedResponse, error) {
 	cReq := &CapturedRequest{}
-	client := http.DefaultClient
+	client := &http.Client{}
 
 	if request.UnfollowRedirect {
 		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {


### PR DESCRIPTION
This is a global variable. Since we import the tests and then run other tests, this broke our other tests which depend on DefaultClient.

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
