### PR TITLE
Fixing verify-boilerplate to work with latest build images

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2015 The Kubernetes Authors.
 #


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
Noticed this in https://github.com/kubernetes-sigs/gateway-api/pull/1673

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
