### PR TITLE
GEP 1709: ConformanceReports prototype API

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -27,8 +27,8 @@ rules:
     max-spaces-after: 1
   comments:
     level: warning
-    require-starting-space: true
-    min-spaces-from-content: 2
+    require-starting-space: false
+    min-spaces-from-content: 1
   comments-indentation:
     level: warning
   document-end: disable

--- a/conformance/apis/v1alpha1/conformanceprofile.go
+++ b/conformance/apis/v1alpha1/conformanceprofile.go
@@ -1,0 +1,70 @@
+//go:build experimental
+// +build experimental
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// ConformanceProfile is the collection of support levels and features for a set
+// of conformance test results which indicates whether or not an implementation
+// is conformant, and what extra features (if any) it supports.
+type ConformanceProfile struct {
+	// Name indicates the name of the conformance profile (e.g. "HTTPRoute",
+	// "TCPRoute", "UDPRoute", e.t.c.).
+	Name string `json:"name"`
+
+	// Core indicates the core support level which includes the set of tests
+	// which are the minimum the implementation must pass to be considered at
+	// all conformant.
+	Core Status `json:"core"`
+
+	// Extended indicates the extended support level which includes additional
+	// optional features which the implementation may choose to implement
+	// support for, but are not required.
+	Extended ExtendedStatus `json:"extended,omitempty"`
+}
+
+// ExtendedStatus shows the testing results for the extended support level.
+type ExtendedStatus struct {
+	Status `json:"status,inline"`
+
+	// SupportedFeatures indicates which extended features were flagged as
+	// supported by the implementation and tests will be attempted for.
+	SupportedFeatures []string `json:"supportedFeatures,omitempty"`
+
+	// UnsupportedFeatures indicates which extended features the implementation
+	// does not have support for and therefore will not attempt to test.
+	UnsupportedFeatures []string `json:"unsupportedFeatures,omitempty"`
+}
+
+// Status includes details on the results of a test.
+type Status struct {
+	Result `json:"status"`
+
+	// Summary is a human-readable message intended for end-users to understand
+	// the overall status at a glance.
+	Summary string `json:"summary"`
+
+	// Statistics includes numerical statistics on the result of the test run.
+	Statistics `json:"statistics"`
+
+	// SkippedTests indicates which tests were explicitly disabled in the test
+	// suite. Skipping tests for Core level support implicitly identifies the
+	// results as being partial and the implementation will not be considered
+	// conformant at any level.
+	SkippedTests []string `json:"skippedTests,omitempty"`
+}

--- a/conformance/apis/v1alpha1/conformancereport.go
+++ b/conformance/apis/v1alpha1/conformancereport.go
@@ -1,0 +1,73 @@
+//go:build experimental
+// +build experimental
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ConformanceReport is a report of conformance testing results including the
+// specific conformance profiles that were tested and the results of the tests
+// with summaries and statistics.
+type ConformanceReport struct {
+	metav1.TypeMeta `json:",inline"`
+	Implementation  `json:"implementation"`
+
+	// Date indicates the date that this report was generated.
+	Date string `json:"date"`
+
+	// GatewayAPIVersion indicates which release version of Gateway API this
+	// test report was made for.
+	GatewayAPIVersion string `json:"gatewayAPIVersion"`
+
+	// Profiles is a list of the conformance profiles that were enabled for
+	// this test run.
+	Profiles []ConformanceProfile `json:"profiles"`
+}
+
+// Implementation provides metadata information on the downstream
+// implementation of Gateway API which ran conformance tests.
+type Implementation struct {
+	// Organization refers to the company, group or individual which maintains
+	// the named implementation. Organizations can provide reports for any
+	// number of distinct Gateway API implementations they maintain, but need
+	// to identify themselves using this organization field for grouping.
+	Organization string `json:"organization"`
+
+	// Project indicates the name of the project or repository for a Gateway API
+	// implementation.
+	Project string `json:"project"`
+
+	// URL indicates a human-usable URL where more information about the
+	// implementation can be found. For open source projects this should
+	// generally link to the code repository.
+	URL string `json:"url"`
+
+	// Version indicates the version of the implementation that was used for
+	// testing. This should generally be a semver version when applicable.
+	Version string `json:"version"`
+
+	// Contact is contact information for the maintainers so that Gateway API
+	// maintainers can get ahold of them as needed. Ideally this should be
+	// Github usernames (in the form of `@<username>`) or team names (in the
+	// form of `@<team>/<name>`), but when that's not possible it can be email
+	// addresses.
+	Contact []string `json:"contact"`
+}

--- a/conformance/apis/v1alpha1/doc.go
+++ b/conformance/apis/v1alpha1/doc.go
@@ -1,0 +1,39 @@
+//go:build experimental
+// +build experimental
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// V1alpha1 includes alpha maturity API types and utilities for creating and
+// handling the results of conformance test runs. These types are _only_
+// intended for use by the conformance test suite OR external test suites that
+// are written in Golang and execute the conformance test suite as a Golang
+// library.
+//
+// Note that currently all sub-packages are considered "experimental" in that
+// they aren't intended for general use or to be distributed as part of a
+// release so there is no way to use them by default when using the Golang
+// library at this time. If you don't know for sure that you want to use these
+// features, then you should not use them. If you would like to opt into these
+// unreleased features use Go build tags to enable them, e.g.:
+//
+//   $ GOFLAGS='-tags=experimental' go test ./conformance/... -args ${CONFORMANCE_ARGS}
+//
+// Please note that everything here is considered experimental and subject to
+// change. Expect breaking changes and/or complete removals if you start using
+// them.
+
+package v1alpha1

--- a/conformance/apis/v1alpha1/result.go
+++ b/conformance/apis/v1alpha1/result.go
@@ -1,0 +1,38 @@
+//go:build experimental
+// +build experimental
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// Result is a simple high-level summary describing the conclusion of a test
+// run.
+type Result string
+
+var (
+	// Success indicates that the test run concluded in all required tests
+	// passing.
+	Success Result = "success"
+
+	// Partial indicates that the test run concluded in some of the required
+	// tests passing without any failures, but some were skipped.
+	Partial Result = "partial"
+
+	// Failure indicates that the test run concluded in one ore more tests
+	// failing to complete successfully.
+	Failure Result = "failure"
+)

--- a/conformance/apis/v1alpha1/statistics.go
+++ b/conformance/apis/v1alpha1/statistics.go
@@ -1,0 +1,35 @@
+//go:build experimental
+// +build experimental
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// Statistics includes numerical summaries of the number of conformance tests
+// that passed, failed or were intentionally skipped.
+type Statistics struct {
+	// Passed indicates how many tests completed successfully.
+	Passed uint32
+
+	// Skipped indicates how many tests were intentionally not run, whether due
+	// to lack of feature support or whether they were explicitly disabled in
+	// the test suite.
+	Skipped uint32
+
+	// Failed indicates how many tests were unsuccessful.
+	Failed uint32
+}

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -280,26 +280,27 @@ The following is an example report:
 apiVersion: v1alpha1
 kind: ConformanceReport
 implementation:
-  name: acmeorg-acme
-  url: https://acmeorg.com
+  organization: acme
+  project: operator
+  url: https://acme.com
   version: v1.0.0
   contact:
-  - @acme-org/maintainers
+  - @acme/maintainers
 date: "2023-02-28 20:29:41+00:00"
 gatewayAPIVersion: v0.7.0
 profiles:
-  tcp:
+  - name: tcp
     core:
       status: success
       summary: "all core functionality passed"
-      stats:
+      statistics:
         passed: 4
         skipped: 0
         failed: 0
     extended:
       status: skipped
       summary: "no extended features supported"
-      stats:
+      statistics:
         passed: 0
         skipped: 6
         failed: 0
@@ -307,18 +308,18 @@ profiles:
       - ExtendedFeature1
       - ExtendedFeature2
       - ExtendedFeature3
-  http:
+  - name: http
     core:
       status: success
       summary: "all core functionality passed"
-      stats:
+      statistics:
         passed: 20
         skipped: 0
         failed: 0
     extended:
       status: success
       summary: "all extended features supported"
-      stats:
+      statistics:
         passed: 8
         skipped: 0
         failed: 0
@@ -336,10 +337,11 @@ profiles:
 > Resource Definition (CRD)][crd] nor will it be made available along with our
 > CRDs. It will be used only by conformance test tooling.
 
-> **NOTE**: In the above the `implementation` field is a combination of
-> `<organization>-<project>`. Organizations can be an open source organization,
-> an individual, a company, e.t.c.. Organizations can theoretically have more
-> than one `<project>` name and submit separate reports for each of them.
+> **NOTE**: The `implementation` field in the above example includes an
+> `organization` and `project` field. Organizations can be an open source
+> organization, an individual, a company, e.t.c.. Organizations can
+> theoretically have multiple projects and should submit separate reports for
+> each of them.
 
 > **NOTE**: The `contact` field indicates the Github usernames or team
 > names of those who are responsible for maintaining this file, so they can be
@@ -351,26 +353,27 @@ The above report describes an implemenation that just released `v1` and has
 `Extended` `HTTP` functionality.
 
 `ConformanceReports` can be stored as a list of reports in chronological order.
-The following shows previous releases of the `acmeorg-acme` implementation and
+The following shows previous releases of the `acme`/`operator` implementation and
 its feature progression:
 
 ```yaml
 apiVersion: v1alpha1
 kind: ConformanceReport
 implementation:
-  name: acmeorg-acme
-  url: https://acmeorg.com
+  organization: acme
+  project: operator
+  url: https://acme.com
   version: v0.91.0
   contact:
-  - @acme-org/maintainers
+  - @acme/maintainers
 date: "2022-09-28 20:29:41+00:00"
 gatewayAPIVersion: v0.6.2
 profiles:
-  tcp:
+  - name: tcp
     core:
       status: partial
       summary: "some tests were manually skipped"
-      stats:
+      statistics:
         passed: 2
         skipped: 2
         failed: 0
@@ -380,7 +383,7 @@ profiles:
     extended:
       status: skipped
       summary: "no extended features supported"
-      stats:
+      statistics:
         passed: 0
         skipped: 4
         failed: 0
@@ -388,18 +391,18 @@ profiles:
       - ExtendedFeature1
       - ExtendedFeature2
       - ExtendedFeature3
-  http:
+  - name: http
     core:
       status: success
       summary: "all core functionality passed"
-      stats:
+      statistics:
         passed: 20
         skipped: 0
         failed: 0
     extended:
       status: success
       summary: "all extended features supported"
-      stats:
+      statistics:
         passed: 5
         skipped: 3
         failed: 0
@@ -414,19 +417,20 @@ profiles:
 apiVersion: v1alpha1
 kind: ConformanceReport
 implementation:
-  name: acmeorg-acme
+  organization: acme
+  project: operator
   url: https://acmeorg.com
   version: v0.90.0
   contact:
-  - @acme-org/maintainers
+  - @acme/maintainers
 date: "2022-08-28 20:29:41+00:00"
 gatewayAPIVersion: v0.6.1
 profiles:
-  tcp:
+  - name: tcp
     core:
       status: failed
       summary: "all tests are failing"
-      stats:
+      statistics:
         passed: 0
         skipped: 0
         failed: 4
@@ -435,18 +439,18 @@ profiles:
       - TCPRouteExampleTest2
       - TCPRouteExampleTest3
       - TCPRouteExampleTest4
-  http:
+  - name: http
     core:
       status: success
       summary: "all core functionality passed"
-      stats:
+      statistics:
         passed: 20
         skipped: 0
         failed: 0
     extended:
       status: skipped
       summary: "no extended features supported"
-      stats:
+      statistics:
         passed: 2
         skipped: 6
         failed: 0
@@ -461,19 +465,20 @@ profiles:
 apiVersion: v1alpha1
 kind: ConformanceReport
 implementation:
-  name: acmeorg-acme
+  organization: acme
+  project: operator
   url: https://acmeorg.com
   version: v0.89.0
   contact:
-  - @acme-org/maintainers
+  - @acme/maintainers
 date: "2022-07-28 20:29:41+00:00"
 gatewayAPIVersion: v0.6.0
 profiles:
-  http:
+  - name: http
     core:
       status: partial
       summary: "some tests were skipped"
-      stats:
+      statistics:
         passed: 16
         skipped: 2
         failed: 0
@@ -483,7 +488,7 @@ profiles:
     extended:
       status: skipped
       summary: "no extended features supported"
-      stats:
+      statistics:
         passed: 0
         skipped: 8
         failed: 0
@@ -507,7 +512,7 @@ profiles:
 
 Implementers can submit their reports upstream by creating a pull request to
 the Gateway API repository and adding new reports to a file specific to their
-implementation's name:
+implementation's project name:
 
 ```console
 conformance/results/<organization>-<project>.yaml


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind gep
/kind test
/area conformance

**What this PR does / why we need it**:

This supports #1784 by adding an experimental version of the `ConformanceReport` as described in [GEP 1709](https://gateway-api.sigs.k8s.io/geps/gep-1709/). Because the GEP is currently considered to be in the `Prototyping` status, the [rules](https://gateway-api.sigs.k8s.io/geps/overview/#status) we've set for that status indicate content must not be distributed in a release, so this PR introduces the idea of using [Golang build tags](https://www.digitalocean.com/community/tutorials/customizing-go-binaries-with-build-tags) as the mechanism to ensure the prototype content is not directly distributed as part of any upcoming release.