### PR TITLE
Add a conformance test that checks adding and removing listeners

### DIFF
--- a/conformance/tests/gateway-modify-listeners.go
+++ b/conformance/tests/gateway-modify-listeners.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayModifyListeners)
+}
+
+var GatewayModifyListeners = suite.ConformanceTest{
+	ShortName:   "GatewayModifyListeners",
+	Description: "A Gateway in the gateway-conformance-infra namespace should handle adding and removing listeners.",
+	Manifests:   []string{"tests/gateway-modify-listeners.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+
+		t.Run("should be able to add a listener that then becomes available for routing traffic", func(t *testing.T) {
+			gwNN := types.NamespacedName{Name: "gateway-add-listener", Namespace: "gateway-conformance-infra"}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+
+			namespaces := []string{"gateway-conformance-infra"}
+			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
+			original := &v1beta1.Gateway{}
+			err := s.Client.Get(ctx, gwNN, original)
+			require.NoErrorf(t, err, "error getting Gateway: %v", err)
+
+			// verify that the implementation is tracking the most recent resource changes
+			kubernetes.GatewayMustHaveLatestConditions(t, original)
+
+			all := v1beta1.NamespacesFromAll
+
+			mutate := original.DeepCopy()
+
+			// add a new listener to the Gateway spec
+			hostname := v1beta1.Hostname("data.test.com")
+			mutate.Spec.Listeners = append(mutate.Spec.Listeners, v1beta1.Listener{
+				Name:     "http",
+				Port:     80,
+				Protocol: v1beta1.HTTPProtocolType,
+				Hostname: &hostname,
+				AllowedRoutes: &v1beta1.AllowedRoutes{
+					Namespaces: &v1beta1.RouteNamespaces{From: &all},
+				},
+			})
+
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(original))
+			require.NoErrorf(t, err, "error patching the Gateway: %v", err)
+
+			// Ensure the generation and observedGeneration sync up
+			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
+			updated := &v1beta1.Gateway{}
+			err = s.Client.Get(ctx, gwNN, updated)
+			require.NoErrorf(t, err, "error getting Gateway: %v", err)
+
+			listeners := []v1beta1.ListenerStatus{
+				{
+					Name: v1beta1.SectionName("https"),
+					SupportedKinds: []v1beta1.RouteGroupKind{{
+						Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
+						Kind:  v1beta1.Kind("HTTPRoute"),
+					}},
+					Conditions: []metav1.Condition{{
+						Type:   string(v1beta1.ListenerConditionAccepted),
+						Status: metav1.ConditionTrue,
+						Reason: "", //any reason
+					}},
+					AttachedRoutes: 1,
+				},
+				{
+					Name: v1beta1.SectionName("http"),
+					SupportedKinds: []v1beta1.RouteGroupKind{{
+						Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
+						Kind:  v1beta1.Kind("HTTPRoute"),
+					}},
+					Conditions: []metav1.Condition{{
+						Type:   string(v1beta1.ListenerConditionAccepted),
+						Status: metav1.ConditionTrue,
+						Reason: "", //any reason
+					}},
+					AttachedRoutes: 1,
+				},
+			}
+
+			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
+
+			// verify that the implementation continues to keep up to date with the resource changes we've been making
+			kubernetes.GatewayMustHaveLatestConditions(t, updated)
+
+			require.NotEqual(t, original.Generation, updated.Generation, "generation should change after an update")
+		})
+
+		t.Run("should be able to remove listeners, which would then stop routing the relevant traffic", func(t *testing.T) {
+			gwNN := types.NamespacedName{Name: "gateway-remove-listener", Namespace: "gateway-conformance-infra"}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+
+			namespaces := []string{"gateway-conformance-infra"}
+			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
+			original := &v1beta1.Gateway{}
+			err := s.Client.Get(ctx, gwNN, original)
+			require.NoErrorf(t, err, "error getting Gateway: %v", err)
+
+			// verify that the implementation is tracking the most recent resource changes
+			kubernetes.GatewayMustHaveLatestConditions(t, original)
+
+			mutate := original.DeepCopy()
+			require.Equalf(t, 2, len(mutate.Spec.Listeners), "the gateway must have 2 listeners")
+
+			// remove the "https" Gateway listener, leaving only the "http" listener
+			var newListeners []v1beta1.Listener
+			for _, listener := range mutate.Spec.Listeners {
+				if listener.Name == "http" {
+					newListeners = append(newListeners, listener)
+				}
+			}
+			mutate.Spec.Listeners = newListeners
+
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(original))
+			require.NoErrorf(t, err, "error patching the Gateway: %v", err)
+
+			// Ensure the generation and observedGeneration sync up
+			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
+			updated := &v1beta1.Gateway{}
+			err = s.Client.Get(ctx, gwNN, updated)
+			require.NoErrorf(t, err, "error getting Gateway: %v", err)
+
+			listeners := []v1beta1.ListenerStatus{
+				{
+					Name: v1beta1.SectionName("http"),
+					SupportedKinds: []v1beta1.RouteGroupKind{{
+						Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
+						Kind:  v1beta1.Kind("HTTPRoute"),
+					}},
+					Conditions: []metav1.Condition{{
+						Type:   string(v1beta1.ListenerConditionAccepted),
+						Status: metav1.ConditionTrue,
+						Reason: "", //any reason
+					}},
+					AttachedRoutes: 1,
+				},
+			}
+
+			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
+
+			// verify that the implementation continues to keep up to date with the resource changes we've been making
+			kubernetes.GatewayMustHaveLatestConditions(t, updated)
+
+			require.NotEqual(t, original.Generation, updated.Generation, "generation should change after an update")
+		})
+	},
+}

--- a/conformance/tests/gateway-modify-listeners.yaml
+++ b/conformance/tests/gateway-modify-listeners.yaml
@@ -1,0 +1,79 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: gateway-add-listener
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: https
+    port: 443
+    protocol: HTTPS
+    hostname: "secure.test.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: tls-validity-checks-certificate
+        namespace: gateway-conformance-infra
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: http-route-1
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - kind: Gateway
+    name: gateway-add-listener
+    namespace: gateway-conformance-infra
+  rules:
+  - backendRefs:
+    - name: foo-svc
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: gateway-remove-listener
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: https
+    port: 443
+    protocol: HTTPS
+    hostname: "secure.test.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: tls-validity-checks-certificate
+        namespace: gateway-conformance-infra
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: http-route-2
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - kind: Gateway
+    name: gateway-remove-listener
+    namespace: gateway-conformance-infra
+  rules:
+  - backendRefs:
+    - name: foo-svc
+      port: 8080


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind test
/area conformance

**What this PR does / why we need it**:

Adds a conformance test that tests adding and removing listeners. 
https://github.com/kubernetes-sigs/gateway-api/issues/1607

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1607

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```