### PR TITLE
conformance: listener status can be in any order

### DIFF
--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -636,12 +636,17 @@ func listenersMatch(t *testing.T, expected, actual []v1beta1.ListenerStatus) boo
 		return false
 	}
 
-	// TODO(mikemorris): Allow for arbitrarily ordered listeners
-	for i, eListener := range expected {
-		aListener := actual[i]
-		if aListener.Name != eListener.Name {
-			t.Logf("Name doesn't match")
-			return false
+	for _, eListener := range expected {
+		var aListener *v1beta1.ListenerStatus
+		for i := range actual {
+			if actual[i].Name == eListener.Name {
+				aListener = &actual[i]
+				break
+			}
+		}
+		if aListener == nil {
+			t.Logf("Expected status for listener %s to be present", eListener.Name)
+			continue
 		}
 
 		if len(eListener.SupportedKinds) == 0 && len(aListener.SupportedKinds) != 0 {

--- a/conformance/utils/kubernetes/helpers_test.go
+++ b/conformance/utils/kubernetes/helpers_test.go
@@ -296,6 +296,20 @@ func Test_listenersMatch(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "expected and actual can be in different orders",
+			expected: []v1beta1.ListenerStatus{
+				{Name: "listener-2"},
+				{Name: "listener-3"},
+				{Name: "listener-1"},
+			},
+			actual: []v1beta1.ListenerStatus{
+				{Name: "listener-1"},
+				{Name: "listener-2"},
+				{Name: "listener-3"},
+			},
+			want: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What type of PR is this?**
/area conformance

**What this PR does / why we need it**:
Allows listener statuses to be in any order.

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
