### PR TITLE
chore: conformance profiles API version and channel

### DIFF
--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -257,7 +257,7 @@ move on to [certification](#certification) to report the results.
 
 The certification is related to a specific API version and a specific channel,
 therefore such information must be included in the final report.
-At `ExperimentalConformanceTestSuite.Setup` time, the conformance profile
+At test suite setup time, the conformance profile
 machinery gets all the CRDs with the field `.spec.group` equal to
 `gateway.networking.k8s.io`, and for each of them checks the annotations
 `gateway.networking.k8s.io/bundle-version` and

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -268,9 +268,28 @@ there are CRDs with different channels, the certification fails specifying
 that it's not possible to run the tests as there are different Gateway API
 channels installed in the cluster. If all the Gateway API `CRD`s have the same
 version and the same channel, the tests can be run and the detected version
-and channel will be set in the `GatewayAPIVersion` and `gatewayAPIChannel` fields of the
-final report. Furthermore, the suite must run all the experimental tests when
-the channel is `experimental`, and the related features are enabled.
+and channel will be set in the `GatewayAPIVersion` and `gatewayAPIChannel`
+fields of the final report. Furthermore, the suite must run all the
+experimental tests when the channel is `experimental`, and the related features
+are enabled.
+
+In addition to the `CRD`s version, the suite needs to check its version in
+relation to the `CRD`s one. To do so, a new `.go` file containing the current
+Gateway API version is introduced in the project and compiled with the
+conformance profile suite:
+
+```go
+const GatewayAPIVersion = "0.7.0"
+```
+
+At test suite setup time the conformance profile suite
+checks the `CRD`s version and the suite version; if the two versions differ,
+the certification fails.
+A new generator will be introduced in the project to generate the
+aforementioned `.go` file starting from a VERSION file contained in the root
+folder. Such a VERSION file contains the semver of the latest release and is
+manually bumped at release time. The script hack/verify-all.sh will be updated
+to ensure the generated `.go` file is up to date with the VERSION file.
 
 ### Certification
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -253,6 +253,25 @@ move on to [certification](#certification) to report the results.
 [go]:https://go.dev
 [lib]:https://pkg.go.dev/sigs.k8s.io/gateway-api@v0.6.2/conformance/utils/suite
 
+### Gateway API version and channel
+
+The certification is related to a specific API version and a specific channel,
+therefore such information must be included in the final report.
+At `ExperimentalConformanceTestSuite.Setup` time, the conformance profile
+machinery gets all the CRDs with the field `.spec.group` equal to
+`gateway.networking.k8s.io`, and for each of them checks the annotations
+`gateway.networking.k8s.io/bundle-version` and
+`gateway.networking.k8s.io/channel`. If there are `CRD`s with different
+versions, the certification fails specifying that it's not possible to run the
+tests as there are different Gateway API versions installed in the cluster. If
+there are CRDs with different channels, the certification fails specifying
+that it's not possible to run the tests as there are different Gateway API
+channels installed in the cluster. If all the Gateway API `CRD`s have the same
+version and the same channel, the tests can be run and the detected version
+and channel will be set in the `GatewayAPIVersion` and `gatewayAPIChannel` fields of the
+final report. Furthermore, the suite must run all the experimental tests when
+the channel is `experimental`, and the related features are enabled.
+
 ### Certification
 
 Implementations will be able to report their conformance testing results using
@@ -280,6 +299,7 @@ implementation:
   - @acme/maintainers
 date: "2023-02-28 20:29:41+00:00"
 gatewayAPIVersion: v0.7.0
+gatewayAPIChannel: standard
 profiles:
   - name: tcp
     core:
@@ -360,6 +380,7 @@ implementation:
   - @acme/maintainers
 date: "2022-09-28 20:29:41+00:00"
 gatewayAPIVersion: v0.6.2
+gatewayAPIChannel: standard
 profiles:
   - name: tcp
     core:
@@ -417,6 +438,7 @@ implementation:
   - @acme/maintainers
 date: "2022-08-28 20:29:41+00:00"
 gatewayAPIVersion: v0.6.1
+gatewayAPIChannel: standard
 profiles:
   - name: tcp
     core:
@@ -465,6 +487,7 @@ implementation:
   - @acme/maintainers
 date: "2022-07-28 20:29:41+00:00"
 gatewayAPIVersion: v0.6.0
+gatewayAPIChannel: standard
 profiles:
   - name: http
     core:

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -256,22 +256,20 @@ move on to [certification](#certification) to report the results.
 ### Gateway API version and channel
 
 The certification is related to a specific API version and a specific channel,
-therefore such information must be included in the final report.
-At test suite setup time, the conformance profile
-machinery gets all the CRDs with the field `.spec.group` equal to
-`gateway.networking.k8s.io`, and for each of them checks the annotations
-`gateway.networking.k8s.io/bundle-version` and
+therefore such information must be included in the final report. At test suite
+setup time, the conformance profile machinery gets all the CRDs with the field
+`.spec.group` equal to `gateway.networking.k8s.io`, and for each of them checks
+the annotations `gateway.networking.k8s.io/bundle-version` and
 `gateway.networking.k8s.io/channel`. If there are `CRD`s with different
 versions, the certification fails specifying that it's not possible to run the
 tests as there are different Gateway API versions installed in the cluster. If
-there are CRDs with different channels, the certification fails specifying
-that it's not possible to run the tests as there are different Gateway API
-channels installed in the cluster. If all the Gateway API `CRD`s have the same
-version and the same channel, the tests can be run and the detected version
-and channel will be set in the `GatewayAPIVersion` and `gatewayAPIChannel`
-fields of the final report. Furthermore, the suite must run all the
-experimental tests when the channel is `experimental`, and the related features
-are enabled.
+there are CRDs with different channels, the certification fails specifying that
+it's not possible to run the tests as there are different Gateway API channels
+installed in the cluster. If all the Gateway API `CRD`s have the same version
+and the same channel, the tests can be run and the detected version and channel
+will be set in the `GatewayAPIVersion` and `gatewayAPIChannel` fields of the
+final report. Furthermore, the suite must run all the experimental tests when
+the channel is `experimental`, and the related features are enabled.
 
 In addition to the `CRD`s version, the suite needs to check its version in
 relation to the `CRD`s one. To do so, a new `.go` file containing the current
@@ -282,14 +280,13 @@ conformance profile suite:
 const GatewayAPIVersion = "0.7.0"
 ```
 
-At test suite setup time the conformance profile suite
-checks the `CRD`s version and the suite version; if the two versions differ,
-the certification fails.
-A new generator will be introduced in the project to generate the
-aforementioned `.go` file starting from a VERSION file contained in the root
-folder. Such a VERSION file contains the semver of the latest release and is
-manually bumped at release time. The script hack/verify-all.sh will be updated
-to ensure the generated `.go` file is up to date with the VERSION file.
+At test suite setup time the conformance profile suite checks the `CRD`s version
+and the suite version; if the two versions differ, the certification fails. A
+new generator will be introduced in the project to generate the aforementioned
+`.go` file starting from a VERSION file contained in the root folder. Such a
+VERSION file contains the semver of the latest release and is manually bumped at
+release time. The script hack/verify-all.sh will be updated to ensure the
+generated `.go` file is up to date with the VERSION file.
 
 ### Certification
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind gep
/area conformance

**What this PR does / why we need it**:

In support of https://github.com/kubernetes-sigs/gateway-api/issues/1709, the GEP-1709 has been updated with content on how to detect the `gatewayAPIVersion` and the `gatewayAPIChannel` and how to check their consistency.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
