### PR TITLE
GEP 1709: small cleanups and clarifications

### DIFF
--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -50,16 +50,21 @@ submitting those reports and displaying the results.
 
 ## API
 
-The API for conformance profiles will be a pipeline that implementations can
-opt into. The workflow is effectively:
+The API for conformance profiles will include an API resource called
+`ConformanceReport` which will be at the center of a workflow that
+implementations can opt into to generate and submit those resources.
+
+The workflow implementers will follow will include the following high-level
+steps:
 
 1. select a [profile](#profiles)
 2. [integrate](#integration) tests in the downstream project
 3. [report results and get certified](#certification)
 
-The goal is to make selecting a conformance profile as simple of a process as
-feasible and support both the existing command line integration approach (e.g. `go test`) as well
-as a [Golang][go] approach using the conformance suite as a library.
+The goal is to make selecting a conformance profile as simple and automatic of a
+process as feasible and support both the existing command line integration
+approach (e.g. `go test`) as well as a [Golang][go] approach using the
+conformance suite as a library.
 
 [go]:https://go.dev
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -5,11 +5,10 @@
 
 ## TLDR
 
-Add selectable profiles for conformance tests which implementations can
-subscribe to. Also add the ability to report conformance results back to the
-Gateway API project and receive recognition. Conformance test reports will
-add conformance data to the implementations page for the reporter which can
-be linked to with badges from projects and repositories.
+Add high level profiles for conformance tests which implementations can select
+when running the conformance test suite. Also add opt-in automated conformance
+reporting to the conformance test suite to report conformance results back to
+the Gateway API project and receive recognition (e.g. badges).
 
 ## Goals
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -36,11 +36,17 @@ the Gateway API project and receive recognition (e.g. badges).
 
 Since our conformance test suite was conceived of it's been our desire to
 provide simple high level profiles that downstream implementations can
-subscribe to. Today there's a little bit of this available in the way of
-`SupportedFeatures` which can be subscribed to when running the tests, but the
-purpose of this GEP is to take that a step further (and a level higher) and
-create subscribable named profiles which indicate a "level of conformance"
-which implementations can prove they satisfy and be recognized for.
+subscribe to.
+
+Today we have `SupportedFeatures` which get us some of what we want in terms of
+easily configuring the conformance test suite, but in this GEP we will describe
+taking that a step further (and a level higher) to create named profiles which
+indicate a "level of conformance" which implementations can prove they satisfy
+and receive certification for.
+
+An API will be provided as the format for conformance test reports. We will
+provide tooling to assist with the reporting and certification process of
+submitting those reports and displaying the results.
 
 ## API
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -84,11 +84,11 @@ grouping of tests. When conformance is reported using one of these profiles
 extra features can be covered according to support levels:
 
 - `extended`
-- `implementation-specific`
 
 > **NOTE**: `implementation-specific` doesn't really have much in the way of
-> tests today, but it is something users want to be able to display so it's
-> considered for reporting purposes.
+> tests today, but it is something users want to be able to display. We leave
+> door open for it later and mention it in the [alternatives
+> considered](#alternatives-considered) section below.
 
 The technical implementation of these profiles is very simple: effectively a
 "profile" is a static compilation of existing [SupportedFeatures][feat] which
@@ -515,6 +515,16 @@ Providing a container image which could be fed deployment instructions for an
 implementation was considered while working on this GET but it seemed like a
 scope all unto itself so we're avoiding it here and perhaps a later iteration
 could take a look at that if there are asks in the community.
+
+### Implementation-Specific Reporting
+
+Users have mentioned the desire to report on `implementation-specific` features
+they support as a part of conformance. At the time of writing, there's not much
+in the way of structure or testing for us to do this with but we remain open to
+the idea. The door is left open in the `ConformanceReport` API for a future
+iteration to add this if desired, but it probably warrants its own GEP as we
+need to make sure we have buy-in from multiple stakeholders with different
+implementations that are implementing those features.
 
 ## References
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -10,6 +10,22 @@ when running the conformance test suite. Also add opt-in automated conformance
 reporting to the conformance test suite to report conformance results back to
 the Gateway API project and receive recognition (e.g. badges).
 
+## TODO
+
+The following are items that we intend to resolve before we consider this GEP
+`implementable`:
+
+- We still need to sort out how we're going to display conformance results.
+  Badges are well and good, but we also want some kind of summarized
+  display of any given implementation's conformance results somewhere on
+  our upstream website (so far the thought has been the [implementations
+  page][impl]). We should look for prior art in Kubernetes SIGs and also
+  reach out to some frontend developers to come up with something really
+  solid prior to moving to `implementable`.
+- We need to think about how we're going to highlight and report on the
+  results for `experimental` features, and make sure this is explicitly
+  written out.
+
 ## Goals
 
 - Add high level profiles which downstream implementations can subscribe to in
@@ -475,14 +491,6 @@ For this initial iteration the raw report data of the `ConformanceReports` will
 live in its own directory and _is predominantly meant for machine consumption_.
 Report data will be compiled into human-friendly displays during the an
 automated certification process.
-
-TODO: We still need to sort out how we're going to display conformance results.
-      Badges are well and good, but we also want some kind of summarized
-      display of any given implementation's conformance results somewhere on
-      our upstream website (so far the thought has been the [implementations
-      page][impl]). We should look for prior art in Kubernetes SIGs and also
-      reach out to some frontend developers to come up with something really
-      solid prior to moving to `implementable`.
 
 Certification starts with the pull request described during the [reporting
 process](#reporting-process). Once the `ConformanceReport` is created or

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -473,9 +473,16 @@ Creating a pull request to add the `ConformanceReport` will start the
 
 For this initial iteration the raw report data of the `ConformanceReports` will
 live in its own directory and _is predominantly meant for machine consumption_.
-Report data will be compiled into human-friendly displays which will be added as
-headers in the [implementations page][impl] and badges which link to these
-displays. We will refer to this process as certification.
+Report data will be compiled into human-friendly displays during the an
+automated certification process.
+
+TODO: We still need to sort out how we're going to display conformance results.
+      Badges are well and good, but we also want some kind of summarized
+      display of any given implementation's conformance results somewhere on
+      our upstream website (so far the thought has been the [implementations
+      page][impl]). We should look for prior art in Kubernetes SIGs and also
+      reach out to some frontend developers to come up with something really
+      solid prior to moving to `implementable`.
 
 Certification starts with the pull request described during the [reporting
 process](#reporting-process). Once the `ConformanceReport` is created or
@@ -487,9 +494,6 @@ point to the new data.
 > and validation, and so that there exists a common Golang type for it in the
 > conformance test suite. When PRs are created the Gateway API repositories'
 > CI will run linting and validation against the reports.
-
-TODO: not sure exactly what the display will look like yet. We will need to
-      sort this out before we consider this `implementable`.
 
 CI will provide [badges][bdg] to contributors at the end of the process which
 link to the implementations page for that specific implementation and can be


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind gep

**What this PR does / why we need it**:

This adds some cleanup and clarifications for GEP 1709.

It **does not add or change concepts or context**, just an attempt to improve how it reads.

In particular, we had mentioned `implementation-specific` conformance in the doc previously, but that was mostly because we wanted to point out we consider that a future possibility. This clarifies that by adding it to the alternatives considered section as a note for follow-up iterations.

Relates to #1709 