### PR TITLE
Requiring "Programmed" condition in conformance tests

### DIFF
--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -46,7 +46,7 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			defer cancel()
 
 			namespaces := []string{"gateway-conformance-infra"}
-			kubernetes.NamespacesMustBeAccepted(t, s.Client, s.TimeoutConfig, namespaces)
+			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
 
 			original := &v1beta1.Gateway{}
 			err := s.Client.Get(ctx, gwNN, original)
@@ -73,7 +73,7 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error updating the Gateway: %v", err)
 
 			// Ensure the generation and observedGeneration sync up
-			kubernetes.NamespacesMustBeAccepted(t, s.Client, s.TimeoutConfig, namespaces)
+			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
 
 			updated := &v1beta1.Gateway{}
 			err = s.Client.Get(ctx, gwNN, updated)

--- a/conformance/tests/httproute-disallowed-kind.go
+++ b/conformance/tests/httproute-disallowed-kind.go
@@ -39,7 +39,7 @@ var HTTPRouteDisallowedKind = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		// This test creates an additional Gateway in the gateway-conformance-infra
 		// namespace so we have to wait for it to be ready.
-		kubernetes.NamespacesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, []string{"gateway-conformance-infra"})
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{"gateway-conformance-infra"})
 
 		routeNN := types.NamespacedName{Name: "disallowed-kind", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "tlsroutes-only", Namespace: "gateway-conformance-infra"}

--- a/conformance/tests/httproute-hostname-intersection.go
+++ b/conformance/tests/httproute-hostname-intersection.go
@@ -42,7 +42,7 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 
 		// This test creates an additional Gateway in the gateway-conformance-infra
 		// namespace so we have to wait for it to be ready.
-		kubernetes.NamespacesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, []string{ns})
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
 
 		t.Run("HTTPRoutes that do intersect with listener hostnames", func(t *testing.T) {
 			routes := []types.NamespacedName{

--- a/conformance/tests/httproute-listener-hostname-matching.go
+++ b/conformance/tests/httproute-listener-hostname-matching.go
@@ -39,7 +39,7 @@ var HTTPRouteListenerHostnameMatching = suite.ConformanceTest{
 
 		// This test creates an additional Gateway in the gateway-conformance-infra
 		// namespace so we have to wait for it to be ready.
-		kubernetes.NamespacesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, []string{ns})
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
 
 		gwNN := types.NamespacedName{Name: "httproute-listener-hostname-matching", Namespace: ns}
 

--- a/conformance/tests/httproute-observed-generation-bump.go
+++ b/conformance/tests/httproute-observed-generation-bump.go
@@ -54,7 +54,7 @@ var HTTPRouteObservedGenerationBump = suite.ConformanceTest{
 			defer cancel()
 
 			namespaces := []string{"gateway-conformance-infra"}
-			kubernetes.NamespacesMustBeAccepted(t, s.Client, s.TimeoutConfig, namespaces)
+			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
 
 			original := &v1beta1.HTTPRoute{}
 			err := s.Client.Get(ctx, routeNN, original)

--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -63,7 +63,10 @@ type TimeoutConfig struct {
 	// Max value for conformant implementation: 30 seconds
 	MaxTimeToConsistency time.Duration
 
-	// NamespacesMustBeReady represents the maximum time for all Pods and Gateways in a namespaces to be marked as ready.
+	// NamespacesMustBeReady represents the maximum time for the following to happen within
+	// specified namespace(s):
+	// * All Pods to be marked as "Ready"
+	// * All Gateways to be marked as "Accepted" and "Programmed"
 	// Max value for conformant implementation: None
 	NamespacesMustBeReady time.Duration
 

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -210,7 +210,7 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 		"gateway-conformance-app-backend",
 		"gateway-conformance-web-backend",
 	}
-	kubernetes.NamespacesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, namespaces)
+	kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, namespaces)
 }
 
 // Run runs the provided set of conformance tests.


### PR DESCRIPTION
**What type of PR is this?**
/kind test
/area conformance

**What this PR does / why we need it**:
This adds a requirement in conformance tests that Gateways must be "Programmed" (previously this was just "Accepted"). Note that this only covers the top level "Programmed" condition, not each Listener.

**Which issue(s) this PR fixes**:
Fixes #1722

**Does this PR introduce a user-facing change?**:
```release-note
Conformance: Gateways must publish the "Programmed" condition.
```
