### PR TITLE
Clarify semantics when port_redirect is unset

### DIFF
--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -901,7 +901,8 @@ type HTTPRequestRedirectFilter struct {
 
 	// Port is the port to be used in the value of the `Location`
 	// header in the response.
-	// When empty, port (if specified) of the request is used.
+	// When empty, port (if specified) in the `Host` header
+	// of the request is used.
 	//
 	// Support: Extended
 	//

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -902,8 +902,10 @@ type HTTPRequestRedirectFilter struct {
 
 	// Port is the port to be used in the value of the `Location`
 	// header in the response.
-	// When empty, the Gateway listener port is used (except
-	// when it is a default port - 80 or 443).
+	// When empty, the Gateway Listener port is used.
+	// In all cases, when the protocol is http and the port is port 80,
+	// then the port must be omitted. Similarly, when the protocol is
+	// https and the port is port 443, then the port must also be omitted.
 	//
 	// Support: Extended
 	//

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -882,7 +882,8 @@ type HTTPRequestRedirectFilter struct {
 
 	// Hostname is the hostname to be used in the value of the `Location`
 	// header in the response.
-	// When empty, the hostname of the request is used.
+	// When empty, the hostname in the `Host` header
+	// of the request is used.
 	//
 	// Support: Core
 	//

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -902,8 +902,8 @@ type HTTPRequestRedirectFilter struct {
 
 	// Port is the port to be used in the value of the `Location`
 	// header in the response.
-	// When empty, port (if specified) in the `Host` header
-	// of the request is used.
+	// When empty, the Gateway listener port is used (except
+	// when it is a default port - 80 or 443).
 	//
 	// Support: Extended
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -571,9 +571,13 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. When empty, the Gateway listener
-                                        port is used (except when it is a default
-                                        port - 80 or 443). \n Support: Extended"
+                                        response. When empty, the Gateway Listener
+                                        port is used. In all cases, when the protocol
+                                        is http and the port is port 80, then the
+                                        port must be omitted. Similarly, when the
+                                        protocol is https and the port is port 443,
+                                        then the port must also be omitted. \n Support:
+                                        Extended"
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -1192,8 +1196,11 @@ spec:
                               port:
                                 description: "Port is the port to be used in the value
                                   of the `Location` header in the response. When empty,
-                                  the Gateway listener port is used (except when it
-                                  is a default port - 80 or 443). \n Support: Extended"
+                                  the Gateway Listener port is used. In all cases,
+                                  when the protocol is http and the port is port 80,
+                                  then the port must be omitted. Similarly, when the
+                                  protocol is https and the port is port 443, then
+                                  the port must also be omitted. \n Support: Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -2428,9 +2435,13 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. When empty, the Gateway listener
-                                        port is used (except when it is a default
-                                        port - 80 or 443). \n Support: Extended"
+                                        response. When empty, the Gateway Listener
+                                        port is used. In all cases, when the protocol
+                                        is http and the port is port 80, then the
+                                        port must be omitted. Similarly, when the
+                                        protocol is https and the port is port 443,
+                                        then the port must also be omitted. \n Support:
+                                        Extended"
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -3049,8 +3060,11 @@ spec:
                               port:
                                 description: "Port is the port to be used in the value
                                   of the `Location` header in the response. When empty,
-                                  the Gateway listener port is used (except when it
-                                  is a default port - 80 or 443). \n Support: Extended"
+                                  the Gateway Listener port is used. In all cases,
+                                  when the protocol is http and the port is port 80,
+                                  then the port must be omitted. Similarly, when the
+                                  protocol is https and the port is port 443, then
+                                  the port must also be omitted. \n Support: Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -511,7 +511,8 @@ spec:
                                       description: "Hostname is the hostname to be
                                         used in the value of the `Location` header
                                         in the response. When empty, the hostname
-                                        of the request is used. \n Support: Core"
+                                        in the `Host` header of the request is used.
+                                        \n Support: Core"
                                       maxLength: 253
                                       minLength: 1
                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -570,8 +571,9 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. When empty, port (if specified)
-                                        of the request is used. \n Support: Extended"
+                                        response. When empty, the Gateway listener
+                                        port is used (except when it is a default
+                                        port - 80 or 443). \n Support: Extended"
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -1135,8 +1137,8 @@ spec:
                               hostname:
                                 description: "Hostname is the hostname to be used
                                   in the value of the `Location` header in the response.
-                                  When empty, the hostname of the request is used.
-                                  \n Support: Core"
+                                  When empty, the hostname in the `Host` header of
+                                  the request is used. \n Support: Core"
                                 maxLength: 253
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -1190,8 +1192,8 @@ spec:
                               port:
                                 description: "Port is the port to be used in the value
                                   of the `Location` header in the response. When empty,
-                                  port (if specified) of the request is used. \n Support:
-                                  Extended"
+                                  the Gateway listener port is used (except when it
+                                  is a default port - 80 or 443). \n Support: Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -2366,7 +2368,8 @@ spec:
                                       description: "Hostname is the hostname to be
                                         used in the value of the `Location` header
                                         in the response. When empty, the hostname
-                                        of the request is used. \n Support: Core"
+                                        in the `Host` header of the request is used.
+                                        \n Support: Core"
                                       maxLength: 253
                                       minLength: 1
                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -2425,8 +2428,9 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. When empty, port (if specified)
-                                        of the request is used. \n Support: Extended"
+                                        response. When empty, the Gateway listener
+                                        port is used (except when it is a default
+                                        port - 80 or 443). \n Support: Extended"
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -2990,8 +2994,8 @@ spec:
                               hostname:
                                 description: "Hostname is the hostname to be used
                                   in the value of the `Location` header in the response.
-                                  When empty, the hostname of the request is used.
-                                  \n Support: Core"
+                                  When empty, the hostname in the `Host` header of
+                                  the request is used. \n Support: Core"
                                 maxLength: 253
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -3045,8 +3049,8 @@ spec:
                               port:
                                 description: "Port is the port to be used in the value
                                   of the `Location` header in the response. When empty,
-                                  port (if specified) of the request is used. \n Support:
-                                  Extended"
+                                  the Gateway listener port is used (except when it
+                                  is a default port - 80 or 443). \n Support: Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -485,7 +485,8 @@ spec:
                                       description: "Hostname is the hostname to be
                                         used in the value of the `Location` header
                                         in the response. When empty, the hostname
-                                        of the request is used. \n Support: Core"
+                                        in the `Host` header of the request is used.
+                                        \n Support: Core"
                                       maxLength: 253
                                       minLength: 1
                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -493,8 +494,9 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. When empty, port (if specified)
-                                        of the request is used. \n Support: Extended"
+                                        response. When empty, the Gateway listener
+                                        port is used (except when it is a default
+                                        port - 80 or 443). \n Support: Extended"
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -888,8 +890,8 @@ spec:
                               hostname:
                                 description: "Hostname is the hostname to be used
                                   in the value of the `Location` header in the response.
-                                  When empty, the hostname of the request is used.
-                                  \n Support: Core"
+                                  When empty, the hostname in the `Host` header of
+                                  the request is used. \n Support: Core"
                                 maxLength: 253
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -897,8 +899,8 @@ spec:
                               port:
                                 description: "Port is the port to be used in the value
                                   of the `Location` header in the response. When empty,
-                                  port (if specified) of the request is used. \n Support:
-                                  Extended"
+                                  the Gateway listener port is used (except when it
+                                  is a default port - 80 or 443). \n Support: Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -1860,7 +1862,8 @@ spec:
                                       description: "Hostname is the hostname to be
                                         used in the value of the `Location` header
                                         in the response. When empty, the hostname
-                                        of the request is used. \n Support: Core"
+                                        in the `Host` header of the request is used.
+                                        \n Support: Core"
                                       maxLength: 253
                                       minLength: 1
                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -1868,8 +1871,9 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. When empty, port (if specified)
-                                        of the request is used. \n Support: Extended"
+                                        response. When empty, the Gateway listener
+                                        port is used (except when it is a default
+                                        port - 80 or 443). \n Support: Extended"
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -2263,8 +2267,8 @@ spec:
                               hostname:
                                 description: "Hostname is the hostname to be used
                                   in the value of the `Location` header in the response.
-                                  When empty, the hostname of the request is used.
-                                  \n Support: Core"
+                                  When empty, the hostname in the `Host` header of
+                                  the request is used. \n Support: Core"
                                 maxLength: 253
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -2272,8 +2276,8 @@ spec:
                               port:
                                 description: "Port is the port to be used in the value
                                   of the `Location` header in the response. When empty,
-                                  port (if specified) of the request is used. \n Support:
-                                  Extended"
+                                  the Gateway listener port is used (except when it
+                                  is a default port - 80 or 443). \n Support: Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -494,9 +494,13 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. When empty, the Gateway listener
-                                        port is used (except when it is a default
-                                        port - 80 or 443). \n Support: Extended"
+                                        response. When empty, the Gateway Listener
+                                        port is used. In all cases, when the protocol
+                                        is http and the port is port 80, then the
+                                        port must be omitted. Similarly, when the
+                                        protocol is https and the port is port 443,
+                                        then the port must also be omitted. \n Support:
+                                        Extended"
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -899,8 +903,11 @@ spec:
                               port:
                                 description: "Port is the port to be used in the value
                                   of the `Location` header in the response. When empty,
-                                  the Gateway listener port is used (except when it
-                                  is a default port - 80 or 443). \n Support: Extended"
+                                  the Gateway Listener port is used. In all cases,
+                                  when the protocol is http and the port is port 80,
+                                  then the port must be omitted. Similarly, when the
+                                  protocol is https and the port is port 443, then
+                                  the port must also be omitted. \n Support: Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -1871,9 +1878,13 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. When empty, the Gateway listener
-                                        port is used (except when it is a default
-                                        port - 80 or 443). \n Support: Extended"
+                                        response. When empty, the Gateway Listener
+                                        port is used. In all cases, when the protocol
+                                        is http and the port is port 80, then the
+                                        port must be omitted. Similarly, when the
+                                        protocol is https and the port is port 443,
+                                        then the port must also be omitted. \n Support:
+                                        Extended"
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -2276,8 +2287,11 @@ spec:
                               port:
                                 description: "Port is the port to be used in the value
                                   of the `Location` header in the response. When empty,
-                                  the Gateway listener port is used (except when it
-                                  is a default port - 80 or 443). \n Support: Extended"
+                                  the Gateway Listener port is used. In all cases,
+                                  when the protocol is http and the port is port 80,
+                                  then the port must be omitted. Similarly, when the
+                                  protocol is https and the port is port 443, then
+                                  the port must also be omitted. \n Support: Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1


### PR DESCRIPTION
Relates to https://github.com/kubernetes-sigs/gateway-api/discussions/1725

/kind documentation
