### PR TITLE
docs: update latest release to v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- [v0.6.2](#v062)
 - [v0.6.1](#v061)
 - [v0.6.0](#v060)
 - [v0.6.0-rc2](#v060-rc2)
@@ -21,6 +22,55 @@
 - [v0.1.0](#v010)
 - [v0.1.0-rc2](#v010-rc2)
 - [v0.1.0-rc1](#v010-rc1)
+
+# v0.6.2
+
+This is a patch release that predominantly includes updated conformance tests
+for implementations to implement.
+
+For all major changes since the `v0.5.x` release series, please see the
+[v0.6.0](/#v060) release notes.
+
+## Maintenance
+
+- As per [changes in upstream to container image registries] we replaced all
+  usage of the k8s.gcr.io registry with registry.k8s.io.
+  (#1736, @shaneutt)
+
+[changes in upstream to container image registries]:https://github.com/kubernetes/k8s.io/issues/4738
+
+## Bug Fixes
+
+- Fix invalid HTTP redirect/rewrite examples.
+  (#1787, @Xunzhuo)
+
+## Conformance Test Updates
+
+- The `HTTPRouteInvalidCrossNamespaceParentRef` conformance test now checks for
+  the `NotAllowedByListeners` reason on the `HTTPRoute`'s `Accepted: false`
+  condition to better indicate why the route was note accepted.
+  (#1714, @skriss)
+- A conformance test was added for `HTTPRoute` to cover the behavior of a
+  non-matching `SectionName` similar to what was already present for
+  `ListenerPort`.
+  (#1719, @zaunist)
+- Fixed an issue where tests may fail erroneously on the removal of resources
+  that are already removed.
+  (#1745, @mlavacca)
+- Logging in conformance utilities related to resource's `ObservedGeneration`
+  has been improved to emit the `ObservedGenerations that are found for the
+  purpose of making it easier to debug test failures and be more verbose about
+  the objects in question.
+  (#1761, @briantkennedy)
+  (#1763, @briantkennedy)
+- Patch instead of update in some places in conformance tests to reduce noise
+  in logs.
+  (#1760, @michaelbeaumont)
+- Added `AttachedRoutes` testing to conformance tests.
+  (#1624, @ChaningHwang)
+- The conformance tests always check that the HTTPRoute ResolvedRefs condition
+  is enforced, even when the status is true.
+  (#1668, @mlavacca)
 
 # v0.6.1
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ the specification and Custom Resource Definitions (CRDs).
 
 ## Status
 
-The latest supported version is `v1beta1` as released by the [v0.6.1
-release](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.6.1) of
+The latest supported version is `v1beta1` as released by the [v0.6.2
+release](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.6.2) of
 this project.
 
 This version of the API is has beta level support for the following resources:

--- a/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/bundle-version: v0.6.2
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/bundle-version: v0.6.2
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/bundle-version: v0.6.2
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: grpcroutes.gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/bundle-version: v0.6.2
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/bundle-version: v0.6.2
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: referencegrants.gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/bundle-version: v0.6.2
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: tcproutes.gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/bundle-version: v0.6.2
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: tlsroutes.gateway.networking.k8s.io

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/bundle-version: v0.6.2
     gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: udproutes.gateway.networking.k8s.io

--- a/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/bundle-version: v0.6.2
     gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/bundle-version: v0.6.2
     gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/bundle-version: v0.6.2
     gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io

--- a/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/bundle-version: v0.6.2
     gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: referencegrants.gateway.networking.k8s.io

--- a/config/webhook/admission_webhook.yaml
+++ b/config/webhook/admission_webhook.yaml
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
       - name: webhook
-        image: gcr.io/k8s-staging-gateway-api/admission-server:v0.6.1
+        image: gcr.io/k8s-staging-gateway-api/admission-server:v0.6.2
         imagePullPolicy: Always
         args:
         - -logtostderr

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -259,7 +259,7 @@ move on to [certification](#certification) to report the results.
 
 [go-test]:https://go.dev/doc/tutorial/add-a-test
 [go]:https://go.dev
-[lib]:https://pkg.go.dev/sigs.k8s.io/gateway-api@v0.6.1/conformance/utils/suite
+[lib]:https://pkg.go.dev/sigs.k8s.io/gateway-api@v0.6.2/conformance/utils/suite
 
 ### Certification
 

--- a/hack/verify-examples-kind.sh
+++ b/hack/verify-examples-kind.sh
@@ -22,7 +22,7 @@ readonly GO111MODULE="on"
 readonly GOFLAGS="-mod=readonly"
 readonly GOPATH="$(mktemp -d)"
 readonly CLUSTER_NAME="verify-gateway-api"
-readonly ADMISSION_WEBHOOK_VERSION="v0.6.1"
+readonly ADMISSION_WEBHOOK_VERSION="v0.6.2"
 
 export KUBECONFIG="${GOPATH}/.kubeconfig"
 export GOFLAGS GO111MODULE GOPATH

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -35,7 +35,7 @@ const (
 	channelAnnotation       = "gateway.networking.k8s.io/channel"
 
 	// These values must be updated during the release process
-	bundleVersion = "v0.6.1"
+	bundleVersion = "v0.6.2"
 	approvalLink  = "https://github.com/kubernetes-sigs/gateway-api/pull/1538"
 )
 

--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -40,7 +40,7 @@ including GatewayClass, Gateway, and HTTPRoute. To install this channel, run the
 following kubectl command:
 
 ```
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.6.1/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.6.2/standard-install.yaml
 ```
 
 ### Install Experimental Channel
@@ -58,7 +58,7 @@ documentation](https://gateway-api.sigs.k8s.io/concepts/versioning/).
 To install the experimental channel, run the following kubectl command:
 
 ```
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.6.1/experimental-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.6.2/experimental-install.yaml
 ```
 
 ### Cleanup


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Now that [v0.6.2](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.6.2) is released this brings some of the changes from the release branch back into `main` so that we're documenting the latest release properly in the `README.md`, e.t.c.