### PR TITLE
Update stale comment for ListenerConditionAccepted

### DIFF
--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -732,15 +732,17 @@ const (
 )
 
 const (
-	// This condition indicates that, even though the listener is
-	// syntactically and semantically valid, the controller is not able
-	// to configure it on the underlying Gateway infrastructure.
+	// This condition indicates that the listener is syntactically and
+	// semantically valid, and that all features used in the listener's spec are
+	// supported.
 	//
-	// A Listener is specified as a logical requirement, but needs to be
-	// configured on a network endpoint (i.e. address and port) by a
-	// controller. The controller may be unable to attach the Listener
-	// if it specifies an unsupported requirement, or prerequisite
-	// resources are not available.
+	// In general, a Listener will be marked as Accepted when the supplied
+	// configuration will generate at least some data plane configuration.
+	//
+	// For example, a Listener with an unsupported protocol will never generate
+	// any data plane config, and so will have Accepted set to `false.`
+	// Conversely, a Listener that does not have any Routes will be able to
+	// generate data plane config, and so will have Accepted set to `true`.
 	//
 	// Possible reasons for this condition to be True are:
 	//


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:
Fixes stale comment for ListenerConditionAccepted (Pretty much copy pasting Nick's suggestion https://github.com/kubernetes-sigs/gateway-api/issues/1896#issuecomment-1493840812 :) )

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/1896

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
