### PR TITLE
conformance: minor GAMMA test fixes

### DIFF
--- a/conformance/mesh/manifests.yaml
+++ b/conformance/mesh/manifests.yaml
@@ -51,14 +51,17 @@ spec:
   ports:
   - name: http
     port: 80
+    appProtocol: http
   - name: http-alt
     port: 8080
+    appProtocol: http
   - name: https
     port: 443
   - name: tcp
     port: 9090
   - name: grpc
     port: 7070
+    appProtocol: grpc
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -104,14 +107,17 @@ spec:
   ports:
   - name: http
     port: 80
+    appProtocol: http
   - name: http-alt
     port: 8080
+    appProtocol: http
   - name: https
     port: 443
   - name: tcp
     port: 9090
   - name: grpc
     port: 7070
+    appProtocol: grpc
 ---
 apiVersion: v1
 kind: Service
@@ -124,11 +130,14 @@ spec:
   ports:
   - name: http
     port: 80
+    appProtocol: http
   - name: http-alt
     port: 8080
+    appProtocol: http
   - name: https
     port: 443
   - name: tcp
     port: 9090
   - name: grpc
     port: 7070
+    appProtocol: grpc

--- a/conformance/tests/mesh-basic.go
+++ b/conformance/tests/mesh-basic.go
@@ -51,7 +51,7 @@ var MeshBasic = suite.ConformanceTest{
 			// reuse issues across parallel tests.
 			tc := cases[i]
 			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
-				client.SendRequest(t, tc)
+				client.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
 			})
 		}
 	},

--- a/conformance/utils/echo/pod.go
+++ b/conformance/utils/echo/pod.go
@@ -90,17 +90,6 @@ func makeRequest(r http.Request) []string {
 	return args
 }
 
-func (m *MeshPod) SendRequest(t *testing.T, exp http.ExpectedResponse) {
-	resp, err := m.request(makeRequest(exp.Request))
-	if err != nil {
-		t.Fatalf("Got error: %v", err)
-	}
-	t.Logf("Got resp %v", resp)
-	if err := compareRequest(exp, resp); err != nil {
-		t.Fatalf("expectations failed: %v", err)
-	}
-}
-
 func compareRequest(exp http.ExpectedResponse, resp Response) error {
 	want := exp.Response
 	if fmt.Sprint(want.StatusCode) != resp.Code {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind test

/area conformance

**What this PR does / why we need it**:
* Expect an eventually consistent matching response in `MeshBasic`
* Set `appProtocol` in mesh test `Services`.

Kuma atm expects a hint that a `Service`/port combo is HTTP. 

Should needing/explicitly not needing `appProtocol` be part of the spec?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
