### PR TITLE
conformance: check HTTPRoute connectivity after deleting relevant ReferenceGrant

### DIFF
--- a/conformance/tests/httproute-reference-grant.go
+++ b/conformance/tests/httproute-reference-grant.go
@@ -17,10 +17,14 @@ limitations under the License.
 package tests
 
 import (
+	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
@@ -54,6 +58,26 @@ var HTTPRouteReferenceGrant = suite.ConformanceTest{
 				Response:  http.Response{StatusCode: 200},
 				Backend:   "web-backend",
 				Namespace: "gateway-conformance-web-backend",
+			})
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), suite.TimeoutConfig.DeleteTimeout)
+		defer cancel()
+		rg := v1beta1.ReferenceGrant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "reference-grant",
+				Namespace: "gateway-conformance-web-backend",
+			},
+		}
+		require.NoError(t, suite.Client.Delete(ctx, &rg))
+
+		t.Run("Simple HTTP request should return 500 after deleting the relevant reference grant", func(t *testing.T) {
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
+				Request: http.Request{
+					Method: "GET",
+					Path:   "/",
+				},
+				Response: http.Response{StatusCode: 500},
 			})
 		})
 	},


### PR DESCRIPTION
**What type of PR is this?**

/kind test
/area conformance

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #1838

**Does this PR introduce a user-facing change?**:

```release-note
HTTPRoute connectivity is in now enforced in conformance tests if a relevant ReferenceGrant gets deleted.
```
