### PR TITLE
[conformance] Gateway Dynamic Listener Ports

### DIFF
--- a/conformance/tests/gateway-dynamic-listeners.go
+++ b/conformance/tests/gateway-dynamic-listeners.go
@@ -179,11 +179,6 @@ var GatewayListenerHTTPRouteDynamicPorts = suite.ConformanceTest{
 			require.NoErrorf(t, err, "timed out waiting for Gateway address to be assigned")
 
 			for _, listener := range mutate.Spec.Listeners {
-				timeoutConfig := s.TimeoutConfig
-				// TODO - It takes much longer for listeners to be consistent
-				if timeoutConfig.MaxTimeToConsistency < timeoutConfig.GatewayStatusMustHaveListeners {
-					timeoutConfig.MaxTimeToConsistency = timeoutConfig.GatewayStatusMustHaveListeners
-				}
 				host, _, err := net.SplitHostPort(gwAddr)
 				require.NoErrorf(t, err, "unable to split gateway address %q", gwAddr)
 
@@ -198,9 +193,9 @@ var GatewayListenerHTTPRouteDynamicPorts = suite.ConformanceTest{
 				if listener.TLS != nil {
 					host := string(*listener.Hostname)
 					expectedResponse.Request.Host = host
-					tls.MakeTLSRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, timeoutConfig, addr, certBytes, keyBytes, host, expectedResponse)
+					tls.MakeTLSRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, s.TimeoutConfig, addr, certBytes, keyBytes, host, expectedResponse)
 				} else {
-					http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, timeoutConfig, addr, expectedResponse)
+					http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, s.TimeoutConfig, addr, expectedResponse)
 				}
 
 			}

--- a/conformance/tests/gateway-dynamic-listeners.go
+++ b/conformance/tests/gateway-dynamic-listeners.go
@@ -165,17 +165,14 @@ var GatewayListenerHTTPRouteDynamicPorts = suite.ConformanceTest{
 
 		sendRequestToEachListener := func(t *testing.T, expectedResponse http.ExpectedResponse, listeners []v1beta1.Listener) {
 			for _, listener := range listeners {
-
 				addr := net.JoinHostPort(host, strconv.Itoa(int(listener.Port)))
 
 				if listener.TLS != nil {
-					host := string(*listener.Hostname)
-					expectedResponse.Request.Host = host
+					expectedResponse.Request.Host = string(*listener.Hostname)
 					tls.MakeTLSRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, s.TimeoutConfig, addr, certBytes, keyBytes, host, expectedResponse)
 				} else {
 					http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, s.TimeoutConfig, addr, expectedResponse)
 				}
-
 			}
 		}
 
@@ -186,13 +183,12 @@ var GatewayListenerHTTPRouteDynamicPorts = suite.ConformanceTest{
 			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
 			defer cancel()
 
-			err := s.Client.Get(ctx, gwNN, original)
+			err = s.Client.Get(ctx, gwNN, original)
 			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			// verify that the implementation is tracking the most recent resource changes
 			kubernetes.GatewayMustHaveLatestConditions(t, s.TimeoutConfig, original)
-			mutate := original.DeepCopy()
-
+			mutate = original.DeepCopy()
 			mutate.Spec.Listeners = append(mutate.Spec.Listeners, listeners...)
 
 			err = s.Client.Patch(ctx, mutate, client.MergeFrom(original))
@@ -213,7 +209,7 @@ var GatewayListenerHTTPRouteDynamicPorts = suite.ConformanceTest{
 			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
 			defer cancel()
 
-			err = s.Client.Update(ctx, original)
+			err = s.Client.Patch(ctx, original, client.MergeFrom(mutate))
 			require.NoErrorf(t, err, "error patching the Gateway: %v", err)
 
 			expectedListeners = []v1beta1.ListenerStatus{{

--- a/conformance/tests/gateway-dynamic-listeners.go
+++ b/conformance/tests/gateway-dynamic-listeners.go
@@ -198,10 +198,10 @@ var GatewayListenerDynamicPorts = suite.ConformanceTest{
 }
 
 func nextPort(start, end int, ports sets.Set[int]) int {
-	port := start + rand.Intn(end-start)
+	port := start + rand.Intn(end-start) //nolint:gosec
 	// We want a unique port
 	for ports.Has(port) {
-		port = start + rand.Intn(end-start)
+		port = start + rand.Intn(end-start) //nolint:gosec
 	}
 	ports.Insert(port)
 	return port

--- a/conformance/tests/gateway-dynamic-listeners.go
+++ b/conformance/tests/gateway-dynamic-listeners.go
@@ -82,6 +82,13 @@ var GatewayListenerDynamicPorts = suite.ConformanceTest{
 				AttachedRoutes: 1,
 			}}
 		)
+		if portEnd < portStart {
+			t.Fatal("DynamicPortRange.Start must be less than DynamicPortRange.End")
+		}
+
+		if portEnd-portStart < portCount {
+			t.Fatal("DynamicPortRange input requires at least 10 ports")
+		}
 
 		for i := 0; i < portCount; i++ {
 			port := nextPort(portStart, portEnd, ports)

--- a/conformance/tests/gateway-dynamic-listeners.go
+++ b/conformance/tests/gateway-dynamic-listeners.go
@@ -51,12 +51,13 @@ var GatewayListenerDynamicPorts = suite.ConformanceTest{
 
 		// Ephemeral port range
 		const (
-			portStart    = 49152
-			portEnd      = 65535
 			portCount    = 10
 			tlsPortCount = 5
 		)
 		var (
+			portStart = s.ListenerConfig.DynamicPortRange.Start
+			portEnd   = s.ListenerConfig.DynamicPortRange.End
+
 			gwNN       = types.NamespacedName{Name: "gateway-dynamic-listener", Namespace: "gateway-conformance-infra"}
 			namespaces = []string{"gateway-conformance-infra"}
 			certNN     = types.NamespacedName{Name: "tls-wildcard-hostname", Namespace: gwNN.Namespace}

--- a/conformance/tests/gateway-dynamic-listeners.go
+++ b/conformance/tests/gateway-dynamic-listeners.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -158,7 +157,7 @@ var GatewayListenerHTTPRouteDynamicPorts = suite.ConformanceTest{
 		require.NoErrorf(t, err, "error getting certificate: %v", err)
 
 		t.Run("should be able to add multiple HTTP listeners with dynamic ports that then becomes available for routing traffic", func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.GetTimeout)
 			defer cancel()
 
 			original := &v1beta1.Gateway{}

--- a/conformance/tests/gateway-dynamic-listeners.go
+++ b/conformance/tests/gateway-dynamic-listeners.go
@@ -146,6 +146,10 @@ var GatewayListenerDynamicPorts = suite.ConformanceTest{
 					Type:   string(v1beta1.ListenerConditionAccepted),
 					Status: metav1.ConditionTrue,
 					Reason: "", //any reason
+				}, {
+					Type:   string(v1beta1.ListenerConditionResolvedRefs),
+					Status: metav1.ConditionTrue,
+					Reason: "", //any reason
 				}},
 				AttachedRoutes: 1,
 			})

--- a/conformance/tests/gateway-dynamic-listeners.go
+++ b/conformance/tests/gateway-dynamic-listeners.go
@@ -43,8 +43,11 @@ func init() {
 }
 
 var GatewayListenerDynamicPorts = suite.ConformanceTest{
-	ShortName:   "GatewayListenerDynamicPorts",
-	Features:    []suite.SupportedFeature{suite.SupportGatewayListenerDynamicPorts},
+	ShortName: "GatewayListenerDynamicPorts",
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportGatewayListenerDynamicPorts,
+	},
 	Description: "A Gateway in the gateway-conformance-infra namespace should handle adding and removing listeners with arbitrary ports",
 	Manifests:   []string{"tests/gateway-dynamic-listeners.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {

--- a/conformance/tests/gateway-dynamic-listeners.go
+++ b/conformance/tests/gateway-dynamic-listeners.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tls"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayListenerDynamicPorts)
+}
+
+var GatewayListenerDynamicPorts = suite.ConformanceTest{
+	ShortName:   "GatewayListenerDynamicPorts",
+	Features:    []suite.SupportedFeature{suite.SupportGatewayListenerDynamicPorts},
+	Description: "A Gateway in the gateway-conformance-infra namespace should handle adding and removing listeners with arbitrary ports",
+	Manifests:   []string{"tests/gateway-dynamic-listeners.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+
+		// Ephemeral port range
+		const (
+			portStart    = 49152
+			portEnd      = 65535
+			portCount    = 10
+			tlsPortCount = 5
+		)
+		var (
+			gwNN       = types.NamespacedName{Name: "gateway-dynamic-listener", Namespace: "gateway-conformance-infra"}
+			namespaces = []string{"gateway-conformance-infra"}
+			certNN     = types.NamespacedName{Name: "tls-wildcard-hostname", Namespace: gwNN.Namespace}
+			ports      = sets.New[int]()
+			listeners  = make([]v1beta1.Listener, 0, portCount)
+			same       = v1beta1.NamespacesFromSame
+
+			expectedListeners = []v1beta1.ListenerStatus{{
+				Name: "http",
+				SupportedKinds: []v1beta1.RouteGroupKind{{
+					Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
+					Kind:  v1beta1.Kind("HTTPRoute"),
+				}},
+				Conditions: []metav1.Condition{{
+					Type:   string(v1beta1.ListenerConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: "", //any reason
+				}},
+				AttachedRoutes: 1,
+			}}
+		)
+
+		for i := 0; i < portCount; i++ {
+			port := nextPort(portStart, portEnd, ports)
+
+			listeners = append(listeners, v1beta1.Listener{
+				Name:     v1beta1.SectionName(strconv.Itoa(port)),
+				Port:     v1beta1.PortNumber(port),
+				Protocol: v1beta1.HTTPProtocolType,
+				AllowedRoutes: &v1beta1.AllowedRoutes{
+					Namespaces: &v1beta1.RouteNamespaces{From: &same},
+				},
+			})
+
+			expectedListeners = append(expectedListeners, v1beta1.ListenerStatus{
+				Name: v1beta1.SectionName(strconv.Itoa(port)),
+				SupportedKinds: []v1beta1.RouteGroupKind{{
+					Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
+					Kind:  v1beta1.Kind("HTTPRoute"),
+				}},
+				Conditions: []metav1.Condition{{
+					Type:   string(v1beta1.ListenerConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: "", //any reason
+				}},
+				AttachedRoutes: 1,
+			})
+		}
+
+		for i := 0; i < tlsPortCount; i++ {
+			port := nextPort(portStart, portEnd, ports)
+			hostname := v1beta1.Hostname(fmt.Sprintf("%v.example.com", port))
+
+			listeners = append(listeners, v1beta1.Listener{
+				Name:     v1beta1.SectionName(strconv.Itoa(port)),
+				Port:     v1beta1.PortNumber(port),
+				Hostname: &hostname,
+				Protocol: v1beta1.HTTPSProtocolType,
+				AllowedRoutes: &v1beta1.AllowedRoutes{
+					Namespaces: &v1beta1.RouteNamespaces{From: &same},
+				},
+				TLS: &v1beta1.GatewayTLSConfig{
+					CertificateRefs: []v1beta1.SecretObjectReference{{
+						Name: v1beta1.ObjectName(certNN.Name),
+					}},
+				},
+			})
+
+			expectedListeners = append(expectedListeners, v1beta1.ListenerStatus{
+				Name: v1beta1.SectionName(strconv.Itoa(port)),
+				SupportedKinds: []v1beta1.RouteGroupKind{{
+					Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
+					Kind:  v1beta1.Kind("HTTPRoute"),
+				}},
+				Conditions: []metav1.Condition{{
+					Type:   string(v1beta1.ListenerConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: "", //any reason
+				}},
+				AttachedRoutes: 1,
+			})
+		}
+
+		kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
+		certBytes, keyBytes, err := GetTLSSecret(s.Client, certNN)
+		require.NoErrorf(t, err, "error getting certificate: %v", err)
+
+		t.Run("should be able to add multiple HTTP listeners with dynamic ports that then becomes available for routing traffic", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+
+			original := &v1beta1.Gateway{}
+			err := s.Client.Get(ctx, gwNN, original)
+			require.NoErrorf(t, err, "error getting Gateway: %v", err)
+
+			// verify that the implementation is tracking the most recent resource changes
+			kubernetes.GatewayMustHaveLatestConditions(t, s.TimeoutConfig, original)
+
+			mutate := original.DeepCopy()
+
+			mutate.Spec.Listeners = append(mutate.Spec.Listeners, listeners...)
+
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(original))
+			require.NoErrorf(t, err, "error patching the Gateway: %v", err)
+
+			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, expectedListeners)
+
+			gwAddr, err := kubernetes.WaitForGatewayAddress(t, s.Client, s.TimeoutConfig, gwNN)
+			require.NoErrorf(t, err, "timed out waiting for Gateway address to be assigned")
+
+			for _, listener := range mutate.Spec.Listeners {
+				timeoutConfig := s.TimeoutConfig
+				if timeoutConfig.MaxTimeToConsistency < 2*time.Minute {
+					timeoutConfig.MaxTimeToConsistency = 2 * time.Minute
+				}
+
+				host, _, err := net.SplitHostPort(gwAddr)
+				require.NoErrorf(t, err, "unable to split gateway address %q", gwAddr)
+
+				expectedResponse := http.ExpectedResponse{
+					Namespace: gwNN.Namespace,
+					Request:   http.Request{Path: "/"},
+					Response:  http.Response{StatusCode: 200},
+				}
+
+				addr := net.JoinHostPort(host, strconv.Itoa(int(listener.Port)))
+
+				if listener.TLS != nil {
+					host := string(*listener.Hostname)
+					expectedResponse.Request.Host = host
+					tls.MakeTLSRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, timeoutConfig, addr, certBytes, keyBytes, host, expectedResponse)
+				} else {
+					http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, timeoutConfig, addr, expectedResponse)
+				}
+
+			}
+		})
+	},
+}
+
+func nextPort(start, end int, ports sets.Set[int]) int {
+	port := start + rand.Intn(end-start)
+	// We want a unique port
+	for ports.Has(port) {
+		port = start + rand.Intn(end-start)
+	}
+	ports.Insert(port)
+	return port
+}

--- a/conformance/tests/gateway-dynamic-listeners.go
+++ b/conformance/tests/gateway-dynamic-listeners.go
@@ -51,7 +51,6 @@ var GatewayListenerDynamicPorts = suite.ConformanceTest{
 	Description: "A Gateway in the gateway-conformance-infra namespace should handle adding and removing listeners with arbitrary ports",
 	Manifests:   []string{"tests/gateway-dynamic-listeners.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
-
 		// Ephemeral port range
 		const (
 			portCount    = 10
@@ -77,7 +76,7 @@ var GatewayListenerDynamicPorts = suite.ConformanceTest{
 				Conditions: []metav1.Condition{{
 					Type:   string(v1beta1.ListenerConditionAccepted),
 					Status: metav1.ConditionTrue,
-					Reason: "", //any reason
+					Reason: "", // any reason
 				}},
 				AttachedRoutes: 1,
 			}}
@@ -111,7 +110,7 @@ var GatewayListenerDynamicPorts = suite.ConformanceTest{
 				Conditions: []metav1.Condition{{
 					Type:   string(v1beta1.ListenerConditionAccepted),
 					Status: metav1.ConditionTrue,
-					Reason: "", //any reason
+					Reason: "", // any reason
 				}},
 				AttachedRoutes: 1,
 			})
@@ -145,11 +144,11 @@ var GatewayListenerDynamicPorts = suite.ConformanceTest{
 				Conditions: []metav1.Condition{{
 					Type:   string(v1beta1.ListenerConditionAccepted),
 					Status: metav1.ConditionTrue,
-					Reason: "", //any reason
+					Reason: "", // any reason
 				}, {
 					Type:   string(v1beta1.ListenerConditionResolvedRefs),
 					Status: metav1.ConditionTrue,
-					Reason: "", //any reason
+					Reason: "", // any reason
 				}},
 				AttachedRoutes: 1,
 			})

--- a/conformance/tests/gateway-dynamic-listeners.yaml
+++ b/conformance/tests/gateway-dynamic-listeners.yaml
@@ -1,0 +1,29 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: gateway-dynamic-listener
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: http-route-dynamic-listener
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - kind: Gateway
+    name: gateway-dynamic-listener
+    namespace: gateway-conformance-infra
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/utils/config/listener.go
+++ b/conformance/utils/config/listener.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package config
+
+type DynamicPortRange struct {
+	Start int
+	End   int
+}
+
+type ListenerConfig struct {
+	DynamicPortRange DynamicPortRange
+}
+
+func DefaultListenerConfig() ListenerConfig {
+	return ListenerConfig{
+		DynamicPortRange: DynamicPortRange{
+			Start: 49152,
+			End:   65535,
+		},
+	}
+}
+func SetupListenerConfig(c *ListenerConfig) {
+	defaultConfig := DefaultListenerConfig()
+
+	if c.DynamicPortRange.Start == 0 {
+		c.DynamicPortRange.Start = defaultConfig.DynamicPortRange.Start
+	}
+	if c.DynamicPortRange.End == 0 {
+		c.DynamicPortRange.End = defaultConfig.DynamicPortRange.End
+	}
+}

--- a/conformance/utils/config/listener.go
+++ b/conformance/utils/config/listener.go
@@ -16,15 +16,22 @@ limitations under the License.
 
 package config
 
+// DynamicPortRange specifies the starting and ending port of a
+// range
 type DynamicPortRange struct {
 	Start int
 	End   int
 }
 
+// ListenerConfig allow conformance test runners to configure
 type ListenerConfig struct {
 	DynamicPortRange DynamicPortRange
 }
 
+// DefaultListenerConfig returns a [ListenerConfig] where the [DynamicPortRange]
+// defaults to the suggested IANA [dynamic port range] (49152-65535)
+//
+// [dynamic port range]: https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml
 func DefaultListenerConfig() ListenerConfig {
 	return ListenerConfig{
 		DynamicPortRange: DynamicPortRange{
@@ -33,6 +40,8 @@ func DefaultListenerConfig() ListenerConfig {
 		},
 	}
 }
+
+// SetupListenerConfig will apply defaults to the passed [ListenerConfig]
 func SetupListenerConfig(c *ListenerConfig) {
 	defaultConfig := DefaultListenerConfig()
 

--- a/conformance/utils/config/listener.go
+++ b/conformance/utils/config/listener.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 type DynamicPortRange struct {

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -65,8 +65,8 @@ const (
 	//       See: https://github.com/kubernetes-sigs/gateway-api/issues/1780
 	SupportGatewayClassObservedGenerationBump SupportedFeature = "GatewayClassObservedGenerationBump"
 
-	// This option indicates support for Gateway to support dynamic ports in their listeners
-	SupportGatewayListenerDynamicPorts SupportedFeature = "GatewayListenerDynamicPorts"
+	// This option indicates support for Gateway to support dynamic HTTP(s) ports in their listeners
+	SupportGatewayListenerHTTPRouteDynamicPorts SupportedFeature = "GatewayListenerHTTPRouteDynamicPorts"
 )
 
 // StandardExtendedFeatures are extra generic features that implementations may
@@ -76,7 +76,7 @@ const (
 // See: https://github.com/kubernetes-sigs/gateway-api/issues/1891
 var StandardExtendedFeatures = sets.New(
 	SupportGatewayClassObservedGenerationBump,
-	SupportGatewayListenerDynamicPorts,
+	SupportGatewayListenerHTTPRouteDynamicPorts,
 ).Insert(StandardCoreFeatures.UnsortedList()...)
 
 // -----------------------------------------------------------------------------

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -64,6 +64,9 @@ const (
 	//
 	//       See: https://github.com/kubernetes-sigs/gateway-api/issues/1780
 	SupportGatewayClassObservedGenerationBump SupportedFeature = "GatewayClassObservedGenerationBump"
+
+	// This option indicates support for Gateway to support dynamic ports in their listeners
+	SupportGatewayListenerDynamicPorts SupportedFeature = "GatewayListenerDynamicPorts"
 )
 
 // StandardExtendedFeatures are extra generic features that implementations may
@@ -73,6 +76,7 @@ const (
 // See: https://github.com/kubernetes-sigs/gateway-api/issues/1891
 var StandardExtendedFeatures = sets.New(
 	SupportGatewayClassObservedGenerationBump,
+	SupportGatewayListenerDynamicPorts,
 ).Insert(StandardCoreFeatures.UnsortedList()...)
 
 // -----------------------------------------------------------------------------

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -49,6 +49,7 @@ type ConformanceTestSuite struct {
 	Applier           kubernetes.Applier
 	SupportedFeatures sets.Set[SupportedFeature]
 	TimeoutConfig     config.TimeoutConfig
+	ListenerConfig    config.ListenerConfig
 	SkipTests         sets.Set[string]
 	FS                embed.FS
 }
@@ -73,6 +74,7 @@ type Options struct {
 	ExemptFeatures             sets.Set[SupportedFeature]
 	EnableAllSupportedFeatures bool
 	TimeoutConfig              config.TimeoutConfig
+	ListenerConfig             config.ListenerConfig
 	// SkipTests contains all the tests not to be run and can be used to opt out
 	// of specific tests
 	SkipTests []string
@@ -83,6 +85,7 @@ type Options struct {
 // New returns a new ConformanceTestSuite.
 func New(s Options) *ConformanceTestSuite {
 	config.SetupTimeoutConfig(&s.TimeoutConfig)
+	config.SetupListenerConfig(&s.ListenerConfig)
 
 	roundTripper := s.RoundTripper
 	if roundTripper == nil {
@@ -90,7 +93,7 @@ func New(s Options) *ConformanceTestSuite {
 	}
 
 	switch {
-	case s.EnableAllSupportedFeatures == true:
+	case s.EnableAllSupportedFeatures:
 		s.SupportedFeatures = AllFeatures
 	case s.SupportedFeatures == nil:
 		s.SupportedFeatures = StandardCoreFeatures
@@ -124,6 +127,7 @@ func New(s Options) *ConformanceTestSuite {
 		},
 		SupportedFeatures: s.SupportedFeatures,
 		TimeoutConfig:     s.TimeoutConfig,
+		ListenerConfig:    s.ListenerConfig,
 		SkipTests:         sets.New(s.SkipTests...),
 		FS:                *s.FS,
 	}

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -154,14 +154,34 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 		suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, suite.BaseManifests, suite.Cleanup)
 
 		t.Logf("Test Setup: Applying programmatic resources")
-		secret := kubernetes.MustCreateSelfSignedCertSecret(t, "gateway-conformance-web-backend", "certificate", []string{"*"})
-		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{secret}, suite.Cleanup)
-		secret = kubernetes.MustCreateSelfSignedCertSecret(t, "gateway-conformance-infra", "tls-validity-checks-certificate", []string{"*", "*.org"})
-		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{secret}, suite.Cleanup)
-		secret = kubernetes.MustCreateSelfSignedCertSecret(t, "gateway-conformance-infra", "tls-passthrough-checks-certificate", []string{"abc.example.com"})
-		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{secret}, suite.Cleanup)
-		secret = kubernetes.MustCreateSelfSignedCertSecret(t, "gateway-conformance-app-backend", "tls-passthrough-checks-certificate", []string{"abc.example.com"})
-		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{secret}, suite.Cleanup)
+		for _, certificate := range []struct {
+			Namespace string
+			Name      string
+			Hosts     []string
+		}{{
+			Namespace: "gateway-conformance-web-backend",
+			Name:      "certificate",
+			Hosts:     []string{"*"},
+		}, {
+			Namespace: "gateway-conformance-infra",
+			Name:      "tls-validity-checks-certificate",
+			Hosts:     []string{"*", "*.org"},
+		}, {
+			Namespace: "gateway-conformance-infra",
+			Name:      "tls-passthrough-checks-certificate",
+			Hosts:     []string{"abc.example.com"},
+		}, {
+			Namespace: "gateway-conformance-infra",
+			Name:      "tls-wildcard-hostname",
+			Hosts:     []string{"*.example.com"},
+		}, {
+			Namespace: "gateway-conformance-app-backend",
+			Name:      "tls-passthrough-checks-certificate",
+			Hosts:     []string{"abc.example.com"},
+		}} {
+			secret := kubernetes.MustCreateSelfSignedCertSecret(t, certificate.Namespace, certificate.Name, certificate.Hosts)
+			suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{secret}, suite.Cleanup)
+		}
 
 		t.Logf("Test Setup: Ensuring Gateways and Pods from base manifests are ready")
 		namespaces := []string{

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 /*


### PR DESCRIPTION
**What type of PR is this?**
/area conformance
/kind feature

**What this PR does / why we need it**:

This adds a conformance tests where  listeners with dynamic ports are added

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Part of https://github.com/kubernetes-sigs/gateway-api/issues/1842

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
