### PR TITLE
unit test for listenersMatch in conformance utils

### DIFF
--- a/conformance/utils/kubernetes/helpers_test.go
+++ b/conformance/utils/kubernetes/helpers_test.go
@@ -34,6 +34,38 @@ func Test_listenersMatch(t *testing.T) {
 		want     bool
 	}{
 		{
+			name: "listeners do not match if a different number of actual and expected listeners are provided",
+			expected: []v1beta1.ListenerStatus{
+				{
+					SupportedKinds: []v1beta1.RouteGroupKind{
+						{
+							Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
+							Kind:  v1beta1.Kind("HTTPRoute"),
+						},
+					},
+				},
+				{
+					SupportedKinds: []v1beta1.RouteGroupKind{
+						{
+							Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
+							Kind:  v1beta1.Kind("GRPCRoute"),
+						},
+					},
+				},
+			},
+			actual: []v1beta1.ListenerStatus{
+				{
+					SupportedKinds: []v1beta1.RouteGroupKind{
+						{
+							Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
+							Kind:  v1beta1.Kind("HTTPRoute"),
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
 			name: "SupportedKinds: expected empty and actual is non empty",
 			expected: []v1beta1.ListenerStatus{
 				{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

I have added the unit test for listenersMatch in conformance utils

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
