### PR TITLE
Fix broken URLs in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 <!--  Thanks for sending a pull request! Here are some tips for you:
 
 1. If this is your first time contributing to Gateway API, please read our
-   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
-   and our community page (https://gateway-api.sigs.k8s.io/community/).
+   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
+   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
 2. If this is your first time contributing to a Kubernetes project, please read
    our contributor guidelines:
    https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution


### PR DESCRIPTION
Fix broken URLs to resources for first-time contributors in PR template.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind documentation

**What this PR does / why we need it**:
Fixes broken link to resources for first-time contributors in the PR template.
Before this PR the links resulted in 404.