### PR TITLE
Fixes to allow the mesh feature to be tested, including alone

### DIFF
--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -28,7 +28,9 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
@@ -42,26 +44,33 @@ func TestConformance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error initializing Kubernetes client: %v", err)
 	}
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("Error initializing Kubernetes REST client: %v", err)
+	}
+
 	v1alpha2.AddToScheme(client.Scheme())
 	v1beta1.AddToScheme(client.Scheme())
 
 	supportedFeatures := parseSupportedFeatures(*flags.SupportedFeatures)
 	exemptFeatures := parseSupportedFeatures(*flags.ExemptFeatures)
-	for feature := range exemptFeatures {
-		supportedFeatures.Delete(feature)
-	}
 
 	t.Logf("Running conformance tests with %s GatewayClass\n cleanup: %t\n debug: %t\n enable all features: %t \n supported features: [%v]\n exempt features: [%v]",
 		*flags.GatewayClassName, *flags.CleanupBaseResources, *flags.ShowDebug, *flags.EnableAllSupportedFeatures, *flags.SupportedFeatures, *flags.ExemptFeatures)
 
 	cSuite := suite.New(suite.Options{
 		Client:                     client,
+		RESTClient:                 clientset.CoreV1().RESTClient().(*rest.RESTClient),
+		RestConfig:                 cfg,
 		GatewayClassName:           *flags.GatewayClassName,
 		Debug:                      *flags.ShowDebug,
 		CleanupBaseResources:       *flags.CleanupBaseResources,
 		SupportedFeatures:          supportedFeatures,
 		EnableAllSupportedFeatures: *flags.EnableAllSupportedFeatures,
 	})
+	for feature := range exemptFeatures {
+		cSuite.SupportedFeatures.Delete(feature)
+	}
 	cSuite.Setup(t)
 
 	cSuite.Run(t, tests.ConformanceTests)
@@ -70,6 +79,9 @@ func TestConformance(t *testing.T) {
 // parseSupportedFeatures parses flag arguments and converts the string to
 // sets.Set[suite.SupportedFeature]
 func parseSupportedFeatures(f string) sets.Set[suite.SupportedFeature] {
+	if f == "" {
+		return nil
+	}
 	res := sets.Set[suite.SupportedFeature]{}
 	for _, value := range strings.Split(f, ",") {
 		res.Insert(suite.SupportedFeature(value))

--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -66,11 +66,9 @@ func TestConformance(t *testing.T) {
 		Debug:                      *flags.ShowDebug,
 		CleanupBaseResources:       *flags.CleanupBaseResources,
 		SupportedFeatures:          supportedFeatures,
+		ExemptFeatures:             exemptFeatures,
 		EnableAllSupportedFeatures: *flags.EnableAllSupportedFeatures,
 	})
-	for feature := range exemptFeatures {
-		cSuite.SupportedFeatures.Delete(feature)
-	}
 	cSuite.Setup(t)
 
 	cSuite.Run(t, tests.ConformanceTests)

--- a/conformance/utils/flags/flags.go
+++ b/conformance/utils/flags/flags.go
@@ -31,9 +31,3 @@ var (
 	ExemptFeatures             = flag.String("exempt-features", "", "Exempt Features excluded from conformance tests suites")
 	EnableAllSupportedFeatures = flag.Bool("all-features", false, "Whether to enable all supported features for conformance tests")
 )
-
-// Mesh specific flags
-var (
-	MeshOnly               = flag.Bool("mesh-only", false, "Whether to run mesh conformance tests only")
-	MeshImplementationName = flag.String("mesh-implementation-name", "", "Name of the mesh implementation being tested")
-)

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -140,14 +140,14 @@ func New(s Options) *ConformanceTestSuite {
 // Setup ensures the base resources required for conformance tests are installed
 // in the cluster. It also ensures that all relevant resources are ready.
 func (suite *ConformanceTestSuite) Setup(t *testing.T) {
+	t.Logf("Test Setup: Ensuring GatewayClass has been accepted")
+	suite.ControllerName = kubernetes.GWCMustHaveAcceptedConditionTrue(t, suite.Client, suite.TimeoutConfig, suite.GatewayClassName)
+
+	suite.Applier.GatewayClass = suite.GatewayClassName
+	suite.Applier.ControllerName = suite.ControllerName
+	suite.Applier.FS = suite.FS
+
 	if suite.SupportedFeatures.Has(SupportGateway) {
-		t.Logf("Test Setup: Ensuring GatewayClass has been accepted")
-		suite.ControllerName = kubernetes.GWCMustHaveAcceptedConditionTrue(t, suite.Client, suite.TimeoutConfig, suite.GatewayClassName)
-
-		suite.Applier.GatewayClass = suite.GatewayClassName
-		suite.Applier.ControllerName = suite.ControllerName
-		suite.Applier.FS = suite.FS
-
 		t.Logf("Test Setup: Applying base manifests")
 		suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, suite.BaseManifests, suite.Cleanup)
 

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -74,6 +74,7 @@ type Options struct {
 	// resources such as Gateways should be cleaned up after the run.
 	CleanupBaseResources       bool
 	SupportedFeatures          sets.Set[SupportedFeature]
+	ExemptFeatures             sets.Set[SupportedFeature]
 	EnableAllSupportedFeatures bool
 	TimeoutConfig              config.TimeoutConfig
 	// SkipTests contains all the tests not to be run and can be used to opt out
@@ -100,6 +101,10 @@ func New(s Options) *ConformanceTestSuite {
 		for feature := range StandardCoreFeatures {
 			s.SupportedFeatures.Insert(feature)
 		}
+	}
+
+	for feature := range s.ExemptFeatures {
+		s.SupportedFeatures.Delete(feature)
 	}
 
 	if s.FS == nil {

--- a/site-src/concepts/conformance.md
+++ b/site-src/concepts/conformance.md
@@ -126,6 +126,20 @@ feature and any relevant API features, e.g:
 go test ./conformance/... -args -supported-features=Mesh,Gateway,HTTPRoute
 ```
 
+#### Excluding Tests
+
+The `Gateway` and `ReferenceGrant` features are enabled by default.
+You do not need to explicty list them using the `-supported-features` flag.
+However, if you don't want to run them, you will need to disable them using
+the `--exempt-features` flag. For example, to run only the `Mesh` tests,
+and nothing else:
+
+```shell
+go test ./conformance/... -args \
+    -supported-features=Mesh \
+    -exempt-features=Gateway,ReferenceGrant
+```
+
 #### Suite Level Options
 
 When running tests of any kind you may not want the test suite to cleanup the

--- a/site-src/concepts/conformance.md
+++ b/site-src/concepts/conformance.md
@@ -129,7 +129,7 @@ go test ./conformance/... -args -supported-features=Mesh,Gateway,HTTPRoute
 #### Excluding Tests
 
 The `Gateway` and `ReferenceGrant` features are enabled by default.
-You do not need to explicty list them using the `-supported-features` flag.
+You do not need to explicitly list them using the `-supported-features` flag.
 However, if you don't want to run them, you will need to disable them using
 the `-exempt-features` flag. For example, to run only the `Mesh` tests,
 and nothing else:

--- a/site-src/concepts/conformance.md
+++ b/site-src/concepts/conformance.md
@@ -131,7 +131,7 @@ go test ./conformance/... -args -supported-features=Mesh,Gateway,HTTPRoute
 The `Gateway` and `ReferenceGrant` features are enabled by default.
 You do not need to explicty list them using the `-supported-features` flag.
 However, if you don't want to run them, you will need to disable them using
-the `--exempt-features` flag. For example, to run only the `Mesh` tests,
+the `-exempt-features` flag. For example, to run only the `Mesh` tests,
 and nothing else:
 
 ```shell


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind test
/area conformance
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:
Some improvements to enable the conformance suite to run mesh tests and to allow the core gateway feature to be excluded from testing. This includes initializing RESTClient, needed to exec into pods for mesh tests.

With these changes, the mesh tests can be run by passing the following args:
```
"--supported-features", "Mesh", "--exempt-features", "Gateway"
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
