### PR TITLE
add option to specify http roundtripper while running conformance tests

### DIFF
--- a/conformance/utils/roundtripper/roundtripper.go
+++ b/conformance/utils/roundtripper/roundtripper.go
@@ -84,8 +84,9 @@ type CapturedResponse struct {
 // DefaultRoundTripper is the default implementation of a RoundTripper. It will
 // be used if a custom implementation is not specified.
 type DefaultRoundTripper struct {
-	Debug         bool
-	TimeoutConfig config.TimeoutConfig
+	Debug            bool
+	TimeoutConfig    config.TimeoutConfig
+	HTTPRoundTripper http.RoundTripper
 }
 
 // CaptureRoundTrip makes a request with the provided parameters and returns the

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -17,6 +17,7 @@ limitations under the License.
 package suite
 
 import (
+	"net/http"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -120,6 +121,7 @@ type Options struct {
 	GatewayClassName string
 	Debug            bool
 	RoundTripper     roundtripper.RoundTripper
+	HTTPRoundTripper http.RoundTripper
 	BaseManifests    string
 	NamespaceLabels  map[string]string
 	// ValidUniqueListenerPorts maps each listener port of each Gateway in the
@@ -147,7 +149,7 @@ func New(s Options) *ConformanceTestSuite {
 
 	roundTripper := s.RoundTripper
 	if roundTripper == nil {
-		roundTripper = &roundtripper.DefaultRoundTripper{Debug: s.Debug, TimeoutConfig: s.TimeoutConfig}
+		roundTripper = &roundtripper.DefaultRoundTripper{Debug: s.Debug, TimeoutConfig: s.TimeoutConfig, HTTPRoundTripper: s.HTTPRoundTripper}
 	}
 
 	if s.EnableAllSupportedFeatures == true {


### PR DESCRIPTION


**What type of PR is this?**
/area conformance

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1496 

**Does this PR introduce a user-facing change?**:
No
```release-note
NONE

```
