### PR TITLE
Drop obsolete sentence about `hostname.match`

### DIFF
--- a/site-src/guides/tls.md
+++ b/site-src/guides/tls.md
@@ -63,9 +63,6 @@ listeners:
       name: default-cert
 ```
 
-If `hostname.match` is set to `Exact`, then the TLS settings apply to only the
-specific hostname that is set in `hostname.name`.
-
 ### Examples
 
 #### Listeners with different certificates


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind documentation

**What this PR does / why we need it**:

[TLS Configuration](https://gateway-api.sigs.k8s.io/guides/tls/?h=ciphers#listeners-and-tls) mentions about `hostname.match`
but it is not available in the current version.

e.g. [v0.1.0-rc1 seems to have it](https://github.com/kubernetes-sigs/gateway-api/blob/v0.1.0-rc1/config/crd/bases/networking.x-k8s.io_gateways.yaml#L71-L88) but it is not found in the current version.

Hence this patch removes the sentence.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
