### PR TITLE
Add method matching to HTTPRoute matching precedence order

### DIFF
--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -158,12 +158,13 @@ type HTTPRouteRule struct {
 	// Proxy or Load Balancer routing configuration generated from HTTPRoutes
 	// MUST prioritize matches based on the following criteria, continuing on
 	// ties. Across all rules specified on applicable Routes, precedence must be
-	// given to the match with the largest number of:
+	// given to the match having:
 	//
-	// * Characters in a matching "Exact" path match
-	// * Characters in a matching "Prefix" path match
-	// * Header matches.
-	// * Query param matches.
+	// * "Exact" path match.
+	// * "Prefix" path match with largest number of characters.
+	// * Method match.
+	// * Largest number of header matches.
+	// * Largest number of query param matches.
 	//
 	// Note: The precedence of RegularExpression path matches are implementation-specific.
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -1509,21 +1509,21 @@ spec:
                         request. \n Proxy or Load Balancer routing configuration generated
                         from HTTPRoutes MUST prioritize matches based on the following
                         criteria, continuing on ties. Across all rules specified on
-                        applicable Routes, precedence must be given to the match with
-                        the largest number of: \n * Characters in a matching \"Exact\"
-                        path match * Characters in a matching \"Prefix\" path match
-                        * Header matches. * Query param matches. \n Note: The precedence
-                        of RegularExpression path matches are implementation-specific.
-                        \n If ties still exist across multiple Routes, matching precedence
-                        MUST be determined in order of the following criteria, continuing
-                        on ties: \n * The oldest Route based on creation timestamp.
-                        * The Route appearing first in alphabetical order by \"{namespace}/{name}\".
-                        \n If ties still exist within an HTTPRoute, matching precedence
-                        MUST be granted to the FIRST matching rule (in list order)
-                        with a match meeting the above criteria. \n When no rules
-                        matching a request have been successfully attached to the
-                        parent a request is coming from, a HTTP 404 status code MUST
-                        be returned."
+                        applicable Routes, precedence must be given to the match having:
+                        \n * \"Exact\" path match. * \"Prefix\" path match with largest
+                        number of characters. * Method match. * Largest number of
+                        header matches. * Largest number of query param matches. \n
+                        Note: The precedence of RegularExpression path matches are
+                        implementation-specific. \n If ties still exist across multiple
+                        Routes, matching precedence MUST be determined in order of
+                        the following criteria, continuing on ties: \n * The oldest
+                        Route based on creation timestamp. * The Route appearing first
+                        in alphabetical order by \"{namespace}/{name}\". \n If ties
+                        still exist within an HTTPRoute, matching precedence MUST
+                        be granted to the FIRST matching rule (in list order) with
+                        a match meeting the above criteria. \n When no rules matching
+                        a request have been successfully attached to the parent a
+                        request is coming from, a HTTP 404 status code MUST be returned."
                       items:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given action. Multiple match types are
@@ -3431,21 +3431,21 @@ spec:
                         request. \n Proxy or Load Balancer routing configuration generated
                         from HTTPRoutes MUST prioritize matches based on the following
                         criteria, continuing on ties. Across all rules specified on
-                        applicable Routes, precedence must be given to the match with
-                        the largest number of: \n * Characters in a matching \"Exact\"
-                        path match * Characters in a matching \"Prefix\" path match
-                        * Header matches. * Query param matches. \n Note: The precedence
-                        of RegularExpression path matches are implementation-specific.
-                        \n If ties still exist across multiple Routes, matching precedence
-                        MUST be determined in order of the following criteria, continuing
-                        on ties: \n * The oldest Route based on creation timestamp.
-                        * The Route appearing first in alphabetical order by \"{namespace}/{name}\".
-                        \n If ties still exist within an HTTPRoute, matching precedence
-                        MUST be granted to the FIRST matching rule (in list order)
-                        with a match meeting the above criteria. \n When no rules
-                        matching a request have been successfully attached to the
-                        parent a request is coming from, a HTTP 404 status code MUST
-                        be returned."
+                        applicable Routes, precedence must be given to the match having:
+                        \n * \"Exact\" path match. * \"Prefix\" path match with largest
+                        number of characters. * Method match. * Largest number of
+                        header matches. * Largest number of query param matches. \n
+                        Note: The precedence of RegularExpression path matches are
+                        implementation-specific. \n If ties still exist across multiple
+                        Routes, matching precedence MUST be determined in order of
+                        the following criteria, continuing on ties: \n * The oldest
+                        Route based on creation timestamp. * The Route appearing first
+                        in alphabetical order by \"{namespace}/{name}\". \n If ties
+                        still exist within an HTTPRoute, matching precedence MUST
+                        be granted to the FIRST matching rule (in list order) with
+                        a match meeting the above criteria. \n When no rules matching
+                        a request have been successfully attached to the parent a
+                        request is coming from, a HTTP 404 status code MUST be returned."
                       items:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given action. Multiple match types are

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -1483,21 +1483,21 @@ spec:
                         request. \n Proxy or Load Balancer routing configuration generated
                         from HTTPRoutes MUST prioritize matches based on the following
                         criteria, continuing on ties. Across all rules specified on
-                        applicable Routes, precedence must be given to the match with
-                        the largest number of: \n * Characters in a matching \"Exact\"
-                        path match * Characters in a matching \"Prefix\" path match
-                        * Header matches. * Query param matches. \n Note: The precedence
-                        of RegularExpression path matches are implementation-specific.
-                        \n If ties still exist across multiple Routes, matching precedence
-                        MUST be determined in order of the following criteria, continuing
-                        on ties: \n * The oldest Route based on creation timestamp.
-                        * The Route appearing first in alphabetical order by \"{namespace}/{name}\".
-                        \n If ties still exist within an HTTPRoute, matching precedence
-                        MUST be granted to the FIRST matching rule (in list order)
-                        with a match meeting the above criteria. \n When no rules
-                        matching a request have been successfully attached to the
-                        parent a request is coming from, a HTTP 404 status code MUST
-                        be returned."
+                        applicable Routes, precedence must be given to the match having:
+                        \n * \"Exact\" path match. * \"Prefix\" path match with largest
+                        number of characters. * Method match. * Largest number of
+                        header matches. * Largest number of query param matches. \n
+                        Note: The precedence of RegularExpression path matches are
+                        implementation-specific. \n If ties still exist across multiple
+                        Routes, matching precedence MUST be determined in order of
+                        the following criteria, continuing on ties: \n * The oldest
+                        Route based on creation timestamp. * The Route appearing first
+                        in alphabetical order by \"{namespace}/{name}\". \n If ties
+                        still exist within an HTTPRoute, matching precedence MUST
+                        be granted to the FIRST matching rule (in list order) with
+                        a match meeting the above criteria. \n When no rules matching
+                        a request have been successfully attached to the parent a
+                        request is coming from, a HTTP 404 status code MUST be returned."
                       items:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given action. Multiple match types are
@@ -3351,21 +3351,21 @@ spec:
                         request. \n Proxy or Load Balancer routing configuration generated
                         from HTTPRoutes MUST prioritize matches based on the following
                         criteria, continuing on ties. Across all rules specified on
-                        applicable Routes, precedence must be given to the match with
-                        the largest number of: \n * Characters in a matching \"Exact\"
-                        path match * Characters in a matching \"Prefix\" path match
-                        * Header matches. * Query param matches. \n Note: The precedence
-                        of RegularExpression path matches are implementation-specific.
-                        \n If ties still exist across multiple Routes, matching precedence
-                        MUST be determined in order of the following criteria, continuing
-                        on ties: \n * The oldest Route based on creation timestamp.
-                        * The Route appearing first in alphabetical order by \"{namespace}/{name}\".
-                        \n If ties still exist within an HTTPRoute, matching precedence
-                        MUST be granted to the FIRST matching rule (in list order)
-                        with a match meeting the above criteria. \n When no rules
-                        matching a request have been successfully attached to the
-                        parent a request is coming from, a HTTP 404 status code MUST
-                        be returned."
+                        applicable Routes, precedence must be given to the match having:
+                        \n * \"Exact\" path match. * \"Prefix\" path match with largest
+                        number of characters. * Method match. * Largest number of
+                        header matches. * Largest number of query param matches. \n
+                        Note: The precedence of RegularExpression path matches are
+                        implementation-specific. \n If ties still exist across multiple
+                        Routes, matching precedence MUST be determined in order of
+                        the following criteria, continuing on ties: \n * The oldest
+                        Route based on creation timestamp. * The Route appearing first
+                        in alphabetical order by \"{namespace}/{name}\". \n If ties
+                        still exist within an HTTPRoute, matching precedence MUST
+                        be granted to the FIRST matching rule (in list order) with
+                        a match meeting the above criteria. \n When no rules matching
+                        a request have been successfully attached to the parent a
+                        request is coming from, a HTTP 404 status code MUST be returned."
                       items:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given action. Multiple match types are

--- a/conformance/tests/httproute-method-matching.go
+++ b/conformance/tests/httproute-method-matching.go
@@ -118,7 +118,7 @@ var HTTPRouteMethodMatching = suite.ConformanceTest{
 			},
 			{
 				Request:   http.Request{Headers: map[string]string{"version": "four"}, Path: "/", Method: "PATCH"},
-				Backend:   "infra-backend-v3",
+				Backend:   "infra-backend-v2",
 				Namespace: ns,
 			},
 		}...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
/kind documentation
/kind test
/area conformance
<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind gep


Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Clarify the precedency that Method matching has while comparing similar HTTPRouteRules.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/1993

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
HTTPRoute Method matching precedence has been clarified
```
