### PR TITLE
Fix invalid example for http redirect

### DIFF
--- a/examples/experimental/http-redirect-rewrite/httproute-redirect-https.yaml
+++ b/examples/experimental/http-redirect-rewrite/httproute-redirect-https.yaml
@@ -11,6 +11,7 @@ spec:
     - filters:
       - type: RequestRedirect
         requestRedirect:
+          port: 443
           scheme: https
           statusCode: 301
       backendRefs:

--- a/examples/standard/http-redirect.yaml
+++ b/examples/standard/http-redirect.yaml
@@ -49,6 +49,7 @@ spec:
     - filters:
       - type: RequestRedirect
         requestRedirect:
+          port: 443
           scheme: https
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1


### PR DESCRIPTION
The example which redirects HTTP to HTTPS uses scheme `HTTPS` but emits the port. However, docs[1] mentions as "When empty, port (if specified) of the request is used.", so the access always is forwared to the HTTPS but `80` port. 

* The result of the test with Istio 1.17-alpha.ebe08a1368b65d93cf51c24675c29409567ca77c. Please find `location: https://redirect.example.com:80/get`.
```
* Mark bundle as not supporting multiuse
< HTTP/1.1 301 Moved Permanently
< location: https://redirect.example.com:80/get
< date: Thu, 19 Jan 2023 10:12:52 GMT
< server: istio-envoy
< content-length: 0
```

This patch fixes it.

[1] https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPRequestRedirectFilter
> Port is the port to be used in the value of the Location header in the response. When empty, port (if specified) of the request is used.

/kind bug
/kind documentation
