### PR TITLE
Doc: SecretObjectReference use "Secret" as Kind

### DIFF
--- a/apis/v1beta1/object_reference_types.go
+++ b/apis/v1beta1/object_reference_types.go
@@ -53,7 +53,7 @@ type SecretObjectReference struct {
 	// +kubebuilder:default=""
 	Group *Group `json:"group"`
 
-	// Kind is kind of the referent. For example "HTTPRoute" or "Service".
+	// Kind is kind of the referent. For example "Secret".
 	//
 	// +optional
 	// +kubebuilder:default=Secret

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -366,7 +366,7 @@ spec:
                               kind:
                                 default: Secret
                                 description: Kind is kind of the referent. For example
-                                  "HTTPRoute" or "Service".
+                                  "Secret".
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1063,7 +1063,7 @@ spec:
                               kind:
                                 default: Secret
                                 description: Kind is kind of the referent. For example
-                                  "HTTPRoute" or "Service".
+                                  "Secret".
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -366,7 +366,7 @@ spec:
                               kind:
                                 default: Secret
                                 description: Kind is kind of the referent. For example
-                                  "HTTPRoute" or "Service".
+                                  "Secret".
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1063,7 +1063,7 @@ spec:
                               kind:
                                 default: Secret
                                 description: Kind is kind of the referent. For example
-                                  "HTTPRoute" or "Service".
+                                  "Secret".
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$


### PR DESCRIPTION
According to the doc:
> A single CertificateRef to a Kubernetes Secret has “Core” support. Implementations MAY choose to support attaching multiple certificates to a Listener, but this behavior is implementation-specific.

and the line below
```
+kubebuilder:default=Secret
```
It looks like Secret should be the default implementation of the SecretObjectReference. And `HTTPRoute` or `Service` is certainly not a secret store.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation

