### PR TITLE
cleanup: GEP-1324 Typo - Fix indentation

### DIFF
--- a/site-src/geps/gep-1324.md
+++ b/site-src/geps/gep-1324.md
@@ -50,7 +50,7 @@ These use-cases are presented as an aid for discussion, and as frames of referen
     1. I want to enforce that all traffic within my cluster is encrypted.
     2. I want to have strict isolation and control at namespace level, so a bug/malicious user can't impact other namespaces
     3. I want to be able to allow app owners to gradually opt-in to a mesh (no mesh, L4 only, L7 enabled) so they can choose the right fit for their applications’ performance and compatibility goals.
-    4. Since mesh can be multi-tenant and hosting multiple services (e.g. foo or bar), as a mesh administrator I need to make sure a client can discover different services. Here are few possible ways:
+    4. Since mesh can be multi-tenant and hosting multiple services (e.g. foo or bar), as a mesh administrator I need to make sure a client can discover different services. Here are a few possible ways:
         1. Each service is allocated a unique IP and port
         2. Or Each service must use unique Host name
         3. Or a unique port and protocol,  (80:http, 443 tls)

--- a/site-src/geps/gep-1324.md
+++ b/site-src/geps/gep-1324.md
@@ -50,10 +50,10 @@ These use-cases are presented as an aid for discussion, and as frames of referen
     1. I want to enforce that all traffic within my cluster is encrypted.
     2. I want to have strict isolation and control at namespace level, so a bug/malicious user can't impact other namespaces
     3. I want to be able to allow app owners to gradually opt-in to a mesh (no mesh, L4 only, L7 enabled) so they can choose the right fit for their applications’ performance and compatibility goals.
-    4. Since mesh can be multi-tenant and hosting multiple services (e.g. foo or bar), as a mesh administrator I need to make sure a client can discover different services. Here are few possible ways
-      1. Each service is allocated a unique IP and port
-      2. Or Each service must use unique Host name
-      3. Or a unique port and protocol,  (80:http, 443 tls)
+    4. Since mesh can be multi-tenant and hosting multiple services (e.g. foo or bar), as a mesh administrator I need to make sure a client can discover different services. Here are few possible ways:
+        1. Each service is allocated a unique IP and port
+        2. Or Each service must use unique Host name
+        3. Or a unique port and protocol,  (80:http, 443 tls)
 
 ## Glossary
 

--- a/site-src/geps/gep-1324.md
+++ b/site-src/geps/gep-1324.md
@@ -52,7 +52,7 @@ These use-cases are presented as an aid for discussion, and as frames of referen
     3. I want to be able to allow app owners to gradually opt-in to a mesh (no mesh, L4 only, L7 enabled) so they can choose the right fit for their applications’ performance and compatibility goals.
     4. Since mesh can be multi-tenant and hosting multiple services (e.g. foo or bar), as a mesh administrator I need to make sure a client can discover different services. Here are a few possible ways:
         1. Each service is allocated a unique IP and port
-        2. Or Each service must use unique Host name
+        2. Or Each service must use a unique hostname
         3. Or a unique port and protocol,  (80:http, 443 tls)
 
 ## Glossary

--- a/site-src/geps/gep-1324.md
+++ b/site-src/geps/gep-1324.md
@@ -53,7 +53,7 @@ These use-cases are presented as an aid for discussion, and as frames of referen
     4. Since mesh can be multi-tenant and hosting multiple services (e.g. foo or bar), as a mesh administrator I need to make sure a client can discover different services. Here are a few possible ways:
         1. Each service is allocated a unique IP and port
         2. Or Each service must use a unique hostname
-        3. Or a unique port and protocol,  (80:http, 443 tls)
+        3. Or a unique port and protocol (80:http, 443:tls)
 
 ## Glossary
 


### PR DESCRIPTION
Fix list nesting underneath [this section](https://gateway-api.sigs.k8s.io/geps/gep-1324/#use-cases) of the GEP.

![Screen Shot 2023-02-10 at 1 31 01 PM](https://user-images.githubusercontent.com/17263955/218170530-aa2e6f01-8605-4584-9eb4-88d565e2279f.png)

These 3 items e, f, and g should be under d