### PR TITLE
Bumping webhook version to v0.7.0-rc1

### DIFF
--- a/config/webhook/admission_webhook.yaml
+++ b/config/webhook/admission_webhook.yaml
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
       - name: webhook
-        image: gcr.io/k8s-staging-gateway-api/admission-server:v0.6.2
+        image: registry.k8s.io/gateway-api/admission-server:v0.7.0-rc1
         imagePullPolicy: Always
         args:
         - -logtostderr


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Last step before v0.7.0-rc1 release, missed this in #1919. (Caught this by following release instructions and running `make generate` with this version).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
