### PR TITLE
Add Tester interface.

### DIFF
--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/tests"
 	"sigs.k8s.io/gateway-api/conformance/utils/flags"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -74,7 +75,7 @@ func TestConformance(t *testing.T) {
 		NamespaceAnnotations:       namespaceAnnotations,
 		SkipTests:                  skipTests,
 	})
-	cSuite.Setup(t)
+	cSuite.Setup(tester.New(t))
 
-	cSuite.Run(t, tests.ConformanceTests)
+	cSuite.Run(tester.New(t), tests.ConformanceTests)
 }

--- a/conformance/experimental_conformance_test.go
+++ b/conformance/experimental_conformance_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/tests"
 	"sigs.k8s.io/gateway-api/conformance/utils/flags"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 var (
@@ -124,8 +125,8 @@ func testExperimentalConformance(t *testing.T) {
 		t.Fatalf("error creating experimental conformance test suite: %v", err)
 	}
 
-	cSuite.Setup(t)
-	cSuite.Run(t, tests.ConformanceTests)
+	cSuite.Setup(tester.New(t))
+	cSuite.Run(tester.New(t), tests.ConformanceTests)
 	report, err := cSuite.Report()
 	if err != nil {
 		t.Fatalf("error generating conformance profile report: %v", err)

--- a/conformance/tests/gateway-invalid-route-kind.go
+++ b/conformance/tests/gateway-invalid-route-kind.go
@@ -17,10 +17,10 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
@@ -38,8 +38,8 @@ var GatewayInvalidRouteKind = suite.ConformanceTest{
 		suite.SupportGateway,
 	},
 	Manifests: []string{"tests/gateway-invalid-route-kind.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
-		t.Run("Gateway listener should have a false ResolvedRefs condition with reason InvalidRouteKinds and no supportedKinds", func(t *testing.T) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
+		t.Run("Gateway listener should have a false ResolvedRefs condition with reason InvalidRouteKinds and no supportedKinds", func(t tester.Tester) {
 			gwNN := types.NamespacedName{Name: "gateway-only-invalid-route-kind", Namespace: "gateway-conformance-infra"}
 			listeners := []v1beta1.ListenerStatus{{
 				Name:           v1beta1.SectionName("http"),
@@ -55,7 +55,7 @@ var GatewayInvalidRouteKind = suite.ConformanceTest{
 			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
 		})
 
-		t.Run("Gateway listener should have a false ResolvedRefs condition with reason InvalidRouteKinds and HTTPRoute must be put in the supportedKinds", func(t *testing.T) {
+		t.Run("Gateway listener should have a false ResolvedRefs condition with reason InvalidRouteKinds and HTTPRoute must be put in the supportedKinds", func(t tester.Tester) {
 			gwNN := types.NamespacedName{Name: "gateway-supported-and-invalid-route-kind", Namespace: "gateway-conformance-infra"}
 			listeners := []v1beta1.ListenerStatus{{
 				Name: v1beta1.SectionName("http"),

--- a/conformance/tests/gateway-invalid-tls-certificateref.go
+++ b/conformance/tests/gateway-invalid-tls-certificateref.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -38,7 +37,7 @@ var GatewayInvalidTLSConfiguration = suite.ConformanceTest{
 		suite.SupportGateway,
 	},
 	Manifests: []string{"tests/gateway-invalid-tls-certificateref.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
 		listeners := []v1beta1.ListenerStatus{{
 			Name: v1beta1.SectionName("https"),
 			SupportedKinds: []v1beta1.RouteGroupKind{{
@@ -77,7 +76,7 @@ var GatewayInvalidTLSConfiguration = suite.ConformanceTest{
 
 		for _, tc := range testCases {
 			tc := tc
-			t.Run(tc.name, func(t *testing.T) {
+			t.Run(tc.name, func(t tester.Tester) {
 				t.Parallel()
 				kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, tc.gatewayNamespacedName, listeners)
 			})

--- a/conformance/tests/gateway-modify-listeners.go
+++ b/conformance/tests/gateway-modify-listeners.go
@@ -18,7 +18,6 @@ package tests
 
 import (
 	"context"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -29,6 +28,7 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -42,8 +42,8 @@ var GatewayModifyListeners = suite.ConformanceTest{
 		suite.SupportGateway,
 	},
 	Manifests: []string{"tests/gateway-modify-listeners.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
-		t.Run("should be able to add a listener that then becomes available for routing traffic", func(t *testing.T) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
+		t.Run("should be able to add a listener that then becomes available for routing traffic", func(t tester.Tester) {
 			gwNN := types.NamespacedName{Name: "gateway-add-listener", Namespace: "gateway-conformance-infra"}
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
@@ -135,7 +135,7 @@ var GatewayModifyListeners = suite.ConformanceTest{
 			require.NotEqual(t, original.Generation, updated.Generation, "generation should change after an update")
 		})
 
-		t.Run("should be able to remove listeners, which would then stop routing the relevant traffic", func(t *testing.T) {
+		t.Run("should be able to remove listeners, which would then stop routing the relevant traffic", func(t tester.Tester) {
 			gwNN := types.NamespacedName{Name: "gateway-remove-listener", Namespace: "gateway-conformance-infra"}
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()

--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -18,7 +18,6 @@ package tests
 
 import (
 	"context"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -28,6 +27,7 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -42,10 +42,10 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 		suite.SupportGatewayPort8080,
 	},
 	Manifests: []string{"tests/gateway-observed-generation-bump.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "gateway-observed-generation-bump", Namespace: "gateway-conformance-infra"}
 
-		t.Run("observedGeneration should increment", func(t *testing.T) {
+		t.Run("observedGeneration should increment", func(t tester.Tester) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 

--- a/conformance/tests/gateway-secret-invalid-reference-grant.go
+++ b/conformance/tests/gateway-secret-invalid-reference-grant.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -39,10 +38,10 @@ var GatewaySecretInvalidReferenceGrant = suite.ConformanceTest{
 		suite.SupportReferenceGrant,
 	},
 	Manifests: []string{"tests/gateway-secret-invalid-reference-grant.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "gateway-secret-invalid-reference-grant", Namespace: "gateway-conformance-infra"}
 
-		t.Run("Gateway listener should have a false ResolvedRefs condition with reason RefNotPermitted", func(t *testing.T) {
+		t.Run("Gateway listener should have a false ResolvedRefs condition with reason RefNotPermitted", func(t tester.Tester) {
 			listeners := []v1beta1.ListenerStatus{{
 				Name: v1beta1.SectionName("https"),
 				SupportedKinds: []v1beta1.RouteGroupKind{{

--- a/conformance/tests/gateway-secret-missing-reference-grant.go
+++ b/conformance/tests/gateway-secret-missing-reference-grant.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -39,10 +38,10 @@ var GatewaySecretMissingReferenceGrant = suite.ConformanceTest{
 		suite.SupportReferenceGrant,
 	},
 	Manifests: []string{"tests/gateway-secret-missing-reference-grant.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "gateway-secret-missing-reference-grant", Namespace: "gateway-conformance-infra"}
 
-		t.Run("Gateway listener should have a false ResolvedRefs condition with reason RefNotPermitted", func(t *testing.T) {
+		t.Run("Gateway listener should have a false ResolvedRefs condition with reason RefNotPermitted", func(t tester.Tester) {
 			listeners := []v1beta1.ListenerStatus{{
 				Name: v1beta1.SectionName("https"),
 				SupportedKinds: []v1beta1.RouteGroupKind{{

--- a/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go
+++ b/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -39,10 +38,10 @@ var GatewaySecretReferenceGrantAllInNamespace = suite.ConformanceTest{
 		suite.SupportReferenceGrant,
 	},
 	Manifests: []string{"tests/gateway-secret-reference-grant-all-in-namespace.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "gateway-secret-reference-grant-all-in-namespace", Namespace: "gateway-conformance-infra"}
 
-		t.Run("Gateway listener should have a true ResolvedRefs condition and a true Programmed condition", func(t *testing.T) {
+		t.Run("Gateway listener should have a true ResolvedRefs condition and a true Programmed condition", func(t tester.Tester) {
 			listeners := []v1beta1.ListenerStatus{{
 				Name: v1beta1.SectionName("https"),
 				SupportedKinds: []v1beta1.RouteGroupKind{{

--- a/conformance/tests/gateway-secret-reference-grant-specific.go
+++ b/conformance/tests/gateway-secret-reference-grant-specific.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -39,10 +38,10 @@ var GatewaySecretReferenceGrantSpecific = suite.ConformanceTest{
 		suite.SupportReferenceGrant,
 	},
 	Manifests: []string{"tests/gateway-secret-reference-grant-specific.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "gateway-secret-reference-grant-specific", Namespace: "gateway-conformance-infra"}
 
-		t.Run("Gateway listener should have a true ResolvedRefs condition and a true Programmed condition", func(t *testing.T) {
+		t.Run("Gateway listener should have a true ResolvedRefs condition and a true Programmed condition", func(t tester.Tester) {
 			listeners := []v1beta1.ListenerStatus{{
 				Name: v1beta1.SectionName("https"),
 				SupportedKinds: []v1beta1.RouteGroupKind{{

--- a/conformance/tests/gateway-with-attached-routes.go
+++ b/conformance/tests/gateway-with-attached-routes.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -38,8 +37,8 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 		suite.SupportGateway,
 	},
 	Manifests: []string{"tests/gateway-with-attached-routes.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
-		t.Run("Gateway listener should have one valid http routes attached", func(t *testing.T) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
+		t.Run("Gateway listener should have one valid http routes attached", func(t tester.Tester) {
 			gwNN := types.NamespacedName{Name: "gateway-with-one-attached-route", Namespace: "gateway-conformance-infra"}
 			listeners := []v1beta1.ListenerStatus{{
 				Name: v1beta1.SectionName("http"),
@@ -65,7 +64,7 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
 		})
 
-		t.Run("Gateway listener should have two valid http routes attached", func(t *testing.T) {
+		t.Run("Gateway listener should have two valid http routes attached", func(t tester.Tester) {
 			gwNN := types.NamespacedName{Name: "gateway-with-two-attached-routes", Namespace: "gateway-conformance-infra"}
 			listeners := []v1beta1.ListenerStatus{{
 				Name: v1beta1.SectionName("http"),
@@ -101,8 +100,8 @@ var GatewayWithAttachedRoutesWithPort8080 = suite.ConformanceTest{
 		suite.SupportGatewayPort8080,
 	},
 	Manifests: []string{"tests/gateway-with-attached-routes-with-port-8080.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
-		t.Run("Gateway listener should have attached route by specifying the sectionName", func(t *testing.T) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
+		t.Run("Gateway listener should have attached route by specifying the sectionName", func(t tester.Tester) {
 			gwNN := types.NamespacedName{Name: "gateway-with-two-listeners-and-one-attached-route", Namespace: "gateway-conformance-infra"}
 			listeners := []v1beta1.ListenerStatus{
 				{

--- a/conformance/tests/gatewayclass-observed-generation-bump.go
+++ b/conformance/tests/gatewayclass-observed-generation-bump.go
@@ -18,7 +18,6 @@ package tests
 
 import (
 	"context"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -28,6 +27,7 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -41,10 +41,10 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 	},
 	Description: "A GatewayClass should update the observedGeneration in all of it's Status.Conditions after an update to the spec",
 	Manifests:   []string{"tests/gatewayclass-observed-generation-bump.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
 		gwc := types.NamespacedName{Name: "gatewayclass-observed-generation-bump"}
 
-		t.Run("observedGeneration should increment", func(t *testing.T) {
+		t.Run("observedGeneration should increment", func(t tester.Tester) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 

--- a/conformance/tests/httproute-cross-namespace.go
+++ b/conformance/tests/httproute-cross-namespace.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -38,13 +37,13 @@ var HTTPRouteCrossNamespace = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-cross-namespace.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "cross-namespace", Namespace: "gateway-conformance-web-backend"}
 		gwNN := types.NamespacedName{Name: "backend-namespaces", Namespace: "gateway-conformance-infra"}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
-		t.Run("Simple HTTP request should reach web-backend", func(t *testing.T) {
+		t.Run("Simple HTTP request should reach web-backend", func(t tester.Tester) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
 				Request:   http.Request{Path: "/"},
 				Response:  http.Response{StatusCode: 200},

--- a/conformance/tests/httproute-disallowed-kind.go
+++ b/conformance/tests/httproute-disallowed-kind.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -40,7 +39,7 @@ var HTTPRouteDisallowedKind = suite.ConformanceTest{
 		suite.SupportTLSRoute,
 	},
 	Manifests: []string{"tests/httproute-disallowed-kind.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		// This test creates an additional Gateway in the gateway-conformance-infra
 		// namespace so we have to wait for it to be ready.
 		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{"gateway-conformance-infra"})
@@ -49,17 +48,17 @@ var HTTPRouteDisallowedKind = suite.ConformanceTest{
 		gwNN := types.NamespacedName{Name: "tlsroutes-only", Namespace: "gateway-conformance-infra"}
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
-		t.Run("Route should not have been accepted with reason NotAllowedByListeners", func(t *testing.T) {
+		t.Run("Route should not have been accepted with reason NotAllowedByListeners", func(t tester.Tester) {
 			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, metav1.Condition{
 				Type:   string(v1beta1.RouteConditionAccepted),
 				Status: metav1.ConditionFalse,
 				Reason: string(v1beta1.RouteReasonNotAllowedByListeners),
 			})
 		})
-		t.Run("Route should not have Parents set in status", func(t *testing.T) {
+		t.Run("Route should not have Parents set in status", func(t tester.Tester) {
 			kubernetes.HTTPRouteMustHaveNoAcceptedParents(t, suite.Client, suite.TimeoutConfig, routeNN)
 		})
-		t.Run("Gateway should have 0 Routes attached", func(t *testing.T) {
+		t.Run("Gateway should have 0 Routes attached", func(t tester.Tester) {
 			kubernetes.GatewayMustHaveZeroRoutes(t, suite.Client, suite.TimeoutConfig, gwNN)
 		})
 	},

--- a/conformance/tests/httproute-exact-path-matching.go
+++ b/conformance/tests/httproute-exact-path-matching.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -38,7 +37,7 @@ var HTTPExactPathMatching = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-exact-path-matching.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "exact-matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -73,7 +72,7 @@ var HTTPExactPathMatching = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-header-matching.go
+++ b/conformance/tests/httproute-header-matching.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -38,7 +37,7 @@ var HTTPRouteHeaderMatching = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-header-matching.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "header-matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -92,7 +91,7 @@ var HTTPRouteHeaderMatching = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-hostname-intersection.go
+++ b/conformance/tests/httproute-hostname-intersection.go
@@ -17,8 +17,6 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -26,6 +24,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -40,7 +39,7 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-hostname-intersection.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		gwNN := types.NamespacedName{Name: "httproute-hostname-intersection", Namespace: ns}
 
@@ -48,7 +47,7 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 		// namespace so we have to wait for it to be ready.
 		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
 
-		t.Run("HTTPRoutes that do intersect with listener hostnames", func(t *testing.T) {
+		t.Run("HTTPRoutes that do intersect with listener hostnames", func(t tester.Tester) {
 			routes := []types.NamespacedName{
 				{Namespace: ns, Name: "specific-host-matches-listener-specific-host"},
 				{Namespace: ns, Name: "specific-host-matches-listener-wildcard-host"},
@@ -195,14 +194,14 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 				// Declare tc here to avoid loop variable
 				// reuse issues across parallel tests.
 				tc := testCases[i]
-				t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 					t.Parallel()
 					http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 				})
 			}
 		})
 
-		t.Run("HTTPRoutes that do not intersect with listener hostnames", func(t *testing.T) {
+		t.Run("HTTPRoutes that do not intersect with listener hostnames", func(t tester.Tester) {
 			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN))
 			routeNN := types.NamespacedName{Namespace: ns, Name: "no-intersecting-hosts"}
 
@@ -235,7 +234,7 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 				// Declare tc here to avoid loop variable
 				// reuse issues across parallel tests.
 				tc := testCases[i]
-				t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 					t.Parallel()
 					http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 				})

--- a/conformance/tests/httproute-invalid-backendref-nonexistent.go
+++ b/conformance/tests/httproute-invalid-backendref-nonexistent.go
@@ -17,8 +17,6 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -26,6 +24,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -40,14 +39,14 @@ var HTTPRouteInvalidNonExistentBackendRef = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-invalid-backendref-nonexistent.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "invalid-nonexistent-backend-ref", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 
 		// Gateway and Route must be Accepted.
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
-		t.Run("HTTPRoute with only a nonexistent BackendRef has a ResolvedRefs Condition with status False and Reason BackendNotFound", func(t *testing.T) {
+		t.Run("HTTPRoute with only a nonexistent BackendRef has a ResolvedRefs Condition with status False and Reason BackendNotFound", func(t tester.Tester) {
 			resolvedRefsCond := metav1.Condition{
 				Type:   string(v1beta1.RouteConditionResolvedRefs),
 				Status: metav1.ConditionFalse,
@@ -57,7 +56,7 @@ var HTTPRouteInvalidNonExistentBackendRef = suite.ConformanceTest{
 			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, resolvedRefsCond)
 		})
 
-		t.Run("HTTP Request to invalid nonexistent backend receive a 500", func(t *testing.T) {
+		t.Run("HTTP Request to invalid nonexistent backend receive a 500", func(t tester.Tester) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
 				Request: http.Request{
 					Method: "GET",

--- a/conformance/tests/httproute-invalid-backendref-unknown-kind.go
+++ b/conformance/tests/httproute-invalid-backendref-unknown-kind.go
@@ -17,8 +17,6 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -26,6 +24,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -40,7 +39,7 @@ var HTTPRouteInvalidBackendRefUnknownKind = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-invalid-backendref-unknown-kind.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "invalid-backend-ref-unknown-kind", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 
@@ -48,7 +47,7 @@ var HTTPRouteInvalidBackendRefUnknownKind = suite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		// The Route must have a ResolvedRefs Condition with a InvalidKind Reason.
-		t.Run("HTTPRoute with Invalid Kind has a ResolvedRefs Condition with status False and Reason InvalidKind", func(t *testing.T) {
+		t.Run("HTTPRoute with Invalid Kind has a ResolvedRefs Condition with status False and Reason InvalidKind", func(t tester.Tester) {
 			resolvedRefsCond := metav1.Condition{
 				Type:   string(v1beta1.RouteConditionResolvedRefs),
 				Status: metav1.ConditionFalse,
@@ -58,7 +57,7 @@ var HTTPRouteInvalidBackendRefUnknownKind = suite.ConformanceTest{
 			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, resolvedRefsCond)
 		})
 
-		t.Run("HTTP Request to invalid backend with invalid Kind receives a 500", func(t *testing.T) {
+		t.Run("HTTP Request to invalid backend with invalid Kind receives a 500", func(t tester.Tester) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
 				Request: http.Request{
 					Method: "GET",

--- a/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
@@ -17,8 +17,6 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -26,6 +24,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -41,14 +40,14 @@ var HTTPRouteInvalidCrossNamespaceBackendRef = suite.ConformanceTest{
 		suite.SupportReferenceGrant,
 	},
 	Manifests: []string{"tests/httproute-invalid-cross-namespace-backend-ref.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "invalid-cross-namespace-backend-ref", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 
 		// The Route must be Attached.
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
-		t.Run("HTTPRoute with a cross-namespace BackendRef and no ReferenceGrant has a ResolvedRefs Condition with status False and Reason RefNotPermitted", func(t *testing.T) {
+		t.Run("HTTPRoute with a cross-namespace BackendRef and no ReferenceGrant has a ResolvedRefs Condition with status False and Reason RefNotPermitted", func(t tester.Tester) {
 			resolvedRefsCond := metav1.Condition{
 				Type:   string(v1beta1.RouteConditionResolvedRefs),
 				Status: metav1.ConditionFalse,
@@ -58,7 +57,7 @@ var HTTPRouteInvalidCrossNamespaceBackendRef = suite.ConformanceTest{
 			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, resolvedRefsCond)
 		})
 
-		t.Run("HTTP Request to invalid cross-namespace backend must receive a 500", func(t *testing.T) {
+		t.Run("HTTP Request to invalid cross-namespace backend must receive a 500", func(t tester.Tester) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
 				Request: http.Request{
 					Method: "GET",

--- a/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -39,7 +38,7 @@ var HTTPRouteInvalidCrossNamespaceParentRef = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-invalid-cross-namespace-parent-ref.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 		routeNN := types.NamespacedName{Name: "invalid-cross-namespace-parent-ref", Namespace: "gateway-conformance-web-backend"}
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
@@ -48,7 +47,7 @@ var HTTPRouteInvalidCrossNamespaceParentRef = suite.ConformanceTest{
 		// must be setting this condition on routes that are not allowed. However, outside of conformance testing,
 		// it's also valid for implementations to run in modes where they only have access to a limited subset of
 		// namespaces, in which case they are not obligated to populate this condition on routes they cannot access.
-		t.Run("HTTPRoute should have an Accepted: false condition with reason NotAllowedByListeners", func(t *testing.T) {
+		t.Run("HTTPRoute should have an Accepted: false condition with reason NotAllowedByListeners", func(t tester.Tester) {
 			acceptedCond := metav1.Condition{
 				Type:   string(v1beta1.RouteConditionAccepted),
 				Status: metav1.ConditionFalse,
@@ -58,11 +57,11 @@ var HTTPRouteInvalidCrossNamespaceParentRef = suite.ConformanceTest{
 			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, acceptedCond)
 		})
 
-		t.Run("Route should not have Parents set in status", func(t *testing.T) {
+		t.Run("Route should not have Parents set in status", func(t tester.Tester) {
 			kubernetes.HTTPRouteMustHaveNoAcceptedParents(t, suite.Client, suite.TimeoutConfig, routeNN)
 		})
 
-		t.Run("Gateway should have 0 Routes attached", func(t *testing.T) {
+		t.Run("Gateway should have 0 Routes attached", func(t tester.Tester) {
 			kubernetes.GatewayMustHaveZeroRoutes(t, suite.Client, suite.TimeoutConfig, gwNN)
 		})
 	},

--- a/conformance/tests/httproute-invalid-parentref-not-matching-listener-port.go
+++ b/conformance/tests/httproute-invalid-parentref-not-matching-listener-port.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -40,13 +39,13 @@ var HTTPRouteInvalidParentRefNotMatchingListenerPort = suite.ConformanceTest{
 		suite.SupportRouteDestinationPortMatching,
 	},
 	Manifests: []string{"tests/httproute-invalid-parentref-not-matching-listener-port.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "httproute-listener-not-matching-route-port", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		// The Route must have an Accepted Condition with a NoMatchingParent Reason.
-		t.Run("HTTPRoute with no matching port in ParentRef has an Accepted Condition with status False and Reason NoMatchingParent", func(t *testing.T) {
+		t.Run("HTTPRoute with no matching port in ParentRef has an Accepted Condition with status False and Reason NoMatchingParent", func(t tester.Tester) {
 			acceptedCond := metav1.Condition{
 				Type:   string(v1beta1.RouteConditionAccepted),
 				Status: metav1.ConditionFalse,
@@ -56,11 +55,11 @@ var HTTPRouteInvalidParentRefNotMatchingListenerPort = suite.ConformanceTest{
 			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, acceptedCond)
 		})
 
-		t.Run("Route should not have Parents accepted in status", func(t *testing.T) {
+		t.Run("Route should not have Parents accepted in status", func(t tester.Tester) {
 			kubernetes.HTTPRouteMustHaveNoAcceptedParents(t, suite.Client, suite.TimeoutConfig, routeNN)
 		})
 
-		t.Run("Gateway should have 0 Routes attached", func(t *testing.T) {
+		t.Run("Gateway should have 0 Routes attached", func(t tester.Tester) {
 			kubernetes.GatewayMustHaveZeroRoutes(t, suite.Client, suite.TimeoutConfig, gwNN)
 		})
 	},

--- a/conformance/tests/httproute-invalid-parentref-not-matching-section-name.go
+++ b/conformance/tests/httproute-invalid-parentref-not-matching-section-name.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -39,12 +38,12 @@ var HTTPRouteInvalidParentRefNotMatchingSectionName = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-invalid-parentref-not-matching-section-name.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "httproute-listener-not-matching-section-name", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 
 		// The Route must have an Accepted Condition with a NoMatchingParent Reason.
-		t.Run("HTTPRoute with no matching sectionName in ParentRef has an Accepted Condition with status False and Reason NoMatchingParent", func(t *testing.T) {
+		t.Run("HTTPRoute with no matching sectionName in ParentRef has an Accepted Condition with status False and Reason NoMatchingParent", func(t tester.Tester) {
 			resolvedRefsCond := metav1.Condition{
 				Type:   string(v1beta1.RouteConditionAccepted),
 				Status: metav1.ConditionFalse,
@@ -54,11 +53,11 @@ var HTTPRouteInvalidParentRefNotMatchingSectionName = suite.ConformanceTest{
 			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, resolvedRefsCond)
 		})
 
-		t.Run("Route should not have Parents accepted in status", func(t *testing.T) {
+		t.Run("Route should not have Parents accepted in status", func(t tester.Tester) {
 			kubernetes.HTTPRouteMustHaveNoAcceptedParents(t, suite.Client, suite.TimeoutConfig, routeNN)
 		})
 
-		t.Run("Gateway should have 0 Routes attached", func(t *testing.T) {
+		t.Run("Gateway should have 0 Routes attached", func(t tester.Tester) {
 			kubernetes.GatewayMustHaveZeroRoutes(t, suite.Client, suite.TimeoutConfig, gwNN)
 		})
 	},

--- a/conformance/tests/httproute-invalid-reference-grant.go
+++ b/conformance/tests/httproute-invalid-reference-grant.go
@@ -17,8 +17,6 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -26,6 +24,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -41,12 +40,12 @@ var HTTPRouteInvalidReferenceGrant = suite.ConformanceTest{
 		suite.SupportReferenceGrant,
 	},
 	Manifests: []string{"tests/httproute-invalid-reference-grant.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "reference-grant", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
-		t.Run("HTTPRoute with BackendRef in another namespace and no ReferenceGrant covering the Service has a ResolvedRefs Condition with status False and Reason RefNotPermitted", func(t *testing.T) {
+		t.Run("HTTPRoute with BackendRef in another namespace and no ReferenceGrant covering the Service has a ResolvedRefs Condition with status False and Reason RefNotPermitted", func(t tester.Tester) {
 			resolvedRefsCond := metav1.Condition{
 				Type:   string(v1beta1.RouteConditionResolvedRefs),
 				Status: metav1.ConditionFalse,
@@ -56,7 +55,7 @@ var HTTPRouteInvalidReferenceGrant = suite.ConformanceTest{
 			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, resolvedRefsCond)
 		})
 
-		t.Run("Simple HTTP request not should reach web-backend", func(t *testing.T) {
+		t.Run("Simple HTTP request not should reach web-backend", func(t tester.Tester) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
 				Request: http.Request{
 					Method: "GET",

--- a/conformance/tests/httproute-listener-hostname-matching.go
+++ b/conformance/tests/httproute-listener-hostname-matching.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -38,7 +37,7 @@ var HTTPRouteListenerHostnameMatching = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-listener-hostname-matching.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 
 		// This test creates an additional Gateway in the gateway-conformance-infra
@@ -95,7 +94,7 @@ var HTTPRouteListenerHostnameMatching = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-matching-across-routes.go
+++ b/conformance/tests/httproute-matching-across-routes.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -38,7 +37,7 @@ var HTTPRouteMatchingAcrossRoutes = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-matching-across-routes.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN1 := types.NamespacedName{Name: "matching-part1", Namespace: ns}
 		routeNN2 := types.NamespacedName{Name: "matching-part2", Namespace: ns}
@@ -112,7 +111,7 @@ var HTTPRouteMatchingAcrossRoutes = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-matching.go
+++ b/conformance/tests/httproute-matching.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -38,7 +37,7 @@ var HTTPRouteMatching = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-matching.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -88,7 +87,7 @@ var HTTPRouteMatching = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-method-matching.go
+++ b/conformance/tests/httproute-method-matching.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -39,7 +38,7 @@ var HTTPRouteMethodMatching = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRouteMethodMatching,
 	},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "method-matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -127,7 +126,7 @@ var HTTPRouteMethodMatching = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-observed-generation-bump.go
+++ b/conformance/tests/httproute-observed-generation-bump.go
@@ -18,7 +18,6 @@ package tests
 
 import (
 	"context"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -29,6 +28,7 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -43,11 +43,11 @@ var HTTPRouteObservedGenerationBump = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-observed-generation-bump.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "observed-generation-bump", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 
-		t.Run("observedGeneration should increment", func(t *testing.T) {
+		t.Run("observedGeneration should increment", func(t tester.Tester) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 

--- a/conformance/tests/httproute-path-match-order.go
+++ b/conformance/tests/httproute-path-match-order.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -38,7 +37,7 @@ var HTTPRoutePathMatchOrder = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-path-match-order.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Namespace: ns, Name: "path-matching-order"}
 		gwNN := types.NamespacedName{Namespace: ns, Name: "same-namespace"}
@@ -75,7 +74,7 @@ var HTTPRoutePathMatchOrder = suite.ConformanceTest{
 
 		for i := range testCases {
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-query-param-matching.go
+++ b/conformance/tests/httproute-query-param-matching.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -39,7 +38,7 @@ var HTTPRouteQueryParamMatching = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRouteQueryParamMatching,
 	},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Namespace: ns, Name: "query-param-matching"}
 		gwNN := types.NamespacedName{Namespace: ns, Name: "same-namespace"}
@@ -148,7 +147,7 @@ var HTTPRouteQueryParamMatching = suite.ConformanceTest{
 
 		for i := range testCases {
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-redirect-host-and-status.go
+++ b/conformance/tests/httproute-redirect-host-and-status.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -39,7 +38,7 @@ var HTTPRouteRedirectHostAndStatus = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-redirect-host-and-status.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "redirect-host-and-status", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -77,7 +76,7 @@ var HTTPRouteRedirectHostAndStatus = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-redirect-path.go
+++ b/conformance/tests/httproute-redirect-path.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -40,7 +39,7 @@ var HTTPRouteRedirectPath = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRoutePathRedirect,
 	},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "redirect-path", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -128,7 +127,7 @@ var HTTPRouteRedirectPath = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-redirect-port-and-scheme.go
+++ b/conformance/tests/httproute-redirect-port-and-scheme.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 	"sigs.k8s.io/gateway-api/conformance/utils/tls"
 )
 
@@ -42,7 +41,7 @@ var HTTPRouteRedirectPortAndScheme = suite.ConformanceTest{
 		suite.SupportHTTPRoutePortRedirect,
 		suite.SupportGatewayPort8080,
 	},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -154,7 +153,7 @@ var HTTPRouteRedirectPortAndScheme = suite.ConformanceTest{
 
 		for i := range testCases {
 			tc := testCases[i]
-			t.Run("http-listener-on-80/"+tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run("http-listener-on-80/"+tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr80, tc)
 			})
@@ -206,7 +205,7 @@ var HTTPRouteRedirectPortAndScheme = suite.ConformanceTest{
 
 		for i := range testCases {
 			tc := testCases[i]
-			t.Run("http-listener-on-8080/"+tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run("http-listener-on-8080/"+tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr8080, tc)
 			})
@@ -301,7 +300,7 @@ var HTTPRouteRedirectPortAndScheme = suite.ConformanceTest{
 
 		for i := range testCases {
 			tc := testCases[i]
-			t.Run("https-listener-on-443/"+tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run("https-listener-on-443/"+tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				tls.MakeTLSRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr443, cPem, keyPem, "example.org", tc)
 			})

--- a/conformance/tests/httproute-redirect-port.go
+++ b/conformance/tests/httproute-redirect-port.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -40,7 +39,7 @@ var HTTPRouteRedirectPort = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRoutePortRedirect,
 	},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "redirect-port", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -104,7 +103,7 @@ var HTTPRouteRedirectPort = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-redirect-scheme.go
+++ b/conformance/tests/httproute-redirect-scheme.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -40,7 +39,7 @@ var HTTPRouteRedirectScheme = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRouteSchemeRedirect,
 	},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "redirect-scheme", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -104,7 +103,7 @@ var HTTPRouteRedirectScheme = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-reference-grant.go
+++ b/conformance/tests/httproute-reference-grant.go
@@ -18,7 +18,6 @@ package tests
 
 import (
 	"context"
-	"testing"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +27,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -43,13 +43,13 @@ var HTTPRouteReferenceGrant = suite.ConformanceTest{
 		suite.SupportReferenceGrant,
 	},
 	Manifests: []string{"tests/httproute-reference-grant.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "reference-grant", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
-		t.Run("Simple HTTP request should reach web-backend", func(t *testing.T) {
+		t.Run("Simple HTTP request should reach web-backend", func(t tester.Tester) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
 				Request: http.Request{
 					Method: "GET",
@@ -71,7 +71,7 @@ var HTTPRouteReferenceGrant = suite.ConformanceTest{
 		}
 		require.NoError(t, suite.Client.Delete(ctx, &rg))
 
-		t.Run("Simple HTTP request should return 500 after deleting the relevant reference grant", func(t *testing.T) {
+		t.Run("Simple HTTP request should return 500 after deleting the relevant reference grant", func(t tester.Tester) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
 				Request: http.Request{
 					Method: "GET",

--- a/conformance/tests/httproute-request-header-modifier.go
+++ b/conformance/tests/httproute-request-header-modifier.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -38,7 +37,7 @@ var HTTPRouteRequestHeaderModifier = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-request-header-modifier.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "request-header-modifier", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -191,7 +190,7 @@ var HTTPRouteRequestHeaderModifier = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-request-mirror.go
+++ b/conformance/tests/httproute-request-mirror.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -39,7 +38,7 @@ var HTTPRouteRequestMirror = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRouteRequestMirror,
 	},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "request-mirror", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -93,7 +92,7 @@ var HTTPRouteRequestMirror = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 				http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path)

--- a/conformance/tests/httproute-request-multiple-mirrors.go
+++ b/conformance/tests/httproute-request-multiple-mirrors.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -40,7 +39,7 @@ var HTTPRouteRequestMultipleMirrors = suite.ConformanceTest{
 		suite.SupportHTTPRouteRequestMirror,
 		suite.SupportHTTPRouteRequestMultipleMirrors,
 	},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "request-multiple-mirrors", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -105,7 +104,7 @@ var HTTPRouteRequestMultipleMirrors = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 				http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path)

--- a/conformance/tests/httproute-response-header-modifier.go
+++ b/conformance/tests/httproute-response-header-modifier.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -39,7 +38,7 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 		suite.SupportHTTPResponseHeaderModification,
 	},
 	Manifests: []string{"tests/httproute-response-header-modifier.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "response-header-modifier", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -216,7 +215,7 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-rewrite-host.go
+++ b/conformance/tests/httproute-rewrite-host.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -39,7 +38,7 @@ var HTTPRouteRewriteHost = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRouteHostRewrite,
 	},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "rewrite-host", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -102,7 +101,7 @@ var HTTPRouteRewriteHost = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-rewrite-path.go
+++ b/conformance/tests/httproute-rewrite-path.go
@@ -17,13 +17,12 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -39,7 +38,7 @@ var HTTPRouteRewritePath = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRoutePathRewrite,
 	},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "rewrite-path", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
@@ -122,7 +121,7 @@ var HTTPRouteRewritePath = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				t.Parallel()
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})

--- a/conformance/tests/httproute-simple-same-namespace.go
+++ b/conformance/tests/httproute-simple-same-namespace.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -39,14 +38,14 @@ var HTTPRouteSimpleSameNamespace = suite.ConformanceTest{
 		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/httproute-simple-same-namespace.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := v1beta1.Namespace("gateway-conformance-infra")
 		routeNN := types.NamespacedName{Name: "gateway-conformance-infra-test", Namespace: string(ns)}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: string(ns)}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
-		t.Run("Simple HTTP request should reach infra-backend", func(t *testing.T) {
+		t.Run("Simple HTTP request should reach infra-backend", func(t tester.Tester) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
 				Request:   http.Request{Path: "/"},
 				Response:  http.Response{StatusCode: 200},

--- a/conformance/tests/mesh-basic.go
+++ b/conformance/tests/mesh-basic.go
@@ -17,11 +17,10 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"sigs.k8s.io/gateway-api/conformance/utils/echo"
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -35,7 +34,7 @@ var MeshBasic = suite.ConformanceTest{
 		suite.SupportMesh,
 	},
 	Manifests: []string{},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
 		client := echo.ConnectToApp(t, s, echo.MeshAppEchoV1)
 		cases := []http.ExpectedResponse{{
 			Request: http.Request{
@@ -50,7 +49,7 @@ var MeshBasic = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := cases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				client.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
 			})
 		}

--- a/conformance/tests/mesh-consumer-route.go
+++ b/conformance/tests/mesh-consumer-route.go
@@ -17,11 +17,10 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"sigs.k8s.io/gateway-api/conformance/utils/echo"
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -37,7 +36,7 @@ var MeshConsumerRoute = suite.ConformanceTest{
 		suite.SupportHTTPResponseHeaderModification,
 	},
 	Manifests: []string{"tests/mesh-consumer-route.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
 		consumerClient := echo.ConnectToAppInNamespace(t, s, echo.MeshAppEchoV1, "gateway-conformance-mesh-consumer")
 		consumerCases := []http.ExpectedResponse{
 			{
@@ -73,12 +72,12 @@ var MeshConsumerRoute = suite.ConformanceTest{
 			},
 		}
 		for i, tc := range consumerCases {
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				consumerClient.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
 			})
 		}
 		for i, tc := range producerCases {
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				producerClient.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
 			})
 		}

--- a/conformance/tests/mesh-frontend-hostname.go
+++ b/conformance/tests/mesh-frontend-hostname.go
@@ -17,11 +17,10 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"sigs.k8s.io/gateway-api/conformance/utils/echo"
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -36,7 +35,7 @@ var MeshFrontendHostname = suite.ConformanceTest{
 		suite.SupportHTTPResponseHeaderModification,
 	},
 	Manifests: []string{"tests/mesh-frontend.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
 		client := echo.ConnectToApp(t, s, echo.MeshAppEchoV1)
 		cases := []http.ExpectedResponse{
 			{
@@ -77,7 +76,7 @@ var MeshFrontendHostname = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := cases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				client.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
 			})
 		}

--- a/conformance/tests/mesh-frontend.go
+++ b/conformance/tests/mesh-frontend.go
@@ -17,11 +17,10 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"sigs.k8s.io/gateway-api/conformance/utils/echo"
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -37,7 +36,7 @@ var MeshFrontend = suite.ConformanceTest{
 		suite.SupportHTTPResponseHeaderModification,
 	},
 	Manifests: []string{"tests/mesh-frontend.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
 		client := echo.ConnectToApp(t, s, echo.MeshAppEchoV1)
 		v2 := echo.ConnectToApp(t, s, echo.MeshAppEchoV2)
 		cases := []http.ExpectedResponse{
@@ -73,7 +72,7 @@ var MeshFrontend = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := cases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				client.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
 			})
 		}

--- a/conformance/tests/mesh-ports.go
+++ b/conformance/tests/mesh-ports.go
@@ -17,11 +17,10 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"sigs.k8s.io/gateway-api/conformance/utils/echo"
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -37,7 +36,7 @@ var MeshPorts = suite.ConformanceTest{
 		suite.SupportHTTPResponseHeaderModification,
 	},
 	Manifests: []string{"tests/mesh-ports.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
 		client := echo.ConnectToApp(t, s, echo.MeshAppEchoV1)
 		cases := []http.ExpectedResponse{
 			{
@@ -101,7 +100,7 @@ var MeshPorts = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := cases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				client.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
 			})
 		}

--- a/conformance/tests/mesh-split.go
+++ b/conformance/tests/mesh-split.go
@@ -17,11 +17,10 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	"sigs.k8s.io/gateway-api/conformance/utils/echo"
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -35,7 +34,7 @@ var MeshTrafficSplit = suite.ConformanceTest{
 		suite.SupportMesh,
 	},
 	Manifests: []string{"tests/mesh-split.yaml"},
-	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, s *suite.ConformanceTestSuite) {
 		client := echo.ConnectToApp(t, s, echo.MeshAppEchoV1)
 		cases := []http.ExpectedResponse{
 			{
@@ -65,7 +64,7 @@ var MeshTrafficSplit = suite.ConformanceTest{
 			// Declare tc here to avoid loop variable
 			// reuse issues across parallel tests.
 			tc := cases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Run(tc.GetTestCaseName(i), func(t tester.Tester) {
 				client.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
 			})
 		}

--- a/conformance/tests/tlsroute-invalid-reference-grant.go
+++ b/conformance/tests/tlsroute-invalid-reference-grant.go
@@ -17,14 +17,13 @@ limitations under the License.
 package tests
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func init() {
@@ -40,13 +39,13 @@ var TLSRouteInvalidReferenceGrant = suite.ConformanceTest{
 		suite.SupportReferenceGrant,
 	},
 	Manifests: []string{"tests/tlsroute-invalid-reference-grant.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "gateway-conformance-infra-test", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "gateway-tlsroute-referencegrant", Namespace: "gateway-conformance-infra"}
 
 		kubernetes.GatewayAndTLSRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
-		t.Run("TLSRoute with BackendRef in another namespace and no ReferenceGrant covering the Service has a ResolvedRefs Condition with status False and Reason RefNotPermitted", func(t *testing.T) {
+		t.Run("TLSRoute with BackendRef in another namespace and no ReferenceGrant covering the Service has a ResolvedRefs Condition with status False and Reason RefNotPermitted", func(t tester.Tester) {
 			resolvedRefsCond := metav1.Condition{
 				Type:   string(v1beta1.RouteConditionResolvedRefs),
 				Status: metav1.ConditionFalse,

--- a/conformance/tests/tlsroute-simple-same-namespace.go
+++ b/conformance/tests/tlsroute-simple-same-namespace.go
@@ -19,7 +19,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"testing"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -30,6 +29,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 	"sigs.k8s.io/gateway-api/conformance/utils/tls"
 )
 
@@ -45,7 +45,7 @@ var TLSRouteSimpleSameNamespace = suite.ConformanceTest{
 		suite.SupportTLSRoute,
 	},
 	Manifests: []string{"tests/tlsroute-simple-same-namespace.yaml"},
-	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+	Test: func(t tester.Tester, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
 		routeNN := types.NamespacedName{Name: "gateway-conformance-infra-test", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "gateway-tlsroute", Namespace: ns}
@@ -63,7 +63,7 @@ var TLSRouteSimpleSameNamespace = suite.ConformanceTest{
 		if err != nil {
 			t.Fatalf("unexpected error finding TLS secret: %v", err)
 		}
-		t.Run("Simple TLS request matching TLSRoute should reach infra-backend", func(t *testing.T) {
+		t.Run("Simple TLS request matching TLSRoute should reach infra-backend", func(t tester.Tester) {
 			tls.MakeTLSRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, cPem, keyPem, serverStr,
 				http.ExpectedResponse{
 					Request:   http.Request{Host: serverStr, Path: "/"},

--- a/conformance/utils/echo/pod.go
+++ b/conformance/utils/echo/pod.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"testing"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -34,6 +33,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/config"
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 // MeshPod represents a connection to a specific pod running in the mesh.
@@ -53,7 +53,7 @@ const (
 	MeshAppEchoV2 MeshApplication = "app=echo,version=v2"
 )
 
-func (m *MeshPod) MakeRequestAndExpectEventuallyConsistentResponse(t *testing.T, exp http.ExpectedResponse, timeoutConfig config.TimeoutConfig) {
+func (m *MeshPod) MakeRequestAndExpectEventuallyConsistentResponse(t tester.Tester, exp http.ExpectedResponse, timeoutConfig config.TimeoutConfig) {
 	t.Helper()
 
 	http.AwaitConvergence(t, timeoutConfig.RequiredConsecutiveSuccesses, timeoutConfig.MaxTimeToConsistency, func(elapsed time.Duration) bool {
@@ -75,7 +75,7 @@ func (m *MeshPod) MakeRequestAndExpectEventuallyConsistentResponse(t *testing.T,
 	t.Logf("Request passed")
 }
 
-func makeRequest(t *testing.T, r http.Request) []string {
+func makeRequest(t tester.Tester, r http.Request) []string {
 	protocol := strings.ToLower(r.Protocol)
 	if protocol == "" {
 		protocol = "http"
@@ -149,11 +149,11 @@ func (m *MeshPod) request(args []string) (Response, error) {
 	return ParseResponse(stdoutBuf.String()), nil
 }
 
-func ConnectToApp(t *testing.T, s *suite.ConformanceTestSuite, app MeshApplication) MeshPod {
+func ConnectToApp(t tester.Tester, s *suite.ConformanceTestSuite, app MeshApplication) MeshPod {
 	return ConnectToAppInNamespace(t, s, app, "gateway-conformance-mesh")
 }
 
-func ConnectToAppInNamespace(t *testing.T, s *suite.ConformanceTestSuite, app MeshApplication, ns string) MeshPod {
+func ConnectToAppInNamespace(t tester.Tester, s *suite.ConformanceTestSuite, app MeshApplication, ns string) MeshPod {
 	lbls, _ := klabels.Parse(string(app))
 
 	podsList := v1.PodList{}

--- a/conformance/utils/http/mirror.go
+++ b/conformance/utils/http/mirror.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"regexp"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -28,9 +27,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
-func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clientset.Interface, mirrorPods []BackendRef, path string) {
+func ExpectMirroredRequest(t tester.Tester, client client.Client, clientset clientset.Interface, mirrorPods []BackendRef, path string) {
 	for i, mirrorPod := range mirrorPods {
 		if mirrorPod.Name == "" {
 			t.Fatalf("Mirrored BackendRef[%d].Name wasn't provided in the testcase, this test should only check http request mirror.", i)

--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"testing"
 
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -35,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/config"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 // Applier prepares manifests depending on the available options and applies
@@ -54,19 +54,19 @@ type Applier struct {
 }
 
 // prepareGateway adjusts the gatewayClassName.
-func (a Applier) prepareGateway(t *testing.T, uObj *unstructured.Unstructured) {
+func (a Applier) prepareGateway(t tester.Tester, uObj *unstructured.Unstructured) {
 	err := unstructured.SetNestedField(uObj.Object, a.GatewayClass, "spec", "gatewayClassName")
 	require.NoErrorf(t, err, "error setting `spec.gatewayClassName` on %s Gateway resource", uObj.GetName())
 }
 
 // prepareGatewayClass adjust the spec.controllerName on the resource
-func (a Applier) prepareGatewayClass(t *testing.T, uObj *unstructured.Unstructured) {
+func (a Applier) prepareGatewayClass(t tester.Tester, uObj *unstructured.Unstructured) {
 	err := unstructured.SetNestedField(uObj.Object, a.ControllerName, "spec", "controllerName")
 	require.NoErrorf(t, err, "error setting `spec.controllerName` on %s GatewayClass resource", uObj.GetName())
 }
 
 // prepareNamespace adjusts the Namespace labels.
-func (a Applier) prepareNamespace(t *testing.T, uObj *unstructured.Unstructured) {
+func (a Applier) prepareNamespace(t tester.Tester, uObj *unstructured.Unstructured) {
 	labels, _, err := unstructured.NestedStringMap(uObj.Object, "metadata", "labels")
 	require.NoErrorf(t, err, "error getting labels on Namespace %s", uObj.GetName())
 
@@ -104,7 +104,7 @@ func (a Applier) prepareNamespace(t *testing.T, uObj *unstructured.Unstructured)
 
 // prepareResources uses the options from an Applier to tweak resources given by
 // a set of manifests.
-func (a Applier) prepareResources(t *testing.T, decoder *yaml.YAMLOrJSONDecoder) ([]unstructured.Unstructured, error) {
+func (a Applier) prepareResources(t tester.Tester, decoder *yaml.YAMLOrJSONDecoder) ([]unstructured.Unstructured, error) {
 	var resources []unstructured.Unstructured
 
 	for {
@@ -136,7 +136,7 @@ func (a Applier) prepareResources(t *testing.T, decoder *yaml.YAMLOrJSONDecoder)
 	return resources, nil
 }
 
-func (a Applier) MustApplyObjectsWithCleanup(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, resources []client.Object, cleanup bool) {
+func (a Applier) MustApplyObjectsWithCleanup(t tester.Tester, c client.Client, timeoutConfig config.TimeoutConfig, resources []client.Object, cleanup bool) {
 	for _, resource := range resources {
 		resource := resource
 
@@ -167,7 +167,7 @@ func (a Applier) MustApplyObjectsWithCleanup(t *testing.T, c client.Client, time
 // MustApplyWithCleanup creates or updates Kubernetes resources defined with the
 // provided YAML file and registers a cleanup function for resources it created.
 // Note that this does not remove resources that already existed in the cluster.
-func (a Applier) MustApplyWithCleanup(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, location string, cleanup bool) {
+func (a Applier) MustApplyWithCleanup(t tester.Tester, c client.Client, timeoutConfig config.TimeoutConfig, location string, cleanup bool) {
 	data, err := getContentsFromPathOrURL(a.FS, location, timeoutConfig)
 	require.NoError(t, err)
 

--- a/conformance/utils/kubernetes/apply_test.go
+++ b/conformance/utils/kubernetes/apply_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	_ "sigs.k8s.io/gateway-api/conformance/utils/flags"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 func TestPrepareResources(t *testing.T) {
@@ -176,7 +177,7 @@ spec:
 
 			tc.applier.GatewayClass = "test-class"
 			tc.applier.ControllerName = "test-controller"
-			resources, err := tc.applier.prepareResources(t, decoder)
+			resources, err := tc.applier.prepareResources(tester.New(t), decoder)
 
 			require.NoError(t, err, "unexpected error preparing resources")
 			require.EqualValues(t, tc.expected, resources)

--- a/conformance/utils/kubernetes/certificate.go
+++ b/conformance/utils/kubernetes/certificate.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"math/big"
 	"net"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -36,6 +35,8 @@ import (
 
 	// ensure auth plugins are loaded
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 const (
@@ -44,7 +45,7 @@ const (
 )
 
 // MustCreateSelfSignedCertSecret creates a self-signed SSL certificate and stores it in a secret
-func MustCreateSelfSignedCertSecret(t *testing.T, namespace, secretName string, hosts []string) *corev1.Secret {
+func MustCreateSelfSignedCertSecret(t tester.Tester, namespace, secretName string, hosts []string) *corev1.Secret {
 	require.Greater(t, len(hosts), 0, "require a non-empty hosts for Subject Alternate Name values")
 
 	var serverKey, serverCert bytes.Buffer

--- a/conformance/utils/kubernetes/helpers_test.go
+++ b/conformance/utils/kubernetes/helpers_test.go
@@ -29,6 +29,7 @@ import (
 
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 // -----------------------------------------------------------------------------
@@ -315,7 +316,7 @@ func Test_listenersMatch(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.want, listenersMatch(t, test.expected, test.actual))
+			assert.Equal(t, test.want, listenersMatch(tester.New(t), test.expected, test.actual))
 		})
 	}
 }

--- a/conformance/utils/suite/experimental_suite.go
+++ b/conformance/utils/suite/experimental_suite.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"testing"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +31,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/config"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 // -----------------------------------------------------------------------------
@@ -183,12 +183,12 @@ func NewExperimentalConformanceTestSuite(s ExperimentalConformanceOptions) (*Exp
 
 // Setup ensures the base resources required for conformance tests are installed
 // in the cluster. It also ensures that all relevant resources are ready.
-func (suite *ExperimentalConformanceTestSuite) Setup(t *testing.T) {
+func (suite *ExperimentalConformanceTestSuite) Setup(t tester.Tester) {
 	suite.ConformanceTestSuite.Setup(t)
 }
 
 // Run runs the provided set of conformance tests.
-func (suite *ExperimentalConformanceTestSuite) Run(t *testing.T, tests []ConformanceTest) error {
+func (suite *ExperimentalConformanceTestSuite) Run(t tester.Tester, tests []ConformanceTest) error {
 	// verify that the test suite isn't already running, don't start a new run
 	// until the previous run finishes
 	suite.lock.Lock()
@@ -206,7 +206,7 @@ func (suite *ExperimentalConformanceTestSuite) Run(t *testing.T, tests []Conform
 	// run all tests and collect the test results for conformance reporting
 	results := make(map[string]testResult)
 	for _, test := range tests {
-		succeeded := t.Run(test.ShortName, func(t *testing.T) {
+		succeeded := t.Run(test.ShortName, func(t tester.Tester) {
 			test.Run(t, &suite.ConformanceTestSuite)
 		})
 		res := testSucceeded

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -19,7 +19,6 @@ package suite
 import (
 	"embed"
 	"strings"
-	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
@@ -30,6 +29,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/config"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 // ConformanceTestSuite defines the test suite used to run Gateway API
@@ -141,7 +141,7 @@ func New(s Options) *ConformanceTestSuite {
 
 // Setup ensures the base resources required for conformance tests are installed
 // in the cluster. It also ensures that all relevant resources are ready.
-func (suite *ConformanceTestSuite) Setup(t *testing.T) {
+func (suite *ConformanceTestSuite) Setup(t tester.Tester) {
 	suite.Applier.FS = suite.FS
 
 	if suite.SupportedFeatures.Has(SupportGateway) {
@@ -187,9 +187,9 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 }
 
 // Run runs the provided set of conformance tests.
-func (suite *ConformanceTestSuite) Run(t *testing.T, tests []ConformanceTest) {
+func (suite *ConformanceTestSuite) Run(t tester.Tester, tests []ConformanceTest) {
 	for _, test := range tests {
-		t.Run(test.ShortName, func(t *testing.T) {
+		t.Run(test.ShortName, func(t tester.Tester) {
 			test.Run(t, suite)
 		})
 	}
@@ -203,12 +203,12 @@ type ConformanceTest struct {
 	Manifests   []string
 	Slow        bool
 	Parallel    bool
-	Test        func(*testing.T, *ConformanceTestSuite)
+	Test        func(tester.Tester, *ConformanceTestSuite)
 }
 
 // Run runs an individual tests, applying and cleaning up the required manifests
 // before calling the Test function.
-func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) {
+func (test *ConformanceTest) Run(t tester.Tester, suite *ConformanceTestSuite) {
 	if test.Parallel {
 		t.Parallel()
 	}

--- a/conformance/utils/tester/tester.go
+++ b/conformance/utils/tester/tester.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tester
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// Tester allows users to add custom logging shims to conformance tests.
+type Tester interface {
+	testing.TB
+
+	// Run calls a subtest and wraps the testing.T.Run call
+	Run(name string, f func(Tester)) bool
+
+	// Parallel should pass through to testing.T.Parallel
+	Parallel()
+}
+
+// New returns a new impl.
+func New(t *testing.T) Tester {
+	return &loggingTester{T: t}
+}
+
+// loggingTester performs basic wrapping of testing.T
+type loggingTester struct {
+	*testing.T
+}
+
+// Run implements Tester
+func (lt *loggingTester) Run(name string, f func(Tester)) bool {
+	return lt.T.Run(name, func(t *testing.T) {
+		f(&loggingTester{T: t})
+	})
+}
+
+// Parallel implements Tester
+func (lt *loggingTester) Parallel() {
+	lt.T.Parallel()
+}
+
+func (lt *loggingTester) formatf(level, format string, args ...any) string {
+	return fmt.Sprintf("%s%s] %s", level, time.Now().Format(time.RFC3339), fmt.Sprintf(format, args...))
+}
+
+func (lt *loggingTester) format(level string, args ...any) string {
+	return fmt.Sprintf("%s%s] %s", level, time.Now().Format(time.RFC3339), fmt.Sprint(args...))
+}
+
+// Log implements testing.TB
+func (lt *loggingTester) Log(args ...any) {
+	lt.T.Helper()
+	lt.T.Log(lt.format("I", args...))
+}
+
+// Logf implements testing.TB
+func (lt *loggingTester) Logf(format string, args ...any) {
+	lt.T.Helper()
+	lt.T.Logf(lt.formatf("I", format, args...))
+}
+
+// Error implements testing.TB
+func (lt *loggingTester) Error(args ...any) {
+	lt.T.Helper()
+	lt.T.Error(lt.format("E", args...))
+}
+
+// Errorf implements testing.TB
+func (lt *loggingTester) Errorf(format string, args ...any) {
+	lt.T.Helper()
+	lt.T.Errorf(lt.formatf("E", format, args...))
+}
+
+// Fatal implements testing.TB
+func (lt *loggingTester) Fatal(args ...any) {
+	lt.T.Helper()
+	lt.T.Fatal(lt.format("F", args...))
+}
+
+// Fatalf implements testing.TB
+func (lt *loggingTester) Fatalf(format string, args ...any) {
+	lt.T.Helper()
+	lt.T.Fatalf(lt.formatf("F", format, args...))
+}
+
+// Skip implements testing.TB
+func (lt *loggingTester) Skip(args ...any) {
+	lt.T.Helper()
+	lt.T.Skip(lt.format("S", args...))
+}
+
+// Skipf implements testing.TB
+func (lt *loggingTester) Skipf(format string, args ...any) {
+	lt.T.Helper()
+	lt.T.Skipf(lt.formatf("S", format, args...))
+}

--- a/conformance/utils/tester/tester_test.go
+++ b/conformance/utils/tester/tester_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tester
+
+import (
+	"testing"
+)
+
+// TestTester is intended to demonstrate implemementation and usage of the Tester interface / struct and not test correctness.
+func TestTester(t *testing.T) {
+	ti := New(t)
+	ti.Log("this should have a timestamp header")
+	ti.Logf("%s %s", "this should have", "a timestamp header")
+	ti.Run("subtest-1", func(ti Tester) {
+		ti.Parallel()
+		ti.Log("Log from subtest-1")
+	})
+	ti.Run("subtest-2", func(ti Tester) {
+		ti.Parallel()
+		ti.Log("Log from subtest-2")
+	})
+}

--- a/conformance/utils/tls/tls.go
+++ b/conformance/utils/tls/tls.go
@@ -17,12 +17,12 @@ limitations under the License.
 package tls
 
 import (
-	"testing"
 	"time"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/config"
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+	"sigs.k8s.io/gateway-api/conformance/utils/tester"
 )
 
 // MakeTLSRequestAndExpectEventuallyConsistentResponse makes a request with the given parameters,
@@ -30,7 +30,7 @@ import (
 //
 // Once the request succeeds consistently with the response having the expected status code, make
 // additional assertions on the response body using the provided ExpectedResponse.
-func MakeTLSRequestAndExpectEventuallyConsistentResponse(t *testing.T, r roundtripper.RoundTripper, timeoutConfig config.TimeoutConfig, gwAddr string, cPem, keyPem []byte, server string, expected http.ExpectedResponse) {
+func MakeTLSRequestAndExpectEventuallyConsistentResponse(t tester.Tester, r roundtripper.RoundTripper, timeoutConfig config.TimeoutConfig, gwAddr string, cPem, keyPem []byte, server string, expected http.ExpectedResponse) {
 	t.Helper()
 
 	req := http.MakeRequest(t, &expected, gwAddr, "HTTPS", "https")
@@ -41,7 +41,7 @@ func MakeTLSRequestAndExpectEventuallyConsistentResponse(t *testing.T, r roundtr
 // WaitForConsistentTLSResponse - repeats the provided request until it completes with a response having
 // the expected response consistently. The provided threshold determines how many times in
 // a row this must occur to be considered "consistent".
-func WaitForConsistentTLSResponse(t *testing.T, r roundtripper.RoundTripper, req roundtripper.Request, expected http.ExpectedResponse, threshold int, maxTimeToConsistency time.Duration, cPem, keyPem []byte, server string) {
+func WaitForConsistentTLSResponse(t tester.Tester, r roundtripper.RoundTripper, req roundtripper.Request, expected http.ExpectedResponse, threshold int, maxTimeToConsistency time.Duration, cPem, keyPem []byte, server string) {
 	http.AwaitConvergence(t, threshold, maxTimeToConsistency, func(elapsed time.Duration) bool {
 		req.KeyPem = keyPem
 		req.CertPem = cPem


### PR DESCRIPTION
This will allow users to run conformanace tests with custom logging headers and enable emitting important info such as timestamps.

**What type of PR is this?**

/kind cleanup
/kind test
/area conformance

**What this PR does / why we need it**:

Updates conformance tests to use a `Tester` interface which wraps `*testing.T` to allow for timestamps in conformance test logs.

**Which issue(s) this PR fixes**:
Fixes #1927

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
