### PR TITLE
`BackendRefs` fixed in `HTTPRoute` conformance tests

### DIFF
--- a/conformance/tests/gateway-modify-listeners.yaml
+++ b/conformance/tests/gateway-modify-listeners.yaml
@@ -32,7 +32,7 @@ spec:
     namespace: gateway-conformance-infra
   rules:
   - backendRefs:
-    - name: foo-svc
+    - name: infra-backend-v1
       port: 8080
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -75,5 +75,5 @@ spec:
     namespace: gateway-conformance-infra
   rules:
   - backendRefs:
-    - name: foo-svc
+    - name: infra-backend-v1
       port: 8080

--- a/conformance/tests/gateway-with-attached-routes.yaml
+++ b/conformance/tests/gateway-with-attached-routes.yaml
@@ -32,7 +32,7 @@ spec:
     namespace: gateway-conformance-infra
   rules:
   - backendRefs:
-    - name: foo-svc
+    - name: infra-backend-v1
       port: 8080
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -69,7 +69,7 @@ spec:
     namespace: gateway-conformance-infra
   rules:
   - backendRefs:
-    - name: foo-svc
+    - name: infra-backend-v1
       port: 8080
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -84,5 +84,5 @@ spec:
     namespace: gateway-conformance-infra
   rules:
   - backendRefs:
-    - name: foo-svc
+    - name: infra-backend-v1
       port: 8080


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind bug

**What this PR does / why we need it**:

The `GatewayWithAttachedRoutes` and `GatewayModifyListeners` conformance tests specify invalid BackendRefs (likely copy-pasted from the examples). This PR fixes them and sets the correct `BackendRefs`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
