### PR TITLE
update regex to comply with RFC-3986

### DIFF
--- a/apis/v1beta1/validation/httproute.go
+++ b/apis/v1beta1/validation/httproute.go
@@ -39,7 +39,7 @@ var (
 	invalidPathSuffixes  = []string{"/..", "/."}
 
 	// All valid path characters per RFC-3986
-	validPathCharacters = "^[A-Za-z0-9\\/\\-._~%!$&'()*+,;=:]+$"
+	validPathCharacters = "^(?:[A-Za-z0-9\\/\\-._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$"
 )
 
 // ValidateHTTPRoute validates HTTPRoute according to the Gateway API specification.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

# Description
Adding `[%][0-9a-fA-F]{2}` as an option to find Hex values. Also adding `@` as a value to find as well.
The subset of single characters can be selected in addition to the set of all Hex values, hence the `(?:<pattern1>|<pattern2>)`

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Complies with RFC-3986 "p-char" characters.

**Which issue(s) this PR fixes**:
Updates this PR [#1599](https://github.com/kubernetes-sigs/gateway-api/pull/1599)

**Does this PR introduce a user-facing change?**:
It might, but not really.
```release-note
update route validation to comply with RFC-3986 "p-char" characters.
```
