### PR TITLE
Conformance: Removing status-only redirect test

### DIFF
--- a/conformance/tests/httproute-redirect-host-and-status.go
+++ b/conformance/tests/httproute-redirect-host-and-status.go
@@ -60,15 +60,6 @@ var HTTPRouteRedirectHostAndStatus = suite.ConformanceTest{
 			Namespace: ns,
 		}, {
 			Request: http.Request{
-				Path:             "/status-code-301",
-				UnfollowRedirect: true,
-			},
-			Response: http.Response{
-				StatusCode: 301,
-			},
-			Namespace: ns,
-		}, {
-			Request: http.Request{
 				Path:             "/host-and-status",
 				UnfollowRedirect: true,
 			},

--- a/conformance/tests/httproute-redirect-host-and-status.yaml
+++ b/conformance/tests/httproute-redirect-host-and-status.yaml
@@ -18,14 +18,6 @@ spec:
   - matches:
     - path:
         type: PathPrefix
-        value: /status-code-301
-    filters:
-    - type: RequestRedirect
-      requestRedirect:
-        statusCode: 301
-  - matches:
-    - path:
-        type: PathPrefix
         value: /host-and-status
     filters:
     - type: RequestRedirect


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/area conformance

**What this PR does / why we need it**:
This was not really a practical form of redirect as it would just result in a redirect loop or similar.

**Which issue(s) this PR fixes**:
Fixes #1928

**Does this PR introduce a user-facing change?**:
```release-note
Conformance: Remove a test that only covered redirect status without any other changes. 
```
