### PR TITLE
Fix grammar in implementation guidelines

### DIFF
--- a/site-src/api-types/referencegrant.md
+++ b/site-src/api-types/referencegrant.md
@@ -94,7 +94,7 @@ When communicating the status of a cross-namespace reference, implementations
 MUST NOT expose information about the existence of a resource in another
 namespace unless a ReferenceGrant exists allowing the reference to occur. This
 means that if a cross-namespace reference is made without a ReferenceGrant to a
-resource that doesn't exist. Any status conditions or warning messages need to
+resource that doesn't exist, any status conditions or warning messages need to
 focus on the fact that a ReferenceGrant does not exist to allow this reference.
 No hints should be provided about whether or not the referenced resource exists.
 


### PR DESCRIPTION
Fix grammar in ReferenceGrant implementation guidelines. Before this PR a sentence is truncated prematurely with a period, and the two chunks of the intended sentence make no sense in isolation. The PR rejoins the two chunks by replacing the period with a comma.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind documentation

**What this PR does / why we need it**:
Fixes a grammar mistake in the documentation.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Fix grammar mistake in ReferenceGrant implementation guidelines.
```
