### PR TITLE
Clarifying HTTPRoute exact match behavior

### DIFF
--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -273,7 +273,9 @@ type HTTPRouteRule struct {
 type PathMatchType string
 
 const (
-	// Matches the URL path exactly and with case sensitivity.
+	// Matches the URL path exactly and with case sensitivity. This means that
+	// an exact path match on `/abc` will only match requests to `/abc`, NOT
+	// `/abc/`, `/Abc`, or `/abcd`.
 	PathMatchExact PathMatchType = "Exact"
 
 	// Matches based on a URL path prefix split by `/`. Matching is

--- a/conformance/tests/httproute-exact-path-matching.go
+++ b/conformance/tests/httproute-exact-path-matching.go
@@ -63,6 +63,9 @@ var HTTPExactPathMatching = suite.ConformanceTest{
 			}, {
 				Request:  http.Request{Path: "/two/"},
 				Response: http.Response{StatusCode: 404},
+			}, {
+				Request:  http.Request{Path: "/Two"},
+				Response: http.Response{StatusCode: 404},
 			},
 		}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/area conformance

**What this PR does / why we need it**:
This clarifies that exact path matches in HTTPRoute are truly exact. Both trailing slashes and capitalization are meaningful. This matches the consensus on https://github.com/kubernetes-sigs/gateway-api/issues/1953 and from our community meeting today. It also largely matches what our conformance tests already covered, this just slightly expands that coverage.

**Which issue(s) this PR fixes**:
Fixes #1953

**Does this PR introduce a user-facing change?**:
```release-note
HTTPRoute: Clarified that exact path matches are truly exact, both trailing slashes and capitalization are meaningful.
```