### PR TITLE
fix: add webhook validation of redirect usage

### DIFF
--- a/apis/v1alpha2/validation/httproute_test.go
+++ b/apis/v1alpha2/validation/httproute_test.go
@@ -805,6 +805,7 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 	tests := []struct {
 		name        string
 		routeFilter gatewayv1a2.HTTPRouteFilter
+		backendRefs []gatewayv1a2.HTTPBackendRef
 		errCount    int
 	}{{
 		name: "valid HTTPRouteFilterRequestHeaderModifier route filter",
@@ -816,6 +817,14 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 				Remove: []string{"remove"},
 			},
 		},
+		backendRefs: []gatewayv1a2.HTTPBackendRef{{
+			BackendRef: gatewayv1a2.BackendRef{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Name: gatewayv1a2.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 0,
 	}, {
 		name: "invalid HTTPRouteFilterRequestHeaderModifier type filter with non-matching field",
@@ -823,12 +832,28 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 			Type:          gatewayv1b1.HTTPRouteFilterRequestHeaderModifier,
 			RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{},
 		},
+		backendRefs: []gatewayv1a2.HTTPBackendRef{{
+			BackendRef: gatewayv1a2.BackendRef{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Name: gatewayv1a2.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 2,
 	}, {
 		name: "invalid HTTPRouteFilterRequestHeaderModifier type filter with empty value field",
 		routeFilter: gatewayv1a2.HTTPRouteFilter{
 			Type: gatewayv1b1.HTTPRouteFilterRequestHeaderModifier,
 		},
+		backendRefs: []gatewayv1a2.HTTPBackendRef{{
+			BackendRef: gatewayv1a2.BackendRef{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Name: gatewayv1a2.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 1,
 	}, {
 		name: "valid HTTPRouteFilterRequestMirror route filter",
@@ -842,6 +867,14 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 				Port:      ptrTo(gatewayv1b1.PortNumber(22)),
 			}},
 		},
+		backendRefs: []gatewayv1a2.HTTPBackendRef{{
+			BackendRef: gatewayv1a2.BackendRef{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Name: gatewayv1a2.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 0,
 	}, {
 		name: "invalid HTTPRouteFilterRequestMirror type filter with non-matching field",
@@ -849,12 +882,28 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 			Type:                  gatewayv1b1.HTTPRouteFilterRequestMirror,
 			RequestHeaderModifier: &gatewayv1a2.HTTPHeaderFilter{},
 		},
+		backendRefs: []gatewayv1a2.HTTPBackendRef{{
+			BackendRef: gatewayv1a2.BackendRef{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Name: gatewayv1a2.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 2,
 	}, {
 		name: "invalid HTTPRouteFilterRequestMirror type filter with empty value field",
 		routeFilter: gatewayv1a2.HTTPRouteFilter{
 			Type: gatewayv1b1.HTTPRouteFilterRequestMirror,
 		},
+		backendRefs: []gatewayv1a2.HTTPBackendRef{{
+			BackendRef: gatewayv1a2.BackendRef{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Name: gatewayv1a2.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 1,
 	}, {
 		name: "valid HTTPRouteFilterRequestRedirect route filter",
@@ -875,12 +924,28 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 			Type:          gatewayv1b1.HTTPRouteFilterRequestRedirect,
 			RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{},
 		},
+		backendRefs: []gatewayv1a2.HTTPBackendRef{{
+			BackendRef: gatewayv1a2.BackendRef{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Name: gatewayv1a2.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 2,
 	}, {
 		name: "invalid HTTPRouteFilterRequestRedirect type filter with empty value field",
 		routeFilter: gatewayv1a2.HTTPRouteFilter{
 			Type: gatewayv1b1.HTTPRouteFilterRequestRedirect,
 		},
+		backendRefs: []gatewayv1a2.HTTPBackendRef{{
+			BackendRef: gatewayv1a2.BackendRef{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Name: gatewayv1a2.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 1,
 	}, {
 		name: "valid HTTPRouteFilterExtensionRef filter",
@@ -892,6 +957,14 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 				Name:  "name",
 			},
 		},
+		backendRefs: []gatewayv1a2.HTTPBackendRef{{
+			BackendRef: gatewayv1a2.BackendRef{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Name: gatewayv1a2.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 0,
 	}, {
 		name: "invalid HTTPRouteFilterExtensionRef type filter with non-matching field",
@@ -899,12 +972,28 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 			Type:          gatewayv1b1.HTTPRouteFilterExtensionRef,
 			RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{},
 		},
+		backendRefs: []gatewayv1a2.HTTPBackendRef{{
+			BackendRef: gatewayv1a2.BackendRef{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Name: gatewayv1a2.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 2,
 	}, {
 		name: "invalid HTTPRouteFilterExtensionRef type filter with empty value field",
 		routeFilter: gatewayv1a2.HTTPRouteFilter{
 			Type: gatewayv1b1.HTTPRouteFilterExtensionRef,
 		},
+		backendRefs: []gatewayv1a2.HTTPBackendRef{{
+			BackendRef: gatewayv1a2.BackendRef{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Name: gatewayv1a2.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 1,
 	}, {
 		name: "valid HTTPRouteFilterURLRewrite route filter",
@@ -915,6 +1004,14 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 				Path:     &gatewayv1a2.HTTPPathModifier{},
 			},
 		},
+		backendRefs: []gatewayv1a2.HTTPBackendRef{{
+			BackendRef: gatewayv1a2.BackendRef{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Name: gatewayv1a2.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 0,
 	}, {
 		name: "invalid HTTPRouteFilterURLRewrite type filter with non-matching field",
@@ -922,17 +1019,41 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 			Type:          gatewayv1b1.HTTPRouteFilterURLRewrite,
 			RequestMirror: &gatewayv1a2.HTTPRequestMirrorFilter{},
 		},
+		backendRefs: []gatewayv1a2.HTTPBackendRef{{
+			BackendRef: gatewayv1a2.BackendRef{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Name: gatewayv1a2.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 2,
 	}, {
 		name: "invalid HTTPRouteFilterURLRewrite type filter with empty value field",
 		routeFilter: gatewayv1a2.HTTPRouteFilter{
 			Type: gatewayv1b1.HTTPRouteFilterURLRewrite,
 		},
+		backendRefs: []gatewayv1a2.HTTPBackendRef{{
+			BackendRef: gatewayv1a2.BackendRef{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Name: gatewayv1a2.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 1,
 	}, {
 		name:        "empty type filter is valid (caught by CRD validation)",
 		routeFilter: gatewayv1a2.HTTPRouteFilter{},
-		errCount:    0,
+		backendRefs: []gatewayv1a2.HTTPBackendRef{{
+			BackendRef: gatewayv1a2.BackendRef{
+				BackendObjectReference: gatewayv1a2.BackendObjectReference{
+					Name: gatewayv1a2.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
+		errCount: 0,
 	}}
 
 	for _, tc := range tests {
@@ -940,15 +1061,8 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 			route := gatewayv1a2.HTTPRoute{
 				Spec: gatewayv1a2.HTTPRouteSpec{
 					Rules: []gatewayv1a2.HTTPRouteRule{{
-						Filters: []gatewayv1a2.HTTPRouteFilter{tc.routeFilter},
-						BackendRefs: []gatewayv1a2.HTTPBackendRef{{
-							BackendRef: gatewayv1a2.BackendRef{
-								BackendObjectReference: gatewayv1a2.BackendObjectReference{
-									Name: gatewayv1a2.ObjectName("test"),
-									Port: ptrTo(gatewayv1b1.PortNumber(8080)),
-								},
-							},
-						}},
+						Filters:     []gatewayv1a2.HTTPRouteFilter{tc.routeFilter},
+						BackendRefs: tc.backendRefs,
 					}},
 				},
 			}

--- a/apis/v1beta1/validation/httproute_test.go
+++ b/apis/v1beta1/validation/httproute_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
 
 	gatewayv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -986,6 +987,7 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 	tests := []struct {
 		name        string
 		routeFilter gatewayv1b1.HTTPRouteFilter
+		backendRefs []gatewayv1b1.HTTPBackendRef
 		errCount    int
 	}{{
 		name: "valid HTTPRouteFilterRequestHeaderModifier route filter",
@@ -997,6 +999,14 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 				Remove: []string{"remove"},
 			},
 		},
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 0,
 	}, {
 		name: "invalid HTTPRouteFilterRequestHeaderModifier type filter with non-matching field",
@@ -1004,12 +1014,28 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 			Type:          gatewayv1b1.HTTPRouteFilterRequestHeaderModifier,
 			RequestMirror: &gatewayv1b1.HTTPRequestMirrorFilter{},
 		},
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 2,
 	}, {
 		name: "invalid HTTPRouteFilterRequestHeaderModifier type filter with empty value field",
 		routeFilter: gatewayv1b1.HTTPRouteFilter{
 			Type: gatewayv1b1.HTTPRouteFilterRequestHeaderModifier,
 		},
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 1,
 	}, {
 		name: "valid HTTPRouteFilterRequestMirror route filter",
@@ -1023,6 +1049,14 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 				Port:      ptrTo(gatewayv1b1.PortNumber(22)),
 			}},
 		},
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 0,
 	}, {
 		name: "invalid HTTPRouteFilterRequestMirror type filter with non-matching field",
@@ -1030,12 +1064,28 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 			Type:                  gatewayv1b1.HTTPRouteFilterRequestMirror,
 			RequestHeaderModifier: &gatewayv1b1.HTTPHeaderFilter{},
 		},
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 2,
 	}, {
 		name: "invalid HTTPRouteFilterRequestMirror type filter with empty value field",
 		routeFilter: gatewayv1b1.HTTPRouteFilter{
 			Type: gatewayv1b1.HTTPRouteFilterRequestMirror,
 		},
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 1,
 	}, {
 		name: "valid HTTPRouteFilterRequestRedirect route filter",
@@ -1051,17 +1101,54 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 		},
 		errCount: 0,
 	}, {
+		name: "invalid HTTPRouteFilterRequestRedirect route filter with backendRefs",
+		routeFilter: gatewayv1b1.HTTPRouteFilter{
+			Type: gatewayv1b1.HTTPRouteFilterRequestRedirect,
+			RequestRedirect: &gatewayv1b1.HTTPRequestRedirectFilter{
+				Scheme:     new(string),
+				Hostname:   new(gatewayv1b1.PreciseHostname),
+				Path:       &gatewayv1b1.HTTPPathModifier{},
+				Port:       new(gatewayv1b1.PortNumber),
+				StatusCode: new(int),
+			},
+		},
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
+		errCount: 1,
+	}, {
 		name: "invalid HTTPRouteFilterRequestRedirect type filter with non-matching field",
 		routeFilter: gatewayv1b1.HTTPRouteFilter{
 			Type:          gatewayv1b1.HTTPRouteFilterRequestRedirect,
 			RequestMirror: &gatewayv1b1.HTTPRequestMirrorFilter{},
 		},
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 2,
 	}, {
 		name: "invalid HTTPRouteFilterRequestRedirect type filter with empty value field",
 		routeFilter: gatewayv1b1.HTTPRouteFilter{
 			Type: gatewayv1b1.HTTPRouteFilterRequestRedirect,
 		},
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 1,
 	}, {
 		name: "valid HTTPRouteFilterExtensionRef filter",
@@ -1073,6 +1160,14 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 				Name:  "name",
 			},
 		},
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 0,
 	}, {
 		name: "invalid HTTPRouteFilterExtensionRef type filter with non-matching field",
@@ -1080,12 +1175,28 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 			Type:          gatewayv1b1.HTTPRouteFilterExtensionRef,
 			RequestMirror: &gatewayv1b1.HTTPRequestMirrorFilter{},
 		},
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 2,
 	}, {
 		name: "invalid HTTPRouteFilterExtensionRef type filter with empty value field",
 		routeFilter: gatewayv1b1.HTTPRouteFilter{
 			Type: gatewayv1b1.HTTPRouteFilterExtensionRef,
 		},
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 1,
 	}, {
 		name: "valid HTTPRouteFilterURLRewrite route filter",
@@ -1096,6 +1207,14 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 				Path:     &gatewayv1b1.HTTPPathModifier{},
 			},
 		},
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 0,
 	}, {
 		name: "invalid HTTPRouteFilterURLRewrite type filter with non-matching field",
@@ -1103,17 +1222,41 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 			Type:          gatewayv1b1.HTTPRouteFilterURLRewrite,
 			RequestMirror: &gatewayv1b1.HTTPRequestMirrorFilter{},
 		},
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 2,
 	}, {
 		name: "invalid HTTPRouteFilterURLRewrite type filter with empty value field",
 		routeFilter: gatewayv1b1.HTTPRouteFilter{
 			Type: gatewayv1b1.HTTPRouteFilterURLRewrite,
 		},
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
 		errCount: 1,
 	}, {
 		name:        "empty type filter is valid (caught by CRD validation)",
 		routeFilter: gatewayv1b1.HTTPRouteFilter{},
-		errCount:    0,
+		backendRefs: []gatewayv1b1.HTTPBackendRef{{
+			BackendRef: gatewayv1b1.BackendRef{
+				BackendObjectReference: gatewayv1b1.BackendObjectReference{
+					Name: gatewayv1b1.ObjectName("test"),
+					Port: ptrTo(gatewayv1b1.PortNumber(8080)),
+				},
+			},
+		}},
+		errCount: 0,
 	}}
 
 	for _, tc := range tests {
@@ -1121,21 +1264,152 @@ func TestValidateHTTPRouteTypeMatchesField(t *testing.T) {
 			route := gatewayv1b1.HTTPRoute{
 				Spec: gatewayv1b1.HTTPRouteSpec{
 					Rules: []gatewayv1b1.HTTPRouteRule{{
-						Filters: []gatewayv1b1.HTTPRouteFilter{tc.routeFilter},
-						BackendRefs: []gatewayv1b1.HTTPBackendRef{{
-							BackendRef: gatewayv1b1.BackendRef{
-								BackendObjectReference: gatewayv1b1.BackendObjectReference{
-									Name: gatewayv1b1.ObjectName("test"),
-									Port: ptrTo(gatewayv1b1.PortNumber(8080)),
-								},
-							},
-						}},
+						Filters:     []gatewayv1b1.HTTPRouteFilter{tc.routeFilter},
+						BackendRefs: tc.backendRefs,
 					}},
 				},
 			}
 			errs := ValidateHTTPRoute(&route)
 			if len(errs) != tc.errCount {
 				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errCount, errs)
+			}
+		})
+	}
+}
+
+func TestValidateInvalidBackendWithRedirectFilter(t *testing.T) {
+	testcases := []struct {
+		name       string
+		inputRules []gatewayv1b1.HTTPRouteRule
+		errorCount int
+	}{
+		{
+			name:       "valid usage of redirect filter",
+			errorCount: 0,
+			inputRules: []gatewayv1b1.HTTPRouteRule{
+				{
+					Filters: []gatewayv1b1.HTTPRouteFilter{
+						{
+							Type: gatewayv1b1.HTTPRouteFilterRequestRedirect,
+							RequestRedirect: &gatewayv1b1.HTTPRequestRedirectFilter{
+								Scheme:     pointer.String("https"),
+								StatusCode: pointer.Int(301),
+							},
+						},
+					},
+				},
+			},
+		}, {
+			name:       "invalid usage of redirect filter in rule level",
+			errorCount: 1,
+			inputRules: []gatewayv1b1.HTTPRouteRule{
+				{
+					Filters: []gatewayv1b1.HTTPRouteFilter{
+						{
+							Type: gatewayv1b1.HTTPRouteFilterRequestRedirect,
+							RequestRedirect: &gatewayv1b1.HTTPRequestRedirectFilter{
+								Scheme:     pointer.String("https"),
+								StatusCode: pointer.Int(301),
+							},
+						},
+					},
+					BackendRefs: []gatewayv1b1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1b1.BackendRef{
+								BackendObjectReference: gatewayv1b1.BackendObjectReference{
+									Name: "example-svc",
+									Port: (*gatewayv1b1.PortNumber)(pointer.Int32(8080)),
+								},
+								Weight: pointer.Int32(1),
+							},
+						},
+					},
+				},
+			},
+		}, {
+			name:       "invalid usage of redirect filter in backend level",
+			errorCount: 1,
+			inputRules: []gatewayv1b1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1b1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1b1.BackendRef{
+								BackendObjectReference: gatewayv1b1.BackendObjectReference{
+									Name: "example-svc",
+									Port: (*gatewayv1b1.PortNumber)(pointer.Int32(8080)),
+								},
+								Weight: pointer.Int32(1),
+							},
+							Filters: []gatewayv1b1.HTTPRouteFilter{
+								{
+									Type: gatewayv1b1.HTTPRouteFilterRequestRedirect,
+									RequestRedirect: &gatewayv1b1.HTTPRequestRedirectFilter{
+										Scheme:     pointer.String("https"),
+										StatusCode: pointer.Int(301),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, {
+			name:       "invalid usage of redirect filter in both rule and backend level",
+			errorCount: 2,
+			inputRules: []gatewayv1b1.HTTPRouteRule{
+				{
+					Filters: []gatewayv1b1.HTTPRouteFilter{
+						{
+							Type: gatewayv1b1.HTTPRouteFilterRequestRedirect,
+							RequestRedirect: &gatewayv1b1.HTTPRequestRedirectFilter{
+								Scheme:     pointer.String("https"),
+								StatusCode: pointer.Int(301),
+							},
+						},
+					},
+					BackendRefs: []gatewayv1b1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1b1.BackendRef{
+								BackendObjectReference: gatewayv1b1.BackendObjectReference{
+									Name: "example-svc",
+									Port: (*gatewayv1b1.PortNumber)(pointer.Int32(8080)),
+								},
+								Weight: pointer.Int32(1),
+							},
+						},
+					},
+				},
+				{
+					BackendRefs: []gatewayv1b1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1b1.BackendRef{
+								BackendObjectReference: gatewayv1b1.BackendObjectReference{
+									Name: "example-svc",
+									Port: (*gatewayv1b1.PortNumber)(pointer.Int32(8080)),
+								},
+								Weight: pointer.Int32(1),
+							},
+							Filters: []gatewayv1b1.HTTPRouteFilter{
+								{
+									Type: gatewayv1b1.HTTPRouteFilterRequestRedirect,
+									RequestRedirect: &gatewayv1b1.HTTPRequestRedirectFilter{
+										Scheme:     pointer.String("https"),
+										StatusCode: pointer.Int(301),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateInvalidBackendWithRedirectFilter(tc.inputRules, field.NewPath("spec").Child("rules"))
+			if len(errs) != tc.errorCount {
+				t.Errorf("got %d errors, want %d errors: %s", len(errs), tc.errorCount, errs)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind bug

**What this PR does / why we need it**:

Webhook validation should prevent a HTTPRoute that specifies a redirect filter from specifying a backendRef

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/kubernetes-sigs/gateway-api/issues/1779

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
