### PR TITLE
conformance: Add additional path matching edge cases

### DIFF
--- a/conformance/tests/httproute-matching.go
+++ b/conformance/tests/httproute-matching.go
@@ -64,6 +64,19 @@ var HTTPRouteMatching = suite.ConformanceTest{
 			Request:   http.Request{Path: "/", Headers: map[string]string{"Version": "two"}},
 			Backend:   "infra-backend-v2",
 			Namespace: ns,
+		}, {
+			Request:   http.Request{Path: "/v2/"},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}, {
+			// Not a path segment prefix so should not match /v2.
+			Request:   http.Request{Path: "/v2example"},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Path: "/foo/v2/example"},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
 		}}
 
 		for i := range testCases {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Adds some test cases (from Contour e2e tests) for edge cases in path matching.

In consolidating this set of test cases: https://github.com/projectcontour/contour/blob/76521b7dbc562815083ec207abef686bc02614ce/test/e2e/gateway/path_condition_match_test.go#L69-L84

We found we can eliminate all but a few that do not have overlap with the upstream conformance tests, so added tests for the following cases:
- trailing slash on path prefix should match
- path prefixes are path segment matches not string prefix matches
- test to ensure a path containing the prefix is not matched

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
