### PR TITLE
Add clarification for ignoring port while matching hostnames and update conformance

### DIFF
--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -56,9 +56,13 @@ type HTTPRouteList struct {
 type HTTPRouteSpec struct {
 	CommonRouteSpec `json:",inline"`
 
-	// Hostnames defines a set of hostname that should match against the HTTP
-	// Host header to select a HTTPRoute to process the request. This matches
-	// the RFC 1123 definition of a hostname with 2 notable exceptions:
+	// Hostnames defines a set of hostname that should match against the HTTP Host
+	// header to select a HTTPRoute used to process the request. Implementations
+	// MUST ignore any port value specified in the HTTP Host header while
+	// performing a match.
+	//
+	// Valid values for Hostnames are determined by RFC 1123 definition of a
+	// hostname with 2 notable exceptions:
 	//
 	// 1. IPs are not allowed.
 	// 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -53,11 +53,13 @@ spec:
             properties:
               hostnames:
                 description: "Hostnames defines a set of hostname that should match
-                  against the HTTP Host header to select a HTTPRoute to process the
-                  request. This matches the RFC 1123 definition of a hostname with
-                  2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname may
-                  be prefixed with a wildcard label (`*.`). The wildcard label must
-                  appear by itself as the first label. \n If a hostname is specified
+                  against the HTTP Host header to select a HTTPRoute used to process
+                  the request. Implementations MUST ignore any port value specified
+                  in the HTTP Host header while performing a match. \n Valid values
+                  for Hostnames are determined by RFC 1123 definition of a hostname
+                  with 2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
+                  may be prefixed with a wildcard label (`*.`). The wildcard label
+                  must appear by itself as the first label. \n If a hostname is specified
                   by both the Listener and HTTPRoute, there must be at least one intersecting
                   hostname for the HTTPRoute to be attached to the Listener. For example:
                   \n * A Listener with `test.example.com` as the hostname matches
@@ -1948,11 +1950,13 @@ spec:
             properties:
               hostnames:
                 description: "Hostnames defines a set of hostname that should match
-                  against the HTTP Host header to select a HTTPRoute to process the
-                  request. This matches the RFC 1123 definition of a hostname with
-                  2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname may
-                  be prefixed with a wildcard label (`*.`). The wildcard label must
-                  appear by itself as the first label. \n If a hostname is specified
+                  against the HTTP Host header to select a HTTPRoute used to process
+                  the request. Implementations MUST ignore any port value specified
+                  in the HTTP Host header while performing a match. \n Valid values
+                  for Hostnames are determined by RFC 1123 definition of a hostname
+                  with 2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
+                  may be prefixed with a wildcard label (`*.`). The wildcard label
+                  must appear by itself as the first label. \n If a hostname is specified
                   by both the Listener and HTTPRoute, there must be at least one intersecting
                   hostname for the HTTPRoute to be attached to the Listener. For example:
                   \n * A Listener with `test.example.com` as the hostname matches

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -53,11 +53,13 @@ spec:
             properties:
               hostnames:
                 description: "Hostnames defines a set of hostname that should match
-                  against the HTTP Host header to select a HTTPRoute to process the
-                  request. This matches the RFC 1123 definition of a hostname with
-                  2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname may
-                  be prefixed with a wildcard label (`*.`). The wildcard label must
-                  appear by itself as the first label. \n If a hostname is specified
+                  against the HTTP Host header to select a HTTPRoute used to process
+                  the request. Implementations MUST ignore any port value specified
+                  in the HTTP Host header while performing a match. \n Valid values
+                  for Hostnames are determined by RFC 1123 definition of a hostname
+                  with 2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
+                  may be prefixed with a wildcard label (`*.`). The wildcard label
+                  must appear by itself as the first label. \n If a hostname is specified
                   by both the Listener and HTTPRoute, there must be at least one intersecting
                   hostname for the HTTPRoute to be attached to the Listener. For example:
                   \n * A Listener with `test.example.com` as the hostname matches
@@ -1894,11 +1896,13 @@ spec:
             properties:
               hostnames:
                 description: "Hostnames defines a set of hostname that should match
-                  against the HTTP Host header to select a HTTPRoute to process the
-                  request. This matches the RFC 1123 definition of a hostname with
-                  2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname may
-                  be prefixed with a wildcard label (`*.`). The wildcard label must
-                  appear by itself as the first label. \n If a hostname is specified
+                  against the HTTP Host header to select a HTTPRoute used to process
+                  the request. Implementations MUST ignore any port value specified
+                  in the HTTP Host header while performing a match. \n Valid values
+                  for Hostnames are determined by RFC 1123 definition of a hostname
+                  with 2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
+                  may be prefixed with a wildcard label (`*.`). The wildcard label
+                  must appear by itself as the first label. \n If a hostname is specified
                   by both the Listener and HTTPRoute, there must be at least one intersecting
                   hostname for the HTTPRoute to be attached to the Listener. For example:
                   \n * A Listener with `test.example.com` as the hostname matches

--- a/conformance/tests/httproute-hostname-intersection.go
+++ b/conformance/tests/httproute-hostname-intersection.go
@@ -69,6 +69,13 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 					Backend:   "infra-backend-v1",
 					Namespace: ns,
 				},
+				// Port value within the Host header MUST not be considered while
+				// performing match against hostname.
+				http.ExpectedResponse{
+					Request:   http.Request{Host: "very.specific.com:1234", Path: "/s1"},
+					Backend:   "infra-backend-v1",
+					Namespace: ns,
+				},
 				http.ExpectedResponse{
 					Request:  http.Request{Host: "non.matching.com", Path: "/s1"},
 					Response: http.Response{StatusCode: 404},


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/kind test
/area conformance
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:
Add clarification for ignoring port while matching HTTPRouteSpec.Hostnames. Update conformance test to add test case covering this scenario

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/1936

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Implementations MUST ignore any port value specified in the HTTP Host header while performing a match against HTTPRoute.Hostnames
```
