### PR TITLE
Fix description of ReferenceGrant example

### DIFF
--- a/site-src/concepts/security-model.md
+++ b/site-src/concepts/security-model.md
@@ -113,8 +113,8 @@ Backends (usually Services). In these cases, the required handshake is
 accomplished with a ReferenceGrant resource. This resource exists within a
 target namespace and can be used to allow references from other namespaces.
 
-For example, the following ReferenceGrant allows references from Gateways in
-the "prod" namespace to HTTPRoutes that are deployed in the same namespace as
+For example, the following ReferenceGrant allows references from HTTPRoutes in
+the "prod" namespace to Services that are deployed in the same namespace as
 the ReferenceGrant.
 
 ```yaml


### PR DESCRIPTION
Fix the description of an example ReferenceGrant in the documentation page of the security model. Before this PR the documentation wrongly claims that the grant is from Gateways to HTTPRoutes, while it is from HTTPRoutes to Services: https://github.com/kubernetes-sigs/gateway-api/blob/main/examples/standard/reference-grant.yaml

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind documentation

**What this PR does / why we need it**:
It fixes wrong statements in the documentation.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Fix description of ReferenceGrant example in documentation by making it use the correct resources.
```
