### PR TITLE
conformance: remove broken ValidUniqueListenerPorts runner functionality

### DIFF
--- a/conformance/utils/kubernetes/apply_test.go
+++ b/conformance/utils/kubernetes/apply_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	_ "sigs.k8s.io/gateway-api/conformance/utils/flags"
 )
 
@@ -105,7 +104,7 @@ metadata:
 			},
 		}},
 	}, {
-		name:    "no listener ports given",
+		name:    "setting the gatewayClassName",
 		applier: Applier{},
 		given: `
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -136,119 +135,6 @@ spec:
 							"name":     "http",
 							"port":     int64(80),
 							"protocol": "HTTP",
-							"allowedRoutes": map[string]interface{}{
-								"namespaces": map[string]interface{}{
-									"from": "Same",
-								},
-							},
-						},
-					},
-				},
-			},
-		}},
-	}, {
-		name: "multiple gateways each with multiple listeners",
-		applier: Applier{
-			ValidUniqueListenerPorts: []v1beta1.PortNumber{8000, 8001, 8002, 8003},
-		},
-		given: `
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind:       Gateway
-metadata:
-  name: test
-spec:
-  gatewayClassName: {GATEWAY_CLASS_NAME}
-  listeners:
-    - name: http
-      port: 80
-      protocol: HTTP
-      allowedRoutes:
-        namespaces:
-          from: Same
-    - name: https
-      port: 443
-      protocol: HTTPS
-      allowedRoutes:
-        namespaces:
-          from: Same
----
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind:       Gateway
-metadata:
-  name: test2
-spec:
-  gatewayClassName: {GATEWAY_CLASS_NAME}
-  listeners:
-    - name: http
-      port: 80
-      protocol: HTTP
-      allowedRoutes:
-        namespaces:
-          from: Same
-    - name: https
-      port: 443
-      protocol: HTTPS
-      allowedRoutes:
-        namespaces:
-          from: Same
-`,
-		expected: []unstructured.Unstructured{{
-			Object: map[string]interface{}{
-				"apiVersion": "gateway.networking.k8s.io/v1beta1",
-				"kind":       "Gateway",
-				"metadata": map[string]interface{}{
-					"name": "test",
-				},
-				"spec": map[string]interface{}{
-					"gatewayClassName": "test-class",
-					"listeners": []interface{}{
-						map[string]interface{}{
-							"name":     "http",
-							"port":     int64(8000),
-							"protocol": "HTTP",
-							"allowedRoutes": map[string]interface{}{
-								"namespaces": map[string]interface{}{
-									"from": "Same",
-								},
-							},
-						},
-						map[string]interface{}{
-							"name":     "https",
-							"port":     int64(8001),
-							"protocol": "HTTPS",
-							"allowedRoutes": map[string]interface{}{
-								"namespaces": map[string]interface{}{
-									"from": "Same",
-								},
-							},
-						},
-					},
-				},
-			},
-		}, {
-			Object: map[string]interface{}{
-				"apiVersion": "gateway.networking.k8s.io/v1beta1",
-				"kind":       "Gateway",
-				"metadata": map[string]interface{}{
-					"name": "test2",
-				},
-				"spec": map[string]interface{}{
-					"gatewayClassName": "test-class",
-					"listeners": []interface{}{
-						map[string]interface{}{
-							"name":     "http",
-							"port":     int64(8002),
-							"protocol": "HTTP",
-							"allowedRoutes": map[string]interface{}{
-								"namespaces": map[string]interface{}{
-									"from": "Same",
-								},
-							},
-						},
-						map[string]interface{}{
-							"name":     "https",
-							"port":     int64(8003),
-							"protocol": "HTTPS",
 							"allowedRoutes": map[string]interface{}{
 								"namespaces": map[string]interface{}{
 									"from": "Same",

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance"
 	"sigs.k8s.io/gateway-api/conformance/utils/config"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
@@ -62,13 +61,6 @@ type Options struct {
 	BaseManifests    string
 	MeshManifests    string
 	NamespaceLabels  map[string]string
-	// ValidUniqueListenerPorts maps each listener port of each Gateway in the
-	// manifests to a valid, unique port. There must be as many
-	// ValidUniqueListenerPorts as there are listeners in the set of manifests.
-	// For example, given two Gateways, each with 2 listeners, there should be
-	// four ValidUniqueListenerPorts.
-	// If empty or nil, ports are not modified.
-	ValidUniqueListenerPorts []v1beta1.PortNumber
 
 	// CleanupBaseResources indicates whether or not the base test
 	// resources such as Gateways should be cleaned up after the run.
@@ -122,8 +114,7 @@ func New(s Options) *ConformanceTestSuite {
 		BaseManifests:    s.BaseManifests,
 		MeshManifests:    s.MeshManifests,
 		Applier: kubernetes.Applier{
-			NamespaceLabels:          s.NamespaceLabels,
-			ValidUniqueListenerPorts: s.ValidUniqueListenerPorts,
+			NamespaceLabels: s.NamespaceLabels,
 		},
 		SupportedFeatures: s.SupportedFeatures,
 		TimeoutConfig:     s.TimeoutConfig,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
/area conformance

**What this PR does / why we need it**:
Due to a recent change from servicelb to metallb for our k3s e2e test environment, this functionality is no longer needed. servicelb allocates a port on the same IP for every LoadBalancer Service, so ports had to be non-overlapping, where metallb allocates a new IP for each LoadBalancer Service.

This functionality is already broken in `main`, see #1217 which aimed to fix it. _This_ PR removes the functionality instead.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
