### PR TITLE
Removes field validation from GRPCRoute Method/Service fields

### DIFF
--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -326,7 +326,6 @@ type GRPCMethodMatch struct {
 	//
 	// +optional
 	// +kubebuilder:validation:MaxLength=1024
-	// +kubebuilder:validation:Pattern=`^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$`
 	Service *string `json:"service,omitempty"`
 
 	// Value of the method to match against. If left empty or omitted, will
@@ -339,7 +338,6 @@ type GRPCMethodMatch struct {
 	//
 	// +optional
 	// +kubebuilder:validation:MaxLength=1024
-	// +kubebuilder:validation:Pattern=`^[A-Za-z_][A-Za-z_0-9]*$`
 	Method *string `json:"method,omitempty"`
 }
 

--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -321,9 +321,6 @@ type GRPCMethodMatch struct {
 	//
 	// At least one of Service and Method MUST be a non-empty string.
 	//
-	// A GRPC Service must be a valid Protobuf Type Name
-	// (https://protobuf.com/docs/language-spec#type-references).
-	//
 	// +optional
 	// +kubebuilder:validation:MaxLength=1024
 	Service *string `json:"service,omitempty"`
@@ -332,9 +329,6 @@ type GRPCMethodMatch struct {
 	// match all services.
 	//
 	// At least one of Service and Method MUST be a non-empty string.
-	//
-	// A GRPC Method must be a valid Protobuf Method
-	// (https://protobuf.com/docs/language-spec#methods).
 	//
 	// +optional
 	// +kubebuilder:validation:MaxLength=1024

--- a/apis/v1alpha2/validation/grpcroute.go
+++ b/apis/v1alpha2/validation/grpcroute.go
@@ -75,7 +75,7 @@ func validateRuleMatches(matches []gatewayv1a2.GRPCRouteMatch, path *field.Path)
 			if m.Method.Service == nil && m.Method.Method == nil {
 				errs = append(errs, field.Required(path.Index(i).Child("method"), "one or both of `service` or `method` must be specified"))
 			}
-			// GRPCRoute method matchers admits two types: Exact and RegularExpression.
+			// GRPCRoute method matcher admits two types: Exact and RegularExpression.
 			// If not specified, the match will be treated as type Exact
 			if m.Method.Type == nil || *m.Method.Type == gatewayv1a2.GRPCMethodMatchExact {
 				if m.Method.Service != nil {

--- a/apis/v1alpha2/validation/grpcroute_test.go
+++ b/apis/v1alpha2/validation/grpcroute_test.go
@@ -29,8 +29,9 @@ import (
 func TestValidateGRPCRoute(t *testing.T) {
 	t.Parallel()
 
-	service := "foo"
-	method := "login"
+	service := "foo.Test.Example"
+	method := "Login"
+	regex := ".*"
 
 	tests := []struct {
 		name  string
@@ -86,6 +87,115 @@ func TestValidateGRPCRoute(t *testing.T) {
 					Detail: "one or both of `service` or `method` must be specified",
 				},
 			},
+		},
+		{
+			name: "GRPCRoute use regex in service and method with undefined match type",
+			rules: []gatewayv1a2.GRPCRouteRule{
+				{
+					Matches: []gatewayv1a2.GRPCRouteMatch{
+						{
+							Method: &gatewayv1a2.GRPCMethodMatch{
+								Service: &regex,
+								Method:  &regex,
+							},
+						},
+					},
+				},
+			},
+			errs: field.ErrorList{
+				{
+					Type:     field.ErrorTypeInvalid,
+					BadValue: regex,
+					Field:    "spec.rules[0].matches[0].method",
+					Detail:   `must only contain valid characters (matching ^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$)`,
+				},
+				{
+					Type:     field.ErrorTypeInvalid,
+					BadValue: regex,
+					Field:    "spec.rules[0].matches[0].method",
+					Detail:   `must only contain valid characters (matching ^[A-Za-z_][A-Za-z_0-9]*$)`,
+				},
+			},
+		},
+		{
+			name: "GRPCRoute use regex in service and method with match type Exact",
+			rules: []gatewayv1a2.GRPCRouteRule{
+				{
+					Matches: []gatewayv1a2.GRPCRouteMatch{
+						{
+							Method: &gatewayv1a2.GRPCMethodMatch{
+								Service: &regex,
+								Method:  &regex,
+								Type:    ptrTo(gatewayv1a2.GRPCMethodMatchExact),
+							},
+						},
+					},
+				},
+			},
+			errs: field.ErrorList{
+				{
+					Type:     field.ErrorTypeInvalid,
+					BadValue: regex,
+					Field:    "spec.rules[0].matches[0].method",
+					Detail:   `must only contain valid characters (matching ^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$)`,
+				},
+				{
+					Type:     field.ErrorTypeInvalid,
+					BadValue: regex,
+					Field:    "spec.rules[0].matches[0].method",
+					Detail:   `must only contain valid characters (matching ^[A-Za-z_][A-Za-z_0-9]*$)`,
+				},
+			},
+		},
+		{
+			name: "GRPCRoute use regex in service and method with match type RegularExpression",
+			rules: []gatewayv1a2.GRPCRouteRule{
+				{
+					Matches: []gatewayv1a2.GRPCRouteMatch{
+						{
+							Method: &gatewayv1a2.GRPCMethodMatch{
+								Service: &regex,
+								Method:  &regex,
+								Type:    ptrTo(gatewayv1a2.GRPCMethodMatchRegularExpression),
+							},
+						},
+					},
+				},
+			},
+			errs: field.ErrorList{},
+		},
+		{
+			name: "GRPCRoute use valid service and method with undefined match type",
+			rules: []gatewayv1a2.GRPCRouteRule{
+				{
+					Matches: []gatewayv1a2.GRPCRouteMatch{
+						{
+							Method: &gatewayv1a2.GRPCMethodMatch{
+								Service: &service,
+								Method:  &method,
+							},
+						},
+					},
+				},
+			},
+			errs: field.ErrorList{},
+		},
+		{
+			name: "GRPCRoute use valid service and method with match type Exact",
+			rules: []gatewayv1a2.GRPCRouteRule{
+				{
+					Matches: []gatewayv1a2.GRPCRouteMatch{
+						{
+							Method: &gatewayv1a2.GRPCMethodMatch{
+								Service: &service,
+								Method:  &method,
+								Type:    ptrTo(gatewayv1a2.GRPCMethodMatchExact),
+							},
+						},
+					},
+				},
+			},
+			errs: field.ErrorList{},
 		},
 		{
 			name: "GRPCRoute with duplicate ExtensionRef filters",

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -1196,19 +1196,15 @@ spec:
                                 description: "Value of the method to match against.
                                   If left empty or omitted, will match all services.
                                   \n At least one of Service and Method MUST be a
-                                  non-empty string. \n A GRPC Method must be a valid
-                                  Protobuf Method (https://protobuf.com/docs/language-spec#methods)."
+                                  non-empty string."
                                 maxLength: 1024
-                                pattern: ^[A-Za-z_][A-Za-z_0-9]*$
                                 type: string
                               service:
                                 description: "Value of the service to match against.
                                   If left empty or omitted, will match any service.
                                   \n At least one of Service and Method MUST be a
-                                  non-empty string. \n A GRPC Service must be a valid
-                                  Protobuf Type Name (https://protobuf.com/docs/language-spec#type-references)."
+                                  non-empty string."
                                 maxLength: 1024
-                                pattern: ^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$
                                 type: string
                               type:
                                 default: Exact


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Removes validation for service and method fields in GRPCMethodMatch to allow use of regular expressions.

**Which issue(s) this PR fixes**:
Fixes #1746

