### PR TITLE
Remove ParentRefNotPermitted

### DIFF
--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -215,7 +215,6 @@ const (
 	// * "NoMatchingListenerHostname"
 	// * "NoMatchingParent"
 	// * "UnsupportedValue"
-	// * "ParentRefNotPermitted"
 	//
 	// Possible reasons for this condition to be Unknown are:
 	//
@@ -248,11 +247,6 @@ const (
 	// This reason is used with the "Accepted" condition when a value for an Enum
 	// is not recognized.
 	RouteReasonUnsupportedValue RouteConditionReason = "UnsupportedValue"
-
-	// This reason is used with the "Accepted" condition when the route has not
-	// been accepted by a Gateway because it has a cross-namespace parentRef,
-	// but no ReferenceGrant in the other namespace allows such a reference.
-	RouteReasonParentRefNotPermitted RouteConditionReason = "ParentRefNotPermitted"
 
 	// This reason is used with the "Accepted" when a controller has not yet
 	// reconciled the route.

--- a/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go
@@ -19,10 +19,8 @@ package tests
 import (
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 )
@@ -38,17 +36,6 @@ var HTTPRouteInvalidCrossNamespaceParentRef = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 		routeNN := types.NamespacedName{Name: "invalid-cross-namespace-parent-ref", Namespace: "gateway-conformance-web-backend"}
-
-		// The Route must have an Accepted Condition with a ParentRefNotPermitted Reason.
-		t.Run("HTTPRoute with a cross-namespace ParentRef where no ReferenceGrants allows such a reference, has an Accepted Condition with status False and Reason ParentRefNotPermitted", func(t *testing.T) {
-			acceptedCond := metav1.Condition{
-				Type:   string(v1beta1.RouteConditionAccepted),
-				Status: metav1.ConditionFalse,
-				Reason: string(v1beta1.RouteReasonParentRefNotPermitted),
-			}
-
-			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, acceptedCond)
-		})
 
 		t.Run("Route should not have Parents set in status", func(t *testing.T) {
 			kubernetes.HTTPRouteMustHaveNoAcceptedParents(t, suite.Client, suite.TimeoutConfig, routeNN)

--- a/conformance/tests/httproute-invalid-parentref-not-matching-listener-port.go
+++ b/conformance/tests/httproute-invalid-parentref-not-matching-listener-port.go
@@ -42,13 +42,13 @@ var HTTPRouteInvalidParentRefNotMatchingListenerPort = suite.ConformanceTest{
 
 		// The Route must have an Accepted Condition with a NoMatchingParent Reason.
 		t.Run("HTTPRoute with no matching port in ParentRef has an Accepted Condition with status False and Reason NoMatchingParent", func(t *testing.T) {
-			acceptedCond := metav1.Condition{
+			resolvedRefsCond := metav1.Condition{
 				Type:   string(v1beta1.RouteConditionAccepted),
 				Status: metav1.ConditionFalse,
 				Reason: string(v1beta1.RouteReasonNoMatchingParent),
 			}
 
-			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, acceptedCond)
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, resolvedRefsCond)
 		})
 
 		t.Run("Route should not have Parents accepted in status", func(t *testing.T) {


### PR DESCRIPTION
While testing v0.6.1 we found that we had included a new type that was not needed. This PR reverts the relevant changes.

Special thanks to @skriss and @mlavacca for your assistance!