### PR TITLE
rm EnableAllSupportedFeatures & add AllGatewayFeatures

### DIFF
--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -51,16 +51,15 @@ func TestConformance(t *testing.T) {
 		supportedFeatures.Delete(feature)
 	}
 
-	t.Logf("Running conformance tests with %s GatewayClass\n cleanup: %t\n debug: %t\n enable all features: %t \n supported features: [%v]\n exempt features: [%v]",
-		*flags.GatewayClassName, *flags.CleanupBaseResources, *flags.ShowDebug, *flags.EnableAllSupportedFeatures, *flags.SupportedFeatures, *flags.ExemptFeatures)
+	t.Logf("Running conformance tests with %s GatewayClass\n cleanup: %t\n debug: %t\n supported features: [%v]\n exempt features: [%v]",
+		*flags.GatewayClassName, *flags.CleanupBaseResources, *flags.ShowDebug, *flags.SupportedFeatures, *flags.ExemptFeatures)
 
 	cSuite := suite.New(suite.Options{
-		Client:                     client,
-		GatewayClassName:           *flags.GatewayClassName,
-		Debug:                      *flags.ShowDebug,
-		CleanupBaseResources:       *flags.CleanupBaseResources,
-		SupportedFeatures:          supportedFeatures,
-		EnableAllSupportedFeatures: *flags.EnableAllSupportedFeatures,
+		Client:               client,
+		GatewayClassName:     *flags.GatewayClassName,
+		Debug:                *flags.ShowDebug,
+		CleanupBaseResources: *flags.CleanupBaseResources,
+		SupportedFeatures:    supportedFeatures,
 	})
 	cSuite.Setup(t)
 

--- a/conformance/utils/flags/flags.go
+++ b/conformance/utils/flags/flags.go
@@ -24,12 +24,11 @@ import (
 )
 
 var (
-	GatewayClassName           = flag.String("gateway-class", "gateway-conformance", "Name of GatewayClass to use for tests")
-	ShowDebug                  = flag.Bool("debug", false, "Whether to print debug logs")
-	CleanupBaseResources       = flag.Bool("cleanup-base-resources", true, "Whether to cleanup base test resources after the run")
-	SupportedFeatures          = flag.String("supported-features", "", "Supported features included in conformance tests suites")
-	ExemptFeatures             = flag.String("exempt-features", "", "Exempt Features excluded from conformance tests suites")
-	EnableAllSupportedFeatures = flag.Bool("all-features", false, "Whether to enable all supported features for conformance tests")
+	GatewayClassName     = flag.String("gateway-class", "gateway-conformance", "Name of GatewayClass to use for tests")
+	ShowDebug            = flag.Bool("debug", false, "Whether to print debug logs")
+	CleanupBaseResources = flag.Bool("cleanup-base-resources", true, "Whether to cleanup base test resources after the run")
+	SupportedFeatures    = flag.String("supported-features", "", "Supported features included in conformance tests suites")
+	ExemptFeatures       = flag.String("exempt-features", "", "Exempt Features excluded from conformance tests suites")
 )
 
 // Mesh specific flags

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -187,13 +187,18 @@ var MeshCoreFeatures = sets.New(
 // Features - Compilations
 // -----------------------------------------------------------------------------
 
+// AllGatewayFeatures are all the features applicable for Gateway (Ingress).
+// NOTE: as new feature sets are added they should be inserted into this set.
+var AllGatewayFeatures = sets.New[SupportedFeature]().
+	Insert(StandardExtendedFeatures.UnsortedList()...).
+	Insert(ExperimentalExtendedFeatures.UnsortedList()...).
+	Insert(HTTPExtendedFeatures.UnsortedList()...).
+	Insert(TLSCoreFeatures.UnsortedList()...)
+
 // AllFeatures contains all the supported features and can be used to run all
 // conformance tests with `all-features` flag.
 //
 // NOTE: as new feature sets are added they should be inserted into this set.
 var AllFeatures = sets.New[SupportedFeature]().
-	Insert(StandardExtendedFeatures.UnsortedList()...).
-	Insert(ExperimentalExtendedFeatures.UnsortedList()...).
-	Insert(HTTPExtendedFeatures.UnsortedList()...).
-	Insert(TLSCoreFeatures.UnsortedList()...).
+	Insert(AllGatewayFeatures.UnsortedList()...).
 	Insert(MeshCoreFeatures.UnsortedList()...)

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -196,7 +196,7 @@ var AllGatewayFeatures = sets.New[SupportedFeature]().
 	Insert(TLSCoreFeatures.UnsortedList()...)
 
 // AllFeatures contains all the supported features and can be used to run all
-// conformance tests with `all-features` flag.
+// conformance tests.
 //
 // NOTE: as new feature sets are added they should be inserted into this set.
 var AllFeatures = sets.New[SupportedFeature]().

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -69,10 +69,9 @@ type Options struct {
 
 	// CleanupBaseResources indicates whether or not the base test
 	// resources such as Gateways should be cleaned up after the run.
-	CleanupBaseResources       bool
-	SupportedFeatures          sets.Set[SupportedFeature]
-	EnableAllSupportedFeatures bool
-	TimeoutConfig              config.TimeoutConfig
+	CleanupBaseResources bool
+	SupportedFeatures    sets.Set[SupportedFeature]
+	TimeoutConfig        config.TimeoutConfig
 	// SkipTests contains all the tests not to be run and can be used to opt out
 	// of specific tests
 	SkipTests []string
@@ -87,9 +86,7 @@ func New(s Options) *ConformanceTestSuite {
 		roundTripper = &roundtripper.DefaultRoundTripper{Debug: s.Debug, TimeoutConfig: s.TimeoutConfig}
 	}
 
-	if s.EnableAllSupportedFeatures == true {
-		s.SupportedFeatures = AllFeatures
-	} else if s.SupportedFeatures == nil {
+	if s.SupportedFeatures == nil {
 		s.SupportedFeatures = StandardCoreFeatures
 	} else {
 		for feature := range StandardCoreFeatures {


### PR DESCRIPTION
* With https://github.com/kubernetes-sigs/gateway-api/pull/1878 the existing flag `EnableAllSupportedFeatures` used in implementations to run conformance tests pertaining to all Gateway/Ingress features will now also run Mesh conformance tests which might not be the intent.
* rm `EnableAllSupportedFeatures` and ask Ingress implementations to set `SupportedFeatures` to `AllGatewayFeatures` to achieve the same intent as before. Mesh implementations that also support Gateway features can set `SupportedFeatures` to `AllFeatures`.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind test
/area conformance
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
the `EnableAllSupportedFeatures` flag has been removed. You can set `SupportedFeatures` to `AllGatewayFeatures` to run all tests related to Gateway/Ingress or you may set `SupportedFeatures` to `AllFeatures` to run all tests related to Gateway as well as Mesh

```
