### PR TITLE
cleanup: remove ioutil for new goversion

### DIFF
--- a/conformance/utils/roundtripper/roundtripper.go
+++ b/conformance/utils/roundtripper/roundtripper.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -143,7 +143,7 @@ func (d *DefaultRoundTripper) CaptureRoundTrip(request Request) (*CapturedReques
 		fmt.Printf("Received Response:\n%s\n\n", formatDump(dump, "< "))
 	}
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 
 	// we cannot assume the response is JSON
 	if resp.Header.Get("Content-type") == "application/json" {

--- a/pkg/admission/server.go
+++ b/pkg/admission/server.go
@@ -19,7 +19,7 @@ package admission
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	admission "k8s.io/api/admission/v1"
@@ -131,7 +131,7 @@ func ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.StatusBadRequest)
 		return
 	}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		log500(w, err)
 		return


### PR DESCRIPTION
/kind cleanup 

The package `io/ioutil` has been deprecated from g0 1.16: https://go.dev/doc/go1.16#ioutil