### PR TITLE
conformance: check reason in HTTPRouteInvalidCrossNamespaceParentRef test

### DIFF
--- a/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go
@@ -19,8 +19,10 @@ package tests
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 )
@@ -36,6 +38,20 @@ var HTTPRouteInvalidCrossNamespaceParentRef = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 		routeNN := types.NamespacedName{Name: "invalid-cross-namespace-parent-ref", Namespace: "gateway-conformance-web-backend"}
+
+		// When running conformance tests, implementations are expected to have visibility across all namespaces, and
+		// must be setting this condition on routes that are not allowed. However, outside of conformance testing,
+		// it's also valid for implementations to run in modes where they only have access to a limited subset of
+		// namespaces, in which case they are not obligated to populate this condition on routes they cannot access.
+		t.Run("HTTPRoute should have an Accepted: false condition with reason NotAllowedByListeners", func(t *testing.T) {
+			acceptedCond := metav1.Condition{
+				Type:   string(v1beta1.RouteConditionAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(v1beta1.RouteReasonNotAllowedByListeners),
+			}
+
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, acceptedCond)
+		})
 
 		t.Run("Route should not have Parents set in status", func(t *testing.T) {
 			kubernetes.HTTPRouteMustHaveNoAcceptedParents(t, suite.Client, suite.TimeoutConfig, routeNN)


### PR DESCRIPTION
Checks for the NotAllowedByListeners reason on
the HTTPRoute's Accepted: false condition in
the HTTPRouteInvalidCrossNamespaceParentRef
test.

Signed-off-by: Steve Kriss <krisss@vmware.com>

**What type of PR is this?**
/area conformance

**What this PR does / why we need it**:
Checks for the NotAllowedByListeners reason on
the HTTPRoute's Accepted: false condition in
the HTTPRouteInvalidCrossNamespaceParentRef
test.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1705

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Checks for the NotAllowedByListeners reason on
the HTTPRoute's Accepted: false condition in
the HTTPRouteInvalidCrossNamespaceParentRef
conformance test.
```
