### PR TITLE
GEP-1686: Add "Conformance Profile" and "Support Levels" sections

### DIFF
--- a/geps/gep-1686.md
+++ b/geps/gep-1686.md
@@ -5,20 +5,31 @@
 
 ## TLDR
 
-This testing plan specifies a new set of tests to define the Mesh [conformance profile](https://github.com/kubernetes-sigs/gateway-api/issues/1709).
-A conformance profile is a set of tests that implementations can run to check their conformance to some subset of the Gateway API spec.
-The Mesh conformance profile in particular checks whether an implementation follows the GAMMA spec.
+This testing plan specifies a new set of tests to define a "Mesh" [conformance profile](https://github.com/kubernetes-sigs/gateway-api/issues/1709).
 
 ## Goals
 
-* define a set of test scenarios to capture conformance with the GAMMA spec
-* rely on existing tests for non-GAMMA-specific Gateway API conformance
+* Define a strategy for segmenting GAMMA tests from the existing conformance test suite
+* Define a set of test scenarios to capture conformance with the GAMMA spec
+* Rely on existing tests for non-GAMMA-specific Gateway API conformance
 
 ## Focus
 
 Currently the GAMMA spec consists of two Gateway API GEPs [defining terminology and goals of Gateway API for service meshes](https://gateway-api.sigs.k8s.io/geps/gep-1324/)
 and specifically [how route resources work in a service mesh context](https://gateway-api.sigs.k8s.io/geps/gep-1426/).
 The goal of the initial conformance testing is to check the essential behavior as defined by GEP-1426, as it differs from the wider Gateway API spec. This GEP focuses on using a `Service` object as an `xRoute` `parentRef` to control how the GAMMA implementation directs traffic to the endpoints specified by the `Services` in `backendRefs` and how the traffic is filtered and modified.
+
+## Conformance Profile
+
+GAMMA intends to introduce a "Mesh" [conformance profile](https://gateway-api.sigs.k8s.io/geps/gep-1709/) to isolate tests specific to East/West functionality from both existing tests focused on North/South functionality and common Gateway API functionality shared by N/S and E/W implementations. A conformance profile is a set of tests that implementations can run to check their conformance to some subset of the Gateway API spec.
+
+This appropach will enable service meshes to certify that an implementation follows the GAMMA spec without requiring a North/South implementation, and importantly avoid any expectation that North/South Gateway API implementations expand their scope to understand GAMMA and E/W traffic flows.
+
+Leveraging existing tests for common functionality between N/S and E/W implementations will both ensure consistency across Gateway API implementations and help limit the maintence burden for the conformance testing suite.
+
+### Support Levels
+
+Using a conformance profile will enable granular conformance definitions for GAMMA, splitting functionality along the existing Gateway API [support levels](https://gateway-api.sigs.k8s.io/concepts/conformance/?h=conformance+levels#2-support-levels), with required functionality as Core, standardized but optional functionality as Extended, and Implementation-specific for things beyond the current or intended scope of GAMMA configuration. It is expected that some capabilities will begin as Implementation-specific and eventually migrate to Extended or Core conformance as GAMMA matures.
 
 ## Tests
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind gep
/area conformance

**What this PR does / why we need it**:

Updates [GEP-1686](https://gateway-api.sigs.k8s.io/geps/gep-1686/) to move some content from the TLDR section into a Conformance Profile section with additional detail, and adds an explicit mention of how support levels will interact with conformance profiles (had previously been included as a stub but was removed in https://github.com/kubernetes-sigs/gateway-api/commit/85599f29351be4bd7da6228d627708bed1c9856a before https://github.com/kubernetes-sigs/gateway-api/pull/1813 merged).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1488

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
