### PR TITLE
docs: GEP 1709 change status to new prototyping GEP status

### DIFF
--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -26,7 +26,7 @@ The following are items that we intend to resolve before we consider this GEP
   results for `experimental` features, and make sure this is explicitly
   written out.
 - We are [gathering feedback from SIG Arch][sig-arch-feedback]. We need to let
-  this soak for a time, bring up the topic at SIG Arch community meetings, and
+  this soak for some time, bring up the topic at SIG Arch community meetings, and
   generally make changes according to their feedback before considering this
   `implementable`.
 - There are lingering concerns from several community members that having high

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -36,6 +36,11 @@ The following are items that we intend to resolve before we consider this GEP
   this soak for a time, bring up the topic at SIG Arch community meetings, and
   generally make changes according to their feedback before considering this
   `implementable`.
+- There are lingering concerns from several community members that having high
+  level profiles like `Layer7` and `Layer4` might not be the best way to start,
+  but instead we should consider focusing on specific APIs, e.g. profiles that
+  we start with might be `HTTPRoute`, `GRPCRoute`, `TCPRoute`, `UDPRoute`
+  e.t.c. so that subscribing to profiles can be more à la carte.
 
 [sig-arch-feedback]:https://groups.google.com/g/kubernetes-sig-architecture/c/YjrVZ4NJQiA/m/7Qg7ScddBwAJ
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -99,11 +99,10 @@ conformance suite as a library.
 
 ### Profiles
 
-Initially there will be three profiles:
+Initially there will be two profiles:
 
 - `Layer4`
 - `Layer7`
-- `Mesh`
 
 > **NOTE**: these are simply the initial profiles we're going to start with,
 > it's plausible for there to be more in the future.
@@ -558,6 +557,14 @@ the idea. The door is left open in the `ConformanceReport` API for a future
 iteration to add this if desired, but it probably warrants its own GEP as we
 need to make sure we have buy-in from multiple stakeholders with different
 implementations that are implementing those features.
+
+### Mesh Profiles
+
+We eventually want profiles for GAMMA/mesh related tests, however at this point
+we believe the test suite for mesh could end up being it's own separate thing
+so it's not a part of this GEP for now, but we should make sure our tooling is
+modular and composable so if we do end up with an eventual mesh conformance
+test suite, it can employ conformance profiles and reporting as-is.
 
 ## References
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -32,6 +32,12 @@ The following are items that we intend to resolve before we consider this GEP
 - We need to think about how we're going to highlight and report on the
   results for `experimental` features, and make sure this is explicitly
   written out.
+- We are [gathering feedback from SIG Arch][sig-arch-feedback]. We need to let
+  this soak for a time, bring up the topic at SIG Arch community meetings, and
+  generally make changes according to their feedback before considering this
+  `implementable`.
+
+[sig-arch-feedback]:https://groups.google.com/g/kubernetes-sig-architecture/c/YjrVZ4NJQiA/m/7Qg7ScddBwAJ
 
 ## Goals
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -312,6 +312,12 @@ profiles:
       - ExtendedFeature5
 ```
 
+> **WARNING**: It is an important clarification that this is NOT a full
+> Kubernetes API. It uses `TypeMeta` for some fields that made sense to re-use
+> and were familiar, but otherwise has it's own structure. It is not a [Custom
+> Resource Definition (CRD)][crd] nor will it be made available along with our
+> CRDs. It will be used only by conformance test tooling.
+
 > **NOTE**: In the above the `implementation` field is a combination of
 > `<organization>-<project>`. Organizations can be an open source organization,
 > an individual, a company, e.t.c.. Organizations can theoretically have more
@@ -497,6 +503,8 @@ Creating a pull request to add the `ConformanceReport` will start the
 > be an issue in our community and even if someone were to try and "cheat" on
 > the reporting the reputation loss for being caught would make them look very
 > bad and would not be worth it.
+
+[crds]:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 
 #### Certification Process
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -1,7 +1,14 @@
 # GEP-1709: Conformance Profiles
 
 * Issue: [#1709](https://github.com/kubernetes-sigs/gateway-api/issues/1709)
-* Status: Provisional
+* Status: Experimental
+
+> **NOTE**: Experimental in this case (since this doesn't propose a new API in
+> the traditional sense, so we're not talking about the experimental API
+> channel) means that we're prototyping and experimenting with the functionality
+> behind an experimental build flag and/or mechanisms that keep them gated from
+> standard use. We will use the experimental period to help inform and update
+> the GEP.
 
 ## TLDR
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -1,14 +1,7 @@
 # GEP-1709: Conformance Profiles
 
 * Issue: [#1709](https://github.com/kubernetes-sigs/gateway-api/issues/1709)
-* Status: Experimental
-
-> **NOTE**: Experimental in this case (since this doesn't propose a new API in
-> the traditional sense, so we're not talking about the experimental API
-> channel) means that we're prototyping and experimenting with the functionality
-> behind an experimental build flag and/or mechanisms that keep them gated from
-> standard use. We will use the experimental period to help inform and update
-> the GEP.
+* Status: Prototyping
 
 ## TLDR
 

--- a/geps/overview.md
+++ b/geps/overview.md
@@ -117,6 +117,15 @@ What is out of scope: see [text from KEP][kep-when-to-use]. Examples:
     key goal of GEPs is to show why we made a decision and which alternatives
     were considered. If separate docs are used, it's important that we can
     still see all relevant context and decisions in the final GEP.
+* Q: When should I mark a GEP as `Prototyping` as opposed to `Provisional`?
+  * A: The `Prototyping` status carries the same base meaning as `Provisional`
+    in that consensus is not complete between stakeholders and we're not ready
+    to move toward releasing content yet. You should use `Prototyping` to
+    indicate to your fellow community members that we're in a state of active
+    practical tests and experiments which are intended to help us learn and
+    iterate on the GEP. These can include distributing content, but not under
+    any release (e.g. it has to be unavailable except when explicitly opted
+    in to).
 
 [kep]: https://github.com/kubernetes/enhancements
 [kep-when-to-use]: https://github.com/kubernetes/enhancements/tree/master/keps#do-i-have-to-use-the-kep-process

--- a/geps/overview.md
+++ b/geps/overview.md
@@ -124,8 +124,7 @@ What is out of scope: see [text from KEP][kep-when-to-use]. Examples:
     indicate to your fellow community members that we're in a state of active
     practical tests and experiments which are intended to help us learn and
     iterate on the GEP. These can include distributing content, but not under
-    any release (e.g. it has to be unavailable except when explicitly opted
-    in to).
+        any release channel.
 
 [kep]: https://github.com/kubernetes/enhancements
 [kep-when-to-use]: https://github.com/kubernetes/enhancements/tree/master/keps#do-i-have-to-use-the-kep-process

--- a/geps/overview.md
+++ b/geps/overview.md
@@ -66,6 +66,11 @@ meeting before merging. Most GEPS will proceed through the following states:
 
 * **Provisional:** The goals described by this GEP have consensus but
   implementation details have not been agreed to yet.
+* **Prototyping:** An extension of `Provisional` which can be opted in to in
+  order to indicate to the community that there are some active practical tests
+  and experiments going on which are intended to be a part of the development
+  of this GEP. This may include APIs or code, but that content _must_ not be
+  distributed with releases.
 * **Implementable:** The goals and implementation details described by this GEP
   have consensus but have not been fully implemented yet.
 * **Experimental:** This GEP has been implemented and is part of the

--- a/geps/overview.md
+++ b/geps/overview.md
@@ -124,7 +124,7 @@ What is out of scope: see [text from KEP][kep-when-to-use]. Examples:
     indicate to your fellow community members that we're in a state of active
     practical tests and experiments which are intended to help us learn and
     iterate on the GEP. These can include distributing content, but not under
-        any release channel.
+    any release channel.
 
 [kep]: https://github.com/kubernetes/enhancements
 [kep-when-to-use]: https://github.com/kubernetes/enhancements/tree/master/keps#do-i-have-to-use-the-kep-process

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
         - geps/gep-1426.md
         - geps/gep-1324.md
         - geps/gep-1282.md
+      - Prototyping:
         - geps/gep-1709.md
       - Experimental:
         - geps/gep-1323.md


### PR DESCRIPTION
**What type of PR is this?**

/kind gep

**What this PR does / why we need it**:

This supports #1709 by moving the GEP into a new `Prototyping` status, indicating that we're going to be doing some active testing and experimentation to see how we like things and ultimately feed back into further iterations on the GEP.

> **NOTE**: Originally I went for `Experimental` to make a clear indication to the community that we're going to be doing some
> experimentation before we seek consensus and move to `implementable`, however we use `Experimental` for something
> somewhat specific right now so there was some concern this would be confusing. The new `Prototyping` status is simply
> an extension of `Provisional` intended to allow community members to signal the intent to incorporate prototyping as part of
> the GEP development process.

This also adds several small TODO notes based on feedback at recent community meetings and general clarifications in the GEP.