### PR TITLE
Marking ServiceImport as Extended support

### DIFF
--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -550,6 +550,8 @@ type GRPCBackendRef struct {
 	//
 	// Support: Core for Kubernetes Service
 	//
+	// Support: Extended for Kubernetes ServiceImport
+	//
 	// Support: Implementation-specific for any other resource
 	//
 	// Support for weight: Core

--- a/apis/v1alpha2/tcproute_types.go
+++ b/apis/v1alpha2/tcproute_types.go
@@ -68,6 +68,8 @@ type TCPRouteRule struct {
 	//
 	// Support: Core for Kubernetes Service
 	//
+	// Support: Extended for Kubernetes ServiceImport
+	//
 	// Support: Implementation-specific for any other resource
 	//
 	// Support for weight: Extended

--- a/apis/v1alpha2/tlsroute_types.go
+++ b/apis/v1alpha2/tlsroute_types.go
@@ -112,6 +112,8 @@ type TLSRouteRule struct {
 	//
 	// Support: Core for Kubernetes Service
 	//
+	// Support: Extended for Kubernetes ServiceImport
+	//
 	// Support: Implementation-specific for any other resource
 	//
 	// Support for weight: Extended

--- a/apis/v1alpha2/udproute_types.go
+++ b/apis/v1alpha2/udproute_types.go
@@ -67,6 +67,9 @@ type UDPRouteRule struct {
 	// the packets, then 80% of packets must be dropped instead.
 	//
 	// Support: Core for Kubernetes Service
+	//
+	// Support: Extended for Kubernetes ServiceImport
+	//
 	// Support: Implementation-specific for any other resource
 	//
 	// Support for weight: Extended

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -235,6 +235,8 @@ type HTTPRouteRule struct {
 	//
 	// Support: Core for Kubernetes Service
 	//
+	// Support: Extended for Kubernetes ServiceImport
+	//
 	// Support: Implementation-specific for any other resource
 	//
 	// Support for weight: Core

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -256,7 +256,8 @@ spec:
                         \n For example, if two backends are specified with equal weights,
                         and one is invalid, 50 percent of traffic must receive a 500.
                         Implementations may choose how that 50 percent is determined.
-                        \n Support: Core for Kubernetes Service \n Support: Implementation-specific
+                        \n Support: Core for Kubernetes Service \n Support: Extended
+                        for Kubernetes ServiceImport \n Support: Implementation-specific
                         for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
@@ -2150,7 +2151,8 @@ spec:
                         \n For example, if two backends are specified with equal weights,
                         and one is invalid, 50 percent of traffic must receive a 500.
                         Implementations may choose how that 50 percent is determined.
-                        \n Support: Core for Kubernetes Service \n Support: Implementation-specific
+                        \n Support: Core for Kubernetes Service \n Support: Extended
+                        for Kubernetes ServiceImport \n Support: Implementation-specific
                         for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -179,7 +179,8 @@ spec:
                         attempts to this backend. Connection rejections must respect
                         weight; if an invalid backend is requested to have 80% of
                         connections, then 80% of connections must be rejected instead.
-                        \n Support: Core for Kubernetes Service \n Support: Implementation-specific
+                        \n Support: Core for Kubernetes Service \n Support: Extended
+                        for Kubernetes ServiceImport \n Support: Implementation-specific
                         for any other resource \n Support for weight: Extended"
                       items:
                         description: "BackendRef defines how a Route should forward

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -228,8 +228,9 @@ spec:
                         code. Request rejections must respect weight; if an invalid
                         backend is requested to have 80% of requests, then 80% of
                         requests must be rejected instead. \n Support: Core for Kubernetes
-                        Service \n Support: Implementation-specific for any other
-                        resource \n Support for weight: Extended"
+                        Service \n Support: Extended for Kubernetes ServiceImport
+                        \n Support: Implementation-specific for any other resource
+                        \n Support for weight: Extended"
                       items:
                         description: "BackendRef defines how a Route should forward
                           a request to a Kubernetes resource. \n Note that when a

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -179,8 +179,9 @@ spec:
                         attempts to this backend. Packet drops must respect weight;
                         if an invalid backend is requested to have 80% of the packets,
                         then 80% of packets must be dropped instead. \n Support: Core
-                        for Kubernetes Service Support: Implementation-specific for
-                        any other resource \n Support for weight: Extended"
+                        for Kubernetes Service \n Support: Extended for Kubernetes
+                        ServiceImport \n Support: Implementation-specific for any
+                        other resource \n Support for weight: Extended"
                       items:
                         description: "BackendRef defines how a Route should forward
                           a request to a Kubernetes resource. \n Note that when a

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -230,7 +230,8 @@ spec:
                         \n For example, if two backends are specified with equal weights,
                         and one is invalid, 50 percent of traffic must receive a 500.
                         Implementations may choose how that 50 percent is determined.
-                        \n Support: Core for Kubernetes Service \n Support: Implementation-specific
+                        \n Support: Core for Kubernetes Service \n Support: Extended
+                        for Kubernetes ServiceImport \n Support: Implementation-specific
                         for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should
@@ -2070,7 +2071,8 @@ spec:
                         \n For example, if two backends are specified with equal weights,
                         and one is invalid, 50 percent of traffic must receive a 500.
                         Implementations may choose how that 50 percent is determined.
-                        \n Support: Core for Kubernetes Service \n Support: Implementation-specific
+                        \n Support: Core for Kubernetes Service \n Support: Extended
+                        for Kubernetes ServiceImport \n Support: Implementation-specific
                         for any other resource \n Support for weight: Core"
                       items:
                         description: HTTPBackendRef defines how a HTTPRoute should


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/kind feature

**What this PR does / why we need it**:
This updates the spec to note that ServiceImport has "Extended" support as a BackendRef per GEP #1748.

**Does this PR introduce a user-facing change?**:
```release-note
ServiceImports now have "Extended" support in BackendRefs
```

Adding a hold until #1843 merges.

/hold
