### PR TITLE
Validate admission Kind first for efficiency

### DIFF
--- a/pkg/admission/server.go
+++ b/pkg/admission/server.go
@@ -96,25 +96,20 @@ var (
 func log500(w http.ResponseWriter, err error) {
 	klog.Errorf("failed to process request: %v\n", err)
 	http.Error(w, err.Error(), http.StatusInternalServerError)
-	return
 }
 
 // ensureKindAdmissionReview check that our admission server is only getting requests
 // for kind AdmissionReview and reject all others
-func ensureKindAdmissionReview(req []byte) bool {
+func ensureKindAdmissionReview(req []byte) (bool, error) {
 	type reqBody struct {
 		Kind  string                 `json:"kind"`
 		Extra map[string]interface{} `json:"-"`
 	}
 	var msg reqBody
-	err := json.Unmarshal(req, &msg)
-	if err != nil {
-		return false
+	if err := json.Unmarshal(req, &msg); err != nil {
+		return false, err
 	}
-	if msg.Kind != "AdmissionReview" {
-		return false
-	}
-	return true
+	return msg.Kind == "AdmissionReview", nil
 }
 
 // ServeHTTP parses AdmissionReview requests and responds back
@@ -137,17 +132,24 @@ func ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	res, err := ensureKindAdmissionReview(data)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !res {
+		invalidKind := "submitted object is not of kind AdmissionReview"
+		http.Error(w, invalidKind, http.StatusBadRequest)
+		return
+	}
+
 	review := admission.AdmissionReview{}
 	err = json.Unmarshal(data, &review)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if !ensureKindAdmissionReview(data) {
-		invalidKind := "submitted object is not of kind AdmissionReview"
-		http.Error(w, invalidKind, http.StatusBadRequest)
-		return
-	}
+
 	response, err := handleValidation(*review.Request)
 	if err != nil {
 		log500(w, err)
@@ -164,7 +166,6 @@ func ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		klog.Errorf("failed to write HTTP response: %v\n", err)
 		return
 	}
-	return
 }
 
 func handleValidation(request admission.AdmissionRequest) (*admission.AdmissionResponse, error) {


### PR DESCRIPTION
Signed-off-by: Kante Yin <kerthcet@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

**What this PR does / why we need it**:
What commits in this PR:
1. Remove redundant `return` who conflicts with go-staticcheck
2. Validate admission Kind first for saving performance in Unmarshal. Maybe bit improves but better than not.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
None
```
