### PR TITLE
Loosen `Accepted` check in GWC Obs Generation test

### DIFF
--- a/conformance/tests/gatewayclass-observed-generation-bump.go
+++ b/conformance/tests/gatewayclass-observed-generation-bump.go
@@ -45,7 +45,7 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
-			kubernetes.GWCMustBeAcceptedConditionAny(t, s.Client, s.TimeoutConfig, gwc.Name)
+			kubernetes.GWCMustHaveAcceptedConditionAny(t, s.Client, s.TimeoutConfig, gwc.Name)
 
 			original := &v1beta1.GatewayClass{}
 			err := s.Client.Get(ctx, gwc, original)
@@ -62,7 +62,7 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error updating the GatewayClass: %v", err)
 
 			// Ensure the generation and observedGeneration sync up
-			kubernetes.GWCMustBeAcceptedConditionAny(t, s.Client, s.TimeoutConfig, gwc.Name)
+			kubernetes.GWCMustHaveAcceptedConditionAny(t, s.Client, s.TimeoutConfig, gwc.Name)
 
 			updated := &v1beta1.GatewayClass{}
 			err = s.Client.Get(ctx, gwc, updated)

--- a/conformance/tests/gatewayclass-observed-generation-bump.go
+++ b/conformance/tests/gatewayclass-observed-generation-bump.go
@@ -45,7 +45,7 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
-			kubernetes.GWCMustBeAccepted(t, s.Client, s.TimeoutConfig, gwc.Name, "")
+			kubernetes.GWCMustBeAcceptedConditionAny(t, s.Client, s.TimeoutConfig, gwc.Name)
 
 			original := &v1beta1.GatewayClass{}
 			err := s.Client.Get(ctx, gwc, original)
@@ -62,7 +62,7 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error updating the GatewayClass: %v", err)
 
 			// Ensure the generation and observedGeneration sync up
-			kubernetes.GWCMustBeAccepted(t, s.Client, s.TimeoutConfig, gwc.Name, "")
+			kubernetes.GWCMustBeAcceptedConditionAny(t, s.Client, s.TimeoutConfig, gwc.Name)
 
 			updated := &v1beta1.GatewayClass{}
 			err = s.Client.Get(ctx, gwc, updated)

--- a/conformance/tests/gatewayclass-observed-generation-bump.go
+++ b/conformance/tests/gatewayclass-observed-generation-bump.go
@@ -45,7 +45,7 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
-			kubernetes.GWCMustBeAccepted(t, s.Client, s.TimeoutConfig, gwc.Name)
+			kubernetes.GWCMustBeAccepted(t, s.Client, s.TimeoutConfig, gwc.Name, "")
 
 			original := &v1beta1.GatewayClass{}
 			err := s.Client.Get(ctx, gwc, original)
@@ -62,7 +62,7 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error updating the GatewayClass: %v", err)
 
 			// Ensure the generation and observedGeneration sync up
-			kubernetes.GWCMustBeAccepted(t, s.Client, s.TimeoutConfig, gwc.Name)
+			kubernetes.GWCMustBeAccepted(t, s.Client, s.TimeoutConfig, gwc.Name, "")
 
 			updated := &v1beta1.GatewayClass{}
 			err = s.Client.Get(ctx, gwc, updated)

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -65,7 +65,7 @@ func NewGatewayRef(nn types.NamespacedName, listenerNames ...string) GatewayRef 
 
 // GWCMustBeAcceptedConditionTrue waits until the specified GatewayClass has an Accepted condition set with a status value equal to True.
 func GWCMustHaveAcceptedConditionTrue(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, gwcName string) string {
-	return gwcMustBeAccepted(t, c, timeoutConfig, gwcName, metav1.ConditionTrue)
+	return gwcMustBeAccepted(t, c, timeoutConfig, gwcName, string(metav1.ConditionTrue))
 }
 
 // GWCMustBeAcceptedConditionAny waits until the specified GatewayClass has an Accepted condition set with a status set to any value.

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -63,11 +63,21 @@ func NewGatewayRef(nn types.NamespacedName, listenerNames ...string) GatewayRef 
 	}
 }
 
-// GWCMustBeAccepted waits until the specified GatewayClass has an Accepted
-// condition set. Passing an empty status string means that any Status will do.
-// It also returns the ControllerName for the GatewayClass.
+// GWCMustBeAcceptedConditionTrue waits until the specified GatewayClass has an Accepted condition set with a status value equal to True.
+func GWCMustHaveAcceptedConditionTrue(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, gwcName string) string {
+	return gwcMustBeAccepted(t, c, timeoutConfig, gwcName, metav1.ConditionTrue)
+}
+
+// GWCMustBeAcceptedConditionAny waits until the specified GatewayClass has an Accepted condition set with a status set to any value.
+func GWCMustHaveAcceptedConditionAny(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, gwcName string) string {
+	return gwcMustBeAccepted(t, c, timeoutConfig, gwcName, "")
+}
+
+// gwcMustBeAccepted waits until the specified GatewayClass has an Accepted
+// condition set. Passing an empty status string means that any value
+// will be accepted. It also returns the ControllerName for the GatewayClass.
 // This will cause the test to halt if the specified timeout is exceeded.
-func GWCMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, gwcName, expectedStatus string) string {
+func gwcMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, gwcName, expectedStatus string) string {
 	t.Helper()
 
 	var controllerName string

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -64,10 +64,10 @@ func NewGatewayRef(nn types.NamespacedName, listenerNames ...string) GatewayRef 
 }
 
 // GWCMustBeAccepted waits until the specified GatewayClass has an Accepted
-// condition set to true. It also returns the ControllerName for the
-// GatewayClass. This will cause the test to halt if the specified timeout is
-// exceeded.
-func GWCMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, gwcName string) string {
+// condition set. Passing an empty status string means that any Status will do.
+// It also returns the ControllerName for the GatewayClass.
+// This will cause the test to halt if the specified timeout is exceeded.
+func GWCMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, gwcName, expectedStatus string) string {
 	t.Helper()
 
 	var controllerName string
@@ -89,9 +89,9 @@ func GWCMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.Timeo
 		}
 
 		// Passing an empty string as the Reason means that any Reason will do.
-		return findConditionInList(t, gwc.Status.Conditions, "Accepted", "True", ""), nil
+		return findConditionInList(t, gwc.Status.Conditions, "Accepted", expectedStatus, ""), nil
 	})
-	require.NoErrorf(t, waitErr, "error waiting for %s GatewayClass to have Accepted condition set to True: %v", gwcName, waitErr)
+	require.NoErrorf(t, waitErr, "error waiting for %s GatewayClass to have Accepted condition to be set: %v", gwcName, waitErr)
 
 	return controllerName
 }
@@ -574,10 +574,12 @@ func conditionsMatch(t *testing.T, expected, actual []metav1.Condition) bool {
 
 // findConditionInList finds a condition in a list of Conditions, checking
 // the Name, Value, and Reason. If an empty reason is passed, any Reason will match.
+// If an empty status is passed, any Status will match.
 func findConditionInList(t *testing.T, conditions []metav1.Condition, condName, expectedStatus, expectedReason string) bool {
 	for _, cond := range conditions {
 		if cond.Type == condName {
-			if cond.Status == metav1.ConditionStatus(expectedStatus) {
+			// an empty Status string means "Match any status".
+			if expectedStatus == "" || cond.Status == metav1.ConditionStatus(expectedStatus) {
 				// an empty Reason string means "Match any reason".
 				if expectedReason == "" || cond.Reason == expectedReason {
 					return true

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -161,7 +161,7 @@ func New(s Options) *ConformanceTestSuite {
 // in the cluster. It also ensures that all relevant resources are ready.
 func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 	t.Logf("Test Setup: Ensuring GatewayClass has been accepted")
-	suite.ControllerName = kubernetes.GWCMustBeAcceptedConditionTrue(t, suite.Client, suite.TimeoutConfig, suite.GatewayClassName)
+	suite.ControllerName = kubernetes.GWCMustHaveAcceptedConditionTrue(t, suite.Client, suite.TimeoutConfig, suite.GatewayClassName)
 
 	suite.Applier.GatewayClass = suite.GatewayClassName
 	suite.Applier.ControllerName = suite.ControllerName

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -161,7 +161,7 @@ func New(s Options) *ConformanceTestSuite {
 // in the cluster. It also ensures that all relevant resources are ready.
 func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 	t.Logf("Test Setup: Ensuring GatewayClass has been accepted")
-	suite.ControllerName = kubernetes.GWCMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.GatewayClassName, "True")
+	suite.ControllerName = kubernetes.GWCMustBeAcceptedConditionTrue(t, suite.Client, suite.TimeoutConfig, suite.GatewayClassName)
 
 	suite.Applier.GatewayClass = suite.GatewayClassName
 	suite.Applier.ControllerName = suite.ControllerName

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -161,7 +161,7 @@ func New(s Options) *ConformanceTestSuite {
 // in the cluster. It also ensures that all relevant resources are ready.
 func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 	t.Logf("Test Setup: Ensuring GatewayClass has been accepted")
-	suite.ControllerName = kubernetes.GWCMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.GatewayClassName)
+	suite.ControllerName = kubernetes.GWCMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.GatewayClassName, "True")
 
 	suite.Applier.GatewayClass = suite.GatewayClassName
 	suite.Applier.ControllerName = suite.ControllerName


### PR DESCRIPTION
* enhance `GWCMustBeAccepted` to pass a status value along, an empty string indicates, any status value is matched.

* Loosen the check within `GatewayClassObservedGenerationBump` to wait for the `Accepted` condition to have any status value

Relates to https://kubernetes.slack.com/archives/CR0H13KGA/p1673836949189379?thread_ts=1673599220.709819&cid=CR0H13KGA

Signed-off-by: Arko Dasgupta <arko@tetrate.io>

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
