### PR TITLE
Update Gateway/Listener status for consistency

### DIFF
--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -536,6 +536,8 @@ const (
 	//
 	// * "Invalid"
 	// * "Pending"
+	// * "NoResources"
+	// * "AddressNotAssigned"
 	//
 	// Possible reasons for this condition to be Unknown are:
 	//
@@ -550,9 +552,20 @@ const (
 	// true.
 	GatewayReasonProgrammed GatewayConditionReason = "Programmed"
 
-	// This reason is used with the "Programmed" condition when the Listener is
+	// This reason is used with the "Programmed" and "Accepted" condition when the Gateway is
 	// syntactically or semantically invalid.
 	GatewayReasonInvalid GatewayConditionReason = "Invalid"
+
+	// This reason is used with the "Programmed" condition when the
+	// Gateway is not scheduled because insufficient infrastructure
+	// resources are available.
+	GatewayReasonNoResources GatewayConditionReason = "NoResources"
+
+	// This reason is used with the "Programmed" condition when none of the requested
+	// addresses have been assigned to the Gateway. This reason can be used to
+	// express a range of circumstances, including (but not limited to) IPAM
+	// address exhaustion, address not yet allocated, or a named address not being found.
+	GatewayReasonAddressNotAssigned GatewayConditionReason = "AddressNotAssigned"
 )
 
 const (
@@ -564,11 +577,13 @@ const (
 	// Possible reasons for this condition to be True are:
 	//
 	// * "Accepted"
+	// * "ListenersNotValid"
 	//
 	// Possible reasons for this condition to be False are:
 	//
+	// * "Invalid"
 	// * "NotReconciled"
-	// * "NoResources"
+	// * "UnsupportedAddress"
 	//
 	// Possible reasons for this condition to be Unknown are:
 	//
@@ -579,12 +594,27 @@ const (
 	// interoperability.
 	GatewayConditionAccepted GatewayConditionType = "Accepted"
 
-	// Deprecated: use "Accepted" instead.
-	GatewayConditionScheduled GatewayConditionType = "Scheduled"
-
 	// This reason is used with the "Accepted" condition when the condition is
 	// True.
 	GatewayReasonAccepted GatewayConditionReason = "Accepted"
+
+	// This reason is used with the "Accepted" and "Programmed"
+	// conditions when the status is "Unknown" and no controller has reconciled
+	// the Gateway.
+	GatewayReasonPending GatewayConditionReason = "Pending"
+
+	// This reason is used with the "Accepted" condition when the Gateway could not be configured
+	// because the requested address is not supported. This reason could be used in a number of
+	// instances, including:
+	//
+	// * The address is already in use.
+	// * The type of address is not supported by the implementation.
+	GatewaReasonUnsupportedAddress GatewayConditionReason = "UnsupportedAddress"
+)
+
+const (
+	// Deprecated: use "Accepted" instead.
+	GatewayConditionScheduled GatewayConditionType = "Scheduled"
 
 	// This reason is used with the "Scheduled" condition when the condition is
 	// True.
@@ -592,63 +622,26 @@ const (
 	// Deprecated: use the "Accepted" condition with reason "Accepted" instead.
 	GatewayReasonScheduled GatewayConditionReason = "Scheduled"
 
-	// This reason is used with the "Accepted", "Programmed" and "Ready"
-	// conditions when the status is "Unknown" and no controller has reconciled
-	// the Gateway.
-	GatewayReasonPending GatewayConditionReason = "Pending"
-
 	// Deprecated: Use "Pending" instead.
 	GatewayReasonNotReconciled GatewayConditionReason = "NotReconciled"
-
-	// This reason is used with the "Accepted" condition when the
-	// Gateway is not scheduled because insufficient infrastructure
-	// resources are available.
-	GatewayReasonNoResources GatewayConditionReason = "NoResources"
 )
 
 const (
-	// Ready is an optional Condition that has Extended support. When it's set,
-	// the condition indicates whether the Gateway has been completely configured
-	// and traffic is ready to flow through the data plane immediately.
+	// "Ready" is a reserved condition type for future use. It should not be used by implementations.
+	// Note: its not really "deprecated", but rather "reserved"; however, deprecated triggers Go linters
+	// to alert about usage.
 	//
-	// If both the "ListenersNotValid" and "ListenersNotReady"
-	// reasons are true, the Gateway controller should prefer the
-	// "ListenersNotValid" reason.
-	//
-	// Possible reasons for this condition to be true are:
-	//
-	// * "Ready"
-	//
-	// Possible reasons for this condition to be False are:
-	//
-	// * "ListenersNotValid"
-	// * "ListenersNotReady"
-	// * "AddressNotAssigned"
-	//
-	// Controllers may raise this condition with other reasons,
-	// but should prefer to use the reasons listed above to improve
-	// interoperability.
+	// Deprecated: Ready is reserved for future use
 	GatewayConditionReady GatewayConditionType = "Ready"
 
-	// This reason is used with the "Ready" condition when the condition is
-	// true.
+	// Deprecated: Ready is reserved for future use
 	GatewayReasonReady GatewayConditionReason = "Ready"
 
-	// This reason is used with the "Ready" condition when one or
-	// more Listeners have an invalid or unsupported configuration
-	// and cannot be configured on the Gateway.
+	// Deprecated: Ready is reserved for future use
 	GatewayReasonListenersNotValid GatewayConditionReason = "ListenersNotValid"
 
-	// This reason is used with the "Ready" condition when one or
-	// more Listeners are not ready to serve traffic.
+	// Deprecated: Ready is reserved for future use
 	GatewayReasonListenersNotReady GatewayConditionReason = "ListenersNotReady"
-
-	// This reason is used with the "Ready" condition when none of the requested
-	// addresses have been assigned to the Gateway. This reason can be used to
-	// express a range of circumstances, including (but not limited to) IPAM
-	// address exhaustion, invalid or unsupported address requests, or a named
-	// address not being found.
-	GatewayReasonAddressNotAssigned GatewayConditionReason = "AddressNotAssigned"
 )
 
 // ListenerStatus is the status associated with a Listener.
@@ -745,7 +738,6 @@ const (
 	//
 	// * "PortUnavailable"
 	// * "UnsupportedProtocol"
-	// * "UnsupportedAddress"
 	//
 	// Possible reasons for this condition to be Unknown are:
 	//
@@ -781,14 +773,6 @@ const (
 	// Listener could not be attached to be Gateway because its
 	// protocol type is not supported.
 	ListenerReasonUnsupportedProtocol ListenerConditionReason = "UnsupportedProtocol"
-
-	// This reason is used with the "Accepted" condition when the Listener could
-	// not be attached to the Gateway because the requested address is not
-	// supported. This reason could be used in a number of instances, including:
-	//
-	// * The address is already in use.
-	// * The type of address is not supported by the implementation.
-	ListenerReasonUnsupportedAddress ListenerConditionReason = "UnsupportedAddress"
 )
 
 const (
@@ -870,34 +854,6 @@ const (
 	// This reason is used with the "Programmed" condition when the condition is
 	// true.
 	ListenerReasonProgrammed ListenerConditionReason = "Programmed"
-)
-
-const (
-	// Ready is an optional Condition that has Extended support. When it's set,
-	// the condition indicates whether the Listener has been configured on the
-	// Gateway and traffic is ready to flow through the data plane immediately.
-	//
-	// Possible reasons for this condition to be True are:
-	//
-	// * "Ready"
-	//
-	// Possible reasons for this condition to be False are:
-	//
-	// * "Invalid"
-	// * "Pending"
-	//
-	// Possible reasons for this condition to be Unknown are:
-	//
-	// * "Pending"
-	//
-	// Controllers may raise this condition with other reasons,
-	// but should prefer to use the reasons listed above to improve
-	// interoperability.
-	ListenerConditionReady ListenerConditionType = "Ready"
-
-	// This reason is used with the "Ready" condition when the condition is
-	// true.
-	ListenerReasonReady ListenerConditionReason = "Ready"
 
 	// This reason is used with the "Ready" and "Programmed" conditions when the
 	// Listener is syntactically or semantically invalid.
@@ -907,4 +863,16 @@ const (
 	// conditions when the Listener is either not yet reconciled or not yet not
 	// online and ready to accept client traffic.
 	ListenerReasonPending ListenerConditionReason = "Pending"
+)
+
+const (
+	// "Ready" is a reserved condition type for future use. It should not be used by implementations.
+	// Note: its not really "deprecated", but rather "reserved"; however, deprecated triggers Go linters
+	// to alert about usage.
+	//
+	// Deprecated: Ready is reserved for future use
+	ListenerConditionReady ListenerConditionType = "Ready"
+
+	// Deprecated: Ready is reserved for future use
+	ListenerReasonReady ListenerConditionReason = "Ready"
 )


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Supercedes https://github.com/kubernetes-sigs/gateway-api/pull/1886
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/1832
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/1877

This PR attempts to introduce a bit more consistency into Gateway conditions, while reducing churn. There are 4 changes here:

* The "Ready" Gateway and Listener condition has been reserved for future use.

This condition has no implementations; while it may have some future value, we cannot justify the additional reason going GA without usage. Additionally, it has caused confusion by the subtle distinction between Programmed and Ready, and has "stolen" some useful Reasons to be not Programmed.

This is expected to have no user impact, as no implementation supports this.

* The UnsupportedAddress Listener condition reason has been moved to a Gateway condition reason

This does not make sense on a Listener, as Listeners do not have addresses

* The AddressNotAssigned Gateway condition reasons has moved from Accepted to Programmed

Accepted is about static analysis of the configuration; assigning an address is about actually programming the resources, so it fits more in Programmed

* The NoResources Gateway condition reasons has moved from Ready to Programmed

Lack of resources is a valid reason to not program the data plane; with the reservation of Ready this is needed in Programmed.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The "Ready" Gateway and Listener condition has been reserved for future use.
The UnsupportedAddress Listener condition reason has been moved to a Gateway condition reason
The AddressNotAssigned Gateway condition reasons has moved from Accepted to Programmed
The NoResources Gateway condition reasons has moved from Ready to Programmed
```
