### PR TITLE
Updating mesh conformance images to point to k8s registry

### DIFF
--- a/conformance/mesh/manifests.yaml
+++ b/conformance/mesh/manifests.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: echo
-        image: gcr.io/istio-release/app:1.17.1
+        image: gcr.io/k8s-staging-gateway-api/echo-server:v20230505-v0.7.0-rc1-10-g497e67da
         imagePullPolicy: IfNotPresent
         args:
         - --tcp=9090
@@ -79,7 +79,7 @@ spec:
     spec:
       containers:
       - name: echo
-        image: gcr.io/istio-release/app:1.17.1
+        image: gcr.io/k8s-staging-gateway-api/echo-server:v20230505-v0.7.0-rc1-10-g497e67da
         imagePullPolicy: IfNotPresent
         args:
         - --tcp=9090


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/area conformance

**What this PR does / why we need it**:
This is the logical next step now that #1991 has merged. I considered just pointing to `:latest` but that would require for us to flip versions with every release to ensure conformance tests at a given release were consistent. Instead pinning to a version seems fine and matches what we're already doing for the other image we're using for conformance tests.

**Which issue(s) this PR fixes**:
Fixes #1895

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
