### PR TITLE
chore: cleanup TODO list and alternatives considered for GEP 1709

### DIFF
--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -25,10 +25,6 @@ The following are items that we intend to resolve before we consider this GEP
 - We need to think about how we're going to highlight and report on the
   results for `experimental` features, and make sure this is explicitly
   written out.
-- We are [gathering feedback from SIG Arch][sig-arch-feedback]. We need to let
-  this soak for some time, bring up the topic at SIG Arch community meetings, and
-  generally make changes according to their feedback before considering this
-  `implementable`.
 - Right now we've said that `GatewayClass` and `Gateway` tests will be
   implicitly added to testing profiles were they are referenced, but we're
   not sure yet whether this is going to work out for `ReferenceGrant` as we
@@ -38,6 +34,13 @@ The following are items that we intend to resolve before we consider this GEP
   this but still be conformant. Needs to be resolved before we move to
   `implementable` as `ReferenceGrant` is already in BETA and is being
   considered in other areas of Kubernetes.
+
+The following are items that **MUST** be resolved before we move past the
+`experimental` status:
+
+- We have been actively [gathering feedback from SIG Arch][sig-arch-feedback].
+  Some time during the `experimental` phase needs to be allowed to continue to
+  engage with SIG Arch and incorporate their feedback into the test suite.
 
 [sig-arch-feedback]:https://groups.google.com/g/kubernetes-sig-architecture/c/YjrVZ4NJQiA/m/7Qg7ScddBwAJ
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -25,15 +25,6 @@ The following are items that we intend to resolve before we consider this GEP
 - We need to think about how we're going to highlight and report on the
   results for `experimental` features, and make sure this is explicitly
   written out.
-- Right now we've said that `GatewayClass` and `Gateway` tests will be
-  implicitly added to testing profiles were they are referenced, but we're
-  not sure yet whether this is going to work out for `ReferenceGrant` as we
-  know of at least one implementation that explicitly doesn't support it.
-  It's possible `ReferenceGrant` is just a special case for a profile we'll
-  have to allow opting into or out of, or maybe some other optional way to do
-  this but still be conformant. Needs to be resolved before we move to
-  `implementable` as `ReferenceGrant` is already in BETA and is being
-  considered in other areas of Kubernetes.
 
 The following are items that **MUST** be resolved before we move past the
 `experimental` status:

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -582,14 +582,6 @@ iteration to add this if desired, but it probably warrants its own GEP as we
 need to make sure we have buy-in from multiple stakeholders with different
 implementations that are implementing those features.
 
-### Mesh Profiles
-
-We eventually want profiles for GAMMA/mesh related tests, however at this point
-we believe the test suite for mesh could end up being it's own separate thing
-so it's not a part of this GEP for now, but we should make sure our tooling is
-modular and composable so if we do end up with an eventual mesh conformance
-test suite, it can employ conformance profiles and reporting as-is.
-
 ### High Level Profiles
 
 We originally started with two high level profiles:

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -12,16 +12,9 @@ the Gateway API project and receive recognition (e.g. badges).
 
 ## TODO
 
-The following are items that we intend to resolve before we consider this GEP
-`implementable`:
+The following are items that **MUST** be resolved before we move past the
+`provisioning/prototyping` status:
 
-- We still need to sort out how we're going to display conformance results.
-  Badges are well and good, but we also want some kind of summarized
-  display of any given implementation's conformance results somewhere on
-  our upstream website (so far the thought has been the [implementations
-  page][impl]). We should look for prior art in Kubernetes SIGs and also
-  reach out to some frontend developers to come up with something really
-  solid prior to moving to `implementable`.
 - We need to think about how we're going to highlight and report on the
   results for `experimental` features, and make sure this is explicitly
   written out.
@@ -32,6 +25,11 @@ The following are items that **MUST** be resolved before we move past the
 - We have been actively [gathering feedback from SIG Arch][sig-arch-feedback].
   Some time during the `experimental` phase needs to be allowed to continue to
   engage with SIG Arch and incorporate their feedback into the test suite.
+- We need to sort out how we're going to display conformance results. We want
+  some kind of summarized display of any given implementation's conformance
+  results somewhere on our upstream website (so far the thought has been the
+  [implementations page][impl]). We should look for prior art in Kubernetes
+  SIGs and also reach out to some frontend developers.
 
 [sig-arch-feedback]:https://groups.google.com/g/kubernetes-sig-architecture/c/YjrVZ4NJQiA/m/7Qg7ScddBwAJ
 


### PR DESCRIPTION
**What type of PR is this?**

/kind gep
/area conformance

**What this PR does / why we need it**:

In support of #1709 this cleans up our alternatives considered and TODO list. It moves some TODO items as blocking for post-`experimental` as opposed to blocking `implementable` based on our recent experience that suggests blocking at that level is not needed.