### PR TITLE
docs: emphasis on GEP discussion process

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -6,12 +6,15 @@ labels: kind/feature
 ---
 <!-- Please only use this template for submitting enhancement requests -->
 
+<!--
+WARNING: depending on the scope of the enhancement you may be asked to use the
+GEP process to build consensus around a proposed change. Please carefully read
+through the GEP overview and include a link to the prerequisite GEP discussion
+when submitting this issue:
+https://gateway-api.sigs.k8s.io/geps/overview/
+-->
+
 **What would you like to be added**:
 
 **Why this is needed**:
 
-<!--
-NOTE: depending on the scope of the enhancement, you may be asked to use the GEP
-process to document your work:
-https://gateway-api.sigs.k8s.io/geps/overview/
--->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,10 @@
    https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
 5. If the PR is unfinished, see how to mark it:
    https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
+6. If this PR includes a new GEP please make sure you've followed the process
+   outlined in our GEP overview, as this will help the community to ensure the
+   best chance of positive outcomes for your proposal:
+   https://gateway-api.sigs.k8s.io/geps/overview/#process
 -->
 
 **What type of PR is this?**

--- a/geps/overview.md
+++ b/geps/overview.md
@@ -30,12 +30,16 @@ flowchart TD
 </div>
 
 ### 1. Discuss with the community
-Before creating a GEP, share your high level idea with the community. This can
-be in one of many forms:
+
+Before creating a GEP, share your high level idea with the community. There are
+several places this may be done:
 
 - A [new GitHub Discussion](https://github.com/kubernetes-sigs/gateway-api/discussions/new)
 - On our [Slack Channel](https://kubernetes.slack.com/archives/CR0H13KGA)
 - On one of our [community meetings](https://gateway-api.sigs.k8s.io/contributing/?h=meetings#meetings)
+
+Please default to GitHub discussions: they work a lot like GitHub issues which
+makes them easy to search.
 
 ### 2. Create an Issue
 [Create a GEP issue](https://github.com/kubernetes-sigs/gateway-api/issues/new?assignees=&labels=kind%2Ffeature&template=enhancement.md) in the repo describing your change.


### PR DESCRIPTION
**What type of PR is this?**

/kind gep
/kind documentation

**What this PR does / why we need it**:

This year there have been a lot of GEPs in flight which has made maintainership more demanding then usual, particularly in the face of our upcoming `v1.0.0` release. The purpose of this PR is to add a bit more of an emphasis on the upfront discussion/consultation part of the GEP process to make the process smoother for everyone and give us (the maintainers) a better chance to coordinate and help contributors submit and graduate their GEPs smoothly.