### PR TITLE
define core protocol/port combinations

### DIFF
--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -70,7 +70,8 @@ type GatewaySpec struct {
 	// At least one Listener MUST be specified.
 	//
 	// Each listener in a Gateway must have a unique combination of Hostname,
-	// Port, and Protocol. Combinations that are considered Core are:
+	// Port, and Protocol. Below combinations are considered Core and MUST be
+	// supported:
 	//
 	// 1. Port: 80, Protocol: HTTP
 	// 2. Port: 443, Protocol: HTTPS

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -70,7 +70,12 @@ type GatewaySpec struct {
 	// At least one Listener MUST be specified.
 	//
 	// Each listener in a Gateway must have a unique combination of Hostname,
-	// Port, and Protocol.
+	// Port, and Protocol. Combinations that are considered Core are:
+	//
+	// 1. Port: 80, Protocol: HTTP
+	// 2. Port: 443, Protocol: HTTPS
+	//
+	// Port and protocol combinations not in this list are considered Extended.
 	//
 	// An implementation MAY group Listeners by Port and then collapse each
 	// group of Listeners into a single Listener if the implementation

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -108,27 +108,30 @@ spec:
                   logical endpoints that are bound on this Gateway's addresses. At
                   least one Listener MUST be specified. \n Each listener in a Gateway
                   must have a unique combination of Hostname, Port, and Protocol.
-                  \n An implementation MAY group Listeners by Port and then collapse
-                  each group of Listeners into a single Listener if the implementation
-                  determines that the Listeners in the group are \"compatible\". An
-                  implementation MAY also group together and collapse compatible Listeners
-                  belonging to different Gateways. \n For example, an implementation
-                  might consider Listeners to be compatible with each other if all
-                  of the following conditions are met: \n 1. Either each Listener
-                  within the group specifies the \"HTTP\" Protocol or each Listener
-                  within the group specifies either the \"HTTPS\" or \"TLS\" Protocol.
-                  \n 2. Each Listener within the group specifies a Hostname that is
-                  unique within the group. \n 3. As a special case, one Listener within
-                  a group may omit Hostname, in which case this Listener matches when
-                  no other Listener matches. \n If the implementation does collapse
-                  compatible Listeners, the hostname provided in the incoming client
-                  request MUST be matched to a Listener to find the correct set of
-                  Routes. The incoming hostname MUST be matched using the Hostname
-                  field for each Listener in order of most to least specific. That
-                  is, exact matches must be processed before wildcard matches. \n
-                  If this field specifies multiple Listeners that have the same Port
-                  value but are not compatible, the implementation must raise a \"Conflicted\"
-                  condition in the Listener status. \n Support: Core"
+                  Combinations that are considered Core are: \n 1. Port: 80, Protocol:
+                  HTTP 2. Port: 443, Protocol: HTTPS \n Port and protocol combinations
+                  not in this list are considered Extended. \n An implementation MAY
+                  group Listeners by Port and then collapse each group of Listeners
+                  into a single Listener if the implementation determines that the
+                  Listeners in the group are \"compatible\". An implementation MAY
+                  also group together and collapse compatible Listeners belonging
+                  to different Gateways. \n For example, an implementation might consider
+                  Listeners to be compatible with each other if all of the following
+                  conditions are met: \n 1. Either each Listener within the group
+                  specifies the \"HTTP\" Protocol or each Listener within the group
+                  specifies either the \"HTTPS\" or \"TLS\" Protocol. \n 2. Each Listener
+                  within the group specifies a Hostname that is unique within the
+                  group. \n 3. As a special case, one Listener within a group may
+                  omit Hostname, in which case this Listener matches when no other
+                  Listener matches. \n If the implementation does collapse compatible
+                  Listeners, the hostname provided in the incoming client request
+                  MUST be matched to a Listener to find the correct set of Routes.
+                  The incoming hostname MUST be matched using the Hostname field for
+                  each Listener in order of most to least specific. That is, exact
+                  matches must be processed before wildcard matches. \n If this field
+                  specifies multiple Listeners that have the same Port value but are
+                  not compatible, the implementation must raise a \"Conflicted\" condition
+                  in the Listener status. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -811,27 +814,30 @@ spec:
                   logical endpoints that are bound on this Gateway's addresses. At
                   least one Listener MUST be specified. \n Each listener in a Gateway
                   must have a unique combination of Hostname, Port, and Protocol.
-                  \n An implementation MAY group Listeners by Port and then collapse
-                  each group of Listeners into a single Listener if the implementation
-                  determines that the Listeners in the group are \"compatible\". An
-                  implementation MAY also group together and collapse compatible Listeners
-                  belonging to different Gateways. \n For example, an implementation
-                  might consider Listeners to be compatible with each other if all
-                  of the following conditions are met: \n 1. Either each Listener
-                  within the group specifies the \"HTTP\" Protocol or each Listener
-                  within the group specifies either the \"HTTPS\" or \"TLS\" Protocol.
-                  \n 2. Each Listener within the group specifies a Hostname that is
-                  unique within the group. \n 3. As a special case, one Listener within
-                  a group may omit Hostname, in which case this Listener matches when
-                  no other Listener matches. \n If the implementation does collapse
-                  compatible Listeners, the hostname provided in the incoming client
-                  request MUST be matched to a Listener to find the correct set of
-                  Routes. The incoming hostname MUST be matched using the Hostname
-                  field for each Listener in order of most to least specific. That
-                  is, exact matches must be processed before wildcard matches. \n
-                  If this field specifies multiple Listeners that have the same Port
-                  value but are not compatible, the implementation must raise a \"Conflicted\"
-                  condition in the Listener status. \n Support: Core"
+                  Combinations that are considered Core are: \n 1. Port: 80, Protocol:
+                  HTTP 2. Port: 443, Protocol: HTTPS \n Port and protocol combinations
+                  not in this list are considered Extended. \n An implementation MAY
+                  group Listeners by Port and then collapse each group of Listeners
+                  into a single Listener if the implementation determines that the
+                  Listeners in the group are \"compatible\". An implementation MAY
+                  also group together and collapse compatible Listeners belonging
+                  to different Gateways. \n For example, an implementation might consider
+                  Listeners to be compatible with each other if all of the following
+                  conditions are met: \n 1. Either each Listener within the group
+                  specifies the \"HTTP\" Protocol or each Listener within the group
+                  specifies either the \"HTTPS\" or \"TLS\" Protocol. \n 2. Each Listener
+                  within the group specifies a Hostname that is unique within the
+                  group. \n 3. As a special case, one Listener within a group may
+                  omit Hostname, in which case this Listener matches when no other
+                  Listener matches. \n If the implementation does collapse compatible
+                  Listeners, the hostname provided in the incoming client request
+                  MUST be matched to a Listener to find the correct set of Routes.
+                  The incoming hostname MUST be matched using the Hostname field for
+                  each Listener in order of most to least specific. That is, exact
+                  matches must be processed before wildcard matches. \n If this field
+                  specifies multiple Listeners that have the same Port value but are
+                  not compatible, the implementation must raise a \"Conflicted\" condition
+                  in the Listener status. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -108,30 +108,30 @@ spec:
                   logical endpoints that are bound on this Gateway's addresses. At
                   least one Listener MUST be specified. \n Each listener in a Gateway
                   must have a unique combination of Hostname, Port, and Protocol.
-                  Combinations that are considered Core are: \n 1. Port: 80, Protocol:
-                  HTTP 2. Port: 443, Protocol: HTTPS \n Port and protocol combinations
-                  not in this list are considered Extended. \n An implementation MAY
-                  group Listeners by Port and then collapse each group of Listeners
-                  into a single Listener if the implementation determines that the
-                  Listeners in the group are \"compatible\". An implementation MAY
-                  also group together and collapse compatible Listeners belonging
-                  to different Gateways. \n For example, an implementation might consider
-                  Listeners to be compatible with each other if all of the following
-                  conditions are met: \n 1. Either each Listener within the group
-                  specifies the \"HTTP\" Protocol or each Listener within the group
-                  specifies either the \"HTTPS\" or \"TLS\" Protocol. \n 2. Each Listener
-                  within the group specifies a Hostname that is unique within the
-                  group. \n 3. As a special case, one Listener within a group may
-                  omit Hostname, in which case this Listener matches when no other
-                  Listener matches. \n If the implementation does collapse compatible
-                  Listeners, the hostname provided in the incoming client request
-                  MUST be matched to a Listener to find the correct set of Routes.
-                  The incoming hostname MUST be matched using the Hostname field for
-                  each Listener in order of most to least specific. That is, exact
-                  matches must be processed before wildcard matches. \n If this field
-                  specifies multiple Listeners that have the same Port value but are
-                  not compatible, the implementation must raise a \"Conflicted\" condition
-                  in the Listener status. \n Support: Core"
+                  Below combinations are considered Core and MUST be supported: \n
+                  1. Port: 80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS \n Port
+                  and protocol combinations not in this list are considered Extended.
+                  \n An implementation MAY group Listeners by Port and then collapse
+                  each group of Listeners into a single Listener if the implementation
+                  determines that the Listeners in the group are \"compatible\". An
+                  implementation MAY also group together and collapse compatible Listeners
+                  belonging to different Gateways. \n For example, an implementation
+                  might consider Listeners to be compatible with each other if all
+                  of the following conditions are met: \n 1. Either each Listener
+                  within the group specifies the \"HTTP\" Protocol or each Listener
+                  within the group specifies either the \"HTTPS\" or \"TLS\" Protocol.
+                  \n 2. Each Listener within the group specifies a Hostname that is
+                  unique within the group. \n 3. As a special case, one Listener within
+                  a group may omit Hostname, in which case this Listener matches when
+                  no other Listener matches. \n If the implementation does collapse
+                  compatible Listeners, the hostname provided in the incoming client
+                  request MUST be matched to a Listener to find the correct set of
+                  Routes. The incoming hostname MUST be matched using the Hostname
+                  field for each Listener in order of most to least specific. That
+                  is, exact matches must be processed before wildcard matches. \n
+                  If this field specifies multiple Listeners that have the same Port
+                  value but are not compatible, the implementation must raise a \"Conflicted\"
+                  condition in the Listener status. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -814,30 +814,30 @@ spec:
                   logical endpoints that are bound on this Gateway's addresses. At
                   least one Listener MUST be specified. \n Each listener in a Gateway
                   must have a unique combination of Hostname, Port, and Protocol.
-                  Combinations that are considered Core are: \n 1. Port: 80, Protocol:
-                  HTTP 2. Port: 443, Protocol: HTTPS \n Port and protocol combinations
-                  not in this list are considered Extended. \n An implementation MAY
-                  group Listeners by Port and then collapse each group of Listeners
-                  into a single Listener if the implementation determines that the
-                  Listeners in the group are \"compatible\". An implementation MAY
-                  also group together and collapse compatible Listeners belonging
-                  to different Gateways. \n For example, an implementation might consider
-                  Listeners to be compatible with each other if all of the following
-                  conditions are met: \n 1. Either each Listener within the group
-                  specifies the \"HTTP\" Protocol or each Listener within the group
-                  specifies either the \"HTTPS\" or \"TLS\" Protocol. \n 2. Each Listener
-                  within the group specifies a Hostname that is unique within the
-                  group. \n 3. As a special case, one Listener within a group may
-                  omit Hostname, in which case this Listener matches when no other
-                  Listener matches. \n If the implementation does collapse compatible
-                  Listeners, the hostname provided in the incoming client request
-                  MUST be matched to a Listener to find the correct set of Routes.
-                  The incoming hostname MUST be matched using the Hostname field for
-                  each Listener in order of most to least specific. That is, exact
-                  matches must be processed before wildcard matches. \n If this field
-                  specifies multiple Listeners that have the same Port value but are
-                  not compatible, the implementation must raise a \"Conflicted\" condition
-                  in the Listener status. \n Support: Core"
+                  Below combinations are considered Core and MUST be supported: \n
+                  1. Port: 80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS \n Port
+                  and protocol combinations not in this list are considered Extended.
+                  \n An implementation MAY group Listeners by Port and then collapse
+                  each group of Listeners into a single Listener if the implementation
+                  determines that the Listeners in the group are \"compatible\". An
+                  implementation MAY also group together and collapse compatible Listeners
+                  belonging to different Gateways. \n For example, an implementation
+                  might consider Listeners to be compatible with each other if all
+                  of the following conditions are met: \n 1. Either each Listener
+                  within the group specifies the \"HTTP\" Protocol or each Listener
+                  within the group specifies either the \"HTTPS\" or \"TLS\" Protocol.
+                  \n 2. Each Listener within the group specifies a Hostname that is
+                  unique within the group. \n 3. As a special case, one Listener within
+                  a group may omit Hostname, in which case this Listener matches when
+                  no other Listener matches. \n If the implementation does collapse
+                  compatible Listeners, the hostname provided in the incoming client
+                  request MUST be matched to a Listener to find the correct set of
+                  Routes. The incoming hostname MUST be matched using the Hostname
+                  field for each Listener in order of most to least specific. That
+                  is, exact matches must be processed before wildcard matches. \n
+                  If this field specifies multiple Listeners that have the same Port
+                  value but are not compatible, the implementation must raise a \"Conflicted\"
+                  condition in the Listener status. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -108,27 +108,30 @@ spec:
                   logical endpoints that are bound on this Gateway's addresses. At
                   least one Listener MUST be specified. \n Each listener in a Gateway
                   must have a unique combination of Hostname, Port, and Protocol.
-                  \n An implementation MAY group Listeners by Port and then collapse
-                  each group of Listeners into a single Listener if the implementation
-                  determines that the Listeners in the group are \"compatible\". An
-                  implementation MAY also group together and collapse compatible Listeners
-                  belonging to different Gateways. \n For example, an implementation
-                  might consider Listeners to be compatible with each other if all
-                  of the following conditions are met: \n 1. Either each Listener
-                  within the group specifies the \"HTTP\" Protocol or each Listener
-                  within the group specifies either the \"HTTPS\" or \"TLS\" Protocol.
-                  \n 2. Each Listener within the group specifies a Hostname that is
-                  unique within the group. \n 3. As a special case, one Listener within
-                  a group may omit Hostname, in which case this Listener matches when
-                  no other Listener matches. \n If the implementation does collapse
-                  compatible Listeners, the hostname provided in the incoming client
-                  request MUST be matched to a Listener to find the correct set of
-                  Routes. The incoming hostname MUST be matched using the Hostname
-                  field for each Listener in order of most to least specific. That
-                  is, exact matches must be processed before wildcard matches. \n
-                  If this field specifies multiple Listeners that have the same Port
-                  value but are not compatible, the implementation must raise a \"Conflicted\"
-                  condition in the Listener status. \n Support: Core"
+                  Combinations that are considered Core are: \n 1. Port: 80, Protocol:
+                  HTTP 2. Port: 443, Protocol: HTTPS \n Port and protocol combinations
+                  not in this list are considered Extended. \n An implementation MAY
+                  group Listeners by Port and then collapse each group of Listeners
+                  into a single Listener if the implementation determines that the
+                  Listeners in the group are \"compatible\". An implementation MAY
+                  also group together and collapse compatible Listeners belonging
+                  to different Gateways. \n For example, an implementation might consider
+                  Listeners to be compatible with each other if all of the following
+                  conditions are met: \n 1. Either each Listener within the group
+                  specifies the \"HTTP\" Protocol or each Listener within the group
+                  specifies either the \"HTTPS\" or \"TLS\" Protocol. \n 2. Each Listener
+                  within the group specifies a Hostname that is unique within the
+                  group. \n 3. As a special case, one Listener within a group may
+                  omit Hostname, in which case this Listener matches when no other
+                  Listener matches. \n If the implementation does collapse compatible
+                  Listeners, the hostname provided in the incoming client request
+                  MUST be matched to a Listener to find the correct set of Routes.
+                  The incoming hostname MUST be matched using the Hostname field for
+                  each Listener in order of most to least specific. That is, exact
+                  matches must be processed before wildcard matches. \n If this field
+                  specifies multiple Listeners that have the same Port value but are
+                  not compatible, the implementation must raise a \"Conflicted\" condition
+                  in the Listener status. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -811,27 +814,30 @@ spec:
                   logical endpoints that are bound on this Gateway's addresses. At
                   least one Listener MUST be specified. \n Each listener in a Gateway
                   must have a unique combination of Hostname, Port, and Protocol.
-                  \n An implementation MAY group Listeners by Port and then collapse
-                  each group of Listeners into a single Listener if the implementation
-                  determines that the Listeners in the group are \"compatible\". An
-                  implementation MAY also group together and collapse compatible Listeners
-                  belonging to different Gateways. \n For example, an implementation
-                  might consider Listeners to be compatible with each other if all
-                  of the following conditions are met: \n 1. Either each Listener
-                  within the group specifies the \"HTTP\" Protocol or each Listener
-                  within the group specifies either the \"HTTPS\" or \"TLS\" Protocol.
-                  \n 2. Each Listener within the group specifies a Hostname that is
-                  unique within the group. \n 3. As a special case, one Listener within
-                  a group may omit Hostname, in which case this Listener matches when
-                  no other Listener matches. \n If the implementation does collapse
-                  compatible Listeners, the hostname provided in the incoming client
-                  request MUST be matched to a Listener to find the correct set of
-                  Routes. The incoming hostname MUST be matched using the Hostname
-                  field for each Listener in order of most to least specific. That
-                  is, exact matches must be processed before wildcard matches. \n
-                  If this field specifies multiple Listeners that have the same Port
-                  value but are not compatible, the implementation must raise a \"Conflicted\"
-                  condition in the Listener status. \n Support: Core"
+                  Combinations that are considered Core are: \n 1. Port: 80, Protocol:
+                  HTTP 2. Port: 443, Protocol: HTTPS \n Port and protocol combinations
+                  not in this list are considered Extended. \n An implementation MAY
+                  group Listeners by Port and then collapse each group of Listeners
+                  into a single Listener if the implementation determines that the
+                  Listeners in the group are \"compatible\". An implementation MAY
+                  also group together and collapse compatible Listeners belonging
+                  to different Gateways. \n For example, an implementation might consider
+                  Listeners to be compatible with each other if all of the following
+                  conditions are met: \n 1. Either each Listener within the group
+                  specifies the \"HTTP\" Protocol or each Listener within the group
+                  specifies either the \"HTTPS\" or \"TLS\" Protocol. \n 2. Each Listener
+                  within the group specifies a Hostname that is unique within the
+                  group. \n 3. As a special case, one Listener within a group may
+                  omit Hostname, in which case this Listener matches when no other
+                  Listener matches. \n If the implementation does collapse compatible
+                  Listeners, the hostname provided in the incoming client request
+                  MUST be matched to a Listener to find the correct set of Routes.
+                  The incoming hostname MUST be matched using the Hostname field for
+                  each Listener in order of most to least specific. That is, exact
+                  matches must be processed before wildcard matches. \n If this field
+                  specifies multiple Listeners that have the same Port value but are
+                  not compatible, the implementation must raise a \"Conflicted\" condition
+                  in the Listener status. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -108,30 +108,30 @@ spec:
                   logical endpoints that are bound on this Gateway's addresses. At
                   least one Listener MUST be specified. \n Each listener in a Gateway
                   must have a unique combination of Hostname, Port, and Protocol.
-                  Combinations that are considered Core are: \n 1. Port: 80, Protocol:
-                  HTTP 2. Port: 443, Protocol: HTTPS \n Port and protocol combinations
-                  not in this list are considered Extended. \n An implementation MAY
-                  group Listeners by Port and then collapse each group of Listeners
-                  into a single Listener if the implementation determines that the
-                  Listeners in the group are \"compatible\". An implementation MAY
-                  also group together and collapse compatible Listeners belonging
-                  to different Gateways. \n For example, an implementation might consider
-                  Listeners to be compatible with each other if all of the following
-                  conditions are met: \n 1. Either each Listener within the group
-                  specifies the \"HTTP\" Protocol or each Listener within the group
-                  specifies either the \"HTTPS\" or \"TLS\" Protocol. \n 2. Each Listener
-                  within the group specifies a Hostname that is unique within the
-                  group. \n 3. As a special case, one Listener within a group may
-                  omit Hostname, in which case this Listener matches when no other
-                  Listener matches. \n If the implementation does collapse compatible
-                  Listeners, the hostname provided in the incoming client request
-                  MUST be matched to a Listener to find the correct set of Routes.
-                  The incoming hostname MUST be matched using the Hostname field for
-                  each Listener in order of most to least specific. That is, exact
-                  matches must be processed before wildcard matches. \n If this field
-                  specifies multiple Listeners that have the same Port value but are
-                  not compatible, the implementation must raise a \"Conflicted\" condition
-                  in the Listener status. \n Support: Core"
+                  Below combinations are considered Core and MUST be supported: \n
+                  1. Port: 80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS \n Port
+                  and protocol combinations not in this list are considered Extended.
+                  \n An implementation MAY group Listeners by Port and then collapse
+                  each group of Listeners into a single Listener if the implementation
+                  determines that the Listeners in the group are \"compatible\". An
+                  implementation MAY also group together and collapse compatible Listeners
+                  belonging to different Gateways. \n For example, an implementation
+                  might consider Listeners to be compatible with each other if all
+                  of the following conditions are met: \n 1. Either each Listener
+                  within the group specifies the \"HTTP\" Protocol or each Listener
+                  within the group specifies either the \"HTTPS\" or \"TLS\" Protocol.
+                  \n 2. Each Listener within the group specifies a Hostname that is
+                  unique within the group. \n 3. As a special case, one Listener within
+                  a group may omit Hostname, in which case this Listener matches when
+                  no other Listener matches. \n If the implementation does collapse
+                  compatible Listeners, the hostname provided in the incoming client
+                  request MUST be matched to a Listener to find the correct set of
+                  Routes. The incoming hostname MUST be matched using the Hostname
+                  field for each Listener in order of most to least specific. That
+                  is, exact matches must be processed before wildcard matches. \n
+                  If this field specifies multiple Listeners that have the same Port
+                  value but are not compatible, the implementation must raise a \"Conflicted\"
+                  condition in the Listener status. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -814,30 +814,30 @@ spec:
                   logical endpoints that are bound on this Gateway's addresses. At
                   least one Listener MUST be specified. \n Each listener in a Gateway
                   must have a unique combination of Hostname, Port, and Protocol.
-                  Combinations that are considered Core are: \n 1. Port: 80, Protocol:
-                  HTTP 2. Port: 443, Protocol: HTTPS \n Port and protocol combinations
-                  not in this list are considered Extended. \n An implementation MAY
-                  group Listeners by Port and then collapse each group of Listeners
-                  into a single Listener if the implementation determines that the
-                  Listeners in the group are \"compatible\". An implementation MAY
-                  also group together and collapse compatible Listeners belonging
-                  to different Gateways. \n For example, an implementation might consider
-                  Listeners to be compatible with each other if all of the following
-                  conditions are met: \n 1. Either each Listener within the group
-                  specifies the \"HTTP\" Protocol or each Listener within the group
-                  specifies either the \"HTTPS\" or \"TLS\" Protocol. \n 2. Each Listener
-                  within the group specifies a Hostname that is unique within the
-                  group. \n 3. As a special case, one Listener within a group may
-                  omit Hostname, in which case this Listener matches when no other
-                  Listener matches. \n If the implementation does collapse compatible
-                  Listeners, the hostname provided in the incoming client request
-                  MUST be matched to a Listener to find the correct set of Routes.
-                  The incoming hostname MUST be matched using the Hostname field for
-                  each Listener in order of most to least specific. That is, exact
-                  matches must be processed before wildcard matches. \n If this field
-                  specifies multiple Listeners that have the same Port value but are
-                  not compatible, the implementation must raise a \"Conflicted\" condition
-                  in the Listener status. \n Support: Core"
+                  Below combinations are considered Core and MUST be supported: \n
+                  1. Port: 80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS \n Port
+                  and protocol combinations not in this list are considered Extended.
+                  \n An implementation MAY group Listeners by Port and then collapse
+                  each group of Listeners into a single Listener if the implementation
+                  determines that the Listeners in the group are \"compatible\". An
+                  implementation MAY also group together and collapse compatible Listeners
+                  belonging to different Gateways. \n For example, an implementation
+                  might consider Listeners to be compatible with each other if all
+                  of the following conditions are met: \n 1. Either each Listener
+                  within the group specifies the \"HTTP\" Protocol or each Listener
+                  within the group specifies either the \"HTTPS\" or \"TLS\" Protocol.
+                  \n 2. Each Listener within the group specifies a Hostname that is
+                  unique within the group. \n 3. As a special case, one Listener within
+                  a group may omit Hostname, in which case this Listener matches when
+                  no other Listener matches. \n If the implementation does collapse
+                  compatible Listeners, the hostname provided in the incoming client
+                  request MUST be matched to a Listener to find the correct set of
+                  Routes. The incoming hostname MUST be matched using the Hostname
+                  field for each Listener in order of most to least specific. That
+                  is, exact matches must be processed before wildcard matches. \n
+                  If this field specifies multiple Listeners that have the same Port
+                  value but are not compatible, the implementation must raise a \"Conflicted\"
+                  condition in the Listener status. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/gateway-api/issues/1842

Unblocks - https://github.com/kubernetes-sigs/gateway-api/pull/1859


### Release Note
```release-note
Define Core supported Listener Port and Protocol Combinations.
```