### PR TITLE
gamma: drop provision to omit backendRef

### DIFF
--- a/geps/gep-1426.md
+++ b/geps/gep-1426.md
@@ -71,30 +71,6 @@ spec:
 
 In the example above, routing rules have been configured to direct 90% of traffic for the `foo` `Service` to the default "backend" endpoints specified by the `foo` `Service` [`selector`](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) field, and 10% to the `foo-v2` `Service`. This is determined based on the `ClusterIP` (for `Service`) and `ClusterSetIP` (for `ServiceImport`) matching, and for "transparent proxy" mesh implementations would match all requests to `foo.svc.cluster.local` (or arbitrary custom suffix, as the hostname is not specified manually) from within the same namespace, all requests to `foo.store.svc.cluster.local` from other namespaces, and all requests to `foo.store.svc.clusterset.local` for multicluster services, within the scope of the service mesh.
 
-### Omitting `backendRefs`
-
-Implementations SHOULD support a terse syntax which allows omitting `backendRefs` to avoid unnecessary redundancy for simple configurations. If no `backendRefs` are specified, implementations should direct traffic to the default endpoints of the `parentRef` service. The behavior should be exactly the same as if the `parentRef` service was explicitly defined as the only `backendRef`, so if the `parentRef` does not have any endpoints, implementations MUST return an HTTP 503 response code (see discussion in [#1210](https://github.com/kubernetes-sigs/gateway-api/pull/1210)).
-
-This syntax has limited utility currently, but could become more relevant if additional functionality beyond traffic splitting is added to the `xRoute` resource. `Routes` configured in this way MAY be used to manually enroll services into a mesh (which could trigger behavior like injecting a sidecar proxy) if they have not already been enrolled by some other mechanism (as proposed in [GEP-1291: Mesh Representation](https://docs.google.com/document/d/1oyA9uUH7pNNxxwy3WZGSWx-edHDBLrujcezr8q3el70/edit) or similar).
-
-```
-metadata:
-  name: foo-route
-  namespace: store
-spec:
-  parentRefs:
-  - kind: Service
-    name: foo
-  rules:
-    matches:
-    - path:
-        value: "/bar"
-```
-
-The example above would drop all incoming traffic for HTTP paths other than `/bar` to the `foo` `Service`, following the existing spec to return HTTP 404 response codes for unmatched requests, and HTTP 500 response codes for requests excluded due to an [`HTTPRouteFilter`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRouteFilter).
-
-When no `HTTPRoute` resources or AuthZ configuration are defined, all traffic should implicitly work - this is just how Kubernetes functions. When you create an `HTTPRoute` targeting a service as a `parentRef` you are replacing that implicit logic - not adding to it. Therefore, you may be reshaping or restricting traffic via an `HTTPRoute` configuration (which should be noted is distinct from disallowing traffic by AuthZ).
-
 ### Allowed service types
 
 Services valid to be selected as a `parentRef` SHOULD have a way to identify traffic to them - typically by one or more virtual IP(s), DNS hostname(s), or name(s).

--- a/geps/gep-1426.md
+++ b/geps/gep-1426.md
@@ -71,6 +71,10 @@ spec:
 
 In the example above, routing rules have been configured to direct 90% of traffic for the `foo` `Service` to the default "backend" endpoints specified by the `foo` `Service` [`selector`](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) field, and 10% to the `foo-v2` `Service`. This is determined based on the `ClusterIP` (for `Service`) and `ClusterSetIP` (for `ServiceImport`) matching, and for "transparent proxy" mesh implementations would match all requests to `foo.svc.cluster.local` (or arbitrary custom suffix, as the hostname is not specified manually) from within the same namespace, all requests to `foo.store.svc.cluster.local` from other namespaces, and all requests to `foo.store.svc.clusterset.local` for multicluster services, within the scope of the service mesh.
 
+### Route presence
+
+When no `xRoute` resources are defined, all traffic should implicitly work - this is just how Kubernetes functions. When you create an `xRoute` targeting a service as a `parentRef` you are replacing that implicit logic - not adding to it. Therefore, you may be reshaping or restricting traffic via an `xRoute` configuration (which should be noted, is distinct from *disallowing* traffic by AuthZ).
+
 ### Allowed service types
 
 Services valid to be selected as a `parentRef` SHOULD have a way to identify traffic to them - typically by one or more virtual IP(s), DNS hostname(s), or name(s).
@@ -456,3 +460,10 @@ For convenience, `ServiceProjection` could have a `meshRef` field that, when set
 
 * May require reconfiguring `Gateway` `HTTPRoutes` to specify `ServiceProjections` as `backendRefs`.
 * Verbose boilerplate for each service.
+
+### Implicit backendRef
+
+An initial iteration of this GEP had the ability to omit a `backendRef` and have it implicitly be set the same as the `parentRef`.
+This has been removed due to inconsistency with Gateway `parentRefs` and tight coupling of the "frontend" and "backend" roles.
+
+Implementations MUST respect the standard `backendRef` rules as defined by the existing spec.


### PR DESCRIPTION
**What type of PR is this?**

/kind gep

**What this PR does / why we need it**:
IMO, this does not make sense as SHOULD. It should be a MUST or not in the spec.

I have proposed removal for the following reasons:
* Inconsistent with Gateway parent ref (which also means you cannot possibly have a service parent and gateway parent)
* Limits ability to have non-Service parents, as it implies the frontend and backend are the same object

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
