### PR TITLE
conformance/utils/kubernetes: Return more errors from DumpEchoLogs

### DIFF
--- a/conformance/utils/kubernetes/logs.go
+++ b/conformance/utils/kubernetes/logs.go
@@ -50,12 +50,12 @@ func DumpEchoLogs(ns, name string, c client.Client, cs *clientset.Clientset) ([]
 		req := cs.CoreV1().Pods(ns).GetLogs(pod.Name, podLogOptions)
 		logStream, err := req.Stream(context.TODO())
 		if err != nil {
-			continue
+			return nil, err
 		}
 		defer logStream.Close()
 		logBytes, err := io.ReadAll(logStream)
 		if err != nil {
-			continue
+			return nil, err
 		}
 		logs = append(logs, logBytes)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind test
/kind flake
/area conformance

**What this PR does / why we need it**:
Errors from streaming pod logs or reading logs were invisible to users running the suite since on error the loop through pods just continued.

This test has been flaky in CI so it would be good to know if that is caused by errors in the request fetching logs or otherwise.

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
