### PR TITLE
Update version links in guide

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,7 +53,7 @@ For a **PATCH** release:
   Github's [release][release] page.
 - Run the `make build-install-yaml` command which will generate install files in the `release/` directory.
   Attach these files to the Github release.
-- Update the `README.md` as needed for any latest release references.
+- Update the `README.md` and `site-src/guides/index.md` files to point links and examples to the new release.
 
 For a **MAJOR** or **MINOR** release:
 - Cut a `release-major.minor` branch that we can tag things in as needed.
@@ -67,7 +67,7 @@ For a **MAJOR** or **MINOR** release:
   Github's [release][release] page.
 - Run the `make build-install-yaml` command which will generate install files in the `release/` directory.
   Attach these files to the Github release.
-- Update the `README.md` as needed for any latest release references.
+- Update the `README.md` and `site-src/guides/index.md` files to point links and examples to the new release.
 
 For an **RC** release:
 - Update `pkg/generator/main.go` with the new semver tag and any updates to the API review URL.

--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -40,7 +40,7 @@ including GatewayClass, Gateway, and HTTPRoute. To install this channel, run the
 following kubectl command:
 
 ```
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.5.1/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.6.1/standard-install.yaml
 ```
 
 ### Install Experimental Channel
@@ -58,7 +58,7 @@ documentation](https://gateway-api.sigs.k8s.io/concepts/versioning/).
 To install the experimental channel, run the following kubectl command:
 
 ```
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.5.1/experimental-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.6.1/experimental-install.yaml
 ```
 
 ### Cleanup


### PR DESCRIPTION
Noticed in https://github.com/kubernetes-sigs/gateway-api/issues/1543, this updates some links to versions that got left behind in recent releases and updates the `RELEASE.md` instructions so they wont be left behind in the future.