### PR TITLE
Clarify HTTPRequestRedirectFilter.Port Semantics

### DIFF
--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -902,10 +902,15 @@ type HTTPRequestRedirectFilter struct {
 
 	// Port is the port to be used in the value of the `Location`
 	// header in the response.
+	//
 	// When empty, the Gateway Listener port is used.
-	// In all cases, when the protocol is http and the port is port 80,
-	// then the port must be omitted. Similarly, when the protocol is
-	// https and the port is port 443, then the port must also be omitted.
+	//
+	// Implementers should _not_ include the port number in the 'Location' header in the following cases:
+	//
+	// * a Location header that will use HTTP (whether that is determined via the Listener protocol
+	//   or the Scheme field) _and_ use port 80.
+	// * a Location header that will use HTTPS (whether that is determined via the Listener protocol
+	//   or the Scheme field) _and_ use port 443.
 	//
 	// Support: Extended
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -582,12 +582,16 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. When empty, the Gateway Listener
-                                        port is used. In all cases, when the protocol
-                                        is http and the port is port 80, then the
-                                        port must be omitted. Similarly, when the
-                                        protocol is https and the port is port 443,
-                                        then the port must also be omitted. \n Support:
+                                        response. \n When empty, the Gateway Listener
+                                        port is used. \n Implementers should _not_
+                                        include the port number in the 'Location'
+                                        header in the following cases: \n * a Location
+                                        header that will use HTTP (whether that is
+                                        determined via the Listener protocol or the
+                                        Scheme field) _and_ use port 80. * a Location
+                                        header that will use HTTPS (whether that is
+                                        determined via the Listener protocol or the
+                                        Scheme field) _and_ use port 443. \n Support:
                                         Extended"
                                       format: int32
                                       maximum: 65535
@@ -1223,12 +1227,16 @@ spec:
                                 type: object
                               port:
                                 description: "Port is the port to be used in the value
-                                  of the `Location` header in the response. When empty,
-                                  the Gateway Listener port is used. In all cases,
-                                  when the protocol is http and the port is port 80,
-                                  then the port must be omitted. Similarly, when the
-                                  protocol is https and the port is port 443, then
-                                  the port must also be omitted. \n Support: Extended"
+                                  of the `Location` header in the response. \n When
+                                  empty, the Gateway Listener port is used. \n Implementers
+                                  should _not_ include the port number in the 'Location'
+                                  header in the following cases: \n * a Location header
+                                  that will use HTTP (whether that is determined via
+                                  the Listener protocol or the Scheme field) _and_
+                                  use port 80. * a Location header that will use HTTPS
+                                  (whether that is determined via the Listener protocol
+                                  or the Scheme field) _and_ use port 443. \n Support:
+                                  Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -2474,12 +2482,16 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. When empty, the Gateway Listener
-                                        port is used. In all cases, when the protocol
-                                        is http and the port is port 80, then the
-                                        port must be omitted. Similarly, when the
-                                        protocol is https and the port is port 443,
-                                        then the port must also be omitted. \n Support:
+                                        response. \n When empty, the Gateway Listener
+                                        port is used. \n Implementers should _not_
+                                        include the port number in the 'Location'
+                                        header in the following cases: \n * a Location
+                                        header that will use HTTP (whether that is
+                                        determined via the Listener protocol or the
+                                        Scheme field) _and_ use port 80. * a Location
+                                        header that will use HTTPS (whether that is
+                                        determined via the Listener protocol or the
+                                        Scheme field) _and_ use port 443. \n Support:
                                         Extended"
                                       format: int32
                                       maximum: 65535
@@ -3115,12 +3127,16 @@ spec:
                                 type: object
                               port:
                                 description: "Port is the port to be used in the value
-                                  of the `Location` header in the response. When empty,
-                                  the Gateway Listener port is used. In all cases,
-                                  when the protocol is http and the port is port 80,
-                                  then the port must be omitted. Similarly, when the
-                                  protocol is https and the port is port 443, then
-                                  the port must also be omitted. \n Support: Extended"
+                                  of the `Location` header in the response. \n When
+                                  empty, the Gateway Listener port is used. \n Implementers
+                                  should _not_ include the port number in the 'Location'
+                                  header in the following cases: \n * a Location header
+                                  that will use HTTP (whether that is determined via
+                                  the Listener protocol or the Scheme field) _and_
+                                  use port 80. * a Location header that will use HTTPS
+                                  (whether that is determined via the Listener protocol
+                                  or the Scheme field) _and_ use port 443. \n Support:
+                                  Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -505,12 +505,16 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. When empty, the Gateway Listener
-                                        port is used. In all cases, when the protocol
-                                        is http and the port is port 80, then the
-                                        port must be omitted. Similarly, when the
-                                        protocol is https and the port is port 443,
-                                        then the port must also be omitted. \n Support:
+                                        response. \n When empty, the Gateway Listener
+                                        port is used. \n Implementers should _not_
+                                        include the port number in the 'Location'
+                                        header in the following cases: \n * a Location
+                                        header that will use HTTP (whether that is
+                                        determined via the Listener protocol or the
+                                        Scheme field) _and_ use port 80. * a Location
+                                        header that will use HTTPS (whether that is
+                                        determined via the Listener protocol or the
+                                        Scheme field) _and_ use port 443. \n Support:
                                         Extended"
                                       format: int32
                                       maximum: 65535
@@ -930,12 +934,16 @@ spec:
                                 type: string
                               port:
                                 description: "Port is the port to be used in the value
-                                  of the `Location` header in the response. When empty,
-                                  the Gateway Listener port is used. In all cases,
-                                  when the protocol is http and the port is port 80,
-                                  then the port must be omitted. Similarly, when the
-                                  protocol is https and the port is port 443, then
-                                  the port must also be omitted. \n Support: Extended"
+                                  of the `Location` header in the response. \n When
+                                  empty, the Gateway Listener port is used. \n Implementers
+                                  should _not_ include the port number in the 'Location'
+                                  header in the following cases: \n * a Location header
+                                  that will use HTTP (whether that is determined via
+                                  the Listener protocol or the Scheme field) _and_
+                                  use port 80. * a Location header that will use HTTPS
+                                  (whether that is determined via the Listener protocol
+                                  or the Scheme field) _and_ use port 443. \n Support:
+                                  Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -1917,12 +1925,16 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. When empty, the Gateway Listener
-                                        port is used. In all cases, when the protocol
-                                        is http and the port is port 80, then the
-                                        port must be omitted. Similarly, when the
-                                        protocol is https and the port is port 443,
-                                        then the port must also be omitted. \n Support:
+                                        response. \n When empty, the Gateway Listener
+                                        port is used. \n Implementers should _not_
+                                        include the port number in the 'Location'
+                                        header in the following cases: \n * a Location
+                                        header that will use HTTP (whether that is
+                                        determined via the Listener protocol or the
+                                        Scheme field) _and_ use port 80. * a Location
+                                        header that will use HTTPS (whether that is
+                                        determined via the Listener protocol or the
+                                        Scheme field) _and_ use port 443. \n Support:
                                         Extended"
                                       format: int32
                                       maximum: 65535
@@ -2342,12 +2354,16 @@ spec:
                                 type: string
                               port:
                                 description: "Port is the port to be used in the value
-                                  of the `Location` header in the response. When empty,
-                                  the Gateway Listener port is used. In all cases,
-                                  when the protocol is http and the port is port 80,
-                                  then the port must be omitted. Similarly, when the
-                                  protocol is https and the port is port 443, then
-                                  the port must also be omitted. \n Support: Extended"
+                                  of the `Location` header in the response. \n When
+                                  empty, the Gateway Listener port is used. \n Implementers
+                                  should _not_ include the port number in the 'Location'
+                                  header in the following cases: \n * a Location header
+                                  that will use HTTP (whether that is determined via
+                                  the Listener protocol or the Scheme field) _and_
+                                  use port 80. * a Location header that will use HTTPS
+                                  (whether that is determined via the Listener protocol
+                                  or the Scheme field) _and_ use port 443. \n Support:
+                                  Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR clarifies Port Redirect Semantics for HTTP and HTTPS in the `HTTPRequestRedirectFilter.Port` doc.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1806 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
