### PR TITLE
Fix SupportedKinds check

### DIFF
--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -626,6 +626,11 @@ func listenersMatch(t *testing.T, expected, actual []v1beta1.ListenerStatus) boo
 			t.Logf("Name doesn't match")
 			return false
 		}
+
+		if len(eListener.SupportedKinds) == 0 && len(aListener.SupportedKinds) != 0 {
+			t.Logf("Expected SupportedKinds to be empty, got %v", aListener.SupportedKinds)
+			return false
+		}
 		// Ensure that the expected Listener.SupportedKinds items are present in actual Listener.SupportedKinds
 		// Find the items instead of performing an exact match of the slice because the implementation
 		// might support more Kinds than defined in the test

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -636,14 +636,8 @@ func listenersMatch(t *testing.T, expected, actual []v1beta1.ListenerStatus) boo
 		// Ensure that the expected Listener.SupportedKinds items are present in actual Listener.SupportedKinds
 		// Find the items instead of performing an exact match of the slice because the implementation
 		// might support more Kinds than defined in the test
-		eSupportedKindsSet := sets.NewString()
-		aSupportedKindsSet := sets.NewString()
-		for _, eKind := range eListener.SupportedKinds {
-			eSupportedKindsSet.Insert(string(eKind.Kind))
-		}
-		for _, aKind := range aListener.SupportedKinds {
-			aSupportedKindsSet.Insert(string(aKind.Kind))
-		}
+		eSupportedKindsSet := sets.New(eListener.SupportedKinds...)
+		aSupportedKindsSet := sets.New(aListener.SupportedKinds...)
 		if !aSupportedKindsSet.IsSuperset(eSupportedKindsSet) {
 			t.Logf("Expected %v kinds to be present in SupportedKinds", eSupportedKindsSet.Difference(aSupportedKindsSet))
 			return false

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -626,9 +626,21 @@ func listenersMatch(t *testing.T, expected, actual []v1beta1.ListenerStatus) boo
 			t.Logf("Name doesn't match")
 			return false
 		}
-		if !reflect.DeepEqual(aListener.SupportedKinds, eListener.SupportedKinds) {
-			t.Logf("Expected SupportedKinds to be %v, got %v", eListener.SupportedKinds, aListener.SupportedKinds)
-			return false
+		// Ensure that the expected Listener.SupportedKinds items are present in actual Listener.SupportedKinds
+		// Find the items instead of performing an exact match of the slice because the implementation
+		// might support more Kinds than defined in the test
+		for _, eKind := range eListener.SupportedKinds {
+			found := false
+			for _, aKind := range aListener.SupportedKinds {
+				if eKind.Kind == aKind.Kind {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Logf("Expected %s to be present in SupportedKinds", eKind.Kind)
+				return false
+			}
 		}
 		if aListener.AttachedRoutes != eListener.AttachedRoutes {
 			t.Logf("Expected AttachedRoutes to be %v, got %v", eListener.AttachedRoutes, aListener.AttachedRoutes)


### PR DESCRIPTION
* Find the expcted SupportedKind element in the actual SupportedKind slice instead of doing an exact match because the actual/implementation populated SupportedKinds field might support more Kind that defined in the test.

Fixes: https://github.com/kubernetes-sigs/gateway-api/issues/1691

Signed-off-by: Arko Dasgupta <arko@tetrate.io>