### PR TITLE
cleanup: Touch up some of the doc comments

### DIFF
--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -552,7 +552,7 @@ const (
 	// true.
 	GatewayReasonProgrammed GatewayConditionReason = "Programmed"
 
-	// This reason is used with the "Programmed" and "Accepted" condition when the Gateway is
+	// This reason is used with the "Programmed" and "Accepted" conditions when the Gateway is
 	// syntactically or semantically invalid.
 	GatewayReasonInvalid GatewayConditionReason = "Invalid"
 
@@ -635,9 +635,7 @@ const (
 )
 
 const (
-	// "Ready" is a reserved condition type for future use. It should not be used by implementations.
-	// Note: This condition is not really "deprecated", but rather "reserved"; however, deprecated triggers Go linters
-	// to alert about usage.
+	// "Ready" is a condition type reserved for future use. It should not be used by implementations.
 	//
 	// If used in the future, "Ready" will represent the final state where all configuration is confirmed good
 	// _and has completely propagated to the data plane_. That is, it is a _guarantee_ that, as soon as something
@@ -646,6 +644,8 @@ const (
 	// This is a very strong guarantee, and to date no implementation has satisfied it enough to implement it.
 	// This reservation can be discussed in the future if necessary.
 	//
+	// Note: This condition is not really "deprecated", but rather "reserved"; however, deprecated triggers Go linters
+	// to alert about usage.
 	// Deprecated: Ready is reserved for future use
 	GatewayConditionReady GatewayConditionType = "Ready"
 
@@ -878,7 +878,7 @@ const (
 )
 
 const (
-	// "Ready" is a reserved condition type for future use. It should not be used by implementations.
+	// "Ready" is a condition type reserved for future use. It should not be used by implementations.
 	// Note: This condition is not really "deprecated", but rather "reserved"; however, deprecated triggers Go linters
 	// to alert about usage.
 	//

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -870,8 +870,7 @@ type HTTPRequestRedirectFilter struct {
 
 	// Hostname is the hostname to be used in the value of the `Location`
 	// header in the response.
-	// When empty, the hostname in the `Host` header
-	// of the request is used.
+	// When empty, the hostname in the `Host` header of the request is used.
 	//
 	// Support: Core
 	//


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
The v0.7.0 API review PR had some wordsmithing suggestions around the type doc comments (e.g https://github.com/kubernetes-sigs/gateway-api/pull/1923#discussion_r1162142228). This change addresses the feedback


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
