### PR TITLE
chore: cleanup err check scoped down

### DIFF
--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -218,7 +218,9 @@ func (a Applier) MustApplyWithCleanup(t *testing.T, c client.Client, timeoutConf
 					defer cancel()
 					t.Logf("Deleting %s %s", uObj.GetName(), uObj.GetKind())
 					err = c.Delete(ctx, uObj)
-					require.NoErrorf(t, err, "error deleting resource")
+					if !apierrors.IsNotFound(err) {
+						require.NoErrorf(t, err, "error deleting resource")
+					}
 				})
 			}
 			continue
@@ -234,7 +236,9 @@ func (a Applier) MustApplyWithCleanup(t *testing.T, c client.Client, timeoutConf
 				defer cancel()
 				t.Logf("Deleting %s %s", uObj.GetName(), uObj.GetKind())
 				err = c.Delete(ctx, uObj)
-				require.NoErrorf(t, err, "error deleting resource")
+				if !apierrors.IsNotFound(err) {
+					require.NoErrorf(t, err, "error deleting resource")
+				}
 			})
 		}
 		require.NoErrorf(t, err, "error updating resource")


### PR DESCRIPTION
The error triggered by the test cleaner makes the test fail only if the error is !NotFound.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

The cleanup might be failing because some resources were already previously deleted. For example, the tests `gateway-secret-reference-grant-specific` and `gateway-secret-reference-grant-all-in-namespaces` create a gateway named in the same way (i.e., the second apply is an update), but the cleaner is called twice. When the cleaner is called the 2nd time on that resource, the cleanup fails because the gateway does not exist anymore, making the test fail.
This PR introduces a check on the error triggered by the cleanup function. If `NotFound`, the cleanup error can be tolerated.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
