### PR TITLE
docs: GEP 1709 profiles at the *Route granularity level

### DIFF
--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -508,7 +508,7 @@ Creating a pull request to add the `ConformanceReport` will start the
 > the reporting the reputation loss for being caught would make them look very
 > bad and would not be worth it.
 
-[crds]:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
+[crd]:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
 
 #### Certification Process
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -29,11 +29,6 @@ The following are items that we intend to resolve before we consider this GEP
   this soak for some time, bring up the topic at SIG Arch community meetings, and
   generally make changes according to their feedback before considering this
   `implementable`.
-- There are lingering concerns from several community members that having high
-  level profiles like `Layer7` and `Layer4` might not be the best way to start,
-  but instead we should consider focusing on specific APIs, e.g. profiles that
-  we start with might be `HTTPRoute`, `GRPCRoute`, `TCPRoute`, `UDPRoute`
-  e.t.c. so that subscribing to profiles can be more à la carte.
 
 [sig-arch-feedback]:https://groups.google.com/g/kubernetes-sig-architecture/c/YjrVZ4NJQiA/m/7Qg7ScddBwAJ
 
@@ -97,24 +92,36 @@ conformance suite as a library.
 
 ### Profiles
 
-Initially there will be two profiles:
+"Profiles" are effectively categories which represent the high level grouping of
+tests related to some feature (or feature set) of Gateway API. When conformance
+is reported using one of these profiles extra features can be covered according
+to support levels:
 
-- `Layer4`
-- `Layer7`
-
-> **NOTE**: these are simply the initial profiles we're going to start with,
-> it's plausible for there to be more in the future.
-
-These named profiles are effectively categories which represent the high level
-grouping of tests. When conformance is reported using one of these profiles
-extra features can be covered according to support levels:
-
+- `core`
 - `extended`
 
 > **NOTE**: `implementation-specific` doesn't really have much in the way of
 > tests today, but it is something users want to be able to display. We leave
 > door open for it later and mention it in the [alternatives
 > considered](#alternatives-considered) section below.
+
+We will start with the following named profiles:
+
+- `HTTPRoute`
+- `TLSRoute`
+
+These profiles correspond with `*Route` type APIs that we currently have tests
+for. As the tests roll in, we'll also eventually have:
+
+- `UDPRoute`
+- `TCPRoute`
+- `GRPCRoute`
+
+> **NOTE**: In time we may have higher level groupings, like `Layer4` (which
+> would include at least `TCPRoute` and `UDPRoute`) but feedback from the
+> community has been strong for a preference on the `*Route` level (see the
+> [alternatives considered](#alternatives-considered) for some more notes on
+> this) for the moment.
 
 The technical implementation of these profiles is very simple: effectively a
 "profile" is a static compilation of existing [SupportedFeatures][feat] which
@@ -563,6 +570,22 @@ we believe the test suite for mesh could end up being it's own separate thing
 so it's not a part of this GEP for now, but we should make sure our tooling is
 modular and composable so if we do end up with an eventual mesh conformance
 test suite, it can employ conformance profiles and reporting as-is.
+
+### High Level Profiles
+
+We originally started with two high level profiles:
+
+- `Layer4`
+- `Layer7`
+
+However the overwhelming feedback from the community was to go a step down and
+define profiles at the level of each individual API (e.g. `HTTPRoute`,
+`TCPRoute`, `GRPCRoute`, e.t.c.). One of the main reasons for this was that we
+already have multiple known implementations of Gateway API which only support
+a single route type (`UDPRoute`, in particular as it turns out).
+
+We may consider in the future doing some of these higher level profiles if
+there's a technical reason or strong desire from implementers.
 
 ## References
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -180,7 +180,7 @@ above):
 ```console
 $ go test ./conformance/... -args \
     -gateway-class=acme \
-    -conformance-profiles=Layer7,Layer4 \
+    -conformance-profiles=HTTPRoute,TCPRoute \
     -unsupported-features=HTTPResponseHeaderModification,HTTPRouteMethodMatching,HTTPRouteQueryParamMatching,
 ```
 
@@ -190,8 +190,8 @@ Or the equivalent configuration using the Golang library:
 cSuite, err := suite.New(suite.Options{
     GatewayClassName: "acme",
     Profiles: sets.New(
-        Layer7,
-        Layer4,
+        HTTPRoute,
+        TCPRoute,
     ),
     UnsupportedFeatures: sets.New(
         suite.SupportHTTPResponseHeaderModification,
@@ -222,8 +222,8 @@ expressions will compile to the same overall list:
 cSuite, err := suite.New(suite.Options{
     GatewayClassName: "acme",
     Profiles: sets.New(
-        Layer7,
-        Layer4,
+        HTTPRoute,
+        TCPRoute,
     ),
     SupportedFeatures: sets.New(
         suite.SupportHTTPRouteMethodMatching,
@@ -274,7 +274,7 @@ implementation:
 date: "2023-02-28 20:29:41+00:00"
 gatewayAPIVersion: v0.7.0
 profiles:
-  layer4:
+  tcproute:
     core:
       status: success
       summary: "all core functionality passed"
@@ -293,7 +293,7 @@ profiles:
       - ExtendedFeature1
       - ExtendedFeature2
       - ExtendedFeature3
-  layer7:
+  httproute:
     core:
       status: success
       summary: "all core functionality passed"
@@ -333,8 +333,8 @@ profiles:
 > regarding conformance, e.t.c.).
 
 The above report describes an implemenation that just released `v1` and has
-`Core` support for Layer4 functionality and full supports both `Core` and
-`Extended` Layer7 functionality.
+`Core` support for `TCPRoute` functionality and full supports both `Core` and
+`Extended` `HTTPRoute` functionality.
 
 `ConformanceReports` can be stored as a list of reports in chronological order.
 The following shows previous releases of the `acmeorg-acme` implementation and
@@ -352,7 +352,7 @@ implementation:
 date: "2022-09-28 20:29:41+00:00"
 gatewayAPIVersion: v0.6.2
 profiles:
-  layer4:
+  tcproute:
     core:
       status: partial
       summary: "some tests were manually skipped"
@@ -374,7 +374,7 @@ profiles:
       - ExtendedFeature1
       - ExtendedFeature2
       - ExtendedFeature3
-  layer7:
+  httproute:
     core:
       status: success
       summary: "all core functionality passed"
@@ -408,7 +408,7 @@ implementation:
 date: "2022-08-28 20:29:41+00:00"
 gatewayAPIVersion: v0.6.1
 profiles:
-  layer4:
+  tcproute:
     core:
       status: failed
       summary: "all tests are failing"
@@ -417,11 +417,11 @@ profiles:
         skipped: 0
         failed: 4
       failedTests:
-      - Layer4ExampleTest1
-      - Layer4ExampleTest2
-      - Layer4ExampleTest3
-      - Layer4ExampleTest4
-  layer7:
+      - TCPRouteExampleTest1
+      - TCPRouteExampleTest2
+      - TCPRouteExampleTest3
+      - TCPRouteExampleTest4
+  httproute:
     core:
       status: success
       summary: "all core functionality passed"
@@ -455,7 +455,7 @@ implementation:
 date: "2022-07-28 20:29:41+00:00"
 gatewayAPIVersion: v0.6.0
 profiles:
-  layer7:
+  httproute:
     core:
       status: partial
       summary: "some tests were skipped"
@@ -482,13 +482,13 @@ profiles:
 ```
 
 > **NOTE**: In the above you can see the `acme` implementation's progression. In
-> their release `v0.89.0` they had started adding `Layer7` support and added the
+> their release `v0.89.0` they had started adding `HTTPRoute` support and added the
 > conformance tests to CI, but they were still skipping some core tests. In
-> their next release `v0.90.0` they completed adding `Layer7` `Core`
+> their next release `v0.90.0` they completed adding `HTTPRoute` `Core`
 > functionality (and even added one extended feature), and also starting adding
-> `Layer4` functionality during `v0.90.0` (but it was failing at that time). In
-> `v0.91.0` they had completed core `Layer7` supported and added two more
-> `Extended` features, and also started to get their `Layer4` functionality to
+> `TCPRoute` functionality during `v0.90.0` (but it was failing at that time). In
+> `v0.91.0` they had completed core `HTTPRoute` supported and added two more
+> `Extended` features, and also started to get their `TCPRoute` functionality to
 > partially pass.
 
 Implementers can submit their reports upstream by creating a pull request to

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -107,26 +107,26 @@ to support levels:
 
 We will start with the following named profiles:
 
-- `HTTPRoute`
-- `TLSRoute`
+- `HTTP`
+- `TLS`
 
 These profiles correspond with `*Route` type APIs that we currently have tests
 for. As the tests roll in, we'll also eventually have:
 
-- `UDPRoute`
-- `TCPRoute`
-- `GRPCRoute`
+- `UDP`
+- `TCP`
+- `GRP`
 
 > **NOTE**: In time we may have higher level groupings, like `Layer4` (which
-> would include at least `TCPRoute` and `UDPRoute`) but feedback from the
-> community has been strong for a preference on the `*Route` level (see the
+> would include at least `TCP` and `UDP`) but feedback from the community has
+> been strong for a preference on the `*Route` level (see the
 > [alternatives considered](#alternatives-considered) for some more notes on
 > this) for the moment.
 
 > **NOTE**: APIs that are referenced to or by `*Route` APIs will be tested as
-> a part of a profile. For instance, running the `HTTPRoute` profile will also
-> run tests for `GatewayClass` and `Gateway` implicitly as these are required
-> components of supporting `HTTPRoute`.
+> a part of a profile. For instance, running the `HTTP` profile will also run
+> tests for `GatewayClass` and `Gateway` implicitly as these are required
+> components of supporting `HTTP`.
 
 The technical implementation of these profiles is very simple: effectively a
 "profile" is a static compilation of existing [SupportedFeatures][feat] which
@@ -185,7 +185,7 @@ above):
 ```console
 $ go test ./conformance/... -args \
     -gateway-class=acme \
-    -conformance-profiles=HTTPRoute,TCPRoute \
+    -conformance-profiles=HTTP,TCP \
     -unsupported-features=HTTPResponseHeaderModification,HTTPRouteMethodMatching,HTTPRouteQueryParamMatching,
 ```
 
@@ -195,8 +195,8 @@ Or the equivalent configuration using the Golang library:
 cSuite, err := suite.New(suite.Options{
     GatewayClassName: "acme",
     Profiles: sets.New(
-        HTTPRoute,
-        TCPRoute,
+        HTTP,
+        TCP,
     ),
     UnsupportedFeatures: sets.New(
         suite.SupportHTTPResponseHeaderModification,
@@ -227,8 +227,8 @@ expressions will compile to the same overall list:
 cSuite, err := suite.New(suite.Options{
     GatewayClassName: "acme",
     Profiles: sets.New(
-        HTTPRoute,
-        TCPRoute,
+        HTTP,
+        TCP,
     ),
     SupportedFeatures: sets.New(
         suite.SupportHTTPRouteMethodMatching,
@@ -279,7 +279,7 @@ implementation:
 date: "2023-02-28 20:29:41+00:00"
 gatewayAPIVersion: v0.7.0
 profiles:
-  tcproute:
+  tcp:
     core:
       status: success
       summary: "all core functionality passed"
@@ -298,7 +298,7 @@ profiles:
       - ExtendedFeature1
       - ExtendedFeature2
       - ExtendedFeature3
-  httproute:
+  http:
     core:
       status: success
       summary: "all core functionality passed"
@@ -338,8 +338,8 @@ profiles:
 > regarding conformance, e.t.c.).
 
 The above report describes an implemenation that just released `v1` and has
-`Core` support for `TCPRoute` functionality and fully supports both `Core` and
-`Extended` `HTTPRoute` functionality.
+`Core` support for `TCP` functionality and fully supports both `Core` and
+`Extended` `HTTP` functionality.
 
 `ConformanceReports` can be stored as a list of reports in chronological order.
 The following shows previous releases of the `acmeorg-acme` implementation and
@@ -357,7 +357,7 @@ implementation:
 date: "2022-09-28 20:29:41+00:00"
 gatewayAPIVersion: v0.6.2
 profiles:
-  tcproute:
+  tcp:
     core:
       status: partial
       summary: "some tests were manually skipped"
@@ -379,7 +379,7 @@ profiles:
       - ExtendedFeature1
       - ExtendedFeature2
       - ExtendedFeature3
-  httproute:
+  http:
     core:
       status: success
       summary: "all core functionality passed"
@@ -413,7 +413,7 @@ implementation:
 date: "2022-08-28 20:29:41+00:00"
 gatewayAPIVersion: v0.6.1
 profiles:
-  tcproute:
+  tcp:
     core:
       status: failed
       summary: "all tests are failing"
@@ -426,7 +426,7 @@ profiles:
       - TCPRouteExampleTest2
       - TCPRouteExampleTest3
       - TCPRouteExampleTest4
-  httproute:
+  http:
     core:
       status: success
       summary: "all core functionality passed"
@@ -460,7 +460,7 @@ implementation:
 date: "2022-07-28 20:29:41+00:00"
 gatewayAPIVersion: v0.6.0
 profiles:
-  httproute:
+  http:
     core:
       status: partial
       summary: "some tests were skipped"
@@ -487,13 +487,13 @@ profiles:
 ```
 
 > **NOTE**: In the above you can see the `acme` implementation's progression. In
-> their release `v0.89.0` they had started adding `HTTPRoute` support and added the
+> their release `v0.89.0` they had started adding `HTTP` support and added the
 > conformance tests to CI, but they were still skipping some core tests. In
-> their next release `v0.90.0` they completed adding `HTTPRoute` `Core`
+> their next release `v0.90.0` they completed adding `HTTP` `Core`
 > functionality (and even added one extended feature), and also starting adding
-> `TCPRoute` functionality during `v0.90.0` (but it was failing at that time). In
-> `v0.91.0` they had completed core `HTTPRoute` supported and added two more
-> `Extended` features, and also started to get their `TCPRoute` functionality to
+> `TCP` functionality during `v0.90.0` (but it was failing at that time). In
+> `v0.91.0` they had completed core `HTTP` supported and added two more
+> `Extended` features, and also started to get their `TCP` functionality to
 > partially pass.
 
 Implementers can submit their reports upstream by creating a pull request to

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -123,6 +123,11 @@ for. As the tests roll in, we'll also eventually have:
 > [alternatives considered](#alternatives-considered) for some more notes on
 > this) for the moment.
 
+> **NOTE**: APIs that are referenced to or by `*Route` APIs will be tested as
+> a part of a profile. For instance, running the `HTTPRoute` profile will also
+> run tests for `GatewayClass` and `Gateway` implicitly as these are required
+> components of supporting `HTTPRoute`.
+
 The technical implementation of these profiles is very simple: effectively a
 "profile" is a static compilation of existing [SupportedFeatures][feat] which
 represent the named category. Features that aren't covered under a "core" level

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -29,6 +29,15 @@ The following are items that we intend to resolve before we consider this GEP
   this soak for some time, bring up the topic at SIG Arch community meetings, and
   generally make changes according to their feedback before considering this
   `implementable`.
+- Right now we've said that `GatewayClass` and `Gateway` tests will be
+  implicitly added to testing profiles were they are referenced, but we're
+  not sure yet whether this is going to work out for `ReferenceGrant` as we
+  know of at least one implementation that explicitly doesn't support it.
+  It's possible `ReferenceGrant` is just a special case for a profile we'll
+  have to allow opting into or out of, or maybe some other optional way to do
+  this but still be conformant. Needs to be resolved before we move to
+  `implementable` as `ReferenceGrant` is already in BETA and is being
+  considered in other areas of Kubernetes.
 
 [sig-arch-feedback]:https://groups.google.com/g/kubernetes-sig-architecture/c/YjrVZ4NJQiA/m/7Qg7ScddBwAJ
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -115,7 +115,7 @@ for. As the tests roll in, we'll also eventually have:
 
 - `UDP`
 - `TCP`
-- `GRP`
+- `GRPC`
 
 > **NOTE**: In time we may have higher level groupings, like `Layer4` (which
 > would include at least `TCP` and `UDP`) but feedback from the community has

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -333,7 +333,7 @@ profiles:
 > regarding conformance, e.t.c.).
 
 The above report describes an implemenation that just released `v1` and has
-`Core` support for `TCPRoute` functionality and full supports both `Core` and
+`Core` support for `TCPRoute` functionality and fully supports both `Core` and
 `Extended` `HTTPRoute` functionality.
 
 `ConformanceReports` can be stored as a list of reports in chronological order.

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -108,7 +108,7 @@ to support levels:
 We will start with the following named profiles:
 
 - `HTTP`
-- `TLS`
+- `TLSPassthrough`
 
 These profiles correspond with `*Route` type APIs that we currently have tests
 for. As the tests roll in, we'll also eventually have:


### PR DESCRIPTION
**What type of PR is this?**

/kind gep
/kind documentation

**What this PR does / why we need it**:

There's been a lot of feedback from the community in community meetings and on recent PRs that there's a preference for named profiles to correspond directly with `*Route` APIs, and move down a level in granularity from `Layer 4` and `Layer 7`. This PR makes the language changes necessary to support that desire.