### PR TITLE
feat: add support for path matching precedence

### DIFF
--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -156,9 +156,12 @@ type HTTPRouteRule struct {
 	// ties. Across all rules specified on applicable Routes, precedence must be
 	// given to the match with the largest number of:
 	//
-	// * Characters in a matching path.
+	// * Characters in a matching "Exact" path match
+	// * Characters in a matching "Prefix" path match
 	// * Header matches.
 	// * Query param matches.
+	//
+	// Note: The precedence of RegularExpression path matches are implementation-specific.
 	//
 	// If ties still exist across multiple Routes, matching precedence MUST be
 	// determined in order of the following criteria, continuing on ties:

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -1483,10 +1483,12 @@ spec:
                         from HTTPRoutes MUST prioritize matches based on the following
                         criteria, continuing on ties. Across all rules specified on
                         applicable Routes, precedence must be given to the match with
-                        the largest number of: \n * Characters in a matching path.
-                        * Header matches. * Query param matches. \n If ties still
-                        exist across multiple Routes, matching precedence MUST be
-                        determined in order of the following criteria, continuing
+                        the largest number of: \n * Characters in a matching \"Exact\"
+                        path match * Characters in a matching \"Prefix\" path match
+                        * Header matches. * Query param matches. \n Note: The precedence
+                        of RegularExpression path matches are implementation-specific.
+                        \n If ties still exist across multiple Routes, matching precedence
+                        MUST be determined in order of the following criteria, continuing
                         on ties: \n * The oldest Route based on creation timestamp.
                         * The Route appearing first in alphabetical order by \"{namespace}/{name}\".
                         \n If ties still exist within an HTTPRoute, matching precedence
@@ -3375,10 +3377,12 @@ spec:
                         from HTTPRoutes MUST prioritize matches based on the following
                         criteria, continuing on ties. Across all rules specified on
                         applicable Routes, precedence must be given to the match with
-                        the largest number of: \n * Characters in a matching path.
-                        * Header matches. * Query param matches. \n If ties still
-                        exist across multiple Routes, matching precedence MUST be
-                        determined in order of the following criteria, continuing
+                        the largest number of: \n * Characters in a matching \"Exact\"
+                        path match * Characters in a matching \"Prefix\" path match
+                        * Header matches. * Query param matches. \n Note: The precedence
+                        of RegularExpression path matches are implementation-specific.
+                        \n If ties still exist across multiple Routes, matching precedence
+                        MUST be determined in order of the following criteria, continuing
                         on ties: \n * The oldest Route based on creation timestamp.
                         * The Route appearing first in alphabetical order by \"{namespace}/{name}\".
                         \n If ties still exist within an HTTPRoute, matching precedence

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -1031,10 +1031,12 @@ spec:
                         from HTTPRoutes MUST prioritize matches based on the following
                         criteria, continuing on ties. Across all rules specified on
                         applicable Routes, precedence must be given to the match with
-                        the largest number of: \n * Characters in a matching path.
-                        * Header matches. * Query param matches. \n If ties still
-                        exist across multiple Routes, matching precedence MUST be
-                        determined in order of the following criteria, continuing
+                        the largest number of: \n * Characters in a matching \"Exact\"
+                        path match * Characters in a matching \"Prefix\" path match
+                        * Header matches. * Query param matches. \n Note: The precedence
+                        of RegularExpression path matches are implementation-specific.
+                        \n If ties still exist across multiple Routes, matching precedence
+                        MUST be determined in order of the following criteria, continuing
                         on ties: \n * The oldest Route based on creation timestamp.
                         * The Route appearing first in alphabetical order by \"{namespace}/{name}\".
                         \n If ties still exist within an HTTPRoute, matching precedence
@@ -2443,10 +2445,12 @@ spec:
                         from HTTPRoutes MUST prioritize matches based on the following
                         criteria, continuing on ties. Across all rules specified on
                         applicable Routes, precedence must be given to the match with
-                        the largest number of: \n * Characters in a matching path.
-                        * Header matches. * Query param matches. \n If ties still
-                        exist across multiple Routes, matching precedence MUST be
-                        determined in order of the following criteria, continuing
+                        the largest number of: \n * Characters in a matching \"Exact\"
+                        path match * Characters in a matching \"Prefix\" path match
+                        * Header matches. * Query param matches. \n Note: The precedence
+                        of RegularExpression path matches are implementation-specific.
+                        \n If ties still exist across multiple Routes, matching precedence
+                        MUST be determined in order of the following criteria, continuing
                         on ties: \n * The oldest Route based on creation timestamp.
                         * The Route appearing first in alphabetical order by \"{namespace}/{name}\".
                         \n If ties still exist within an HTTPRoute, matching precedence

--- a/conformance/tests/httproute-path-match-order.go
+++ b/conformance/tests/httproute-path-match-order.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRoutePathMatchOrder)
+}
+
+var HTTPRoutePathMatchOrder = suite.ConformanceTest{
+	ShortName:   "HTTPRoutePathMatchOrder",
+	Description: "An HTTPRoute where there are multiple matches routing to any given backend follows match order precedence",
+	Manifests:   []string{"tests/httproute-path-match-order.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Namespace: ns, Name: "path-matching-order"}
+		gwNN := types.NamespacedName{Namespace: ns, Name: "same-namespace"}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		testCases := []http.ExpectedResponse{{
+			Request:   http.Request{Path: "/match/exact/one"},
+			Backend:   "infra-backend-v3",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Path: "/match/exact"},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Path: "/match"},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Path: "/match/prefix/one/any"},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Path: "/match/prefix/any"},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Path: "/match/any"},
+			Backend:   "infra-backend-v3",
+			Namespace: ns,
+		},
+		}
+
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-path-match-order.yaml
+++ b/conformance/tests/httproute-path-match-order.yaml
@@ -1,0 +1,51 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: path-matching-order
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /match
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - matches:
+    - path:
+        type: Exact
+        value: /match/exact
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080
+  - matches:
+    - path:
+        type: Exact
+        value: /match/exact/one
+    backendRefs:
+    - name: infra-backend-v3
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /match/
+    backendRefs:
+    - name: infra-backend-v3
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /match/prefix/
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /match/prefix/one
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind bug
/area conformance

**What this PR does / why we need it**:

Path matches in following orders:
1. Exact
2. Prefix

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1770

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
* Updated spec to clarify that Exact matches have precedence over Prefix matches and RegularExpression matches have implementation specific precedence.
* Added conformance test to verify that path matching precedence is implemented.
```
