### PR TITLE
`GatewayClassObservedGenerationBump` as a core feature

### DIFF
--- a/conformance/tests/gatewayclass-observed-generation-bump.go
+++ b/conformance/tests/gatewayclass-observed-generation-bump.go
@@ -38,7 +38,6 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 	ShortName: "GatewayClassObservedGenerationBump",
 	Features: []suite.SupportedFeature{
 		suite.SupportGateway,
-		suite.SupportGatewayClassObservedGenerationBump,
 	},
 	Description: "A GatewayClass should update the observedGeneration in all of it's Status.Conditions after an update to the spec",
 	Manifests:   []string{"tests/gatewayclass-observed-generation-bump.yaml"},

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -55,15 +55,6 @@ var StandardCoreFeatures = sets.New(
 // -----------------------------------------------------------------------------
 
 const (
-	// This option indicates GatewayClass will update the observedGeneration in
-	// it's conditions when reconciling (extended conformance).
-	//
-	// NOTE: we intend to make this core and require implementations to do it
-	//       as we expect this is something every implementation should be able
-	//       to do and it's ideal behavior.
-	//
-	//       See: https://github.com/kubernetes-sigs/gateway-api/issues/1780
-	SupportGatewayClassObservedGenerationBump SupportedFeature = "GatewayClassObservedGenerationBump"
 	// This option indicates that the Gateway can also use port 8080
 	SupportGatewayPort8080 SupportedFeature = "GatewayPort8080"
 )
@@ -74,7 +65,6 @@ const (
 // TODO: we need clarity for standard vs experimental features.
 // See: https://github.com/kubernetes-sigs/gateway-api/issues/1891
 var StandardExtendedFeatures = sets.New(
-	SupportGatewayClassObservedGenerationBump,
 	SupportGatewayPort8080,
 ).Insert(StandardCoreFeatures.UnsortedList()...)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

The additional feature `GatewayClassObservedGenerationBump` has been removed, and the test is now executed as a core one.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1780 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
