### PR TITLE
Fix mermaid diagram rendering

### DIFF
--- a/geps/overview.md
+++ b/geps/overview.md
@@ -14,6 +14,7 @@ process for the main Kubernetes project:
 This diagram shows the state diagram of the GEP process at a high level, but the details are below.
 
 <div align="center">
+  
 ```mermaid
 flowchart TD
     D([Discuss with<br />the community]) --> C
@@ -25,6 +26,7 @@ flowchart TD
     Experimental -->|Supported in<br />multiple implementations<br />+ Conformance tests| Standard
     Standard -->|Entire change is GA or implemented| Completed
 ```
+
 </div>
 
 ### 1. Discuss with the community


### PR DESCRIPTION
Seems like GitHub doesn't render the flow chart when the mermaid block is right under the div tag

/kind cleanup
/kind documentation

