### PR TITLE
Clarify port redirect behaviour and add conformance tests for the same

### DIFF
--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -855,6 +855,9 @@ type HTTPRequestRedirectFilter struct {
 	// Scheme is the scheme to be used in the value of the `Location` header in
 	// the response. When empty, the scheme of the request is used.
 	//
+	// Scheme redirects can affect the port of the redirect, for more information,
+	// refer to the documentation for the port field of this filter.
+	//
 	// Note that values may be added to this enum, implementations
 	// must ensure that unknown values will not cause a crash.
 	//
@@ -889,7 +892,15 @@ type HTTPRequestRedirectFilter struct {
 	// Port is the port to be used in the value of the `Location`
 	// header in the response.
 	//
-	// When empty, the Gateway Listener port is used.
+	// If no port is specified, the redirect port MUST be derived using the
+	// following rules:
+	//
+	// * If redirect scheme is not-empty, the redirect port MUST be the well-known
+	//   port associated with the redirect scheme. Specifically "http" to port 80
+	//   and "https" to port 443. If the redirect scheme does not have a
+	//   well-known port, the listener port of the Gateway SHOULD be used.
+	// * If redirect scheme is empty, the redirect port MUST be the Gateway
+	//   Listener port.
 	//
 	// Implementations SHOULD NOT add the port number in the 'Location'
 	// header in the following cases:

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -580,8 +580,17 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. \n When empty, the Gateway Listener
-                                        port is used. \n Implementations SHOULD NOT
+                                        response. \n If no port is specified, the
+                                        redirect port MUST be derived using the following
+                                        rules: \n * If redirect scheme is not-empty,
+                                        the redirect port MUST be the well-known port
+                                        associated with the redirect scheme. Specifically
+                                        \"http\" to port 80 and \"https\" to port
+                                        443. If the redirect scheme does not have
+                                        a well-known port, the listener port of the
+                                        Gateway SHOULD be used. * If redirect scheme
+                                        is empty, the redirect port MUST be the Gateway
+                                        Listener port. \n Implementations SHOULD NOT
                                         add the port number in the 'Location' header
                                         in the following cases: \n * A Location header
                                         that will use HTTP (whether that is determined
@@ -598,8 +607,11 @@ spec:
                                       description: "Scheme is the scheme to be used
                                         in the value of the `Location` header in the
                                         response. When empty, the scheme of the request
-                                        is used. \n Note that values may be added
-                                        to this enum, implementations must ensure
+                                        is used. \n Scheme redirects can affect the
+                                        port of the redirect, for more information,
+                                        refer to the documentation for the port field
+                                        of this filter. \n Note that values may be
+                                        added to this enum, implementations must ensure
                                         that unknown values will not cause a crash.
                                         \n Unknown values here must result in the
                                         implementation setting the Accepted Condition
@@ -1221,16 +1233,24 @@ spec:
                                 type: object
                               port:
                                 description: "Port is the port to be used in the value
-                                  of the `Location` header in the response. \n When
-                                  empty, the Gateway Listener port is used. \n Implementations
-                                  SHOULD NOT add the port number in the 'Location'
-                                  header in the following cases: \n * A Location header
-                                  that will use HTTP (whether that is determined via
-                                  the Listener protocol or the Scheme field) _and_
-                                  use port 80. * A Location header that will use HTTPS
-                                  (whether that is determined via the Listener protocol
-                                  or the Scheme field) _and_ use port 443. \n Support:
-                                  Extended"
+                                  of the `Location` header in the response. \n If
+                                  no port is specified, the redirect port MUST be
+                                  derived using the following rules: \n * If redirect
+                                  scheme is not-empty, the redirect port MUST be the
+                                  well-known port associated with the redirect scheme.
+                                  Specifically \"http\" to port 80 and \"https\" to
+                                  port 443. If the redirect scheme does not have a
+                                  well-known port, the listener port of the Gateway
+                                  SHOULD be used. * If redirect scheme is empty, the
+                                  redirect port MUST be the Gateway Listener port.
+                                  \n Implementations SHOULD NOT add the port number
+                                  in the 'Location' header in the following cases:
+                                  \n * A Location header that will use HTTP (whether
+                                  that is determined via the Listener protocol or
+                                  the Scheme field) _and_ use port 80. * A Location
+                                  header that will use HTTPS (whether that is determined
+                                  via the Listener protocol or the Scheme field) _and_
+                                  use port 443. \n Support: Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -1239,7 +1259,10 @@ spec:
                                 description: "Scheme is the scheme to be used in the
                                   value of the `Location` header in the response.
                                   When empty, the scheme of the request is used. \n
-                                  Note that values may be added to this enum, implementations
+                                  Scheme redirects can affect the port of the redirect,
+                                  for more information, refer to the documentation
+                                  for the port field of this filter. \n Note that
+                                  values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a
                                   crash. \n Unknown values here must result in the
                                   implementation setting the Accepted Condition for
@@ -2475,8 +2498,17 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. \n When empty, the Gateway Listener
-                                        port is used. \n Implementations SHOULD NOT
+                                        response. \n If no port is specified, the
+                                        redirect port MUST be derived using the following
+                                        rules: \n * If redirect scheme is not-empty,
+                                        the redirect port MUST be the well-known port
+                                        associated with the redirect scheme. Specifically
+                                        \"http\" to port 80 and \"https\" to port
+                                        443. If the redirect scheme does not have
+                                        a well-known port, the listener port of the
+                                        Gateway SHOULD be used. * If redirect scheme
+                                        is empty, the redirect port MUST be the Gateway
+                                        Listener port. \n Implementations SHOULD NOT
                                         add the port number in the 'Location' header
                                         in the following cases: \n * A Location header
                                         that will use HTTP (whether that is determined
@@ -2493,8 +2525,11 @@ spec:
                                       description: "Scheme is the scheme to be used
                                         in the value of the `Location` header in the
                                         response. When empty, the scheme of the request
-                                        is used. \n Note that values may be added
-                                        to this enum, implementations must ensure
+                                        is used. \n Scheme redirects can affect the
+                                        port of the redirect, for more information,
+                                        refer to the documentation for the port field
+                                        of this filter. \n Note that values may be
+                                        added to this enum, implementations must ensure
                                         that unknown values will not cause a crash.
                                         \n Unknown values here must result in the
                                         implementation setting the Accepted Condition
@@ -3116,16 +3151,24 @@ spec:
                                 type: object
                               port:
                                 description: "Port is the port to be used in the value
-                                  of the `Location` header in the response. \n When
-                                  empty, the Gateway Listener port is used. \n Implementations
-                                  SHOULD NOT add the port number in the 'Location'
-                                  header in the following cases: \n * A Location header
-                                  that will use HTTP (whether that is determined via
-                                  the Listener protocol or the Scheme field) _and_
-                                  use port 80. * A Location header that will use HTTPS
-                                  (whether that is determined via the Listener protocol
-                                  or the Scheme field) _and_ use port 443. \n Support:
-                                  Extended"
+                                  of the `Location` header in the response. \n If
+                                  no port is specified, the redirect port MUST be
+                                  derived using the following rules: \n * If redirect
+                                  scheme is not-empty, the redirect port MUST be the
+                                  well-known port associated with the redirect scheme.
+                                  Specifically \"http\" to port 80 and \"https\" to
+                                  port 443. If the redirect scheme does not have a
+                                  well-known port, the listener port of the Gateway
+                                  SHOULD be used. * If redirect scheme is empty, the
+                                  redirect port MUST be the Gateway Listener port.
+                                  \n Implementations SHOULD NOT add the port number
+                                  in the 'Location' header in the following cases:
+                                  \n * A Location header that will use HTTP (whether
+                                  that is determined via the Listener protocol or
+                                  the Scheme field) _and_ use port 80. * A Location
+                                  header that will use HTTPS (whether that is determined
+                                  via the Listener protocol or the Scheme field) _and_
+                                  use port 443. \n Support: Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -3134,7 +3177,10 @@ spec:
                                 description: "Scheme is the scheme to be used in the
                                   value of the `Location` header in the response.
                                   When empty, the scheme of the request is used. \n
-                                  Note that values may be added to this enum, implementations
+                                  Scheme redirects can affect the port of the redirect,
+                                  for more information, refer to the documentation
+                                  for the port field of this filter. \n Note that
+                                  values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a
                                   crash. \n Unknown values here must result in the
                                   implementation setting the Accepted Condition for

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -554,8 +554,17 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. \n When empty, the Gateway Listener
-                                        port is used. \n Implementations SHOULD NOT
+                                        response. \n If no port is specified, the
+                                        redirect port MUST be derived using the following
+                                        rules: \n * If redirect scheme is not-empty,
+                                        the redirect port MUST be the well-known port
+                                        associated with the redirect scheme. Specifically
+                                        \"http\" to port 80 and \"https\" to port
+                                        443. If the redirect scheme does not have
+                                        a well-known port, the listener port of the
+                                        Gateway SHOULD be used. * If redirect scheme
+                                        is empty, the redirect port MUST be the Gateway
+                                        Listener port. \n Implementations SHOULD NOT
                                         add the port number in the 'Location' header
                                         in the following cases: \n * A Location header
                                         that will use HTTP (whether that is determined
@@ -572,8 +581,11 @@ spec:
                                       description: "Scheme is the scheme to be used
                                         in the value of the `Location` header in the
                                         response. When empty, the scheme of the request
-                                        is used. \n Note that values may be added
-                                        to this enum, implementations must ensure
+                                        is used. \n Scheme redirects can affect the
+                                        port of the redirect, for more information,
+                                        refer to the documentation for the port field
+                                        of this filter. \n Note that values may be
+                                        added to this enum, implementations must ensure
                                         that unknown values will not cause a crash.
                                         \n Unknown values here must result in the
                                         implementation setting the Accepted Condition
@@ -1195,16 +1207,24 @@ spec:
                                 type: object
                               port:
                                 description: "Port is the port to be used in the value
-                                  of the `Location` header in the response. \n When
-                                  empty, the Gateway Listener port is used. \n Implementations
-                                  SHOULD NOT add the port number in the 'Location'
-                                  header in the following cases: \n * A Location header
-                                  that will use HTTP (whether that is determined via
-                                  the Listener protocol or the Scheme field) _and_
-                                  use port 80. * A Location header that will use HTTPS
-                                  (whether that is determined via the Listener protocol
-                                  or the Scheme field) _and_ use port 443. \n Support:
-                                  Extended"
+                                  of the `Location` header in the response. \n If
+                                  no port is specified, the redirect port MUST be
+                                  derived using the following rules: \n * If redirect
+                                  scheme is not-empty, the redirect port MUST be the
+                                  well-known port associated with the redirect scheme.
+                                  Specifically \"http\" to port 80 and \"https\" to
+                                  port 443. If the redirect scheme does not have a
+                                  well-known port, the listener port of the Gateway
+                                  SHOULD be used. * If redirect scheme is empty, the
+                                  redirect port MUST be the Gateway Listener port.
+                                  \n Implementations SHOULD NOT add the port number
+                                  in the 'Location' header in the following cases:
+                                  \n * A Location header that will use HTTP (whether
+                                  that is determined via the Listener protocol or
+                                  the Scheme field) _and_ use port 80. * A Location
+                                  header that will use HTTPS (whether that is determined
+                                  via the Listener protocol or the Scheme field) _and_
+                                  use port 443. \n Support: Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -1213,7 +1233,10 @@ spec:
                                 description: "Scheme is the scheme to be used in the
                                   value of the `Location` header in the response.
                                   When empty, the scheme of the request is used. \n
-                                  Note that values may be added to this enum, implementations
+                                  Scheme redirects can affect the port of the redirect,
+                                  for more information, refer to the documentation
+                                  for the port field of this filter. \n Note that
+                                  values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a
                                   crash. \n Unknown values here must result in the
                                   implementation setting the Accepted Condition for
@@ -2395,8 +2418,17 @@ spec:
                                     port:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
-                                        response. \n When empty, the Gateway Listener
-                                        port is used. \n Implementations SHOULD NOT
+                                        response. \n If no port is specified, the
+                                        redirect port MUST be derived using the following
+                                        rules: \n * If redirect scheme is not-empty,
+                                        the redirect port MUST be the well-known port
+                                        associated with the redirect scheme. Specifically
+                                        \"http\" to port 80 and \"https\" to port
+                                        443. If the redirect scheme does not have
+                                        a well-known port, the listener port of the
+                                        Gateway SHOULD be used. * If redirect scheme
+                                        is empty, the redirect port MUST be the Gateway
+                                        Listener port. \n Implementations SHOULD NOT
                                         add the port number in the 'Location' header
                                         in the following cases: \n * A Location header
                                         that will use HTTP (whether that is determined
@@ -2413,8 +2445,11 @@ spec:
                                       description: "Scheme is the scheme to be used
                                         in the value of the `Location` header in the
                                         response. When empty, the scheme of the request
-                                        is used. \n Note that values may be added
-                                        to this enum, implementations must ensure
+                                        is used. \n Scheme redirects can affect the
+                                        port of the redirect, for more information,
+                                        refer to the documentation for the port field
+                                        of this filter. \n Note that values may be
+                                        added to this enum, implementations must ensure
                                         that unknown values will not cause a crash.
                                         \n Unknown values here must result in the
                                         implementation setting the Accepted Condition
@@ -3036,16 +3071,24 @@ spec:
                                 type: object
                               port:
                                 description: "Port is the port to be used in the value
-                                  of the `Location` header in the response. \n When
-                                  empty, the Gateway Listener port is used. \n Implementations
-                                  SHOULD NOT add the port number in the 'Location'
-                                  header in the following cases: \n * A Location header
-                                  that will use HTTP (whether that is determined via
-                                  the Listener protocol or the Scheme field) _and_
-                                  use port 80. * A Location header that will use HTTPS
-                                  (whether that is determined via the Listener protocol
-                                  or the Scheme field) _and_ use port 443. \n Support:
-                                  Extended"
+                                  of the `Location` header in the response. \n If
+                                  no port is specified, the redirect port MUST be
+                                  derived using the following rules: \n * If redirect
+                                  scheme is not-empty, the redirect port MUST be the
+                                  well-known port associated with the redirect scheme.
+                                  Specifically \"http\" to port 80 and \"https\" to
+                                  port 443. If the redirect scheme does not have a
+                                  well-known port, the listener port of the Gateway
+                                  SHOULD be used. * If redirect scheme is empty, the
+                                  redirect port MUST be the Gateway Listener port.
+                                  \n Implementations SHOULD NOT add the port number
+                                  in the 'Location' header in the following cases:
+                                  \n * A Location header that will use HTTP (whether
+                                  that is determined via the Listener protocol or
+                                  the Scheme field) _and_ use port 80. * A Location
+                                  header that will use HTTPS (whether that is determined
+                                  via the Listener protocol or the Scheme field) _and_
+                                  use port 443. \n Support: Extended"
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -3054,7 +3097,10 @@ spec:
                                 description: "Scheme is the scheme to be used in the
                                   value of the `Location` header in the response.
                                   When empty, the scheme of the request is used. \n
-                                  Note that values may be added to this enum, implementations
+                                  Scheme redirects can affect the port of the redirect,
+                                  for more information, refer to the documentation
+                                  for the port field of this filter. \n Note that
+                                  values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a
                                   crash. \n Unknown values here must result in the
                                   implementation setting the Accepted Condition for

--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -31,6 +31,42 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
+  name: same-namespace-with-http-listener-on-8080
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: http
+    port: 8080
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: same-namespace-with-https-listener
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: https
+    port: 443
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: Same
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: tls-validity-checks-certificate
+        namespace: gateway-conformance-infra
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
   name: all-namespaces
   namespace: gateway-conformance-infra
 spec:

--- a/conformance/tests/httproute-redirect-port-and-scheme.go
+++ b/conformance/tests/httproute-redirect-port-and-scheme.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tls"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteRedirectPortAndScheme)
+}
+
+var HTTPRouteRedirectPortAndScheme = suite.ConformanceTest{
+	ShortName:   "HTTPRouteRedirectPortAndScheme",
+	Description: "An HTTPRoute with port and scheme redirect filter",
+	Manifests:   []string{"tests/httproute-redirect-port-and-scheme.yaml"},
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportHTTPRoute,
+		suite.SupportHTTPRoutePortRedirect,
+	},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		routeNN := types.NamespacedName{Name: "http-route-for-listener-on-port-80", Namespace: ns}
+		gwAddr80 := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		gwNN = types.NamespacedName{Name: "same-namespace-with-http-listener-on-8080", Namespace: ns}
+		routeNN = types.NamespacedName{Name: "http-route-for-listener-on-port-8080", Namespace: ns}
+		gwAddr8080 := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		gwNN = types.NamespacedName{Name: "same-namespace-with-https-listener", Namespace: ns}
+		routeNN = types.NamespacedName{Name: "http-route-for-listener-on-port-443", Namespace: ns}
+		gwAddr443 := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		certNN := types.NamespacedName{Name: "tls-validity-checks-certificate", Namespace: string(ns)}
+		cPem, keyPem, err := GetTLSSecret(suite.Client, certNN)
+		if err != nil {
+			t.Fatalf("unexpected error finding TLS secret: %v", err)
+		}
+
+		// NOTE: In all the test cases, a missing value of expected Port within
+		//   RedirectRequest implies that it is still valid and acceptable for a
+		//   port to be specified in the redirect if it corresponds to the scheme
+		//   (80 and 443).
+
+		////////////////////////////////////////////////////////////////////////////
+		// Test cases that use http-route-for-listener-on-port-80
+		////////////////////////////////////////////////////////////////////////////
+
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Path:             "/scheme-nil-and-port-nil",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{StatusCode: 302},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "http",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path:             "/scheme-nil-and-port-80",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{StatusCode: 302},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "http",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path:             "/scheme-nil-and-port-8080",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{StatusCode: 302},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "http",
+					Port:   "8080",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path:             "/scheme-https-and-port-nil",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{StatusCode: 302},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "https",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path:             "/scheme-https-and-port-443",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{StatusCode: 302},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "https",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path:             "/scheme-https-and-port-8443",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{StatusCode: 302},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "https",
+					Port:   "8443",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+		}
+
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run("http-listener-on-80/"+tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr80, tc)
+			})
+		}
+
+		////////////////////////////////////////////////////////////////////////////
+		// Test cases that use same-namespace-with-http-listener-on-8080
+		////////////////////////////////////////////////////////////////////////////
+
+		testCases = []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Path:             "/scheme-nil-and-port-nil",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{StatusCode: 302},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "http",
+					Port:   "8080",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path:             "/scheme-nil-and-port-80",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{StatusCode: 302},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "http",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path:             "/scheme-https-and-port-nil",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{StatusCode: 302},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "https",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+		}
+
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run("http-listener-on-8080/"+tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr8080, tc)
+			})
+		}
+
+		////////////////////////////////////////////////////////////////////////////
+		// Test cases that use http-route-for-listener-on-port-443
+		////////////////////////////////////////////////////////////////////////////
+
+		testCases = []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Path:             "/scheme-nil-and-port-nil",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{StatusCode: 302},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "https",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path:             "/scheme-nil-and-port-443",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{StatusCode: 302},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "https",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path:             "/scheme-nil-and-port-8443",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{StatusCode: 302},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "https",
+					Port:   "8443",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path:             "/scheme-http-and-port-nil",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{StatusCode: 302},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "http",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path:             "/scheme-http-and-port-80",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{StatusCode: 302},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "http",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path:             "/scheme-http-and-port-8080",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{StatusCode: 302},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "http",
+					Port:   "8080",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+		}
+
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run("https-listener-on-443/"+tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				tls.MakeTLSRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr443, cPem, keyPem, "example", tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-redirect-port-and-scheme.yaml
+++ b/conformance/tests/httproute-redirect-port-and-scheme.yaml
@@ -1,0 +1,166 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: http-route-for-listener-on-port-80
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-nil-and-port-nil
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: example.org
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-nil-and-port-80
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        port: 80
+        hostname: example.org
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-nil-and-port-8080
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        port: 8080
+        hostname: example.org
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-https-and-port-nil
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: "https"
+        hostname: example.org
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-https-and-port-443
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: "https"
+        port: 443
+        hostname: example.org
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-https-and-port-8443
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: "https"
+        port: 8443
+        hostname: example.org
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: http-route-for-listener-on-port-8080
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace-with-http-listener-on-8080
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-nil-and-port-nil
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: example.org
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-nil-and-port-80
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        port: 80
+        hostname: example.org
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-https-and-port-nil
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: "https"
+        hostname: example.org
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: http-route-for-listener-on-port-443
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace-with-https-listener
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-nil-and-port-nil
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: example.org
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-nil-and-port-443
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        port: 443
+        hostname: example.org
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-nil-and-port-8443
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        port: 8443
+        hostname: example.org
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-http-and-port-nil
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: "http"
+        hostname: example.org
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-http-and-port-80
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: "http"
+        port: 80
+        hostname: example.org
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-http-and-port-8080
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: "http"
+        port: 8080
+        hostname: example.org
+---

--- a/conformance/utils/tls/tls.go
+++ b/conformance/utils/tls/tls.go
@@ -53,8 +53,8 @@ func WaitForConsistentTLSResponse(t *testing.T, r roundtripper.RoundTripper, req
 			return false
 		}
 
-		if err := http.CompareRequest(&req, cReq, cRes, expected); err != nil {
-			t.Logf("Response expectation failed for request: %v  not ready yet: %v (after %v)", req, err, elapsed)
+		if err := http.CompareRequest(t, &req, cReq, cRes, expected); err != nil {
+			t.Logf("Response expectation failed for request: %+v  not ready yet: %v (after %v)", req, err, elapsed)
 			return false
 		}
 


### PR DESCRIPTION
### **What type of PR is this?**
/kind documentation
/area conformance
/kind test

### **What this PR does / why we need it**:
Clarify port redirect behaviour and add conformance tests for the same:
```
// When empty, the redirect port MUST be derived using the following rules:
//
// * If redirect scheme is not-empty, the redirect port MUST be the well-known
//   port associated with the redirect scheme. Specifically "http" to port 80
//   and "https" to port 443. If the redirect scheme does not have a
//   well-known port, the listener port of the Gateway SHOULD be used.
// * If redirect scheme is empty, the redirect port MUST be the Gateway
//   Listener port.
```

Proposal doc: https://docs.google.com/document/d/1fx8kuWh2bmBge9IRGn7NlhGqTP0Kj21Cz5RZyUW6428

### **Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/1805
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/1909

### **Does this PR introduce a user-facing change?**:
```release-note
Port redirect when empty will depend on the configured Redirect scheme
```
