### PR TITLE
chore: replace usage of the deprecated k8s.gcr.io registry

### DIFF
--- a/config/webhook/certificate_config.yaml
+++ b/config/webhook/certificate_config.yaml
@@ -88,7 +88,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -122,7 +122,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
           imagePullPolicy: IfNotPresent
           args:
             - patch


### PR DESCRIPTION
As per https://github.com/kubernetes/k8s.io/issues/4738 this resolves our usage of the [now deprecated k8s.gcr.io registry](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/).