### PR TITLE
conformance: add MeshConsumerRoute case for GAMMA

### DIFF
--- a/conformance/mesh/manifests.yaml
+++ b/conformance/mesh/manifests.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     gateway-conformance: mesh
 ---
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -141,3 +140,33 @@ spec:
   - name: grpc
     port: 7070
     appProtocol: grpc
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gateway-conformance-mesh-consumer
+  labels:
+    gateway-conformance: mesh-consumer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-v1
+  namespace: gateway-conformance-mesh-consumer
+  labels:
+    app: echo
+spec:
+  selector:
+    matchLabels:
+      app: echo
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: echo
+        version: v1
+    spec:
+      containers:
+      - name: echo
+        image: gcr.io/k8s-staging-gateway-api/echo-server:v20230505-v0.7.0-rc1-10-g497e67da
+        imagePullPolicy: IfNotPresent

--- a/conformance/tests/mesh-consumer-route.go
+++ b/conformance/tests/mesh-consumer-route.go
@@ -41,6 +41,7 @@ var MeshConsumerRoute = suite.ConformanceTest{
 		consumerClient := echo.ConnectToAppInNamespace(t, s, echo.MeshAppEchoV1, "gateway-conformance-mesh-consumer")
 		consumerCases := []http.ExpectedResponse{
 			{
+				TestCaseName: "request from consumer route's namespace modified by HTTPRoute",
 				Request: http.Request{
 					Host:   "echo-v1.gateway-conformance-mesh",
 					Method: "GET",
@@ -58,6 +59,7 @@ var MeshConsumerRoute = suite.ConformanceTest{
 		producerClient := echo.ConnectToAppInNamespace(t, s, echo.MeshAppEchoV1, "gateway-conformance-mesh")
 		producerCases := []http.ExpectedResponse{
 			{
+				TestCaseName: "request not from consumer route's namespace not modified by HTTPRoute",
 				Request: http.Request{
 					Host:   "echo-v1.gateway-conformance-mesh",
 					Method: "GET",

--- a/conformance/tests/mesh-consumer-route.go
+++ b/conformance/tests/mesh-consumer-route.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/echo"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, MeshConsumerRoute)
+}
+
+var MeshConsumerRoute = suite.ConformanceTest{
+	ShortName:   "MeshConsumerRoute",
+	Description: "An HTTPRoute in a namespace other than its parentRef's namespace only affects requests from the route's namespace",
+	Features: []suite.SupportedFeature{
+		suite.SupportMesh,
+		suite.SupportHTTPRoute,
+		suite.SupportHTTPResponseHeaderModification,
+	},
+	Manifests: []string{"tests/mesh-consumer-route.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		consumerClient := echo.ConnectToAppInNamespace(t, s, echo.MeshAppEchoV1, "gateway-conformance-mesh-consumer")
+		consumerCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Host:   "echo-v1.gateway-conformance-mesh",
+					Method: "GET",
+					Path:   "/",
+				},
+				Response: http.Response{
+					StatusCode: 200,
+					Headers: map[string]string{
+						"X-Header-Set": "set",
+					},
+				},
+				Backend: "echo-v1",
+			},
+		}
+		producerClient := echo.ConnectToAppInNamespace(t, s, echo.MeshAppEchoV1, "gateway-conformance-mesh")
+		producerCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Host:   "echo-v1.gateway-conformance-mesh",
+					Method: "GET",
+					Path:   "/",
+				},
+				Response: http.Response{
+					StatusCode:    200,
+					AbsentHeaders: []string{"X-Header-Set"},
+				},
+				Backend: "echo-v1",
+			},
+		}
+		for i, tc := range consumerCases {
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				consumerClient.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
+			})
+		}
+		for i, tc := range producerCases {
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				producerClient.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
+			})
+		}
+	},
+}

--- a/conformance/tests/mesh-consumer-route.yaml
+++ b/conformance/tests/mesh-consumer-route.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: mesh-echo-add-header
+  namespace: gateway-conformance-mesh-consumer
+spec:
+  parentRefs:
+  - kind: Service
+    name: echo-v1
+    namespace: gateway-conformance-mesh
+  rules:
+  - filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        set:
+        - name: X-Header-Set
+          value: set

--- a/conformance/tests/mesh-consumer-route.yaml
+++ b/conformance/tests/mesh-consumer-route.yaml
@@ -17,4 +17,5 @@ spec:
           value: set
     backendRefs:
     - name: echo-v1
+      namespace: gateway-conformance-mesh
       port: 80

--- a/conformance/tests/mesh-consumer-route.yaml
+++ b/conformance/tests/mesh-consumer-route.yaml
@@ -15,3 +15,6 @@ spec:
         set:
         - name: X-Header-Set
           value: set
+    backendRefs:
+    - name: echo-v1
+      port: 80

--- a/conformance/utils/echo/pod.go
+++ b/conformance/utils/echo/pod.go
@@ -149,9 +149,10 @@ func (m *MeshPod) request(args []string) (Response, error) {
 }
 
 func ConnectToApp(t *testing.T, s *suite.ConformanceTestSuite, app MeshApplication) MeshPod {
-	// hardcoded, for now
-	ns := "gateway-conformance-mesh"
+	return ConnectToAppInNamespace(t, s, app, "gateway-conformance-mesh")
+}
 
+func ConnectToAppInNamespace(t *testing.T, s *suite.ConformanceTestSuite, app MeshApplication, ns string) MeshPod {
 	lbls, _ := klabels.Parse(string(app))
 
 	podsList := v1.PodList{}

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -171,7 +171,7 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 	if suite.SupportedFeatures.Has(SupportMesh) {
 		t.Logf("Test Setup: Applying base manifests")
 		suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, suite.MeshManifests, suite.Cleanup)
-		t.Logf("Test Setup: Ensuring Gateways and Pods from base manifests are ready")
+		t.Logf("Test Setup: Ensuring Gateways and Pods from mesh manifests are ready")
 		namespaces := []string{
 			"gateway-conformance-mesh",
 			"gateway-conformance-mesh-consumer",

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -174,6 +174,7 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 		t.Logf("Test Setup: Ensuring Gateways and Pods from base manifests are ready")
 		namespaces := []string{
 			"gateway-conformance-mesh",
+			"gateway-conformance-mesh-consumer",
 			"gateway-conformance-app-backend",
 			"gateway-conformance-web-backend",
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind test
/area conformance

**What this PR does / why we need it**:
Tests the namespace-dependent behavior of HTTPRoute aka consumer routes.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
