### PR TITLE
conformance: don't require k8s version v1.21

### DIFF
--- a/conformance/tests/gateway-with-attached-routes.yaml
+++ b/conformance/tests/gateway-with-attached-routes.yaml
@@ -16,9 +16,7 @@ spec:
         from: Selector
         selector:
           matchLabels:
-            # This label is added automatically as of K8s 1.22
-            # to all namespaces
-            kubernetes.io/metadata.name: gateway-conformance-infra
+            gateway-conformance: infra
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
@@ -53,9 +51,7 @@ spec:
         from: Selector
         selector:
           matchLabels:
-            # This label is added automatically as of K8s 1.22
-            # to all namespaces
-            kubernetes.io/metadata.name: gateway-conformance-infra
+            gateway-conformance: infra
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute


### PR DESCRIPTION
**What type of PR is this?**
/kind test
/area conformance

**What this PR does / why we need it**:
Makes it possible to pass the tests on k8s before `v1.21`, which is the first version the `kubernetes.io/metadata.name` label is set automatically. [Might be worth noting that use of arbitrary labels like this is somewhat unsafe](https://gateway-api.sigs.k8s.io/concepts/security-model/#risks-of-other-labels), but it serves to test implementations nevertheless.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
