### PR TITLE
conformance: add conformance test for gateway addresses

### DIFF
--- a/conformance/tests/gateway-with-addresses.go
+++ b/conformance/tests/gateway-with-addresses.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayWithAddresses)
+}
+
+var GatewayWithAddresses = suite.ConformanceTest{
+	ShortName:   "GatewayWithAddresses",
+	Description: "A Gateway with addresses in the gateway-conformance-infra namespace should be populated in its status.",
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportGatewayWithAddresses,
+	},
+	Manifests: []string{"tests/gateway-with-addresses.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		t.Run("Gateway should have one valid address in status", func(t *testing.T) {
+			gwNN := types.NamespacedName{Name: "gateway-with-one-address", Namespace: "gateway-conformance-infra"}
+			addresses := []v1beta1.GatewayAddress{{
+				Type:  kubernetes.PtrTo(v1beta1.IPAddressType),
+				Value: "1.2.3.4",
+			}}
+
+			kubernetes.GatewayStatusMustHaveAddresses(t, s.Client, s.TimeoutConfig, gwNN, addresses)
+		})
+
+		t.Run("Gateway should have two valid addresses in status", func(t *testing.T) {
+			gwNN := types.NamespacedName{Name: "gateway-with-two-addresses", Namespace: "gateway-conformance-infra"}
+			addresses := []v1beta1.GatewayAddress{{
+				Type:  kubernetes.PtrTo(v1beta1.IPAddressType),
+				Value: "1.2.3.4",
+			}, {
+				Type:  kubernetes.PtrTo(v1beta1.HostnameAddressType),
+				Value: "foo.bar",
+			}}
+
+			kubernetes.GatewayStatusMustHaveAddresses(t, s.Client, s.TimeoutConfig, gwNN, addresses)
+		})
+	},
+}

--- a/conformance/tests/gateway-with-addresses.yaml
+++ b/conformance/tests/gateway-with-addresses.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: gateway-with-one-address
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  addresses:
+    - type: IPAddress
+      value: 1.2.3.4
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: gateway-with-two-addresses
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  addresses:
+    - type: IPAddress
+      value: 1.2.3.4
+    - type: Hostname
+      value: foo.bar

--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -39,6 +39,10 @@ type TimeoutConfig struct {
 	// Max value for conformant implementation: None
 	GatewayStatusMustHaveListeners time.Duration
 
+	// GatewayStatusMustHaveAddresses represents the maximum time for a Gateway to have addresses in status that match the expected addresses.
+	// Max value for conformant implementation: None
+	GatewayStatusMustHaveAddresses time.Duration
+
 	// GWCMustBeAccepted represents the maximum time for a GatewayClass to have an Accepted condition set to true.
 	// Max value for conformant implementation: None
 	GWCMustBeAccepted time.Duration
@@ -92,6 +96,7 @@ func DefaultTimeoutConfig() TimeoutConfig {
 		GetTimeout:                     10 * time.Second,
 		GatewayMustHaveAddress:         180 * time.Second,
 		GatewayStatusMustHaveListeners: 60 * time.Second,
+		GatewayStatusMustHaveAddresses: 60 * time.Second,
 		GWCMustBeAccepted:              180 * time.Second,
 		HTTPRouteMustNotHaveParents:    60 * time.Second,
 		HTTPRouteMustHaveCondition:     60 * time.Second,
@@ -121,6 +126,9 @@ func SetupTimeoutConfig(timeoutConfig *TimeoutConfig) {
 	}
 	if timeoutConfig.GatewayStatusMustHaveListeners == 0 {
 		timeoutConfig.GatewayStatusMustHaveListeners = defaultTimeoutConfig.GatewayStatusMustHaveListeners
+	}
+	if timeoutConfig.GatewayStatusMustHaveAddresses == 0 {
+		timeoutConfig.GatewayStatusMustHaveAddresses = defaultTimeoutConfig.GatewayStatusMustHaveAddresses
 	}
 	if timeoutConfig.GWCMustBeAccepted == 0 {
 		timeoutConfig.GWCMustBeAccepted = defaultTimeoutConfig.GWCMustBeAccepted

--- a/conformance/utils/kubernetes/helpers_test.go
+++ b/conformance/utils/kubernetes/helpers_test.go
@@ -319,3 +319,99 @@ func Test_listenersMatch(t *testing.T) {
 		})
 	}
 }
+
+func Test_addressesMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected []v1beta1.GatewayAddress
+		actual   []v1beta1.GatewayAddress
+		want     bool
+	}{
+		{
+			name: "addresses do not match if actual addresses is smaller than the expected one",
+			expected: []v1beta1.GatewayAddress{
+				{
+					Type:  PtrTo(v1beta1.IPAddressType),
+					Value: "1.2.3.4",
+				},
+				{
+					Type:  PtrTo(v1beta1.IPAddressType),
+					Value: "12:34:56::",
+				},
+			},
+			actual: []v1beta1.GatewayAddress{
+				{
+					Type:  PtrTo(v1beta1.IPAddressType),
+					Value: "1.2.3.4",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "addresses do not match if actual addresses is empty",
+			expected: []v1beta1.GatewayAddress{
+				{
+					Type:  PtrTo(v1beta1.IPAddressType),
+					Value: "1.2.3.4",
+				},
+			},
+			actual: []v1beta1.GatewayAddress{},
+			want:   false,
+		},
+		{
+			name: "addresses matched when expected and actual are equal",
+			expected: []v1beta1.GatewayAddress{
+				{
+					Type:  PtrTo(v1beta1.IPAddressType),
+					Value: "1.2.3.4",
+				},
+				{
+					Type:  PtrTo(v1beta1.HostnameAddressType),
+					Value: "test.com",
+				},
+			},
+			actual: []v1beta1.GatewayAddress{
+				{
+					Type:  PtrTo(v1beta1.IPAddressType),
+					Value: "1.2.3.4",
+				},
+				{
+					Type:  PtrTo(v1beta1.HostnameAddressType),
+					Value: "test.com",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "address do not match if one expected address is not showing up",
+			expected: []v1beta1.GatewayAddress{
+				{
+					Type:  PtrTo(v1beta1.HostnameAddressType),
+					Value: "test.com",
+				},
+				{
+					Type:  PtrTo(v1beta1.IPAddressType),
+					Value: "1.2.3.4",
+				},
+			},
+			actual: []v1beta1.GatewayAddress{
+				{
+					Type:  PtrTo(v1beta1.IPAddressType),
+					Value: "1.2.3.4",
+				},
+				{
+					Type:  PtrTo(v1beta1.IPAddressType),
+					Value: "5.6.7.8",
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, addressesMatch(t, test.expected, test.actual))
+		})
+	}
+}

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -64,6 +64,8 @@ const (
 	//
 	//       See: https://github.com/kubernetes-sigs/gateway-api/issues/1780
 	SupportGatewayClassObservedGenerationBump SupportedFeature = "GatewayClassObservedGenerationBump"
+	// This option indicates support for Gateway with addresses.
+	SupportGatewayWithAddresses SupportedFeature = "GatewayWithAddresses"
 )
 
 // StandardExtendedFeatures are extra generic features that implementations may
@@ -73,6 +75,7 @@ const (
 // See: https://github.com/kubernetes-sigs/gateway-api/issues/1891
 var StandardExtendedFeatures = sets.New(
 	SupportGatewayClassObservedGenerationBump,
+	SupportGatewayWithAddresses,
 ).Insert(StandardCoreFeatures.UnsortedList()...)
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind test
/area conformance

**What this PR does / why we need it**:
add conformance tests for Addresses which are extended. the test covers single and multiple addresses.

**Which issue(s) this PR fixes**:
Fixes #2035 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
No
```
