### PR TITLE
Add `all-features` flag to add ability to enable all supported feature conformance tests.

### DIFF
--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -54,11 +54,12 @@ func TestConformance(t *testing.T) {
 		*flags.GatewayClassName, *flags.CleanupBaseResources, *flags.ShowDebug, *flags.SupportedFeatures, *flags.ExemptFeatures)
 
 	cSuite := suite.New(suite.Options{
-		Client:               client,
-		GatewayClassName:     *flags.GatewayClassName,
-		Debug:                *flags.ShowDebug,
-		CleanupBaseResources: *flags.CleanupBaseResources,
-		SupportedFeatures:    supportedFeatures,
+		Client:                     client,
+		GatewayClassName:           *flags.GatewayClassName,
+		Debug:                      *flags.ShowDebug,
+		CleanupBaseResources:       *flags.CleanupBaseResources,
+		SupportedFeatures:          supportedFeatures,
+		EnableAllSupportedFeatures: *flags.EnableAllSupportedFeatures,
 	})
 	cSuite.Setup(t)
 	cSuite.Run(t, tests.ConformanceTests)

--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -51,8 +51,8 @@ func TestConformance(t *testing.T) {
 		supportedFeatures.Delete(feature)
 	}
 
-	t.Logf("Running conformance tests with %s GatewayClass\n cleanup: %t\n debug: %t\n supported features: [%v]\n exempt features: [%v]",
-		*flags.GatewayClassName, *flags.CleanupBaseResources, *flags.ShowDebug, *flags.SupportedFeatures, *flags.ExemptFeatures)
+	t.Logf("Running conformance tests with %s GatewayClass\n cleanup: %t\n debug: %t\n enable all features: %t \n supported features: [%v]\n exempt features: [%v]",
+		*flags.GatewayClassName, *flags.CleanupBaseResources, *flags.ShowDebug, *flags.EnableAllSupportedFeatures, *flags.SupportedFeatures, *flags.ExemptFeatures)
 
 	cSuite := suite.New(suite.Options{
 		Client:                     client,

--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/flags"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -47,7 +48,7 @@ func TestConformance(t *testing.T) {
 	supportedFeatures := parseSupportedFeatures(*flags.SupportedFeatures)
 	exemptFeatures := parseSupportedFeatures(*flags.ExemptFeatures)
 	for feature := range exemptFeatures {
-		supportedFeatures[feature] = false
+		supportedFeatures.Delete(feature)
 	}
 
 	t.Logf("Running conformance tests with %s GatewayClass\n cleanup: %t\n debug: %t\n supported features: [%v]\n exempt features: [%v]",
@@ -67,10 +68,10 @@ func TestConformance(t *testing.T) {
 
 // parseSupportedFeatures parses flag arguments and converts the string to
 // map[suite.SupportedFeature]bool
-func parseSupportedFeatures(f string) map[suite.SupportedFeature]bool {
-	res := map[suite.SupportedFeature]bool{}
+func parseSupportedFeatures(f string) sets.Set[suite.SupportedFeature] {
+	res := sets.Set[suite.SupportedFeature]{}
 	for _, value := range strings.Split(f, ",") {
-		res[suite.SupportedFeature(value)] = true
+		res.Insert(suite.SupportedFeature(value))
 	}
 	return res
 }

--- a/conformance/utils/flags/flags.go
+++ b/conformance/utils/flags/flags.go
@@ -24,9 +24,10 @@ import (
 )
 
 var (
-	GatewayClassName     = flag.String("gateway-class", "gateway-conformance", "Name of GatewayClass to use for tests")
-	ShowDebug            = flag.Bool("debug", false, "Whether to print debug logs")
-	CleanupBaseResources = flag.Bool("cleanup-base-resources", true, "Whether to cleanup base test resources after the run")
-	SupportedFeatures    = flag.String("supported-features", "", "Supported features included in conformance tests suites")
-	ExemptFeatures       = flag.String("exempt-features", "", "Exempt Features excluded from conformance tests suites")
+	GatewayClassName            = flag.String("gateway-class", "gateway-conformance", "Name of GatewayClass to use for tests")
+	ShowDebug                   = flag.Bool("debug", false, "Whether to print debug logs")
+	CleanupBaseResources        = flag.Bool("cleanup-base-resources", true, "Whether to cleanup base test resources after the run")
+	SupportedFeatures           = flag.String("supported-features", "", "Supported features included in conformance tests suites")
+	ExemptFeatures              = flag.String("exempt-features", "", "Exempt Features excluded from conformance tests suites")
+	EnableAllSupportedFeatures  = flag.Bool("all-features", false, "Whether to enable all supported feature conformance tests")
 )

--- a/conformance/utils/flags/flags.go
+++ b/conformance/utils/flags/flags.go
@@ -29,5 +29,5 @@ var (
 	CleanupBaseResources       = flag.Bool("cleanup-base-resources", true, "Whether to cleanup base test resources after the run")
 	SupportedFeatures          = flag.String("supported-features", "", "Supported features included in conformance tests suites")
 	ExemptFeatures             = flag.String("exempt-features", "", "Exempt Features excluded from conformance tests suites")
-	EnableAllSupportedFeatures = flag.Bool("all-features", false, "Whether to enable all supported feature conformance tests")
+	EnableAllSupportedFeatures = flag.Bool("all-features", false, "Whether to enable all supported features for conformance tests")
 )

--- a/conformance/utils/flags/flags.go
+++ b/conformance/utils/flags/flags.go
@@ -24,10 +24,10 @@ import (
 )
 
 var (
-	GatewayClassName            = flag.String("gateway-class", "gateway-conformance", "Name of GatewayClass to use for tests")
-	ShowDebug                   = flag.Bool("debug", false, "Whether to print debug logs")
-	CleanupBaseResources        = flag.Bool("cleanup-base-resources", true, "Whether to cleanup base test resources after the run")
-	SupportedFeatures           = flag.String("supported-features", "", "Supported features included in conformance tests suites")
-	ExemptFeatures              = flag.String("exempt-features", "", "Exempt Features excluded from conformance tests suites")
-	EnableAllSupportedFeatures  = flag.Bool("all-features", false, "Whether to enable all supported feature conformance tests")
+	GatewayClassName           = flag.String("gateway-class", "gateway-conformance", "Name of GatewayClass to use for tests")
+	ShowDebug                  = flag.Bool("debug", false, "Whether to print debug logs")
+	CleanupBaseResources       = flag.Bool("cleanup-base-resources", true, "Whether to cleanup base test resources after the run")
+	SupportedFeatures          = flag.String("supported-features", "", "Supported features included in conformance tests suites")
+	ExemptFeatures             = flag.String("exempt-features", "", "Exempt Features excluded from conformance tests suites")
+	EnableAllSupportedFeatures = flag.Bool("all-features", false, "Whether to enable all supported feature conformance tests")
 )

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -243,7 +243,7 @@ func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) {
 	// Check that all features exercised by the test have been opted into by
 	// the suite.
 	for _, feature := range test.Features {
-		if suite.SupportedFeatures.Has(feature) {
+		if !suite.SupportedFeatures.Has(feature) {
 			t.Skipf("Skipping %s: suite does not support %s", test.ShortName, feature)
 		}
 	}

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -136,6 +136,9 @@ type Options struct {
 	SupportedFeatures          map[SupportedFeature]bool
 	EnableAllSupportedFeatures bool
 	TimeoutConfig              config.TimeoutConfig
+	// SkipTests contains all the tests not to be run and can be used to opt out
+	// of specific tests
+	SkipTests []string
 }
 
 // New returns a new ConformanceTestSuite.

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -80,6 +80,9 @@ var StandardCoreFeatures = map[SupportedFeature]bool{
 
 // AllFeatures contains all the supported features and can be used to run all
 // conformance tests with `all-features` flag.
+//
+// Note that the AllFeatures must in sync with defined features when the
+// feature constants change.
 var AllFeatures = map[SupportedFeature]bool{
 	SupportReferenceGrant:                     true,
 	SupportTLSRoute:                           true,

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -113,19 +113,19 @@ type ConformanceTestSuite struct {
 
 // Options can be used to initialize a ConformanceTestSuite.
 type Options struct {
-	Client                     client.Client
-	GatewayClassName           string
-	Debug                      bool
-	RoundTripper               roundtripper.RoundTripper
-	BaseManifests              string
-	NamespaceLabels            map[string]string
+	Client           client.Client
+	GatewayClassName string
+	Debug            bool
+	RoundTripper     roundtripper.RoundTripper
+	BaseManifests    string
+	NamespaceLabels  map[string]string
 	// ValidUniqueListenerPorts maps each listener port of each Gateway in the
 	// manifests to a valid, unique port. There must be as many
 	// ValidUniqueListenerPorts as there are listeners in the set of manifests.
 	// For example, given two Gateways, each with 2 listeners, there should be
 	// four ValidUniqueListenerPorts.
 	// If empty or nil, ports are not modified.
-	ValidUniqueListenerPorts   []v1beta1.PortNumber
+	ValidUniqueListenerPorts []v1beta1.PortNumber
 
 	// CleanupBaseResources indicates whether or not the base test
 	// resources such as Gateways should be cleaned up after the run.

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -81,18 +81,18 @@ var StandardCoreFeatures = map[SupportedFeature]bool{
 // AllFeatures contains all the supported features and can be used to run all
 // conformance tests with `all-features` flag.
 var AllFeatures = map[SupportedFeature]bool{
-	SupportReferenceGrant: true,
-	SupportTLSRoute: true,
-	SupportHTTPRouteQueryParamMatching: true,
-	SupportHTTPRouteMethodMatching: true,
-	SupportHTTPResponseHeaderModification: true,
-	SupportRouteDestinationPortMatching: true,
+	SupportReferenceGrant:                     true,
+	SupportTLSRoute:                           true,
+	SupportHTTPRouteQueryParamMatching:        true,
+	SupportHTTPRouteMethodMatching:            true,
+	SupportHTTPResponseHeaderModification:     true,
+	SupportRouteDestinationPortMatching:       true,
 	SupportGatewayClassObservedGenerationBump: true,
-	SupportHTTPRoutePortRedirect: true,
-	SupportHTTPRouteSchemeRedirect: true,
-	SupportHTTPRoutePathRedirect: true,
-	SupportHTTPRouteHostRewrite: true,
-	SupportHTTPRoutePathRewrite: true,
+	SupportHTTPRoutePortRedirect:              true,
+	SupportHTTPRouteSchemeRedirect:            true,
+	SupportHTTPRoutePathRedirect:              true,
+	SupportHTTPRouteHostRewrite:               true,
+	SupportHTTPRoutePathRewrite:               true,
 }
 
 // ConformanceTestSuite defines the test suite used to run Gateway API

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -78,6 +78,23 @@ var StandardCoreFeatures = map[SupportedFeature]bool{
 	SupportReferenceGrant: true,
 }
 
+// AllFeatures contains all the supported features and can be used to run all
+// conformance tests with `all-features` flag.
+var AllFeatures = map[SupportedFeature]bool{
+	SupportReferenceGrant: true,
+	SupportTLSRoute: true,
+	SupportHTTPRouteQueryParamMatching: true,
+	SupportHTTPRouteMethodMatching: true,
+	SupportHTTPResponseHeaderModification: true,
+	SupportRouteDestinationPortMatching: true,
+	SupportGatewayClassObservedGenerationBump: true,
+	SupportHTTPRoutePortRedirect: true,
+	SupportHTTPRouteSchemeRedirect: true,
+	SupportHTTPRoutePathRedirect: true,
+	SupportHTTPRouteHostRewrite: true,
+	SupportHTTPRoutePathRewrite: true,
+}
+
 // ConformanceTestSuite defines the test suite used to run Gateway API
 // conformance tests.
 type ConformanceTestSuite struct {
@@ -96,28 +113,26 @@ type ConformanceTestSuite struct {
 
 // Options can be used to initialize a ConformanceTestSuite.
 type Options struct {
-	Client           client.Client
-	GatewayClassName string
-	Debug            bool
-	RoundTripper     roundtripper.RoundTripper
-	BaseManifests    string
-	NamespaceLabels  map[string]string
+	Client                     client.Client
+	GatewayClassName           string
+	Debug                      bool
+	RoundTripper               roundtripper.RoundTripper
+	BaseManifests              string
+	NamespaceLabels            map[string]string
 	// ValidUniqueListenerPorts maps each listener port of each Gateway in the
 	// manifests to a valid, unique port. There must be as many
 	// ValidUniqueListenerPorts as there are listeners in the set of manifests.
 	// For example, given two Gateways, each with 2 listeners, there should be
 	// four ValidUniqueListenerPorts.
 	// If empty or nil, ports are not modified.
-	ValidUniqueListenerPorts []v1beta1.PortNumber
+	ValidUniqueListenerPorts   []v1beta1.PortNumber
 
 	// CleanupBaseResources indicates whether or not the base test
 	// resources such as Gateways should be cleaned up after the run.
-	CleanupBaseResources bool
-	SupportedFeatures    map[SupportedFeature]bool
-	TimeoutConfig        config.TimeoutConfig
-	// SkipTests contains all the tests not to be run and can be used to opt out
-	// of specific tests
-	SkipTests []string
+	CleanupBaseResources       bool
+	SupportedFeatures          map[SupportedFeature]bool
+	EnableAllSupportedFeatures bool
+	TimeoutConfig              config.TimeoutConfig
 }
 
 // New returns a new ConformanceTestSuite.
@@ -129,7 +144,9 @@ func New(s Options) *ConformanceTestSuite {
 		roundTripper = &roundtripper.DefaultRoundTripper{Debug: s.Debug, TimeoutConfig: s.TimeoutConfig}
 	}
 
-	if s.SupportedFeatures == nil {
+	if s.EnableAllSupportedFeatures == true {
+		s.SupportedFeatures = AllFeatures
+	} else if s.SupportedFeatures == nil {
 		s.SupportedFeatures = StandardCoreFeatures
 	} else {
 		for feature, val := range StandardCoreFeatures {

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -156,9 +156,7 @@ func New(s Options) *ConformanceTestSuite {
 		s.SupportedFeatures = StandardCoreFeatures
 	} else {
 		for feature := range StandardCoreFeatures {
-			if !s.SupportedFeatures.Has(feature) {
-				s.SupportedFeatures.Insert(feature)
-			}
+			s.SupportedFeatures.Insert(feature)
 		}
 	}
 

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -74,29 +74,29 @@ const (
 
 // StandardCoreFeatures are the features that are required to be conformant with
 // the Core API features that are part of the Standard release channel.
-var StandardCoreFeatures = sets.Set[SupportedFeature]{
-	SupportReferenceGrant: {},
-}
+var StandardCoreFeatures = sets.New(
+	SupportReferenceGrant,
+)
 
 // AllFeatures contains all the supported features and can be used to run all
 // conformance tests with `all-features` flag.
 //
 // Note that the AllFeatures must in sync with defined features when the
 // feature constants change.
-var AllFeatures = sets.Set[SupportedFeature]{
-	SupportReferenceGrant:                     {},
-	SupportTLSRoute:                           {},
-	SupportHTTPRouteQueryParamMatching:        {},
-	SupportHTTPRouteMethodMatching:            {},
-	SupportHTTPResponseHeaderModification:     {},
-	SupportRouteDestinationPortMatching:       {},
-	SupportGatewayClassObservedGenerationBump: {},
-	SupportHTTPRoutePortRedirect:              {},
-	SupportHTTPRouteSchemeRedirect:            {},
-	SupportHTTPRoutePathRedirect:              {},
-	SupportHTTPRouteHostRewrite:               {},
-	SupportHTTPRoutePathRewrite:               {},
-}
+var AllFeatures = sets.New(
+	SupportReferenceGrant,
+	SupportTLSRoute,
+	SupportHTTPRouteQueryParamMatching,
+	SupportHTTPRouteMethodMatching,
+	SupportHTTPResponseHeaderModification,
+	SupportRouteDestinationPortMatching,
+	SupportGatewayClassObservedGenerationBump,
+	SupportHTTPRoutePortRedirect,
+	SupportHTTPRouteSchemeRedirect,
+	SupportHTTPRoutePathRedirect,
+	SupportHTTPRouteHostRewrite,
+	SupportHTTPRoutePathRewrite,
+)
 
 // ConformanceTestSuite defines the test suite used to run Gateway API
 // conformance tests.


### PR DESCRIPTION



<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

**What this PR does / why we need it**:

It adds `all-features` flag to add ability to enable all supported feature conformance tests. For example:

```
go test ./conformance --gateway-class istio --debug --all-features
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1638 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
1. Add `all-features` flag to enable all supported feature conformance tests.
```
