### PR TITLE
apis/v1beta1: Host header must not be modified

### DIFF
--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -59,7 +59,8 @@ type HTTPRouteSpec struct {
 	// Hostnames defines a set of hostname that should match against the HTTP Host
 	// header to select a HTTPRoute used to process the request. Implementations
 	// MUST ignore any port value specified in the HTTP Host header while
-	// performing a match.
+	// performing a match and (absent of any applicable header modification
+	// configuration) MUST forward this header unmodified to the backend.
 	//
 	// Valid values for Hostnames are determined by RFC 1123 definition of a
 	// hostname with 2 notable exceptions:

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -55,12 +55,14 @@ spec:
                 description: "Hostnames defines a set of hostname that should match
                   against the HTTP Host header to select a HTTPRoute used to process
                   the request. Implementations MUST ignore any port value specified
-                  in the HTTP Host header while performing a match. \n Valid values
-                  for Hostnames are determined by RFC 1123 definition of a hostname
-                  with 2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                  may be prefixed with a wildcard label (`*.`). The wildcard label
-                  must appear by itself as the first label. \n If a hostname is specified
-                  by both the Listener and HTTPRoute, there must be at least one intersecting
+                  in the HTTP Host header while performing a match and (absent of
+                  any applicable header modification configuration) MUST forward this
+                  header unmodified to the backend. \n Valid values for Hostnames
+                  are determined by RFC 1123 definition of a hostname with 2 notable
+                  exceptions: \n 1. IPs are not allowed. 2. A hostname may be prefixed
+                  with a wildcard label (`*.`). The wildcard label must appear by
+                  itself as the first label. \n If a hostname is specified by both
+                  the Listener and HTTPRoute, there must be at least one intersecting
                   hostname for the HTTPRoute to be attached to the Listener. For example:
                   \n * A Listener with `test.example.com` as the hostname matches
                   HTTPRoutes that have either not specified any hostnames, or have
@@ -1977,12 +1979,14 @@ spec:
                 description: "Hostnames defines a set of hostname that should match
                   against the HTTP Host header to select a HTTPRoute used to process
                   the request. Implementations MUST ignore any port value specified
-                  in the HTTP Host header while performing a match. \n Valid values
-                  for Hostnames are determined by RFC 1123 definition of a hostname
-                  with 2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                  may be prefixed with a wildcard label (`*.`). The wildcard label
-                  must appear by itself as the first label. \n If a hostname is specified
-                  by both the Listener and HTTPRoute, there must be at least one intersecting
+                  in the HTTP Host header while performing a match and (absent of
+                  any applicable header modification configuration) MUST forward this
+                  header unmodified to the backend. \n Valid values for Hostnames
+                  are determined by RFC 1123 definition of a hostname with 2 notable
+                  exceptions: \n 1. IPs are not allowed. 2. A hostname may be prefixed
+                  with a wildcard label (`*.`). The wildcard label must appear by
+                  itself as the first label. \n If a hostname is specified by both
+                  the Listener and HTTPRoute, there must be at least one intersecting
                   hostname for the HTTPRoute to be attached to the Listener. For example:
                   \n * A Listener with `test.example.com` as the hostname matches
                   HTTPRoutes that have either not specified any hostnames, or have

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -55,12 +55,14 @@ spec:
                 description: "Hostnames defines a set of hostname that should match
                   against the HTTP Host header to select a HTTPRoute used to process
                   the request. Implementations MUST ignore any port value specified
-                  in the HTTP Host header while performing a match. \n Valid values
-                  for Hostnames are determined by RFC 1123 definition of a hostname
-                  with 2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                  may be prefixed with a wildcard label (`*.`). The wildcard label
-                  must appear by itself as the first label. \n If a hostname is specified
-                  by both the Listener and HTTPRoute, there must be at least one intersecting
+                  in the HTTP Host header while performing a match and (absent of
+                  any applicable header modification configuration) MUST forward this
+                  header unmodified to the backend. \n Valid values for Hostnames
+                  are determined by RFC 1123 definition of a hostname with 2 notable
+                  exceptions: \n 1. IPs are not allowed. 2. A hostname may be prefixed
+                  with a wildcard label (`*.`). The wildcard label must appear by
+                  itself as the first label. \n If a hostname is specified by both
+                  the Listener and HTTPRoute, there must be at least one intersecting
                   hostname for the HTTPRoute to be attached to the Listener. For example:
                   \n * A Listener with `test.example.com` as the hostname matches
                   HTTPRoutes that have either not specified any hostnames, or have
@@ -1923,12 +1925,14 @@ spec:
                 description: "Hostnames defines a set of hostname that should match
                   against the HTTP Host header to select a HTTPRoute used to process
                   the request. Implementations MUST ignore any port value specified
-                  in the HTTP Host header while performing a match. \n Valid values
-                  for Hostnames are determined by RFC 1123 definition of a hostname
-                  with 2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
-                  may be prefixed with a wildcard label (`*.`). The wildcard label
-                  must appear by itself as the first label. \n If a hostname is specified
-                  by both the Listener and HTTPRoute, there must be at least one intersecting
+                  in the HTTP Host header while performing a match and (absent of
+                  any applicable header modification configuration) MUST forward this
+                  header unmodified to the backend. \n Valid values for Hostnames
+                  are determined by RFC 1123 definition of a hostname with 2 notable
+                  exceptions: \n 1. IPs are not allowed. 2. A hostname may be prefixed
+                  with a wildcard label (`*.`). The wildcard label must appear by
+                  itself as the first label. \n If a hostname is specified by both
+                  the Listener and HTTPRoute, there must be at least one intersecting
                   hostname for the HTTPRoute to be attached to the Listener. For example:
                   \n * A Listener with `test.example.com` as the hostname matches
                   HTTPRoutes that have either not specified any hostnames, or have


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds clarification to the spec to go along with existing conformance test from #1980.

**Which issue(s) this PR fixes**:
Fixes #2091

**Does this PR introduce a user-facing change?**:
```release-note
Clarify that implementations must not modify HTTP Host header. Adds specificity alongside spec that port in Host header must be ignored when matching on host.
```
