### PR TITLE
Clarifying Port Redirect Behavior

### DIFF
--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -894,12 +894,13 @@ type HTTPRequestRedirectFilter struct {
 	//
 	// When empty, the Gateway Listener port is used.
 	//
-	// Implementers should _not_ include the port number in the 'Location' header in the following cases:
+	// Implementations SHOULD NOT add the port number in the 'Location'
+	// header in the following cases:
 	//
-	// * a Location header that will use HTTP (whether that is determined via the Listener protocol
-	//   or the Scheme field) _and_ use port 80.
-	// * a Location header that will use HTTPS (whether that is determined via the Listener protocol
-	//   or the Scheme field) _and_ use port 443.
+	// * A Location header that will use HTTP (whether that is determined via
+	//   the Listener protocol or the Scheme field) _and_ use port 80.
+	// * A Location header that will use HTTPS (whether that is determined via
+	//   the Listener protocol or the Scheme field) _and_ use port 443.
 	//
 	// Support: Extended
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -580,16 +580,15 @@ spec:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
                                         response. \n When empty, the Gateway Listener
-                                        port is used. \n Implementers should _not_
-                                        include the port number in the 'Location'
-                                        header in the following cases: \n * a Location
-                                        header that will use HTTP (whether that is
-                                        determined via the Listener protocol or the
-                                        Scheme field) _and_ use port 80. * a Location
-                                        header that will use HTTPS (whether that is
-                                        determined via the Listener protocol or the
-                                        Scheme field) _and_ use port 443. \n Support:
-                                        Extended"
+                                        port is used. \n Implementations SHOULD NOT
+                                        add the port number in the 'Location' header
+                                        in the following cases: \n * A Location header
+                                        that will use HTTP (whether that is determined
+                                        via the Listener protocol or the Scheme field)
+                                        _and_ use port 80. * A Location header that
+                                        will use HTTPS (whether that is determined
+                                        via the Listener protocol or the Scheme field)
+                                        _and_ use port 443. \n Support: Extended"
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -1222,12 +1221,12 @@ spec:
                               port:
                                 description: "Port is the port to be used in the value
                                   of the `Location` header in the response. \n When
-                                  empty, the Gateway Listener port is used. \n Implementers
-                                  should _not_ include the port number in the 'Location'
-                                  header in the following cases: \n * a Location header
+                                  empty, the Gateway Listener port is used. \n Implementations
+                                  SHOULD NOT add the port number in the 'Location'
+                                  header in the following cases: \n * A Location header
                                   that will use HTTP (whether that is determined via
                                   the Listener protocol or the Scheme field) _and_
-                                  use port 80. * a Location header that will use HTTPS
+                                  use port 80. * A Location header that will use HTTPS
                                   (whether that is determined via the Listener protocol
                                   or the Scheme field) _and_ use port 443. \n Support:
                                   Extended"
@@ -2476,16 +2475,15 @@ spec:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
                                         response. \n When empty, the Gateway Listener
-                                        port is used. \n Implementers should _not_
-                                        include the port number in the 'Location'
-                                        header in the following cases: \n * a Location
-                                        header that will use HTTP (whether that is
-                                        determined via the Listener protocol or the
-                                        Scheme field) _and_ use port 80. * a Location
-                                        header that will use HTTPS (whether that is
-                                        determined via the Listener protocol or the
-                                        Scheme field) _and_ use port 443. \n Support:
-                                        Extended"
+                                        port is used. \n Implementations SHOULD NOT
+                                        add the port number in the 'Location' header
+                                        in the following cases: \n * A Location header
+                                        that will use HTTP (whether that is determined
+                                        via the Listener protocol or the Scheme field)
+                                        _and_ use port 80. * A Location header that
+                                        will use HTTPS (whether that is determined
+                                        via the Listener protocol or the Scheme field)
+                                        _and_ use port 443. \n Support: Extended"
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -3118,12 +3116,12 @@ spec:
                               port:
                                 description: "Port is the port to be used in the value
                                   of the `Location` header in the response. \n When
-                                  empty, the Gateway Listener port is used. \n Implementers
-                                  should _not_ include the port number in the 'Location'
-                                  header in the following cases: \n * a Location header
+                                  empty, the Gateway Listener port is used. \n Implementations
+                                  SHOULD NOT add the port number in the 'Location'
+                                  header in the following cases: \n * A Location header
                                   that will use HTTP (whether that is determined via
                                   the Listener protocol or the Scheme field) _and_
-                                  use port 80. * a Location header that will use HTTPS
+                                  use port 80. * A Location header that will use HTTPS
                                   (whether that is determined via the Listener protocol
                                   or the Scheme field) _and_ use port 443. \n Support:
                                   Extended"

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -554,16 +554,15 @@ spec:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
                                         response. \n When empty, the Gateway Listener
-                                        port is used. \n Implementers should _not_
-                                        include the port number in the 'Location'
-                                        header in the following cases: \n * a Location
-                                        header that will use HTTP (whether that is
-                                        determined via the Listener protocol or the
-                                        Scheme field) _and_ use port 80. * a Location
-                                        header that will use HTTPS (whether that is
-                                        determined via the Listener protocol or the
-                                        Scheme field) _and_ use port 443. \n Support:
-                                        Extended"
+                                        port is used. \n Implementations SHOULD NOT
+                                        add the port number in the 'Location' header
+                                        in the following cases: \n * A Location header
+                                        that will use HTTP (whether that is determined
+                                        via the Listener protocol or the Scheme field)
+                                        _and_ use port 80. * A Location header that
+                                        will use HTTPS (whether that is determined
+                                        via the Listener protocol or the Scheme field)
+                                        _and_ use port 443. \n Support: Extended"
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -1088,12 +1087,12 @@ spec:
                               port:
                                 description: "Port is the port to be used in the value
                                   of the `Location` header in the response. \n When
-                                  empty, the Gateway Listener port is used. \n Implementers
-                                  should _not_ include the port number in the 'Location'
-                                  header in the following cases: \n * a Location header
+                                  empty, the Gateway Listener port is used. \n Implementations
+                                  SHOULD NOT add the port number in the 'Location'
+                                  header in the following cases: \n * A Location header
                                   that will use HTTP (whether that is determined via
                                   the Listener protocol or the Scheme field) _and_
-                                  use port 80. * a Location header that will use HTTPS
+                                  use port 80. * A Location header that will use HTTPS
                                   (whether that is determined via the Listener protocol
                                   or the Scheme field) _and_ use port 443. \n Support:
                                   Extended"
@@ -2187,16 +2186,15 @@ spec:
                                       description: "Port is the port to be used in
                                         the value of the `Location` header in the
                                         response. \n When empty, the Gateway Listener
-                                        port is used. \n Implementers should _not_
-                                        include the port number in the 'Location'
-                                        header in the following cases: \n * a Location
-                                        header that will use HTTP (whether that is
-                                        determined via the Listener protocol or the
-                                        Scheme field) _and_ use port 80. * a Location
-                                        header that will use HTTPS (whether that is
-                                        determined via the Listener protocol or the
-                                        Scheme field) _and_ use port 443. \n Support:
-                                        Extended"
+                                        port is used. \n Implementations SHOULD NOT
+                                        add the port number in the 'Location' header
+                                        in the following cases: \n * A Location header
+                                        that will use HTTP (whether that is determined
+                                        via the Listener protocol or the Scheme field)
+                                        _and_ use port 80. * A Location header that
+                                        will use HTTPS (whether that is determined
+                                        via the Listener protocol or the Scheme field)
+                                        _and_ use port 443. \n Support: Extended"
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -2721,12 +2719,12 @@ spec:
                               port:
                                 description: "Port is the port to be used in the value
                                   of the `Location` header in the response. \n When
-                                  empty, the Gateway Listener port is used. \n Implementers
-                                  should _not_ include the port number in the 'Location'
-                                  header in the following cases: \n * a Location header
+                                  empty, the Gateway Listener port is used. \n Implementations
+                                  SHOULD NOT add the port number in the 'Location'
+                                  header in the following cases: \n * A Location header
                                   that will use HTTP (whether that is determined via
                                   the Listener protocol or the Scheme field) _and_
-                                  use port 80. * a Location header that will use HTTPS
+                                  use port 80. * A Location header that will use HTTPS
                                   (whether that is determined via the Listener protocol
                                   or the Scheme field) _and_ use port 443. \n Support:
                                   Extended"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is a follow up to address some of the limitations of the current spec discovered in https://github.com/kubernetes-sigs/gateway-api/pull/1880. Specifically this adjust the spec to say that port shouldn't be added in these cases, not that it needs to be unset/removed.

**Does this PR introduce a user-facing change?**:
```release-note
Clarification that port redirects should not add port number to Location header for HTTP and HTTPS requests on 80 and 443.
```
