### PR TITLE
Conformance Tests: No implicit test runs without features

### DIFF
--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -70,7 +70,7 @@ func TestConformance(t *testing.T) {
 	if supportedFeatures.Has(suite.SupportGateway) {
 		toRun = append(toRun, tests.ConformanceTests...)
 	}
-	if supportedFeatures.Has(suite.SupportGAMMA) {
+	if supportedFeatures.Has(suite.SupportMesh) {
 		toRun = append(toRun, tests.MeshConformanceTests...)
 	}
 

--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -64,17 +64,7 @@ func TestConformance(t *testing.T) {
 	})
 	cSuite.Setup(t)
 
-	// TODO(https://github.com/kubernetes-sigs/gateway-api/issues/1891) this will likely changed;
-	// for now, we use this mechanism to split mesh and gateway types
-	var toRun []suite.ConformanceTest
-	if supportedFeatures.Has(suite.SupportGateway) {
-		toRun = append(toRun, tests.ConformanceTests...)
-	}
-	if supportedFeatures.Has(suite.SupportMesh) {
-		toRun = append(toRun, tests.MeshConformanceTests...)
-	}
-
-	cSuite.Run(t, toRun)
+	cSuite.Run(t, tests.ConformanceTests)
 }
 
 // parseSupportedFeatures parses flag arguments and converts the string to

--- a/conformance/tests/gateway-invalid-route-kind.go
+++ b/conformance/tests/gateway-invalid-route-kind.go
@@ -34,7 +34,10 @@ func init() {
 var GatewayInvalidRouteKind = suite.ConformanceTest{
 	ShortName:   "GatewayInvalidRouteKind",
 	Description: "A Gateway in the gateway-conformance-infra namespace should fail to become ready an invalid Route kind is specified.",
-	Manifests:   []string{"tests/gateway-invalid-route-kind.yaml"},
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+	},
+	Manifests: []string{"tests/gateway-invalid-route-kind.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		t.Run("Gateway listener should have a false ResolvedRefs condition with reason InvalidRouteKinds and no supportedKinds", func(t *testing.T) {
 			gwNN := types.NamespacedName{Name: "gateway-only-invalid-route-kind", Namespace: "gateway-conformance-infra"}

--- a/conformance/tests/gateway-invalid-tls-certificateref.go
+++ b/conformance/tests/gateway-invalid-tls-certificateref.go
@@ -34,7 +34,10 @@ func init() {
 var GatewayInvalidTLSConfiguration = suite.ConformanceTest{
 	ShortName:   "GatewayInvalidTLSConfiguration",
 	Description: "A Gateway should fail to become ready if the Gateway has an invalid TLS configuration",
-	Manifests:   []string{"tests/gateway-invalid-tls-certificateref.yaml"},
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+	},
+	Manifests: []string{"tests/gateway-invalid-tls-certificateref.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		listeners := []v1beta1.ListenerStatus{{
 			Name: v1beta1.SectionName("https"),

--- a/conformance/tests/gateway-modify-listeners.go
+++ b/conformance/tests/gateway-modify-listeners.go
@@ -38,7 +38,10 @@ func init() {
 var GatewayModifyListeners = suite.ConformanceTest{
 	ShortName:   "GatewayModifyListeners",
 	Description: "A Gateway in the gateway-conformance-infra namespace should handle adding and removing listeners.",
-	Manifests:   []string{"tests/gateway-modify-listeners.yaml"},
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+	},
+	Manifests: []string{"tests/gateway-modify-listeners.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 
 		t.Run("should be able to add a listener that then becomes available for routing traffic", func(t *testing.T) {

--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -37,7 +37,10 @@ func init() {
 var GatewayObservedGenerationBump = suite.ConformanceTest{
 	ShortName:   "GatewayObservedGenerationBump",
 	Description: "A Gateway in the gateway-conformance-infra namespace should update the observedGeneration in all of its Status.Conditions after an update to the spec",
-	Manifests:   []string{"tests/gateway-observed-generation-bump.yaml"},
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+	},
+	Manifests: []string{"tests/gateway-observed-generation-bump.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 
 		gwNN := types.NamespacedName{Name: "gateway-observed-generation-bump", Namespace: "gateway-conformance-infra"}

--- a/conformance/tests/gateway-secret-invalid-reference-grant.go
+++ b/conformance/tests/gateway-secret-invalid-reference-grant.go
@@ -34,8 +34,11 @@ func init() {
 var GatewaySecretInvalidReferenceGrant = suite.ConformanceTest{
 	ShortName:   "GatewaySecretInvalidReferenceGrant",
 	Description: "A Gateway in the gateway-conformance-infra namespace should fail to become ready if the Gateway has a certificateRef for a Secret in the gateway-conformance-web-backend namespace and a ReferenceGrant exists but does not grant permission to that specific Secret",
-	Features:    []suite.SupportedFeature{suite.SupportReferenceGrant},
-	Manifests:   []string{"tests/gateway-secret-invalid-reference-grant.yaml"},
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportReferenceGrant,
+	},
+	Manifests: []string{"tests/gateway-secret-invalid-reference-grant.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "gateway-secret-invalid-reference-grant", Namespace: "gateway-conformance-infra"}
 

--- a/conformance/tests/gateway-secret-missing-reference-grant.go
+++ b/conformance/tests/gateway-secret-missing-reference-grant.go
@@ -34,8 +34,11 @@ func init() {
 var GatewaySecretMissingReferenceGrant = suite.ConformanceTest{
 	ShortName:   "GatewaySecretMissingReferenceGrant",
 	Description: "A Gateway in the gateway-conformance-infra namespace should fail to become programmed if the Gateway has a certificateRef for a Secret in the gateway-conformance-web-backend namespace and a ReferenceGrant granting permission to the Secret does not exist",
-	Features:    []suite.SupportedFeature{suite.SupportReferenceGrant},
-	Manifests:   []string{"tests/gateway-secret-missing-reference-grant.yaml"},
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportReferenceGrant,
+	},
+	Manifests: []string{"tests/gateway-secret-missing-reference-grant.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "gateway-secret-missing-reference-grant", Namespace: "gateway-conformance-infra"}
 

--- a/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go
+++ b/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go
@@ -34,8 +34,11 @@ func init() {
 var GatewaySecretReferenceGrantAllInNamespace = suite.ConformanceTest{
 	ShortName:   "GatewaySecretReferenceGrantAllInNamespace",
 	Description: "A Gateway in the gateway-conformance-infra namespace should become programmed if the Gateway has a certificateRef for a Secret in the gateway-conformance-web-backend namespace and a ReferenceGrant granting permission to all Secrets in the namespace exists",
-	Features:    []suite.SupportedFeature{suite.SupportReferenceGrant},
-	Manifests:   []string{"tests/gateway-secret-reference-grant-all-in-namespace.yaml"},
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportReferenceGrant,
+	},
+	Manifests: []string{"tests/gateway-secret-reference-grant-all-in-namespace.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "gateway-secret-reference-grant", Namespace: "gateway-conformance-infra"}
 

--- a/conformance/tests/gateway-secret-reference-grant-specific.go
+++ b/conformance/tests/gateway-secret-reference-grant-specific.go
@@ -34,8 +34,11 @@ func init() {
 var GatewaySecretReferenceGrantSpecific = suite.ConformanceTest{
 	ShortName:   "GatewaySecretReferenceGrantSpecific",
 	Description: "A Gateway in the gateway-conformance-infra namespace should become programmed if the Gateway has a certificateRef for a Secret in the gateway-conformance-web-backend namespace and a ReferenceGrant granting permission to the specific Secret exists",
-	Features:    []suite.SupportedFeature{suite.SupportReferenceGrant},
-	Manifests:   []string{"tests/gateway-secret-reference-grant-specific.yaml"},
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportReferenceGrant,
+	},
+	Manifests: []string{"tests/gateway-secret-reference-grant-specific.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "gateway-secret-reference-grant", Namespace: "gateway-conformance-infra"}
 

--- a/conformance/tests/gateway-with-attached-routes.go
+++ b/conformance/tests/gateway-with-attached-routes.go
@@ -34,7 +34,10 @@ func init() {
 var GatewayWithAttachedRoutes = suite.ConformanceTest{
 	ShortName:   "GatewayWithAttachedRoutes",
 	Description: "A Gateway in the gateway-conformance-infra namespace should be attached to routes.",
-	Manifests:   []string{"tests/gateway-with-attached-routes.yaml"},
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+	},
+	Manifests: []string{"tests/gateway-with-attached-routes.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		t.Run("Gateway listener should have one valid http routes attached", func(t *testing.T) {
 			gwNN := types.NamespacedName{Name: "gateway-with-one-attached-route", Namespace: "gateway-conformance-infra"}

--- a/conformance/tests/gatewayclass-observed-generation-bump.go
+++ b/conformance/tests/gatewayclass-observed-generation-bump.go
@@ -35,8 +35,11 @@ func init() {
 }
 
 var GatewayClassObservedGenerationBump = suite.ConformanceTest{
-	ShortName:   "GatewayClassObservedGenerationBump",
-	Features:    []suite.SupportedFeature{suite.SupportGatewayClassObservedGenerationBump},
+	ShortName: "GatewayClassObservedGenerationBump",
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportGatewayClassObservedGenerationBump,
+	},
 	Description: "A GatewayClass should update the observedGeneration in all of it's Status.Conditions after an update to the spec",
 	Manifests:   []string{"tests/gatewayclass-observed-generation-bump.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {

--- a/conformance/tests/httproute-cross-namespace.go
+++ b/conformance/tests/httproute-cross-namespace.go
@@ -34,6 +34,7 @@ var HTTPRouteCrossNamespace = suite.ConformanceTest{
 	ShortName:   "HTTPRouteCrossNamespace",
 	Description: "A single HTTPRoute in the gateway-conformance-web-backend namespace should attach to Gateway in another namespace",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-cross-namespace.yaml"},

--- a/conformance/tests/httproute-disallowed-kind.go
+++ b/conformance/tests/httproute-disallowed-kind.go
@@ -35,6 +35,7 @@ var HTTPRouteDisallowedKind = suite.ConformanceTest{
 	ShortName:   "HTTPRouteDisallowedKind",
 	Description: "A single HTTPRoute in the gateway-conformance-infra namespace should fail to attach to a Gateway with no listeners that allow the HTTPRoute kind",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportTLSRoute,
 	},

--- a/conformance/tests/httproute-exact-path-matching.go
+++ b/conformance/tests/httproute-exact-path-matching.go
@@ -34,6 +34,7 @@ var HTTPExactPathMatching = suite.ConformanceTest{
 	ShortName:   "HTTPExactPathMatching",
 	Description: "A single HTTPRoute with exact path matching for different backends",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-exact-path-matching.yaml"},

--- a/conformance/tests/httproute-header-matching.go
+++ b/conformance/tests/httproute-header-matching.go
@@ -34,6 +34,7 @@ var HTTPRouteHeaderMatching = suite.ConformanceTest{
 	ShortName:   "HTTPRouteHeaderMatching",
 	Description: "A single HTTPRoute with header matching for different backends",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-header-matching.yaml"},

--- a/conformance/tests/httproute-hostname-intersection.go
+++ b/conformance/tests/httproute-hostname-intersection.go
@@ -36,6 +36,7 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 	ShortName:   "HTTPRouteHostnameIntersection",
 	Description: "HTTPRoutes should attach to listeners only if they have intersecting hostnames, and should accept requests only for the intersecting hostnames",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-hostname-intersection.yaml"},

--- a/conformance/tests/httproute-invalid-backendref-nonexistent.go
+++ b/conformance/tests/httproute-invalid-backendref-nonexistent.go
@@ -36,6 +36,7 @@ var HTTPRouteInvalidNonExistentBackendRef = suite.ConformanceTest{
 	ShortName:   "HTTPRouteInvalidNonExistentBackendRef",
 	Description: "A single HTTPRoute in the gateway-conformance-infra namespace should set a ResolvedRefs status False with reason BackendNotFound and return 500 when binding to a Gateway in the same namespace if the route has a BackendRef Service that does not exist",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-invalid-backendref-nonexistent.yaml"},

--- a/conformance/tests/httproute-invalid-backendref-unknown-kind.go
+++ b/conformance/tests/httproute-invalid-backendref-unknown-kind.go
@@ -36,6 +36,7 @@ var HTTPRouteInvalidBackendRefUnknownKind = suite.ConformanceTest{
 	ShortName:   "HTTPRouteInvalidBackendRefUnknownKind",
 	Description: "A single HTTPRoute in the gateway-conformance-infra namespace should set a ResolvedRefs status False with reason InvalidKind when attempting to bind to a Gateway in the same namespace if the route has a BackendRef that points to an unknown Kind.",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-invalid-backendref-unknown-kind.yaml"},

--- a/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
@@ -36,6 +36,7 @@ var HTTPRouteInvalidCrossNamespaceBackendRef = suite.ConformanceTest{
 	ShortName:   "HTTPRouteInvalidCrossNamespaceBackendRef",
 	Description: "A single HTTPRoute in the gateway-conformance-infra namespace should set a ResolvedRefs status False with reason RefNotPermitted when attempting to bind to a Gateway in the same namespace if the route has a BackendRef Service in the gateway-conformance-web-backend namespace and a ReferenceGrant granting permission to route to that Service does not exist",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportReferenceGrant,
 	},

--- a/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go
@@ -35,6 +35,7 @@ var HTTPRouteInvalidCrossNamespaceParentRef = suite.ConformanceTest{
 	ShortName:   "HTTPRouteInvalidCrossNamespaceParentRef",
 	Description: "A single HTTPRoute in the gateway-conformance-web-backend namespace should fail to attach to a Gateway in another namespace that it is not allowed to",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-invalid-cross-namespace-parent-ref.yaml"},

--- a/conformance/tests/httproute-invalid-parentref-not-matching-listener-port.go
+++ b/conformance/tests/httproute-invalid-parentref-not-matching-listener-port.go
@@ -35,6 +35,7 @@ var HTTPRouteInvalidParentRefNotMatchingListenerPort = suite.ConformanceTest{
 	ShortName:   "HTTPRouteInvalidParentRefNotMatchingListenerPort",
 	Description: "A single HTTPRoute in the gateway-conformance-infra namespace should set the Accepted status to False with reason NoMatchingParent when attempting to bind to a Gateway that does not have a matching ListenerPort.",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportRouteDestinationPortMatching,
 	},

--- a/conformance/tests/httproute-invalid-parentref-not-matching-section-name.go
+++ b/conformance/tests/httproute-invalid-parentref-not-matching-section-name.go
@@ -35,6 +35,7 @@ var HTTPRouteInvalidParentRefNotMatchingSectionName = suite.ConformanceTest{
 	ShortName:   "HTTPRouteInvalidParentRefNotMatchingSectionName",
 	Description: "A single HTTPRoute in the gateway-conformance-infra namespace should set the Accepted status to False with reason NoMatchingParent when attempting to bind to a Gateway that does not have a matching SectionName.",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-invalid-parentref-not-matching-section-name.yaml"},

--- a/conformance/tests/httproute-listener-hostname-matching.go
+++ b/conformance/tests/httproute-listener-hostname-matching.go
@@ -34,6 +34,7 @@ var HTTPRouteListenerHostnameMatching = suite.ConformanceTest{
 	ShortName:   "HTTPRouteListenerHostnameMatching",
 	Description: "Multiple HTTP listeners with the same port and different hostnames, each with a different HTTPRoute",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-listener-hostname-matching.yaml"},

--- a/conformance/tests/httproute-matching-across-routes.go
+++ b/conformance/tests/httproute-matching-across-routes.go
@@ -34,6 +34,7 @@ var HTTPRouteMatchingAcrossRoutes = suite.ConformanceTest{
 	ShortName:   "HTTPRouteMatchingAcrossRoutes",
 	Description: "Two HTTPRoutes with path matching for different backends",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-matching-across-routes.yaml"},

--- a/conformance/tests/httproute-matching.go
+++ b/conformance/tests/httproute-matching.go
@@ -34,6 +34,7 @@ var HTTPRouteMatching = suite.ConformanceTest{
 	ShortName:   "HTTPRouteMatching",
 	Description: "A single HTTPRoute with path and header matching for different backends",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-matching.yaml"},

--- a/conformance/tests/httproute-method-matching.go
+++ b/conformance/tests/httproute-method-matching.go
@@ -35,6 +35,7 @@ var HTTPRouteMethodMatching = suite.ConformanceTest{
 	Description: "A single HTTPRoute with method matching for different backends",
 	Manifests:   []string{"tests/httproute-method-matching.yaml"},
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRouteMethodMatching,
 	},

--- a/conformance/tests/httproute-observed-generation-bump.go
+++ b/conformance/tests/httproute-observed-generation-bump.go
@@ -39,6 +39,7 @@ var HTTPRouteObservedGenerationBump = suite.ConformanceTest{
 	ShortName:   "HTTPRouteObservedGenerationBump",
 	Description: "A HTTPRoute in the gateway-conformance-infra namespace should update the observedGeneration in all of it's Status.Conditions after an update to the spec",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-observed-generation-bump.yaml"},

--- a/conformance/tests/httproute-partially-invalid-via-reference-grant.go
+++ b/conformance/tests/httproute-partially-invalid-via-reference-grant.go
@@ -36,6 +36,7 @@ var HTTPRoutePartiallyInvalidViaInvalidReferenceGrant = suite.ConformanceTest{
 	ShortName:   "HTTPRoutePartiallyInvalidViaInvalidReferenceGrant",
 	Description: "A single HTTPRoute in the gateway-conformance-infra namespace should attach to a Gateway in the same namespace if the route has a backendRef Service in the gateway-conformance-app-backend namespace and a ReferenceGrant exists but does not grant permission to route to that specific Service",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportReferenceGrant,
 	},

--- a/conformance/tests/httproute-path-match-order.go
+++ b/conformance/tests/httproute-path-match-order.go
@@ -34,6 +34,7 @@ var HTTPRoutePathMatchOrder = suite.ConformanceTest{
 	ShortName:   "HTTPRoutePathMatchOrder",
 	Description: "An HTTPRoute where there are multiple matches routing to any given backend follows match order precedence",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-path-match-order.yaml"},

--- a/conformance/tests/httproute-query-param-matching.go
+++ b/conformance/tests/httproute-query-param-matching.go
@@ -35,6 +35,7 @@ var HTTPRouteQueryParamMatching = suite.ConformanceTest{
 	Description: "A single HTTPRoute with query param matching for different backends",
 	Manifests:   []string{"tests/httproute-query-param-matching.yaml"},
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRouteQueryParamMatching,
 	},

--- a/conformance/tests/httproute-redirect-host-and-status.go
+++ b/conformance/tests/httproute-redirect-host-and-status.go
@@ -35,6 +35,7 @@ var HTTPRouteRedirectHostAndStatus = suite.ConformanceTest{
 	ShortName:   "HTTPRouteRedirectHostAndStatus",
 	Description: "An HTTPRoute with hostname and statusCode redirect filters",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-redirect-host-and-status.yaml"},

--- a/conformance/tests/httproute-redirect-path.go
+++ b/conformance/tests/httproute-redirect-path.go
@@ -36,6 +36,7 @@ var HTTPRouteRedirectPath = suite.ConformanceTest{
 	Description: "An HTTPRoute with scheme redirect filter",
 	Manifests:   []string{"tests/httproute-redirect-path.yaml"},
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRoutePathRedirect,
 	},

--- a/conformance/tests/httproute-redirect-port.go
+++ b/conformance/tests/httproute-redirect-port.go
@@ -36,6 +36,7 @@ var HTTPRouteRedirectPort = suite.ConformanceTest{
 	Description: "An HTTPRoute with a port redirect filter",
 	Manifests:   []string{"tests/httproute-redirect-port.yaml"},
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRoutePortRedirect,
 	},

--- a/conformance/tests/httproute-redirect-scheme.go
+++ b/conformance/tests/httproute-redirect-scheme.go
@@ -36,6 +36,7 @@ var HTTPRouteRedirectScheme = suite.ConformanceTest{
 	Description: "An HTTPRoute with a scheme redirect filter",
 	Manifests:   []string{"tests/httproute-redirect-scheme.yaml"},
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRouteSchemeRedirect,
 	},

--- a/conformance/tests/httproute-reference-grant.go
+++ b/conformance/tests/httproute-reference-grant.go
@@ -34,6 +34,7 @@ var HTTPRouteReferenceGrant = suite.ConformanceTest{
 	ShortName:   "HTTPRouteReferenceGrant",
 	Description: "A single HTTPRoute in the gateway-conformance-infra namespace, with a backendRef in the gateway-conformance-web-backend namespace, should attach to Gateway in the gateway-conformance-infra namespace",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportReferenceGrant,
 	},

--- a/conformance/tests/httproute-request-header-modifier.go
+++ b/conformance/tests/httproute-request-header-modifier.go
@@ -34,6 +34,7 @@ var HTTPRouteRequestHeaderModifier = suite.ConformanceTest{
 	ShortName:   "HTTPRouteRequestHeaderModifier",
 	Description: "An HTTPRoute has request header modifier filters applied correctly",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-request-header-modifier.yaml"},

--- a/conformance/tests/httproute-response-header-modifier.go
+++ b/conformance/tests/httproute-response-header-modifier.go
@@ -34,6 +34,7 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 	ShortName:   "HTTPRouteResponseHeaderModifier",
 	Description: "An HTTPRoute has response header modifier filters applied correctly",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPResponseHeaderModification,
 	},

--- a/conformance/tests/httproute-rewrite-host.go
+++ b/conformance/tests/httproute-rewrite-host.go
@@ -35,6 +35,7 @@ var HTTPRouteRewriteHost = suite.ConformanceTest{
 	Description: "An HTTPRoute with hostname rewrite filter",
 	Manifests:   []string{"tests/httproute-rewrite-host.yaml"},
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRouteHostRewrite,
 	},

--- a/conformance/tests/httproute-rewrite-path.go
+++ b/conformance/tests/httproute-rewrite-path.go
@@ -35,6 +35,7 @@ var HTTPRouteRewritePath = suite.ConformanceTest{
 	Description: "An HTTPRoute with path rewrite filter",
 	Manifests:   []string{"tests/httproute-rewrite-path.yaml"},
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRoutePathRewrite,
 	},

--- a/conformance/tests/httproute-simple-same-namespace.go
+++ b/conformance/tests/httproute-simple-same-namespace.go
@@ -35,6 +35,7 @@ var HTTPRouteSimpleSameNamespace = suite.ConformanceTest{
 	ShortName:   "HTTPRouteSimpleSameNamespace",
 	Description: "A single HTTPRoute in the gateway-conformance-infra namespace attaches to a Gateway in the same namespace",
 	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-simple-same-namespace.yaml"},

--- a/conformance/tests/main.go
+++ b/conformance/tests/main.go
@@ -19,4 +19,3 @@ package tests
 import "sigs.k8s.io/gateway-api/conformance/utils/suite"
 
 var ConformanceTests []suite.ConformanceTest
-var MeshConformanceTests []suite.ConformanceTest

--- a/conformance/tests/mesh-basic.go
+++ b/conformance/tests/mesh-basic.go
@@ -31,7 +31,10 @@ func init() {
 var MeshBasic = suite.ConformanceTest{
 	ShortName:   "MeshBasic",
 	Description: "A mesh client can communicate with a mesh server. This tests basic reachability with no configuration applied.",
-	Manifests:   []string{},
+	Features: []suite.SupportedFeature{
+		suite.SupportMesh,
+	},
+	Manifests: []string{},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		client := echo.ConnectToApp(t, s, echo.MeshAppEchoV1)
 		cases := []http.ExpectedResponse{{

--- a/conformance/tests/mesh-basic.go
+++ b/conformance/tests/mesh-basic.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	MeshConformanceTests = append(MeshConformanceTests, MeshBasic)
+	ConformanceTests = append(ConformanceTests, MeshBasic)
 }
 
 var MeshBasic = suite.ConformanceTest{

--- a/conformance/tests/mesh-split.go
+++ b/conformance/tests/mesh-split.go
@@ -31,7 +31,10 @@ func init() {
 var MeshTrafficSplit = suite.ConformanceTest{
 	ShortName:   "MeshTrafficSplit",
 	Description: "A mesh client can send traffic to a Service which is split between two versions",
-	Manifests:   []string{"tests/mesh-split.yaml"},
+	Features: []suite.SupportedFeature{
+		suite.SupportMesh,
+	},
+	Manifests: []string{"tests/mesh-split.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		client := echo.ConnectToApp(t, s, echo.MeshAppEchoV1)
 		cases := []http.ExpectedResponse{

--- a/conformance/tests/mesh-split.go
+++ b/conformance/tests/mesh-split.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	MeshConformanceTests = append(MeshConformanceTests, MeshTrafficSplit)
+	ConformanceTests = append(ConformanceTests, MeshTrafficSplit)
 }
 
 var MeshTrafficSplit = suite.ConformanceTest{

--- a/conformance/tests/tlsroute-simple-same-namespace.go
+++ b/conformance/tests/tlsroute-simple-same-namespace.go
@@ -41,8 +41,11 @@ func init() {
 var TLSRouteSimpleSameNamespace = suite.ConformanceTest{
 	ShortName:   "TLSRouteSimpleSameNamespace",
 	Description: "A single TLSRoute in the gateway-conformance-infra namespace attaches to a Gateway in the same namespace",
-	Features:    []suite.SupportedFeature{suite.SupportTLSRoute},
-	Manifests:   []string{"tests/tlsroute-simple-same-namespace.yaml"},
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportTLSRoute,
+	},
+	Manifests: []string{"tests/tlsroute-simple-same-namespace.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := v1beta1.Namespace("gateway-conformance-infra")
 		routeNN := types.NamespacedName{Name: "gateway-conformance-infra-test", Namespace: string(ns)}

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -169,17 +169,18 @@ var TLSCoreFeatures = sets.New(
 )
 
 // -----------------------------------------------------------------------------
-// Features - Mesh Conformance
+// Features - Mesh Conformance (Core)
 // -----------------------------------------------------------------------------
+
 const (
-	// This option indicates general support for GAMMA
-	SupportGAMMA SupportedFeature = "GAMMA"
+	// This option indicates general support for service mesh
+	SupportMesh SupportedFeature = "Mesh"
 )
 
-// GAMMACoreFeatures includes all the supported features for the GAMMA API at
+// MeshCoreFeatures includes all the supported features for the service mesh at
 // a Core level of support.
-var GAMMACoreFeatures = sets.New(
-	SupportGAMMA,
+var MeshCoreFeatures = sets.New(
+	SupportMesh,
 )
 
 // -----------------------------------------------------------------------------
@@ -195,4 +196,4 @@ var AllFeatures = sets.New[SupportedFeature]().
 	Insert(ExperimentalExtendedFeatures.UnsortedList()...).
 	Insert(HTTPExtendedFeatures.UnsortedList()...).
 	Insert(TLSCoreFeatures.UnsortedList()...).
-	Insert(GAMMACoreFeatures.UnsortedList()...)
+	Insert(MeshCoreFeatures.UnsortedList()...)

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -156,7 +156,7 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 		}
 		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, namespaces)
 	}
-	if suite.SupportedFeatures.Has(SupportGAMMA) {
+	if suite.SupportedFeatures.Has(SupportMesh) {
 		t.Logf("Test Setup: Applying base manifests")
 		suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, suite.MeshManifests, suite.Cleanup)
 		t.Logf("Test Setup: Ensuring Gateways and Pods from base manifests are ready")

--- a/site-src/concepts/conformance.md
+++ b/site-src/concepts/conformance.md
@@ -74,27 +74,76 @@ capabilities.
 
 ### Running Tests
 
-By default, conformance tests will expect a GatewayClass named `gateway-conformance`
-to be installed in the cluster, and tests will be run against that. Most often,
-you'll use a different class, which can be specified with the `-gateway-class` flag along with the
-corresponding test command. Check your instance for the `gateway-class` name to use.
+There are two main contrasting sets of conformance tests:
+
+* Gateway related tests (can also be thought of as ingress tests)
+* Service Mesh related tests
+
+For `Gateway` tests you must enable the `Gateway` test feature, and then
+opt-in to any other specific tests you want to run (e.g. `HTTPRoute`). For
+Mesh related tests you must enable `Mesh`.
+
+We'll cover each use case separately, but it's also possible to combine these
+if your implementation implements both. There are also options which pertain
+to the entire test suite regardless of which tests you're running.
+
+#### Gateway Tests
+
+By default `Gateway` oriented conformance tests will expect a GatewayClass
+named `gateway-conformance` to be installed in the cluster, and tests will be
+run against that. Most often, you'll use a different class, which can be
+specified with the `-gateway-class` flag along with the corresponding test
+command. Check your instance for the `gateway-class` name to use. You must
+also enable `Gateway` support and test support for any `*Routes` your
+implementation supports.
+
+The following runs all the tests relevant to `Gateway`, `HTTPRoute`, and
+`ReferenceGrant`:
 
 ```shell
-go test ./conformance/... -args -gateway-class=my-gateway-class
+go test ./conformance/... -args \
+    -gateway-class=my-gateway-class \
+    -supported-features=Gateway,HTTPRoute
 ```
 
-Other useful flags may be found in
-[conformance flags](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/utils/flags/flags.go).
-For example, if you'd like to examine the objects in Kubernetes after your test runs, you can pass a flag to
-suppress cleanup:
+Other useful flags may be found in [conformance flags][cflags].
+
+[cflags]:https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/utils/flags/flags.go
+
+#### Mesh Tests
+
+Mesh tests can be run by simply enabling the `Mesh` feature:
+
 ```shell
-go test ./conformance/... -args -gateway-class=istio -cleanup-base-resources=false
+go test ./conformance/... -args -supported-features=Mesh
 ```
-If you'd like to run a single test instead of the entire conformance suite, find your test name
-`(suite.ConformanceTest.ShortName)` and use it like this:
+
+If your mesh also includes ingress support with an API such as `HTTPRoute`, you
+can run the relevant tests in the same test run by enabling the `Gateway`
+feature and any relevant API features, e.g:
+
 ```shell
-go test ./conformance/... --run TestConformance/YOURTESTNAME --gateway-class=istio
+go test ./conformance/... -args -supported-features=Mesh,Gateway,HTTPRoute
 ```
+
+#### Suite Level Options
+
+When running tests of any kind you may not want the test suite to cleanup the
+test resources when it completes (i.e. so that you can inspect the cluster
+state in the event of a failure). You can skip cleanup with:
+
+```shell
+go test ./conformance/... -args -cleanup-base-resources=false
+```
+
+It may be helpful (particularly when working on implementing a specific
+feature) to run a very specific test by name. This can be done using the
+`ShortName` of that test:
+
+```shell
+go test ./conformance/... --run TestConformance/<ShortName>
+```
+
 ## Contributing to Conformance
 
 Many implementations run conformance tests as part of their full e2e test suite.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind test
/area conformance

**What this PR does / why we need it**:

In #1890 we removed implicit support for `HTTPRoute`, and created #1891 as a follow up to do this for all types. With #1878 bringing Mesh conformance tests soon this patch makes it cleaner for implementations which ONLY support mesh to simply not run any unrelated conformance tests.

**Which issue(s) this PR fixes**:

This doesn't completely fix, but does support #1891.

**Does this PR introduce a user-facing change?**:

```release-note
No conformance tests run by default anymore, including tests for GatewayClass and Gateway. A new
SupportGateway feature must be opted into in order to run those tests (similar to what we've done
previously for ReferenceGrant and HTTPRoute). Also with this release, `EnableAllSupportedFeatures`
enables all Gateway AND Mesh features (where previously that was just Gateway).
```