### PR TITLE
Log Generation / Observed generation.

### DIFF
--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -147,13 +147,14 @@ func ConditionsHaveLatestObservedGeneration(obj metav1.Object, conditions []meta
 		return nil
 	}
 
+	wantGeneration := obj.GetGeneration()
 	var b strings.Builder
-	fmt.Fprint(&b, "expected observedGeneration to be updated for all conditions")
+	fmt.Fprintf(&b, "expected observedGeneration to be updated to %d for all conditions", wantGeneration)
 	fmt.Fprintf(&b, ", only %d/%d were updated.", len(conditions)-len(staleConditions), len(conditions))
 	fmt.Fprintf(&b, " stale conditions are: ")
 
 	for i, c := range staleConditions {
-		fmt.Fprintf(&b, c.Type)
+		fmt.Fprintf(&b, "%s (generation %d)", c.Type, c.ObservedGeneration)
 		if i != len(staleConditions)-1 {
 			fmt.Fprintf(&b, ", ")
 		}

--- a/conformance/utils/kubernetes/helpers_test.go
+++ b/conformance/utils/kubernetes/helpers_test.go
@@ -108,7 +108,7 @@ func TestVerifyConditionsMatchGeneration(t *testing.T) {
 				{Type: "FakeCondition2", ObservedGeneration: 19},
 				{Type: "FakeCondition3", ObservedGeneration: 20},
 			},
-			expected: fmt.Errorf("expected observedGeneration to be updated for all conditions, only 2/3 were updated. stale conditions are: FakeCondition2"),
+			expected: fmt.Errorf("expected observedGeneration to be updated to 20 for all conditions, only 2/3 were updated. stale conditions are: FakeCondition2 (generation 19)"),
 		},
 		{
 			name: "conditions where most do not match the generation fail verification",
@@ -121,7 +121,7 @@ func TestVerifyConditionsMatchGeneration(t *testing.T) {
 				{Type: "FakeCondition5", ObservedGeneration: 16},
 				{Type: "FakeCondition6", ObservedGeneration: 15},
 			},
-			expected: fmt.Errorf("expected observedGeneration to be updated for all conditions, only 1/6 were updated. stale conditions are: FakeCondition1, FakeCondition2, FakeCondition3, FakeCondition5, FakeCondition6"),
+			expected: fmt.Errorf("expected observedGeneration to be updated to 20 for all conditions, only 1/6 were updated. stale conditions are: FakeCondition1 (generation 18), FakeCondition2 (generation 18), FakeCondition3 (generation 14), FakeCondition5 (generation 16), FakeCondition6 (generation 15)"),
 		},
 	}
 


### PR DESCRIPTION
While waiting for GatewayClass to be ready, log the Generation / ObservedGeneration since it gives a useful signal on whether the controller is stuck, or trying to converge forever.

/kind cleanup
/kind tet
/area conformance

**What this PR does / why we need it**:

Improve conformance debug.

**Which issue(s) this PR fixes**:

Minor improvement, no issue filed.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
