### PR TITLE
Moved Response Header from Experimental to Standard

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,12 +88,12 @@ nav:
         - geps/gep-1709.md
       - Experimental:
         - geps/gep-1748.md
-        - geps/gep-1323.md
         - geps/gep-1016.md
         - geps/gep-957.md
         - geps/gep-713.md
       - Standard:
         - geps/gep-1364.md
+        - geps/gep-1323.md
         - geps/gep-922.md
         - geps/gep-917.md
         - geps/gep-851.md


### PR DESCRIPTION
Doc update: moving Response Header from Experimental to Standard with v0.7.0 release

**What type of PR is this?**
/kind documentation

**Does this PR introduce a user-facing change?:**
No

```release-note
Minor doc update
```


