### PR TITLE
Fix GEP template - status link was wrong

### DIFF
--- a/site-src/geps/gep-696.md
+++ b/site-src/geps/gep-696.md
@@ -3,7 +3,7 @@
 * Issue: [#696](https://github.com/kubernetes-sigs/gateway-api/issues/696)
 * Status: Provisional|Implementable|Experimental|Standard|Deferred|Rejected|Withdrawn|Replaced
 
-(See definitions in [GEP Status][/contributing/gep#status].)
+(See status definitions [here](overview.md#status).)
 
 ## TLDR
 


### PR DESCRIPTION
Status definitions were pointing to the wrong file