### PR TITLE
conformance: Fixes to port and scheme redirect tests

### DIFF
--- a/conformance/tests/httproute-redirect-port-and-scheme.go
+++ b/conformance/tests/httproute-redirect-port-and-scheme.go
@@ -218,6 +218,7 @@ var HTTPRouteRedirectPortAndScheme = suite.ConformanceTest{
 		testCases = []http.ExpectedResponse{
 			{
 				Request: http.Request{
+					Host:             "example.org",
 					Path:             "/scheme-nil-and-port-nil",
 					UnfollowRedirect: true,
 				},
@@ -230,6 +231,7 @@ var HTTPRouteRedirectPortAndScheme = suite.ConformanceTest{
 			},
 			{
 				Request: http.Request{
+					Host:             "example.org",
 					Path:             "/scheme-nil-and-port-443",
 					UnfollowRedirect: true,
 				},
@@ -242,6 +244,7 @@ var HTTPRouteRedirectPortAndScheme = suite.ConformanceTest{
 			},
 			{
 				Request: http.Request{
+					Host:             "example.org",
 					Path:             "/scheme-nil-and-port-8443",
 					UnfollowRedirect: true,
 				},
@@ -255,6 +258,7 @@ var HTTPRouteRedirectPortAndScheme = suite.ConformanceTest{
 			},
 			{
 				Request: http.Request{
+					Host:             "example.org",
 					Path:             "/scheme-http-and-port-nil",
 					UnfollowRedirect: true,
 				},
@@ -267,6 +271,7 @@ var HTTPRouteRedirectPortAndScheme = suite.ConformanceTest{
 			},
 			{
 				Request: http.Request{
+					Host:             "example.org",
 					Path:             "/scheme-http-and-port-80",
 					UnfollowRedirect: true,
 				},
@@ -279,6 +284,7 @@ var HTTPRouteRedirectPortAndScheme = suite.ConformanceTest{
 			},
 			{
 				Request: http.Request{
+					Host:             "example.org",
 					Path:             "/scheme-http-and-port-8080",
 					UnfollowRedirect: true,
 				},
@@ -296,7 +302,7 @@ var HTTPRouteRedirectPortAndScheme = suite.ConformanceTest{
 			tc := testCases[i]
 			t.Run("https-listener-on-443/"+tc.GetTestCaseName(i), func(t *testing.T) {
 				t.Parallel()
-				tls.MakeTLSRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr443, cPem, keyPem, "example", tc)
+				tls.MakeTLSRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr443, cPem, keyPem, "example.org", tc)
 			})
 		}
 	},

--- a/conformance/utils/kubernetes/certificate.go
+++ b/conformance/utils/kubernetes/certificate.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"math/big"
 	"net"
-	"strings"
 	"testing"
 	"time"
 
@@ -50,9 +49,7 @@ func MustCreateSelfSignedCertSecret(t *testing.T, namespace, secretName string, 
 
 	var serverKey, serverCert bytes.Buffer
 
-	host := strings.Join(hosts, ",")
-
-	require.NoError(t, generateRSACert(host, &serverKey, &serverCert), "failed to generate RSA certificate")
+	require.NoError(t, generateRSACert(hosts, &serverKey, &serverCert), "failed to generate RSA certificate")
 
 	data := map[string][]byte{
 		corev1.TLSCertKey:       serverCert.Bytes(),
@@ -72,7 +69,7 @@ func MustCreateSelfSignedCertSecret(t *testing.T, namespace, secretName string, 
 }
 
 // generateRSACert generates a basic self signed certificate valid for a year
-func generateRSACert(host string, keyOut, certOut io.Writer) error {
+func generateRSACert(hosts []string, keyOut, certOut io.Writer) error {
 	priv, err := rsa.GenerateKey(rand.Reader, rsaBits)
 	if err != nil {
 		return fmt.Errorf("failed to generate key: %w", err)
@@ -101,7 +98,6 @@ func generateRSACert(host string, keyOut, certOut io.Writer) error {
 		BasicConstraintsValid: true,
 	}
 
-	hosts := strings.Split(host, ",")
 	for _, h := range hosts {
 		if ip := net.ParseIP(h); ip != nil {
 			template.IPAddresses = append(template.IPAddresses, ip)

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -155,7 +155,7 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 		t.Logf("Test Setup: Applying programmatic resources")
 		secret := kubernetes.MustCreateSelfSignedCertSecret(t, "gateway-conformance-web-backend", "certificate", []string{"*"})
 		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{secret}, suite.Cleanup)
-		secret = kubernetes.MustCreateSelfSignedCertSecret(t, "gateway-conformance-infra", "tls-validity-checks-certificate", []string{"*"})
+		secret = kubernetes.MustCreateSelfSignedCertSecret(t, "gateway-conformance-infra", "tls-validity-checks-certificate", []string{"*", "*.org"})
 		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{secret}, suite.Cleanup)
 		secret = kubernetes.MustCreateSelfSignedCertSecret(t, "gateway-conformance-infra", "tls-passthrough-checks-certificate", []string{"abc.example.com"})
 		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{secret}, suite.Cleanup)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup
/area conformance

**What this PR does / why we need it**:
Tests expected redirect host was not consistent with request host, were sending HTTPS requests send inconsistent SNI and Host, cert presented by Gateway did not have the correct SANs.

**Which issue(s) this PR fixes**:
Fixes #2038

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
