### PR TITLE
fix: reuse gc name in GatewayClassObservedGenerationBump conformance

### DIFF
--- a/conformance/tests/gatewayclass-observed-generation-bump.yaml
+++ b/conformance/tests/gatewayclass-observed-generation-bump.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
-  name: gatewayclass-observed-generation-bump
+  name: "{GATEWAY_CLASS_NAME}"
 spec:
   controllerName: "{GATEWAY_CONTROLLER_NAME}"
   description: "old"

--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -92,6 +92,9 @@ func (a Applier) prepareGateway(t *testing.T, uObj *unstructured.Unstructured, p
 func (a Applier) prepareGatewayClass(t *testing.T, uObj *unstructured.Unstructured) {
 	err := unstructured.SetNestedField(uObj.Object, a.ControllerName, "spec", "controllerName")
 	require.NoErrorf(t, err, "error setting `spec.controllerName` on %s GatewayClass resource", uObj.GetName())
+
+	err = unstructured.SetNestedField(uObj.Object, a.GatewayClass, "metadata", "name")
+	require.NoErrorf(t, err, "error setting `metadata.name` on %s GatewayClass resource", uObj.GetName())
 }
 
 // prepareNamespace adjusts the Namespace labels.

--- a/conformance/utils/kubernetes/apply_test.go
+++ b/conformance/utils/kubernetes/apply_test.go
@@ -260,13 +260,13 @@ spec:
 			},
 		}},
 	}, {
-		name:    "setting the controllerName for a GatewayClass",
+		name:    "setting the controllerName/gatewayClassName for a GatewayClass",
 		applier: Applier{},
 		given: `
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind:       GatewayClass
 metadata:
-  name: test
+  name: {GATEWAY_CLASS_NAME}
 spec:
   controllerName: {GATEWAY_CONTROLLER_NAME}
 `,
@@ -275,7 +275,7 @@ spec:
 				"apiVersion": "gateway.networking.k8s.io/v1beta1",
 				"kind":       "GatewayClass",
 				"metadata": map[string]interface{}{
-					"name": "test",
+					"name": "test-class",
 				},
 				"spec": map[string]interface{}{
 					"controllerName": "test-controller",


### PR DESCRIPTION
Signed-off-by: bitliu <bitliu@tencent.com>

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
