### PR TITLE
Add validation for `gateway.spec.addresses` to validate whether fields of addresses are set according to the Gateway API specification

### DIFF
--- a/apis/v1beta1/validation/gateway.go
+++ b/apis/v1beta1/validation/gateway.go
@@ -45,8 +45,8 @@ var (
 		gatewayv1b1.TLSProtocolType:   {},
 	}
 
-	validHostnameAddress   = `^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-	validHostnameRegexp, _ = regexp.Compile(validHostnameAddress)
+	validHostnameAddress = `^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	validHostnameRegexp  = regexp.MustCompile(validHostnameAddress)
 )
 
 // ValidateGateway validates gw according to the Gateway API specification.

--- a/apis/v1beta1/validation/gateway.go
+++ b/apis/v1beta1/validation/gateway.go
@@ -45,7 +45,7 @@ var (
 		gatewayv1b1.TLSProtocolType:   {},
 	}
 
-	validHostnameAddress   = `^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`
+	validHostnameAddress   = `^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 	validHostnameRegexp, _ = regexp.Compile(validHostnameAddress)
 )
 

--- a/apis/v1beta1/validation/gateway_test.go
+++ b/apis/v1beta1/validation/gateway_test.go
@@ -281,6 +281,29 @@ func TestValidateGateway(t *testing.T) {
 			},
 			expectErrsOnFields: []string{"spec.addresses[0]", "spec.addresses[1]", "spec.addresses[2]"},
 		},
+		"duplicate ip address or hostname": {
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Addresses = []gatewayv1b1.GatewayAddress{
+					{
+						Type:  ptrTo(gatewayv1b1.IPAddressType),
+						Value: "1.2.3.4",
+					},
+					{
+						Type:  ptrTo(gatewayv1b1.IPAddressType),
+						Value: "1.2.3.4",
+					},
+					{
+						Type:  ptrTo(gatewayv1b1.HostnameAddressType),
+						Value: "foo.bar",
+					},
+					{
+						Type:  ptrTo(gatewayv1b1.HostnameAddressType),
+						Value: "foo.bar",
+					},
+				}
+			},
+			expectErrsOnFields: []string{"spec.addresses[1]", "spec.addresses[3]"},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/apis/v1beta1/validation/gateway_test.go
+++ b/apis/v1beta1/validation/gateway_test.go
@@ -247,6 +247,40 @@ func TestValidateGateway(t *testing.T) {
 			},
 			expectErrsOnFields: nil,
 		},
+		"ip address and hostname in addresses are valid": {
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Addresses = []gatewayv1b1.GatewayAddress{
+					{
+						Type:  ptrTo(gatewayv1b1.IPAddressType),
+						Value: "1.2.3.4",
+					},
+					{
+						Type:  ptrTo(gatewayv1b1.HostnameAddressType),
+						Value: "foo.bar",
+					},
+				}
+			},
+			expectErrsOnFields: nil,
+		},
+		"ip address and hostname in addresses are invalid": {
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Addresses = []gatewayv1b1.GatewayAddress{
+					{
+						Type:  ptrTo(gatewayv1b1.IPAddressType),
+						Value: "1.2.3.4:8080",
+					},
+					{
+						Type:  ptrTo(gatewayv1b1.HostnameAddressType),
+						Value: "*foo/bar",
+					},
+					{
+						Type:  ptrTo(gatewayv1b1.HostnameAddressType),
+						Value: "12:34:56::",
+					},
+				}
+			},
+			expectErrsOnFields: []string{"spec.addresses[0]", "spec.addresses[1]", "spec.addresses[2]"},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/apis/v1beta1/validation/gateway_test.go
+++ b/apis/v1beta1/validation/gateway_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package validation
 
 import (
+	"fmt"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	gatewayv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -49,52 +51,80 @@ func TestValidateGateway(t *testing.T) {
 	tlsConfig := gatewayv1b1.GatewayTLSConfig{}
 
 	testCases := map[string]struct {
-		mutate             func(gw *gatewayv1b1.Gateway)
-		expectErrsOnFields []string
+		mutate     func(gw *gatewayv1b1.Gateway)
+		expectErrs []field.Error
 	}{
 		"tls config present with http protocol": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
 				gw.Spec.Listeners[0].Protocol = gatewayv1b1.HTTPProtocolType
 				gw.Spec.Listeners[0].TLS = &tlsConfig
 			},
-			expectErrsOnFields: []string{"spec.listeners[0].tls"},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].tls",
+					Detail:   "should be empty for protocol HTTP",
+					BadValue: "",
+				},
+			},
 		},
 		"tls config present with tcp protocol": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
 				gw.Spec.Listeners[0].Protocol = gatewayv1b1.TCPProtocolType
 				gw.Spec.Listeners[0].TLS = &tlsConfig
 			},
-			expectErrsOnFields: []string{"spec.listeners[0].tls"},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].tls",
+					Detail:   "should be empty for protocol TCP",
+					BadValue: "",
+				},
+			},
 		},
 		"tls config not set with https protocol": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
 				gw.Spec.Listeners[0].Protocol = gatewayv1b1.HTTPSProtocolType
 			},
-			expectErrsOnFields: []string{"spec.listeners[0].tls"},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].tls",
+					Detail:   "must be set for protocol HTTPS",
+					BadValue: "",
+				},
+			},
 		},
 		"tls config not set with tls protocol": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
 				gw.Spec.Listeners[0].Protocol = gatewayv1b1.TLSProtocolType
 			},
-			expectErrsOnFields: []string{"spec.listeners[0].tls"},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].tls",
+					Detail:   "must be set for protocol TLS",
+					BadValue: "",
+				},
+			},
 		},
 		"tls config not set with http protocol": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
 				gw.Spec.Listeners[0].Protocol = gatewayv1b1.HTTPProtocolType
 			},
-			expectErrsOnFields: nil,
+			expectErrs: nil,
 		},
 		"tls config not set with tcp protocol": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
 				gw.Spec.Listeners[0].Protocol = gatewayv1b1.TCPProtocolType
 			},
-			expectErrsOnFields: nil,
+			expectErrs: nil,
 		},
 		"tls config not set with udp protocol": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
 				gw.Spec.Listeners[0].Protocol = gatewayv1b1.UDPProtocolType
 			},
-			expectErrsOnFields: nil,
+			expectErrs: nil,
 		},
 		"hostname present with tcp protocol": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
@@ -102,7 +132,14 @@ func TestValidateGateway(t *testing.T) {
 				gw.Spec.Listeners[0].Hostname = &hostname
 				gw.Spec.Listeners[0].Protocol = gatewayv1b1.TCPProtocolType
 			},
-			expectErrsOnFields: []string{"spec.listeners[0].hostname"},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].hostname",
+					Detail:   "should be empty for protocol TCP",
+					BadValue: "",
+				},
+			},
 		},
 		"hostname present with udp protocol": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
@@ -110,7 +147,14 @@ func TestValidateGateway(t *testing.T) {
 				gw.Spec.Listeners[0].Hostname = &hostname
 				gw.Spec.Listeners[0].Protocol = gatewayv1b1.UDPProtocolType
 			},
-			expectErrsOnFields: []string{"spec.listeners[0].hostname"},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].hostname",
+					Detail:   "should be empty for protocol UDP",
+					BadValue: "",
+				},
+			},
 		},
 		"certificatedRefs not set with https protocol and TLS terminate mode": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
@@ -121,7 +165,14 @@ func TestValidateGateway(t *testing.T) {
 				gw.Spec.Listeners[0].TLS = &tlsConfig
 				gw.Spec.Listeners[0].TLS.Mode = &tlsMode
 			},
-			expectErrsOnFields: []string{"spec.listeners[0].tls.certificateRefs"},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].tls.certificateRefs",
+					Detail:   "should be set and not empty when TLSModeType is Terminate\n",
+					BadValue: "",
+				},
+			},
 		},
 		"certificatedRefs not set with tls protocol and TLS terminate mode": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
@@ -132,7 +183,14 @@ func TestValidateGateway(t *testing.T) {
 				gw.Spec.Listeners[0].TLS = &tlsConfig
 				gw.Spec.Listeners[0].TLS.Mode = &tlsMode
 			},
-			expectErrsOnFields: []string{"spec.listeners[0].tls.certificateRefs"},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeForbidden,
+					Field:    "spec.listeners[0].tls.certificateRefs",
+					Detail:   "should be set and not empty when TLSModeType is Terminate\n",
+					BadValue: "",
+				},
+			},
 		},
 		"names are not unique within the Gateway": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
@@ -147,7 +205,13 @@ func TestValidateGateway(t *testing.T) {
 					},
 				)
 			},
-			expectErrsOnFields: []string{"spec.listeners[1].name"},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeDuplicate,
+					Field:    "spec.listeners[1].name",
+					BadValue: "must be unique within the Gateway\n",
+				},
+			},
 		},
 		"combination of port, protocol, and hostname are not unique for each listener": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
@@ -165,7 +229,13 @@ func TestValidateGateway(t *testing.T) {
 					},
 				)
 			},
-			expectErrsOnFields: []string{"spec.listeners[1]"},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeDuplicate,
+					Field:    "spec.listeners[1]",
+					BadValue: "combination of port, protocol, and hostname must be unique for each listener\n",
+				},
+			},
 		},
 		"combination of port and protocol are not unique for each listenr when hostnames not set": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
@@ -180,7 +250,13 @@ func TestValidateGateway(t *testing.T) {
 					},
 				)
 			},
-			expectErrsOnFields: []string{"spec.listeners[1]"},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeDuplicate,
+					Field:    "spec.listeners[1]",
+					BadValue: "combination of port, protocol, and hostname must be unique for each listener\n",
+				},
+			},
 		},
 		"port is unique when protocol and hostname are the same": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
@@ -198,7 +274,7 @@ func TestValidateGateway(t *testing.T) {
 					},
 				)
 			},
-			expectErrsOnFields: nil,
+			expectErrs: nil,
 		},
 		"hostname is unique when protocol and port are the same": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
@@ -217,7 +293,7 @@ func TestValidateGateway(t *testing.T) {
 					},
 				)
 			},
-			expectErrsOnFields: nil,
+			expectErrs: nil,
 		},
 		"protocol is unique when port and hostname are the same": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
@@ -245,7 +321,7 @@ func TestValidateGateway(t *testing.T) {
 					},
 				)
 			},
-			expectErrsOnFields: nil,
+			expectErrs: nil,
 		},
 		"ip address and hostname in addresses are valid": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
@@ -255,12 +331,16 @@ func TestValidateGateway(t *testing.T) {
 						Value: "1.2.3.4",
 					},
 					{
+						Type:  ptrTo(gatewayv1b1.IPAddressType),
+						Value: "1111:2222:3333:4444::",
+					},
+					{
 						Type:  ptrTo(gatewayv1b1.HostnameAddressType),
 						Value: "foo.bar",
 					},
 				}
 			},
-			expectErrsOnFields: nil,
+			expectErrs: nil,
 		},
 		"ip address and hostname in addresses are invalid": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
@@ -279,7 +359,26 @@ func TestValidateGateway(t *testing.T) {
 					},
 				}
 			},
-			expectErrsOnFields: []string{"spec.addresses[0]", "spec.addresses[1]", "spec.addresses[2]"},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeInvalid,
+					Field:    "spec.addresses[0]",
+					Detail:   "invalid ip address\n",
+					BadValue: "1.2.3.4:8080",
+				},
+				{
+					Type:     field.ErrorTypeInvalid,
+					Field:    "spec.addresses[1]",
+					Detail:   fmt.Sprintf("must only contain valid characters (matching %s)", validHostnameAddress),
+					BadValue: "*foo/bar",
+				},
+				{
+					Type:     field.ErrorTypeInvalid,
+					Field:    "spec.addresses[2]",
+					Detail:   fmt.Sprintf("must only contain valid characters (matching %s)", validHostnameAddress),
+					BadValue: "12:34:56::",
+				},
+			},
 		},
 		"duplicate ip address or hostname": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
@@ -302,7 +401,18 @@ func TestValidateGateway(t *testing.T) {
 					},
 				}
 			},
-			expectErrsOnFields: []string{"spec.addresses[1]", "spec.addresses[3]"},
+			expectErrs: []field.Error{
+				{
+					Type:     field.ErrorTypeDuplicate,
+					Field:    "spec.addresses[1]",
+					BadValue: "1.2.3.4",
+				},
+				{
+					Type:     field.ErrorTypeDuplicate,
+					Field:    "spec.addresses[3]",
+					BadValue: "foo.bar",
+				},
+			},
 		},
 	}
 
@@ -312,12 +422,21 @@ func TestValidateGateway(t *testing.T) {
 			gw := baseGateway.DeepCopy()
 			tc.mutate(gw)
 			errs := ValidateGateway(gw)
-			if len(tc.expectErrsOnFields) != len(errs) {
-				t.Fatalf("Expected %d errors, got %d errors: %v", len(tc.expectErrsOnFields), len(errs), errs)
+			if len(tc.expectErrs) != len(errs) {
+				t.Fatalf("Expected %d errors, got %d errors: %v", len(tc.expectErrs), len(errs), errs)
 			}
 			for i, err := range errs {
-				if err.Field != tc.expectErrsOnFields[i] {
-					t.Errorf("Expected error on field: %s, got: %s", tc.expectErrsOnFields[i], err.Error())
+				if err.Type != tc.expectErrs[i].Type {
+					t.Errorf("Expected error on type: %s, got: %s", tc.expectErrs[i].Type, err.Type)
+				}
+				if err.Field != tc.expectErrs[i].Field {
+					t.Errorf("Expected error on field: %s, got: %s", tc.expectErrs[i].Field, err.Field)
+				}
+				if err.Detail != tc.expectErrs[i].Detail {
+					t.Errorf("Expected error on detail: %s, got: %s", tc.expectErrs[i].Detail, err.Detail)
+				}
+				if err.BadValue != tc.expectErrs[i].BadValue {
+					t.Errorf("Expected error on bad value: %s, got: %s", tc.expectErrs[i].BadValue, err.BadValue)
 				}
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind feature

**What this PR does / why we need it**:

Add validation for `Gateway.Spec.Addresses` field.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1960 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
no
