### PR TITLE
GEP 1709: ConformanceReport validation

### DIFF
--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -453,8 +453,6 @@ conformance/results/<organization>-<project>.yaml
 Creating a pull request to add the `ConformanceReport` will start the
 [certification process](#certification-process).
 
-TODO: need to add some linting and validation for `ConformanceReports`
-
 > **NOTE**: No verification process (to prevent intentionally incorrect
 > conformance results) will be implemented at this time. We expect that this wont
 > be an issue in our community and even if someone were to try and "cheat" on
@@ -473,6 +471,12 @@ Certification starts with the pull request described during the [reporting
 process](#reporting-process). Once the `ConformanceReport` is created or
 updated a display layer in the implementations page will need to be updated to
 point to the new data.
+
+> **NOTE**: The `ConformanceReport` API will be defined in Golang like our
+> other `apis/` so that we can utilize build tags from kubebuilder for defaults
+> and validation, and so that there exists a common Golang type for it in the
+> conformance test suite. When PRs are created the Gateway API repositories'
+> CI will run linting and validation against the reports.
 
 TODO: not sure exactly what the display will look like yet. We will need to
       sort this out before we consider this `implementable`.


### PR DESCRIPTION
**What type of PR is this?**

/kind gep

**What this PR does / why we need it**:

There was an existing TODO in GEP 1709 to determine how we can validate `ConformanceReport` resources. This small patch clarifies how that will be done, and that CI will validate and lint these reports when submitted by maintainers.