### PR TITLE
conformance: HTTPRoute resolvedRefs condition always checked

### DIFF
--- a/conformance/tests/httproute-cross-namespace.go
+++ b/conformance/tests/httproute-cross-namespace.go
@@ -38,6 +38,7 @@ var HTTPRouteCrossNamespace = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "cross-namespace", Namespace: "gateway-conformance-web-backend"}
 		gwNN := types.NamespacedName{Name: "backend-namespaces", Namespace: "gateway-conformance-infra"}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		t.Run("Simple HTTP request should reach web-backend", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{

--- a/conformance/tests/httproute-disallowed-kind.go
+++ b/conformance/tests/httproute-disallowed-kind.go
@@ -43,6 +43,7 @@ var HTTPRouteDisallowedKind = suite.ConformanceTest{
 
 		routeNN := types.NamespacedName{Name: "disallowed-kind", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "tlsroutes-only", Namespace: "gateway-conformance-infra"}
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		t.Run("Route should not have been accepted with reason NotAllowedByListeners", func(t *testing.T) {
 			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, metav1.Condition{

--- a/conformance/tests/httproute-exact-path-matching.go
+++ b/conformance/tests/httproute-exact-path-matching.go
@@ -39,6 +39,7 @@ var HTTPExactPathMatching = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "exact-matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		testCases := []http.ExpectedResponse{
 			{

--- a/conformance/tests/httproute-header-matching.go
+++ b/conformance/tests/httproute-header-matching.go
@@ -39,6 +39,7 @@ var HTTPRouteHeaderMatching = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "header-matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request:   http.Request{Path: "/", Headers: map[string]string{"Version": "one"}},

--- a/conformance/tests/httproute-hostname-intersection.go
+++ b/conformance/tests/httproute-hostname-intersection.go
@@ -52,6 +52,9 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 				{Namespace: ns, Name: "wildcard-host-matches-listener-wildcard-host"},
 			}
 			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routes...)
+			for _, routeNN := range routes {
+				kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+			}
 
 			var testCases []http.ExpectedResponse
 

--- a/conformance/tests/httproute-listener-hostname-matching.go
+++ b/conformance/tests/httproute-listener-hostname-matching.go
@@ -41,17 +41,19 @@ var HTTPRouteListenerHostnameMatching = suite.ConformanceTest{
 		// namespace so we have to wait for it to be ready.
 		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
 
+		routeNN1 := types.NamespacedName{Name: "backend-v1", Namespace: ns}
+		routeNN2 := types.NamespacedName{Name: "backend-v2", Namespace: ns}
+		routeNN3 := types.NamespacedName{Name: "backend-v3", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "httproute-listener-hostname-matching", Namespace: ns}
 
-		_ = kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-1"),
-			types.NamespacedName{Namespace: ns, Name: "backend-v1"},
-		)
-		_ = kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-2"),
-			types.NamespacedName{Namespace: ns, Name: "backend-v2"},
-		)
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-3", "listener-4"),
-			types.NamespacedName{Namespace: ns, Name: "backend-v3"},
-		)
+		kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-1"), routeNN1)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN1, gwNN)
+
+		kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-2"), routeNN2)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN2, gwNN)
+
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-3", "listener-4"), routeNN3)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN3, gwNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request:   http.Request{Host: "bar.com", Path: "/"},

--- a/conformance/tests/httproute-matching-across-routes.go
+++ b/conformance/tests/httproute-matching-across-routes.go
@@ -40,6 +40,8 @@ var HTTPRouteMatchingAcrossRoutes = suite.ConformanceTest{
 		routeNN2 := types.NamespacedName{Name: "matching-part2", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN1, routeNN2)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN1, gwNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN2, gwNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request: http.Request{

--- a/conformance/tests/httproute-matching.go
+++ b/conformance/tests/httproute-matching.go
@@ -39,6 +39,7 @@ var HTTPRouteMatching = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request:   http.Request{Path: "/"},

--- a/conformance/tests/httproute-method-matching.go
+++ b/conformance/tests/httproute-method-matching.go
@@ -40,6 +40,7 @@ var HTTPRouteMethodMatching = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "method-matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		testCases := []http.ExpectedResponse{
 			{

--- a/conformance/tests/httproute-observed-generation-bump.go
+++ b/conformance/tests/httproute-observed-generation-bump.go
@@ -39,26 +39,19 @@ var HTTPRouteObservedGenerationBump = suite.ConformanceTest{
 	ShortName:   "HTTPRouteObservedGenerationBump",
 	Description: "A HTTPRoute in the gateway-conformance-infra namespace should update the observedGeneration in all of it's Status.Conditions after an update to the spec",
 	Manifests:   []string{"tests/httproute-observed-generation-bump.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
-
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "observed-generation-bump", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
-
-		acceptedCondition := metav1.Condition{
-			Type:   string(v1beta1.RouteConditionAccepted),
-			Status: metav1.ConditionTrue,
-			Reason: "", // any reason
-		}
 
 		t.Run("observedGeneration should increment", func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
 			namespaces := []string{"gateway-conformance-infra"}
-			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
+			kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, namespaces)
 
 			original := &v1beta1.HTTPRoute{}
-			err := s.Client.Get(ctx, routeNN, original)
+			err := suite.Client.Get(ctx, routeNN, original)
 			require.NoErrorf(t, err, "error getting HTTPRoute: %v", err)
 
 			// Sanity check
@@ -66,13 +59,18 @@ var HTTPRouteObservedGenerationBump = suite.ConformanceTest{
 
 			mutate := original.DeepCopy()
 			mutate.Spec.Rules[0].BackendRefs[0].Name = "infra-backend-v2"
-			err = s.Client.Patch(ctx, mutate, client.MergeFrom(original))
+			err = suite.Client.Patch(ctx, mutate, client.MergeFrom(original))
 			require.NoErrorf(t, err, "error patching the HTTPRoute: %v", err)
 
-			kubernetes.HTTPRouteMustHaveCondition(t, s.Client, s.TimeoutConfig, routeNN, gwNN, acceptedCondition)
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, metav1.Condition{
+				Type:   string(v1beta1.RouteConditionAccepted),
+				Status: metav1.ConditionTrue,
+				Reason: "", // any reason
+			})
+			kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 			updated := &v1beta1.HTTPRoute{}
-			err = s.Client.Get(ctx, routeNN, updated)
+			err = suite.Client.Get(ctx, routeNN, updated)
 			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			// Sanity check

--- a/conformance/tests/httproute-query-param-matching.go
+++ b/conformance/tests/httproute-query-param-matching.go
@@ -36,12 +36,11 @@ var HTTPRouteQueryParamMatching = suite.ConformanceTest{
 	Manifests:   []string{"tests/httproute-query-param-matching.yaml"},
 	Features:    []suite.SupportedFeature{suite.SupportHTTPRouteQueryParamMatching},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
-		var (
-			ns      = "gateway-conformance-infra"
-			routeNN = types.NamespacedName{Namespace: ns, Name: "query-param-matching"}
-			gwNN    = types.NamespacedName{Namespace: ns, Name: "same-namespace"}
-			gwAddr  = kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
-		)
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Namespace: ns, Name: "query-param-matching"}
+		gwNN := types.NamespacedName{Namespace: ns, Name: "same-namespace"}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request:   http.Request{Path: "/?animal=whale"},

--- a/conformance/tests/httproute-redirect-host-and-status.go
+++ b/conformance/tests/httproute-redirect-host-and-status.go
@@ -40,6 +40,7 @@ var HTTPRouteRedirectHostAndStatus = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "redirect-host-and-status", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request: http.Request{

--- a/conformance/tests/httproute-redirect-path.go
+++ b/conformance/tests/httproute-redirect-path.go
@@ -41,6 +41,7 @@ var HTTPRouteRedirectPath = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "redirect-path", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request: http.Request{

--- a/conformance/tests/httproute-redirect-port.go
+++ b/conformance/tests/httproute-redirect-port.go
@@ -41,6 +41,7 @@ var HTTPRouteRedirectPort = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "redirect-port", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request: http.Request{

--- a/conformance/tests/httproute-redirect-scheme.go
+++ b/conformance/tests/httproute-redirect-scheme.go
@@ -41,6 +41,7 @@ var HTTPRouteRedirectScheme = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "redirect-scheme", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request: http.Request{

--- a/conformance/tests/httproute-reference-grant.go
+++ b/conformance/tests/httproute-reference-grant.go
@@ -35,13 +35,14 @@ var HTTPRouteReferenceGrant = suite.ConformanceTest{
 	Description: "A single HTTPRoute in the gateway-conformance-infra namespace, with a backendRef in the gateway-conformance-web-backend namespace, should attach to Gateway in the gateway-conformance-infra namespace",
 	Features:    []suite.SupportedFeature{suite.SupportReferenceGrant},
 	Manifests:   []string{"tests/httproute-reference-grant.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "reference-grant", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, s.Client, s.TimeoutConfig, s.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		t.Run("Simple HTTP request should reach web-backend", func(t *testing.T) {
-			http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, s.TimeoutConfig, gwAddr, http.ExpectedResponse{
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
 				Request: http.Request{
 					Method: "GET",
 					Path:   "/",

--- a/conformance/tests/httproute-request-header-modifier.go
+++ b/conformance/tests/httproute-request-header-modifier.go
@@ -39,6 +39,7 @@ var HTTPRouteRequestHeaderModifier = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "request-header-modifier", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request: http.Request{

--- a/conformance/tests/httproute-response-header-modifier.go
+++ b/conformance/tests/httproute-response-header-modifier.go
@@ -40,6 +40,7 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "response-header-modifier", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		testCases := []http.ExpectedResponse{{
 			Request: http.Request{

--- a/conformance/tests/httproute-rewrite-host.go
+++ b/conformance/tests/httproute-rewrite-host.go
@@ -40,6 +40,7 @@ var HTTPRouteRewriteHost = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "rewrite-host", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		testCases := []http.ExpectedResponse{
 			{

--- a/conformance/tests/httproute-rewrite-path.go
+++ b/conformance/tests/httproute-rewrite-path.go
@@ -40,6 +40,7 @@ var HTTPRouteRewritePath = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "rewrite-path", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		testCases := []http.ExpectedResponse{
 			{

--- a/conformance/tests/httproute-simple-same-namespace.go
+++ b/conformance/tests/httproute-simple-same-namespace.go
@@ -40,6 +40,7 @@ var HTTPRouteSimpleSameNamespace = suite.ConformanceTest{
 		routeNN := types.NamespacedName{Name: "gateway-conformance-infra-test", Namespace: string(ns)}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: string(ns)}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		t.Run("Simple HTTP request should reach infra-backend", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -562,6 +562,16 @@ func HTTPRouteMustHaveCondition(t *testing.T, client client.Client, timeoutConfi
 	require.NoErrorf(t, waitErr, "error waiting for HTTPRoute status to have a Condition matching expectations")
 }
 
+// HTTPRouteMustHaveResolvedRefsConditionsTrue checks that the supplied HTTPRoute has the resolvedRefsCondition
+// set to true.
+func HTTPRouteMustHaveResolvedRefsConditionsTrue(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, routeNN types.NamespacedName, gwNN types.NamespacedName) {
+	HTTPRouteMustHaveCondition(t, client, timeoutConfig, routeNN, gwNN, metav1.Condition{
+		Type:   string(v1beta1.RouteConditionResolvedRefs),
+		Status: metav1.ConditionTrue,
+		Reason: string(v1beta1.RouteReasonResolvedRefs),
+	})
+}
+
 func parentRefToString(p v1beta1.ParentReference) string {
 	if p.Namespace != nil && *p.Namespace != "" {
 		return fmt.Sprintf("%v/%v", p.Namespace, p.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

**What this PR does / why we need it**:

In the conformance tests, the ResolvedRefs condition existence is always checked, even when true.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1314 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The conformance tests always check that the HTTPRoute ResolvedRefs condition is enforced, even when the status is true.
```
