### PR TITLE
GEP-1897 Explicit Backend TLS Connection Configuration (was TLS from Gateway to Backend...) Update with API details

### DIFF
--- a/geps/gep-1897.md
+++ b/geps/gep-1897.md
@@ -1,4 +1,4 @@
-# GEP-1897: Explicit Backend TLS Connection Configuration
+# GEP-1897: TLSConnectionPolicy - Explicit Backend TLS Connection Configuration
 
 * Issue: [#1897](https://github.com/kubernetes-sigs/gateway-api/issues/1897)
 * Status: Provisional
@@ -43,7 +43,8 @@ address the case where connections to TLS are **implicitly configured** on behal
 This GEP is about the case where an application developer needs to **explicitly express** that they expect TLS when
 there is no automatic, implicit configuration available.
 3. Service mesh use cases are not addressed here because this GEP is specifically concerned with the connection between
-Gateways and Backends, not Service to Service.  Service mesh use cases should ignore TLSConnectionPolicy.
+Gateways and Backends, not Service to Service.  Service mesh use cases should ignore the design components described in
+this proposal.
 
 ## Non-Goals
 
@@ -141,12 +142,12 @@ This GEP is the outcome of the TLS use cases #4 and #5 in
 ## API
 
 To allow the gateway client to know how to connect to the backend pod, when the backend pod has its own
-certificate, we implement a metaresource that is already mentioned as an example in
+certificate, we implement a metaresource named `TLSConnectionPolicy`, that is already mentioned as an example in
 [GEP-713: Metaresources and PolicyAttachment](https://gateway-api.sigs.k8s.io/geps/gep-713/), and as a hypothetical in the
 [Policy Attachment](https://gateway-api.sigs.k8s.io/references/policy-attachment/#direct-policy-attachment)
 documentation.
 
-This metaresource is named TLSConnectionPolicy.  In this document, because naming is hard, we chose to retain the
+In this document, because naming is hard, we chose to retain the
 name TLSConnectionPolicy to advertise alignment with a previously discussed naming choice, but a new name may be
 substituted without blocking acceptance of the content of the API change.
 
@@ -182,7 +183,6 @@ For the use case where certificates are stored in their own namespace, users may
 for a TLSConnectionPolicy-to-Secret binding.  Implementations must respect a ReferenceGrant for cross-namespace Secret
 sharing to TLSConnectionPolicy, even if they don't for other cross-namespace sharing.
 
-
 One of the areas of concern for this API is that we need to indicate how and when the API implementations should use the
 backend destination certificate authority.  This solution proposes, as introduced in
 [GEP-713](https://gateway-api.sigs.k8s.io/geps/gep-713/), that the implementation
@@ -216,12 +216,13 @@ trusted certificates, then a TLS connection must fail when the field is empty.  
 different namespace are invalid.
 
 TLSConnectionPolicySpec supports the configuration of Subject Alternative Name certificates via the `AllowedSANs` field.
-One or more (up to 1024) subject alternative names may be declared.  SAN certificates allow authentication with a single
+One or more (up to 64) subject alternative names may be declared.  SAN certificates allow authentication with a single
 certificate that can serve multiple domain
 names that are intended to represent the same endpoint.  For example, these five SAN hosts: example.com, 
 www.example.com, example.net, IPv4 x.x.x.x, and IPv6 x.x.x.x.x.x.x.x all resolve to the same endpoint. If `AllowedSANs`
 is set, then an implementation must validate that the backend pod-provided certificate represents a SAN in its list.
-If empty, then any SAN is allowed.
+If empty, then TLS fails.  In the future, we will define more specific ways to handle the case of an empty `AllowedSANs`
+list.
 
 Finally, TLSConnectionPolicy allows the configuration of expected TLS versions via the `TLSVersions` field.
 TLS versions specify one or more (up to 3) TLS versions that the connection may use.  If the `TLSVersions` field is set,
@@ -286,7 +287,7 @@ type TLSConnectionPolicyConfig struct {
     // ConfigMapName.
     //
     // Support: Implementation-specific (No reference, more than one
-    // reference, or other resource types.)
+    // reference, or other resource types; service mesh may ignore.)
     //
     // +kubebuilder:validation:MaxItems=64
     // +optional
@@ -299,9 +300,9 @@ type TLSConnectionPolicyConfig struct {
     // If AllowedSANs is set, then an implementation must validate that
     // the certificate provided by the pod represents a SAN in its list.
     //
-    // If AllowedSANs is empty, then any SAN is allowed.
+    // If AllowedSANs is empty, then a TLS connection must fail.
     //
-    // +kubebuilder:validation:MaxItems=1024
+    // +kubebuilder:validation:MaxItems=64
     // +optional
     AllowedSANs []string `json:"allowedSans,omitempty"`
 

--- a/geps/gep-1897.md
+++ b/geps/gep-1897.md
@@ -69,7 +69,7 @@ including:
 * SANs for validating upstream service (server authentication)
 * client certificate of the gateway (client authentication)
 
-## Purpose - why do we want to this?
+## Purpose - why do we want to do this?
 
 This proposal is _very_ tightly scoped because we have tried and failed to address this well-known
 gap in the API specification. The lack of support for this fundamental concept is holding back
@@ -125,7 +125,234 @@ This GEP is the outcome of the TLS use cases #4 and #5 in
 
 ## API
 
-Details deferred until we reach consensus on what we want to do, and why we want to do this.
+To allow the gateway client to know how to connect to the backend pod, when the backend pod has its own
+certificate, we implement a metaresource that is already mentioned as an example in
+[GEP-713: Metaresources and PolicyAttachment](https://gateway-api.sigs.k8s.io/geps/gep-713/), and as a hypothetical in the
+[Policy Attachment](https://gateway-api.sigs.k8s.io/references/policy-attachment/#direct-policy-attachment)
+documentation.
+
+This metaresource is named TLSConnectionPolicy.  In this document, because naming is hard, we chose to retain the
+name TLSConnectionPolicy to advertise alignment with a previously discussed naming choice, but a new name may be
+substituted without blocking acceptance of the content of the API change.
+
+The selection of the applicable Gateway API persona is important in the design of this proposal, because each
+persona is assigned a role which handles specific Gateway API resources.  TLSConnectionPolicy is used by the application
+developer Gateway API persona to convey client certificate settings used in the TLS handshake from Gateway to backend,
+because this persona handles resources involved with application access and configuration, such as Routes and Services.
+Choosing any other role would move the application-related responsibility from the application developer role to that
+role, which violates the role-oriented design principle of Gateway API. As mentioned in Non-goal #7, providing a
+mechanism for the cluster operator gateway role to override gateway to backend TLS settings is not covered here, but can
+be addressed in a future update should the need arise.
+
+TLSConnectionPolicy is defined as a Direct Policy Attachment without defaults or overrides, applied to a Service that
+accesses the backend in question, where the TLSConnectionPolicy resides in the same namespace as the Service it is
+applied to.  The TLSConnectionPolicy and the Service must reside in the same namespace in order to prevent the
+complications involved with sharing trust across namespace boundaries.  By choosing the Service resource rather than the
+Route resource, we can reuse the same TLSConnectionPolicy for all the different Routes that might point to this Service.
+For the use case where certificates are stored in their own namespace, users may create Secrets and use ReferenceGrants
+for a TLSConnectionPolicy-to-Secret binding.
+
+In the API defined here, the definition of TrustedCACertRefs follows a convention established by TLSRoute in
+https://github.com/kubernetes-sigs/gateway-api/blob/main/apis/v1beta1/gateway_types.go#L340
+
+One of the areas of concern for this API is that we need to indicate how and when the API implementations should use the
+backend destination certificate authority.  This solution proposes, as introduced in
+[GEP-713](https://gateway-api.sigs.k8s.io/geps/gep-713/), that the implementation
+should watch the connections to a specific port on a specified targetRef (such as a Service), and if the port and
+Service match a TLSConnectionPolicy, then assume the connection is TLS, and verify that the targetRef’s certificate can
+be validated by the provided trusted CA certificates before the connection is made.  On the question of how to signal
+that there was a failure in the certificate validation, this is left up to the implementation to return a response error
+that is appropriate, such as one of the HTTP error codes: 400 (Bad Request), 401 (Unauthorized), 403 (Forbidden), or
+other signal that makes the failure sufficiently clear to the requester without revealing too much about the transaction,
+based on established security requirements.
+
+Not covered here, but possible to add would be additional configuration options mentioned in [SIG-NET Gateway API: TLS
+to the K8s.Service/Backend](https://docs.google.com/document/d/1RTYh2brg_vLX9o3pTcrWxtZSsf8Y5NQvIG52lpFcZlo).  All of
+these are currently implementation-dependent, with the following recommended defaults:
+- Visibility: the visibility level could be all or none, indicating that if the connection failed due to validation
+failures, it would drop the connection silently if the visibility level were none, and report an error if the visibility
+level were all.  This is left as implementation-dependent.
+- Server Name Indication: enables passing of the server name through server name indication, in the TLS transaction, to
+assist with selection of certificates when several hosts share the same IP address. (default to enabled)
+- Subject Alternative Name certificates: enable the use of a single certificate that can serve multiple domains.
+(default to enabled)
+- Version: specifies the minimum TLS version that the connection may use (default TLSv1.2)
+- Ciphers: specifies enabled ciphers to be used in TLS exchanges. (default to align with TLS versions 1.1, 1.2, and/or
+1.3 as described in [RFC4346 TLS 1.1](https://datatracker.ietf.org/doc/html/rfc4346#appendix-A.5),
+[RFC 5246 TLS 1.2](https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5), and
+[RFC 8446 TLS 1.3](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.4).
+- Version: specifies the minimum TLS version that the connection may use (default TLSv1.2)
+- Visibility: the visibility level could be all or none, indicating that if the connection failed due to validation
+failures, it would drop the connection silently if the visibility level were none, and report an error if the visibility
+level were all.  (default to all)
+
+```go
+// TLSConnectionPolicy provides a way to publish TLS configuration
+// that enables a gateway client to connect to a backend pod.
+type TLSConnectionPolicy struct {
+    metav1.TypeMeta   `json:",inline"`
+    metav1.ObjectMeta `json:"metadata,omitempty"`
+
+    // Spec defines the desired state of TLSConnectionPolicy.
+    Spec TLSConnectionPolicySpec `json:"spec"`
+
+    // Status defines the current state of TLSConnectionPolicy.
+    Status TLSConnectionPolicyStatus `json:"status,omitempty"`
+}
+
+// TLSConnectionPolicySpec defines the desired state of
+// TLSConnectionPolicy.
+// Note: there is no Override or Default policy configuration.
+type TLSConnectionPolicySpec struct {
+    // TargetRef identifies an API object to apply policy to.
+    TargetRef gatewayv1a2.PolicyTargetReference `json:"targetRef"`
+
+    // TLS contains TLS connection policy configuration.
+    TLS *TLSConnectionPolicyConfig `json:”tls”`
+}
+
+// TLSConnectionPolicyConfig contains TLS connection policy configuration.
+type TLSConnectionPolicyConfig struct {
+    // TrustedCACertRefs contains one or more references to
+    // Kubernetes objects that contain TLS certificates, which are
+    // used to establish a TLS handshake between the gateway and
+    // backend pod.
+    //
+    // A single TrustedCACertRef to a Kubernetes Secret has "Core"
+    // support.  Implementations MAY choose to support attaching
+    // multiple certificates to a backend, but this behavior is 
+    // implementation-specific.
+    //
+    // References to a resource in a different namespace are 
+    // invalid.
+    // 
+    // This field is required for any TLSConnectionPolicyConfig.
+    // 
+    // Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
+    //
+    // Support: Implementation-specific (More than one reference or other resource types)
+    //
+    // +kubebuilder:validation:MaxItems=64
+    // +kubebuilder:validation:MinItems=1
+    TrustedCACertRefs []SecretObjectReference `json:”trustedCACertRefs”`
+
+    // Port is the network port that the implementation watches to
+    // know if the connection should be TLS and the targetRef’s
+    // certificate should be validated by the certs in TrustedCACertRefs
+    // If empty, then all ports for the targetRef are watched to know
+    // if the connection should be TLS, the targetRef’s certificate
+    // should be validated by the certs in TrustedCACertRefs, and a
+    // status delivered in the response for validation failures.
+    Port PortNumber `json:port,omitempty`
+}
+
+// TLSConnectionPolicyStatus defines the observed state of TLSConnectionPolicy.
+type TLSConnectionPolicyStatus struct {
+    // Conditions describe the current conditions of the TLSConnectionPolicy.
+    //
+    // Implementations should prefer to express TLSConnectionPolicy
+    // conditions using the `TLSConnectionPolicyConditionType` and
+    // `TLSConnectionPolicyConditionReason` constants so that 
+    // operators and tools can converge on a common vocabulary to 
+    // describe TLSConnectionPolicy state.
+    // Known condition types are:
+    // 
+    // * “Accepted”
+    // 
+    // +optional
+    // +listType=map
+    // +listMapKey=type
+    // +kubebuilder:validation:MaxItems=8
+    // +kubebuilder:default={type: "Accepted", status: "Unknown", reason:"Pending", message:"Waiting for validation", lastTransitionTime: "1970-01-01T00:00:00Z"}
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// TLSConnectionPolicyConditionType is the type of a condition used
+// as a signal by TLSConnectionPolicy.  This type should be used with
+// the TLSConnectionPolicyStatus.Conditions field.
+type TLSConnectionPolicyConditionType string
+
+//  TLSConnectionPolicyConditionReason is a reason that explains why a
+// particular TLSConnectionPolicyConditionType was generated.
+type TLSConnectionPolicyConditionReason string
+
+const (
+    // This condition indicates that the TLSConnectionPolicy has been
+    // accepted as valid.
+    // Possible reason for this condition to be True is:
+    // * “Validated”
+    // Possible reasons for this condition to be False are:
+    // * “Invalid”
+    // * “Pending”
+    TLSConnectionPolicyConditionAccepted TLSConnectionPolicyConditionType = “Accepted”
+
+	// This reason is used with the “Accepted” condition when the condition is true.
+    TLSConnectionPolicyReasonAccepted TLSConnectionPolicyConditionReason = “Valid”
+
+    // This reason is used with the “Accepted” condition when the TLSConnectionPolicy is invalid, e.g. crossing namespace boundaries.
+    TLSConnectionPolicyReasonInvalid TLSConnectionPolicyConditionReason = “Invalid”
+
+    // This reason is used with the “Accepted” condition when the TLSConnectionPolicy is pending validation.
+    TLSConnectionPolicyReasonPending TLSConnectionPolicyConditionReason = “Pending”
+)
+```
+
+## How a client behaves
+
+This table describes the effect that a TLSConnectionPolicy has on a Route.  There are only two cases where the
+TLSConnectionPolicy will signal a Route to connect to a backend using TLS, an HTTPRoute with a backend that is targeted
+by a TLSConnectionPolicy, either with or without listener TLS configured.  (There are a few other cases where it may be
+possible, but is purposely marked “not supported” due to a desire for less confusion on the assigned purpose of each of
+the protocol-affiliated types of Routes.)
+
+| Route Type | Gateway Config             | Backend is targeted by a TLSConnectionPolicy? | Connect to backend  with TLS? |
+|------------|----------------------------|-----------------------------------------------|-------------------------------|
+| HTTPRoute  | Listener tls               | Yes                                           | **Yes**                       |
+| HTTPRoute  | No listener tls            | Yes                                           | **Yes**                       |
+| HTTPRoute  | Listener tls               | No                                            | No                            |
+| HTTPRoute  | No listener tls            | No                                            | No                            |
+| TLSRoute   | Listener Mode: Passthrough | Yes                                           | No                            |
+| TLSRoute   | Listener Mode: Terminate   | Yes                                           | Not supported                 |
+| TLSRoute   | Listener Mode: Passthrough | No                                            | No                            |
+| TLSRoute   | Listener Mode: Terminate   | No                                            | No                            |
+| TCPRoute   | Listener TLS               | Yes                                           | Not supported                 |
+| TCPRoute   | No listener TLS            | Yes                                           | Not supported                 |
+| TCPRoute   | Listener TLS               | No                                            | No                            |
+| TCPRoute   | No listener TLS            | No                                            | No                            |
+| UDPRoute   | Listener TLS               | N/A                                           | No                            |
+| UDPRoute   | No listener TLS            | N/A                                           | No                            |
+| UDPRoute   | Listener TLS               | N/A                                           | No                            |
+| UDPRoute   | No listener TLS            | N/A                                           | No                            |
+| GRPCRoute  | N/A                        | N/A                                           | No                            |
+
+## Request Flow
+
+One additional step would be added to the typical client/gateway API request flow for a gateway implemented using a
+reverse proxy. This is shown as step 6 below.
+
+1. A client makes a request to http://foo.example.com.
+2. DNS resolves the name to a Gateway address.
+3. The reverse proxy receives the request on a Listener and uses the Host header to match an HTTPRoute.
+4. Optionally, the reverse proxy can perform request header and/or path matching based on match rules of the HTTPRoute.
+5. Optionally, the reverse proxy can modify the request, i.e. add/remove headers, based on filter rules of the HTTPRoute.
+6. __(New) Optionally, the reverse proxy can determine the outcome of verifying the cert served by the backend, based on
+backendRef rules of the HTTPRoute.__
+7. Lastly, the reverse proxy forwards the request to one or more objects, i.e. Service, in the cluster based on
+backendRefs rules of the HTTPRoute.
+
+## Alternatives
+Most alternatives are enumerated in the section on the history of backend TLS above.  A couple of additional
+alternatives are also listed here.
+
+1. Expand BackendRef, which is already an expansion point.  At first, it seems logical that since listeners are handling
+the client-gateway certs, BackendRefs could handle the gateway-backend certs.  However, when multiple Routes to target
+the same Service, there would be unnecessary copying of the BackendRef every time the Service was targeted.  As well,
+there could be multiple bBackendRefs with multiple rules on a rRoute, each of which might need the gateway-backend cert
+configuration so it is not the appropriate pattern.
+2. Extend HTTPRoute to indicate TLS backend support. Extending HTTPRoute would interfere with deployed implementations
+too much to be a practical solution.
+3. Add a new type of Route for backend TLS.  This is impractical because we might want to enable backend TLS on other
+route types in the future, and because we might want to have both TLS listeners and backend TLS on a single route.
 
 ## Prior Art
 
@@ -181,19 +408,34 @@ Ref: [Upstream.TLS](https://docs.nginx.com/nginx-ingress-controller/configuratio
 Ref: [EgressMTLS](https://docs.nginx.com/nginx-ingress-controller/configuration/policy-resource/#egressmtls)
 Ref: [IngressMTLS](https://docs.nginx.com/nginx-ingress-controller/configuration/policy-resource/#ingressmtls)
 
-## Open Questions (TODO)
+## Open Questions
 
-This section is to record issues that should be discussed in the implementation section before this GEP moves
+This section is to record issues that were warranted for discussion in the API section before this GEP moves
 out of `Provisional` status.
 
 1. Bowei recommended that we mention the approach of cross-namespace referencing between Route and Service.
-Be explicit about using the standard rules with respect to attaching policies to resources.
+Be explicit about using the standard rules with respect to attaching policies to resources.  This is mentioned in the
+API section.
 2. Costin recommended that Gateway SHOULD authenticate with either a JWT with audience or client cert
-or some other means - so gateway added headers can be trusted, etc.
+or some other means - so gateway added headers can be trusted, amongst other things.  This is out of scope for this
+proposal, which centers around application developer persona resources such as HTTPRoute and Service.
 3. Costin mentioned we need to answer the question - is configuring the connection to a backend and TLS
-something the route author decides - or the backend owner?  Same for SANs.  However, providing a mechanism
-for the cluster operator to override gateway to backend TLS settings is already listed as a Non-Goal.
+something the route author decides - or the backend owner?  Same for SAN (Subject Alternative Name) certificates.
+The use of SAN certificates and the use of SNI, as a part of TLS, can be implementation-dependent, though the
+application can still reject any request or certificate that it doesn’t support, including requests with SNI or a
+certificate with SANs.
 
 ## References
 
 [Gateway API TLS Use Cases](https://docs.google.com/document/d/17sctu2uMJtHmJTGtBi_awGB0YzoCLodtR6rUNmKMCs8/edit#heading=h.cxuq8vo8pcxm)
+https://gateway-api.sigs.k8s.io/geps/gep-713/
+https://gateway-api.sigs.k8s.io/references/policy-attachment/
+https://gateway-api.sigs.k8s.io/v1alpha2/guides/tls/
+https://docs.nginx.com/nginx-ingress-controller/configuration/policy-resource/#egressmtls
+[SIG-NET[Gateway API]: TLS to the K8s.Service/Backend](https://docs.google.com/document/d/1RTYh2brg_vLX9o3pTcrWxtZSsf8Y5NQvIG52lpFcZlo)
+https://serverfault.com/questions/807959/what-is-the-difference-between-san-and-sni-ssl-certificates
+[GEP-713: Metaresources and PolicyAttachment](https://gateway-api.sigs.k8s.io/geps/gep-713/)
+[Policy Attachment](https://gateway-api.sigs.k8s.io/references/policy-attachment/#direct-policy-attachment)
+[RFC4346 TLS 1.1](https://datatracker.ietf.org/doc/html/rfc4346#appendix-A.5)
+[RFC 5246 TLS 1.2](https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5)
+[RFC 8446 TLS 1.3](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.4)

--- a/geps/gep-1897.md
+++ b/geps/gep-1897.md
@@ -64,6 +64,7 @@ has its own certificate and the gateway client needs to know how to connect to t
 
 Gateway API is missing a mechanism for separately providing the details for the backend TLS handshake,
 including:
+
 * use of TLS
 * destination CA (certificate authority) or CA bundle
 * SANs for validating upstream service (server authentication)
@@ -152,8 +153,8 @@ Route resource, we can reuse the same TLSConnectionPolicy for all the different 
 For the use case where certificates are stored in their own namespace, users may create Secrets and use ReferenceGrants
 for a TLSConnectionPolicy-to-Secret binding.
 
-In the API defined here, the definition of TrustedCACertRefs follows a convention established by the CertificateRefs field on Gateway in
-https://github.com/kubernetes-sigs/gateway-api/blob/18e79909f7310aafc625ba7c862dfcc67b385250/apis/v1beta1/gateway_types.go#L340
+In the API defined here, the definition of TrustedCACertRefs follows a convention established by the [CertificateRefs
+field on Gateway.](https://github.com/kubernetes-sigs/gateway-api/blob/18e79909f7310aafc625ba7c862dfcc67b385250/apis/v1beta1/gateway_types.go#L340)
 
 One of the areas of concern for this API is that we need to indicate how and when the API implementations should use the
 backend destination certificate authority.  This solution proposes, as introduced in
@@ -179,7 +180,6 @@ assist with selection of certificates when several hosts share the same IP addre
 1.3 as described in [RFC4346 TLS 1.1](https://datatracker.ietf.org/doc/html/rfc4346#appendix-A.5),
 [RFC 5246 TLS 1.2](https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5), and
 [RFC 8446 TLS 1.3](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.4).
-- Version: specifies the minimum TLS version that the connection may use (default TLSv1.2)
 - Visibility: the visibility level could be all or none, indicating that if the connection failed due to validation
 failures, it would drop the connection silently if the visibility level were none, and report an error if the visibility
 level were all.  (default to all)
@@ -203,6 +203,7 @@ type TLSConnectionPolicy struct {
 // Note: there is no Override or Default policy configuration.
 type TLSConnectionPolicySpec struct {
     // TargetRef identifies an API object to apply policy to.
+    // Services are the only valid API target references.
     TargetRef gatewayv1a2.PolicyTargetReference `json:"targetRef"`
 
     // TLS contains TLS connection policy configuration.
@@ -278,8 +279,11 @@ const (
     // This condition indicates that the TLSConnectionPolicy has been
     // accepted as valid.
     // Possible reason for this condition to be True is:
-    // * “Validated”
+    //
+    // * “Accepted” 
+    // 
     // Possible reasons for this condition to be False are:
+    //
     // * “Invalid”
     // * “Pending”
     TLSConnectionPolicyConditionAccepted TLSConnectionPolicyConditionType = “Accepted”
@@ -333,7 +337,7 @@ reverse proxy. This is shown as step 6 below.
 3. The reverse proxy receives the request on a Listener and uses the Host header to match an HTTPRoute.
 4. Optionally, the reverse proxy can perform request header and/or path matching based on match rules of the HTTPRoute.
 5. Optionally, the reverse proxy can modify the request, i.e. add/remove headers, based on filter rules of the HTTPRoute.
-6. __(New) Optionally, the reverse proxy can determine the outcome of verifying the cert served by the backend, based on
+6. __(New) Optionally, the reverse proxy can can employ TLS to verify the cert served by the backend, based on
 backendRef rules of the HTTPRoute.__
 7. Lastly, the reverse proxy forwards the request to one or more objects, i.e. Service, in the cluster based on
 backendRefs rules of the HTTPRoute.
@@ -403,12 +407,14 @@ Ref: [TLS Origination](https://www.getambassador.io/docs/emissary/latest/topics/
 * A corresponding 'IngressMTLS' policy also exists for mTLS verification of client connections to the proxy.  The Policy object is used for anything that implies AuthN/AuthZ.
 
 Ref: [Upstream.TLS](https://docs.nginx.com/nginx-ingress-controller/configuration/virtualserver-and-virtualserverroute-resources/#upstreamtls)
+
 Ref: [EgressMTLS](https://docs.nginx.com/nginx-ingress-controller/configuration/policy-resource/#egressmtls)
+
 Ref: [IngressMTLS](https://docs.nginx.com/nginx-ingress-controller/configuration/policy-resource/#ingressmtls)
 
 ## Open Questions
 
-This section is to record issues that were warranted for discussion in the API section before this GEP moves
+This section is to record issues that were requested for discussion in the API section before this GEP moves
 out of `Provisional` status.
 
 1. Bowei recommended that we mention the approach of cross-namespace referencing between Route and Service.

--- a/geps/gep-1897.md
+++ b/geps/gep-1897.md
@@ -25,11 +25,17 @@ Gateway to backend**, such as TLS versions and cipher suites. (Use case #5 in [G
 
 ## Longer Term Goals
 
-These are worthy goals, but may need a different GEP for proper attention.
+These are worthy goals, but may need a different GEP for proper attention.  This GEP is concerned entirely with the
+controlplane, i.e. the hop between gateway and backend.
 
-1. TCPRoute use cases (completed by GA)
-2. Mutual TLS use cases
-3. Service mesh use cases
+1. [TCPRoute](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute) and
+[GRPCRoute](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRoute) use cases
+are not addressed here, because at this point in time these two route types are not graduated to beta.
+2. Mutual TLS (mTLS) use cases are not thoroughly addressed here because we have tried and failed in the past to
+generalize around mTLS, and the treatment of mTLS should be taken outside the context of the hop between gateway and
+backend.
+3. Service mesh use cases are not addressed here because the main concern is the controlplane hop between gateway
+and backend, which is only one part of the picture in a service mesh.
 
 ## Non-Goals
 
@@ -151,38 +157,51 @@ applied to.  The TLSConnectionPolicy and the Service must reside in the same nam
 complications involved with sharing trust across namespace boundaries.  By choosing the Service resource rather than the
 Route resource, we can reuse the same TLSConnectionPolicy for all the different Routes that might point to this Service.
 For the use case where certificates are stored in their own namespace, users may create Secrets and use ReferenceGrants
-for a TLSConnectionPolicy-to-Secret binding.
+for a TLSConnectionPolicy-to-Secret binding.  Implementations must respect a ReferenceGrant for cross-namespace Secret
+sharing to TLCConnectionPolicy, even if they don't for other cross-namespace sharing.
 
-In the API defined here, the definition of TrustedCACertRefs follows a convention established by the [CertificateRefs
-field on Gateway.](https://github.com/kubernetes-sigs/gateway-api/blob/18e79909f7310aafc625ba7c862dfcc67b385250/apis/v1beta1/gateway_types.go#L340)
+In the API defined here, the TrustedCACertRef is a slice of named config maps containing a single cert. We originally
+proposed to follow the convention established by the 
+[CertificateRefs field on Gateway](https://github.com/kubernetes-sigs/gateway-api/blob/18e79909f7310aafc625ba7c862dfcc67b385250/apis/v1beta1/gateway_types.go#L340)
+, but the CertificateRef requires both a tls.key and tls.crt and a TrustedCACertRef really only requires a tls.crt.
 
 One of the areas of concern for this API is that we need to indicate how and when the API implementations should use the
 backend destination certificate authority.  This solution proposes, as introduced in
 [GEP-713](https://gateway-api.sigs.k8s.io/geps/gep-713/), that the implementation
-should watch the connections to a specific port on a specified targetRef (such as a Service), and if the port and
-Service match a TLSConnectionPolicy, then assume the connection is TLS, and verify that the targetRef’s certificate can
+should watch the connections to a specified TargetRef (Service), and if the Service matches a TLSConnectionPolicy, then
+assume the connection is TLS, and verify that the TargetRef’s certificate can
 be validated by the provided trusted CA certificates before the connection is made.  On the question of how to signal
 that there was a failure in the certificate validation, this is left up to the implementation to return a response error
 that is appropriate, such as one of the HTTP error codes: 400 (Bad Request), 401 (Unauthorized), 403 (Forbidden), or
 other signal that makes the failure sufficiently clear to the requester without revealing too much about the transaction,
 based on established security requirements.
 
+All policy resources must include TargetRef with the fields specified 
+[here](https://github.com/kubernetes-sigs/gateway-api/blob/a33a934af9ec6997b34fd9b00d2ecd13d143e48b/apis/v1alpha2/policy_types.go#L24-L41).
+In an upcoming extension to TargetRef, policy resources _may_ also choose to include `SectionName` and/or `Port` in the
+TargetRef following the same mechanics as `ParentRef`.
+
 Not covered here, but possible to add would be additional configuration options mentioned in [SIG-NET Gateway API: TLS
 to the K8s.Service/Backend](https://docs.google.com/document/d/1RTYh2brg_vLX9o3pTcrWxtZSsf8Y5NQvIG52lpFcZlo).  All of
 these are currently implementation-dependent, with the following recommended defaults:
 
-- Server Name Indication: enables passing of the server name through server name indication, in the TLS transaction, to
+- Server Name Indication: allow passing of the server name through server name indication, in the TLS transaction, to
 assist with selection of certificates when several hosts share the same IP address. (default to enabled)
-- Subject Alternative Name certificates: enable the use of a single certificate that can serve multiple domains.
+- Subject Alternative Name certificates: allow authentication with a single certificate that can serve multiple domain
+names that are intended to represent the same endpoint.  For example, these five SAN hosts: example.com, 
+www.example.com, example.net, IPv4 x.x.x.x, and IPv6 x.x.x.x.x.x.x.x all resolve to the same endpoint.
 (default to enabled)
 - Version: specifies the minimum TLS version that the connection may use (default TLSv1.2)
-- Ciphers: specifies enabled ciphers to be used in TLS exchanges. (default to align with TLS versions 1.1, 1.2, and/or
-1.3 as described in [RFC4346 TLS 1.1](https://datatracker.ietf.org/doc/html/rfc4346#appendix-A.5),
-[RFC 5246 TLS 1.2](https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5), and
+- Ciphers: specifies enabled ciphers to be used in TLS exchanges. (default to align with default TLS version chosen for
+Version, e.g. ciphers mentioned for TLS version 1.1, 1.2, or 1.3 as described in 
+[RFC4346 TLS 1.1](https://datatracker.ietf.org/doc/html/rfc4346#appendix-A.5),
+[RFC 5246 TLS 1.2](https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5), or
 [RFC 8446 TLS 1.3](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.4).
-- Visibility: the visibility level could be all or none, indicating that if the connection failed due to validation
-failures, it would drop the connection silently if the visibility level were none, and report an error if the visibility
-level were all.  (default to all)
+- Visibility: the visibility level could be `all` or `none`, and represents that if the connection failed, 
+the implmentation would drop the connection silently if the visibility level were `none`, or report an error if the
+visibility level were `all`.  (default to `all`)
+
+Thus, the following additions would be made to the Gateway API:
 
 ```go
 // TLSConnectionPolicy provides a way to publish TLS configuration
@@ -201,6 +220,8 @@ type TLSConnectionPolicy struct {
 // TLSConnectionPolicySpec defines the desired state of
 // TLSConnectionPolicy.
 // Note: there is no Override or Default policy configuration.
+//
+// Support: Core
 type TLSConnectionPolicySpec struct {
     // TargetRef identifies an API object to apply policy to.
     // Services are the only valid API target references.
@@ -213,36 +234,39 @@ type TLSConnectionPolicySpec struct {
 // TLSConnectionPolicyConfig contains TLS connection policy configuration.
 type TLSConnectionPolicyConfig struct {
     // TrustedCACertRefs contains one or more references to
-    // Kubernetes objects that contain TLS certificates, which are
-    // used to establish a TLS handshake between the gateway and
-    // backend pod.
+    // Kubernetes objects that contain PEM-encoded TLS certificates,
+    // which are used to establish a TLS handshake between the gateway
+    // and backend pod.
     //
-    // A single TrustedCACertRef to a Kubernetes Secret has "Core"
+    // If the TrustedCACertRefs is empty, then the system trusted
+    // certificates should be used. If there are none, or the
+    // implementation doesn't define system trusted certificates,
+    // then a TLS connection must fail.
+    //
+    // A single TrustedCACertRef to a Kubernetes ConfigMap has "Core"
     // support.  Implementations MAY choose to support attaching
-    // multiple certificates to a backend, but this behavior is 
+    // multiple certificates to a backend, but this behavior is
     // implementation-specific.
     //
     // References to a resource in a different namespace are 
     // invalid.
     // 
-    // This field is required for any TLSConnectionPolicyConfig.
-    // 
-    // Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
+    // Support: Core - An optional single reference to a Kubernetes
+    // ConfigMapName.
     //
-    // Support: Implementation-specific (More than one reference or other resource types)
+    // Support: Implementation-specific (No reference, more than one
+    // reference, or other resource types.)
     //
     // +kubebuilder:validation:MaxItems=64
-    // +kubebuilder:validation:MinItems=1
-    TrustedCACertRefs []SecretObjectReference `json:”trustedCACertRefs”`
+    // +optional
+    TrustedCACertRefs []ConfigMapName `json:”trustedCACertRefs”`
+}
 
-    // Port is the network port that the implementation watches to
-    // know if the connection should be TLS and the targetRef’s
-    // certificate should be validated by the certs in TrustedCACertRefs
-    // If empty, then all ports for the targetRef are watched to know
-    // if the connection should be TLS, the targetRef’s certificate
-    // should be validated by the certs in TrustedCACertRefs, and a
-    // status delivered in the response for validation failures.
-    Port PortNumber `json:port,omitempty`
+// ConfigMapName references a named config map.
+type ConfigMapName struct {
+    // name is the metadata.name of the referenced config map.
+    // +kubebuilder:validation:Required
+    Name string `json"name"`
 }
 
 // TLSConnectionPolicyStatus defines the observed state of TLSConnectionPolicy.
@@ -288,7 +312,7 @@ const (
     // * “Pending”
     TLSConnectionPolicyConditionAccepted TLSConnectionPolicyConditionType = “Accepted”
 
-	// This reason is used with the “Accepted” condition when the condition is true.
+    // This reason is used with the “Accepted” condition when the condition is true.
     TLSConnectionPolicyReasonAccepted TLSConnectionPolicyConditionReason = “Valid”
 
     // This reason is used with the “Accepted” condition when the TLSConnectionPolicy is invalid, e.g. crossing namespace boundaries.
@@ -329,18 +353,16 @@ the protocol-affiliated types of Routes.)
 
 ## Request Flow
 
-One additional step would be added to the typical client/gateway API request flow for a gateway implemented using a
-reverse proxy. This is shown as step 6 below.
+Step 6 would be changed in the typical client/gateway API request flow for a gateway implemented using a
+reverse proxy. This is shown as **bolded** additions in step 6 below.
 
 1. A client makes a request to http://foo.example.com.
 2. DNS resolves the name to a Gateway address.
 3. The reverse proxy receives the request on a Listener and uses the Host header to match an HTTPRoute.
 4. Optionally, the reverse proxy can perform request header and/or path matching based on match rules of the HTTPRoute.
 5. Optionally, the reverse proxy can modify the request, i.e. add/remove headers, based on filter rules of the HTTPRoute.
-6. __(New) Optionally, the reverse proxy can can employ TLS to verify the cert served by the backend, based on
-backendRef rules of the HTTPRoute.__
-7. Lastly, the reverse proxy forwards the request to one or more objects, i.e. Service, in the cluster based on
-backendRefs rules of the HTTPRoute.
+6. Lastly, the reverse proxy **optionally performs a TLS handshake** and forwards the request to one or more objects,
+i.e. Service, in the cluster based on backendRefs rules of the HTTPRoute **and TLSTargetRef of the TLSConnectionPolicy**.
 
 ## Alternatives
 Most alternatives are enumerated in the section on the history of backend TLS above.  A couple of additional

--- a/geps/gep-1897.md
+++ b/geps/gep-1897.md
@@ -37,10 +37,11 @@ controlplane, i.e. the hop between gateway and backend.
 1. [TCPRoute](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute) and
 [GRPCRoute](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRoute) use cases
 are not addressed here, because at this point in time these two route types are not graduated to beta.
-2. Mutual TLS (mTLS) use cases are intentionally out of scope for this GEP because this GEP does not address the case
-where connections to TLS are implicitly configured on behalf of the user, such as in Service Mesh.  It is about the
-case where an application developer needs to explicitly express that they expect TLS when there is no automatic,
-implicit configuration of that.
+2. Mutual TLS (mTLS) use cases are intentionally out of scope for this GEP for two reasons.  First, the design of Gateway
+API is backend-attached and does not currently support mutual authentication, and also because this GEP does not
+address the case where connections to TLS are **implicitly configured** on behalf of the user, which is the norm for mTLS.
+This GEP is about the case where an application developer needs to **explicitly express** that they expect TLS when
+there is no automatic, implicit configuration available.
 3. Service mesh use cases are not addressed here because this GEP is specifically concerned with the connection between
 Gateways and Backends, not Service to Service.  Service mesh use cases should ignore TLSConnectionPolicy.
 
@@ -179,48 +180,54 @@ complications involved with sharing trust across namespace boundaries.  By choos
 Route resource, we can reuse the same TLSConnectionPolicy for all the different Routes that might point to this Service.
 For the use case where certificates are stored in their own namespace, users may create Secrets and use ReferenceGrants
 for a TLSConnectionPolicy-to-Secret binding.  Implementations must respect a ReferenceGrant for cross-namespace Secret
-sharing to TLCConnectionPolicy, even if they don't for other cross-namespace sharing.
+sharing to TLSConnectionPolicy, even if they don't for other cross-namespace sharing.
 
-In the API defined here, the TrustedCACertRef is a slice of named config maps containing a single cert. We originally
-proposed to follow the convention established by the 
-[CertificateRefs field on Gateway](https://github.com/kubernetes-sigs/gateway-api/blob/18e79909f7310aafc625ba7c862dfcc67b385250/apis/v1beta1/gateway_types.go#L340)
-, but the CertificateRef requires both a tls.key and tls.crt and a TrustedCACertRef really only requires a tls.crt.
 
 One of the areas of concern for this API is that we need to indicate how and when the API implementations should use the
 backend destination certificate authority.  This solution proposes, as introduced in
 [GEP-713](https://gateway-api.sigs.k8s.io/geps/gep-713/), that the implementation
 should watch the connections to a specified TargetRef (Service), and if the Service matches a TLSConnectionPolicy, then
-assume the connection is TLS, and verify that the TargetRef’s certificate can
-be validated by the provided trusted CA certificates before the connection is made.  On the question of how to signal
+assume the connection is TLS, and verify that the TargetRef’s certificate can be validated by the client (Gateway) using
+the provided trusted CA certificates, subject alternative names, and TLS versions, before the connection is made.
+On the question of how to signal
 that there was a failure in the certificate validation, this is left up to the implementation to return a response error
 that is appropriate, such as one of the HTTP error codes: 400 (Bad Request), 401 (Unauthorized), 403 (Forbidden), or
 other signal that makes the failure sufficiently clear to the requester without revealing too much about the transaction,
 based on established security requirements.
 
-All policy resources must include TargetRef with the fields specified 
+All policy resources must include `TargetRef` with the fields specified
 [here](https://github.com/kubernetes-sigs/gateway-api/blob/a33a934af9ec6997b34fd9b00d2ecd13d143e48b/apis/v1alpha2/policy_types.go#L24-L41).
 In an upcoming extension to TargetRef, policy resources _may_ also choose to include `SectionName` and/or `Port` in the
 TargetRef following the same mechanics as `ParentRef`.
 
-Not covered here, but possible to add would be additional configuration options mentioned in [SIG-NET Gateway API: TLS
-to the K8s.Service/Backend](https://docs.google.com/document/d/1RTYh2brg_vLX9o3pTcrWxtZSsf8Y5NQvIG52lpFcZlo).  All of
-these are currently implementation-dependent, with the following recommended defaults:
+TLSConnectionPolicySpec includes `TargetRef` and `TLS` fields.  The `TLS` field is a `TLSConnectionPolicyConfig` and
+contains `TrustedCACertRefs`, `AllowedSANs`, and `TLSVersions` to describe the fields that implementations may cover.
+The names of the fields were chosen to facilitate discussion, but may be substituted without blocking acceptance of the
+content of the API change.
 
-- Server Name Indication: allow passing of the server name through server name indication, in the TLS transaction, to
-assist with selection of certificates when several hosts share the same IP address. (default to enabled)
-- Subject Alternative Name certificates: allow authentication with a single certificate that can serve multiple domain
+In the API defined here, the `TrustedCACertRefs` is a slice of named config maps containing a single cert. We originally
+proposed to follow the convention established by the
+[CertificateRefs field on Gateway](https://github.com/kubernetes-sigs/gateway-api/blob/18e79909f7310aafc625ba7c862dfcc67b385250/apis/v1beta1/gateway_types.go#L340)
+, but the CertificateRef requires both a tls.key and tls.crt and a `TrustedCACertRef` really only requires a tls.crt.
+`TrustedCACertRefs` contains one or more (up to 64) references to Kubernetes objects that contain PEM-encoded TLS certificates,
+which are used to establish a TLS handshake between the gateway and backend pod.  If empty, then the system trusted
+certificates should be used.  If there are no system trusted certificates or the implementation doesn't define system
+trusted certificates, then a TLS connection must fail when the field is empty.  References to a resource in a
+different namespace are invalid.
+
+TLSConnectionPolicySpec supports the configuration of Subject Alternative Name certificates via the `AllowedSANs` field.
+One or more (up to 1024) subject alternative names may be declared.  SAN certificates allow authentication with a single
+certificate that can serve multiple domain
 names that are intended to represent the same endpoint.  For example, these five SAN hosts: example.com, 
-www.example.com, example.net, IPv4 x.x.x.x, and IPv6 x.x.x.x.x.x.x.x all resolve to the same endpoint.
-(default to enabled)
-- Version: specifies the minimum TLS version that the connection may use (default TLSv1.2)
-- Ciphers: specifies enabled ciphers to be used in TLS exchanges. (default to align with default TLS version chosen for
-Version, e.g. ciphers mentioned for TLS version 1.1, 1.2, or 1.3 as described in 
-[RFC4346 TLS 1.1](https://datatracker.ietf.org/doc/html/rfc4346#appendix-A.5),
-[RFC 5246 TLS 1.2](https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5), or
-[RFC 8446 TLS 1.3](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.4).
-- Visibility: the visibility level could be `all` or `none`, and represents that if the connection failed, 
-the implmentation would drop the connection silently if the visibility level were `none`, or report an error if the
-visibility level were `all`.  (default to `all`)
+www.example.com, example.net, IPv4 x.x.x.x, and IPv6 x.x.x.x.x.x.x.x all resolve to the same endpoint. If `AllowedSANs`
+is set, then an implementation must validate that the backend pod-provided certificate represents a SAN in its list.
+If empty, then any SAN is allowed.
+
+Finally, TLSConnectionPolicy allows the configuration of expected TLS versions via the `TLSVersions` field.
+TLS versions specify one or more (up to 3) TLS versions that the connection may use.  If the `TLSVersions` field is set,
+then the implementation must use the given versions if they are allowed.  If none of the versions are allowed, then the
+TLS connection must fail.  If no TLS versions are specified, then an implementation may choose to apply a self-determined
+default version.
 
 Thus, the following additions would be made to the Gateway API:
 
@@ -328,9 +335,9 @@ type TLSConnectionPolicyConfig struct {
 type TLSVersionType string
 
 const (
-    TLSVersion1.1 TLSVersionType = "1.1"
-    TLSVersion1.2 TLSVersionType = "1.2"
-    TLSVersion1.3 TLSVersionType = "1.3"
+    VersionTLS11 TLSVersionType = "1.1"
+    VersionTLS12 TLSVersionType = "1.2"
+    VersionTLS13 TLSVersionType = "1.3"
 )
 
 // ConfigMapName references a named config map.

--- a/geps/gep-1897.md
+++ b/geps/gep-1897.md
@@ -1,4 +1,4 @@
-# GEP-1897: TLSConnectionPolicy - Explicit Backend TLS Connection Configuration
+# GEP-1897: BackendTLSPolicy - Explicit Backend TLS Connection Configuration
 
 * Issue: [#1897](https://github.com/kubernetes-sigs/gateway-api/issues/1897)
 * Status: Provisional
@@ -143,31 +143,29 @@ This GEP is the outcome of the TLS use case #4 in
 ## API
 
 To allow the gateway client to know how to connect to the backend pod, when the backend pod has its own
-certificate, we implement a metaresource named `TLSConnectionPolicy`, that was previously introduced as a
-hypothetical Direct Policy Attachment example in
+certificate, we implement a metaresource named `BackendTLSPolicy`, that was previously introduced with the name
+`TLSConnectionPolicy` as a hypothetical Direct Policy Attachment example in
 [GEP-713: Metaresources and PolicyAttachment](https://gateway-api.sigs.k8s.io/geps/gep-713/).
-
-In this document, and because naming is hard, we chose to retain the
-name TLSConnectionPolicy to advertise alignment with a previously discussed naming choice, but a new name may be
+Because naming is hard, a new name may be
 substituted without blocking acceptance of the content of the API change.
 
-The selection of the applicable Gateway API persona is important in the design of TLSConnectionPolicy, because it provides
-a way to explicitly describe the _expectations_ of the connection to the application.  TLSConnectionPolicy is configured
+The selection of the applicable Gateway API persona is important in the design of BackendTLSPolicy, because it provides
+a way to explicitly describe the _expectations_ of the connection to the application.  BackendTLSPolicy is configured
 by the application developer Gateway API persona to signal what the application developer _expects_ in connections to
 the application, from a TLS perspective.  Only the application developer can know what the application expects, so it is
 important that this configuration be managed by that persona.
 
 During the course of discussion of this proposal, we did consider allowing the cluster operator persona to have some access
-to Gateway cert validation, but as mentioned, TLSConnectionPolicy is used primarily to signal what the application
+to Gateway cert validation, but as mentioned, BackendTLSPolicy is used primarily to signal what the application
 developer expects in the connection.  Granting this expectation to any other role would blur the lines between role
 responsibilities, which compromises the role-oriented design principle of Gateway API. As mentioned in Non-goal #8,
 providing a mechanism for the cluster operator gateway role to override gateway to backend TLS settings is not covered
-by this proposal, but should be addressed in a future update.  One idea is to use two types: ApplicationTLSConnectionPolicy,
-and GatewayTLSConnectionPolicy, where the application developer is responsible for the former, the cluster operator is
+by this proposal, but should be addressed in a future update.  One idea is to use two types: ApplicationBackendTLSPolicy,
+and GatewayBackendTLSPolicy, where the application developer is responsible for the former, the cluster operator is
 responsible for the latter, and the cluster operator may configure whether certain settings may be overridden by
 application developers.
 
-The TLSConnectionPolicy must contain these configuration items to allow the Gateway to operate successfully
+The BackendTLSPolicy must contain these configuration items to allow the Gateway to operate successfully
 as a TLS Client:
 
 - An explicit signal that TLS should be used by this connection.
@@ -175,20 +173,20 @@ as a TLS Client:
 - A reference to one or more certificates to use in the TLS handshake, signed by a CA or self-signed.
 - An indication that system certificates may be used.
 
-TLSConnectionPolicy is defined as a Direct Policy Attachment without defaults or overrides, applied to a Service that
-accesses the backend in question, where the TLSConnectionPolicy resides in the same namespace as the Service it is
-applied to.  The TLSConnectionPolicy and the Service must reside in the same namespace in order to prevent the
+BackendTLSPolicy is defined as a Direct Policy Attachment without defaults or overrides, applied to a Service that
+accesses the backend in question, where the BackendTLSPolicy resides in the same namespace as the Service it is
+applied to.  The BackendTLSPolicy and the Service must reside in the same namespace in order to prevent the
 complications involved with sharing trust across namespace boundaries.  We chose the Service resource as a target,
-rather than the Route resource, so that we can reuse the same TLSConnectionPolicy for all the different Routes that
+rather than the Route resource, so that we can reuse the same BackendTLSPolicy for all the different Routes that
 might point to this Service.
 For the use case where certificates are stored in their own namespace, users may create Secrets and use ReferenceGrants
-for a TLSConnectionPolicy-to-Secret binding.  Implementations must respect a ReferenceGrant for cross-namespace Secret
-sharing to TLSConnectionPolicy, even if they don't for other cross-namespace sharing.
+for a BackendTLSPolicy-to-Secret binding.  Implementations must respect a ReferenceGrant for cross-namespace Secret
+sharing to BackendTLSPolicy, even if they don't for other cross-namespace sharing.
 
 One of the areas of concern for this API is that we need to indicate how and when the API implementations should use the
 backend destination certificate authority.  This solution proposes, as introduced in
 [GEP-713](https://gateway-api.sigs.k8s.io/geps/gep-713/), that the implementation
-should watch the connections to a specified TargetRef (Service), and if the Service matches a TLSConnectionPolicy, then
+should watch the connections to a specified TargetRef (Service), and if the Service matches a BackendTLSPolicy, then
 assume the connection is TLS, and verify that the TargetRef’s certificate can be validated by the client (Gateway) using
 the provided certificates and hostname before the connection is made. On the question of how to signal
 that there was a failure in the certificate validation, this is left up to the implementation to return a response error
@@ -201,7 +199,7 @@ All policy resources must include `TargetRef` with the fields specified
 In an upcoming [extension](https://github.com/kubernetes-sigs/gateway-api/issues/2147) to TargetRef, policy resources
 _may_ also choose to include `SectionName` and/or `Port` in the TargetRef following the same mechanics as `ParentRef`.
 
-TLSConnectionPolicySpec contains the `TargetRef` and `TLS` fields.  The `TLS` field is a `TLSConnectionPolicyConfig` and
+BackendTLSPolicySpec contains the `TargetRef` and `TLS` fields.  The `TLS` field is a `BackendTLSPolicyConfig` and
 contains `CertRefs`, `StandardCerts`, and `Hostname`.
 The names of the fields were chosen to facilitate discussion, but may be substituted without blocking acceptance of the
 content of the API change.
@@ -237,25 +235,25 @@ Thus, the following additions would be made to the Gateway API:
 ```go
 import "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-// TLSConnectionPolicy provides a way to publish TLS configuration
+// BackendTLSPolicy provides a way to publish TLS configuration
 // that enables a gateway client to connect to a backend pod.
-type TLSConnectionPolicy struct {
+type BackendTLSPolicy struct {
     metav1.TypeMeta   `json:",inline"`
     metav1.ObjectMeta `json:"metadata,omitempty"`
 
-    // Spec defines the desired state of TLSConnectionPolicy.
-    Spec TLSConnectionPolicySpec `json:"spec"`
+    // Spec defines the desired state of BackendTLSPolicy.
+    Spec BackendTLSPolicySpec `json:"spec"`
 
-    // Status defines the current state of TLSConnectionPolicy.
-    Status TLSConnectionPolicyStatus `json:"status,omitempty"`
+    // Status defines the current state of BackendTLSPolicy.
+    Status BackendTLSPolicyStatus `json:"status,omitempty"`
 }
 
-// TLSConnectionPolicySpec defines the desired state of
-// TLSConnectionPolicy.
+// BackendTLSPolicySpec defines the desired state of
+// BackendTLSPolicy.
 // Note: there is no Override or Default policy configuration.
 //
 // Support: Core
-type TLSConnectionPolicySpec struct {
+type BackendTLSPolicySpec struct {
     // TargetRef identifies an API object to apply policy to.
     // Services are the only valid API target references.
     // Note that this config applies to the entire referenced resource
@@ -263,14 +261,14 @@ type TLSConnectionPolicySpec struct {
     // a more granular application of the policy.
     TargetRef gatewayv1a2.PolicyTargetReference `json:"targetRef"`
 
-    // TLS contains TLS connection policy configuration.
-    TLS *TLSConnectionPolicyConfig `json:”tls”`
+    // TLS contains backend TLS policy configuration.
+    TLS *BackendTLSPolicyConfig `json:”tls”`
 }
 
-// TLSConnectionPolicyConfig contains TLS connection policy configuration.
+// BackendTLSPolicyConfig contains backend TLS policy configuration.
 // +kubebuilder:validation:XValidation:message="must not contain both CertRefs and StandardCerts",rule="(has(self.certRefs) && size(self.certRefs > 0) && has(self.standardCerts) && self.standardCerts != "")"
 // +kubebuilder:validation:XValidation:message="must specify either CertRefs or StandardCerts",rule="!(has(self.certRefs) && size(self.certRefs > 0) || has(self.standardCerts) && self.standardCerts != "")"
-type TLSConnectionPolicyConfig struct {
+type BackendTLSPolicyConfig struct {
     // CertRefs contains one or more references to
     // Kubernetes objects that contain PEM-encoded TLS certificates,
     // which are used to establish a TLS handshake between the gateway
@@ -301,7 +299,7 @@ type TLSConnectionPolicyConfig struct {
     // reference, or resource types other than ConfigMaps.
     // Service mesh may ignore.)
     //
-    // +kubebuilder:validation:MaxItems=64
+    // +kubebuilder:validation:MaxItems=8
     // +optional
     CertRefs []ConfigMapObjectReference `json:”certRefs,omitempty”`
 
@@ -343,8 +341,8 @@ type TLSConnectionPolicyConfig struct {
     // certificate served by the matching backend.
     //
     // Support: Core - A required value used by the Gateway to connect to
-    // the backend when a TLSConnectionPolicy is specified.
-    Hostname v1beta1.PreciseHostname `json:"hostname,omitempty"`
+    // the backend when a BackendTLSPolicy is specified.
+    Hostname v1beta1.PreciseHostname `json:"hostname"`
 }
 
 // StandardCertType is the type of CA certificate that will be used when
@@ -396,15 +394,15 @@ type ConfigMapObjectReference struct {
     Namespace *Namespace `json:"namespace,omitempty"`
 }
 
-// TLSConnectionPolicyStatus defines the observed state of TLSConnectionPolicy.
-type TLSConnectionPolicyStatus struct {
-    // Conditions describe the current conditions of the TLSConnectionPolicy.
+// BackendTLSPolicyStatus defines the observed state of BackendTLSPolicy.
+type BackendTLSPolicyStatus struct {
+    // Conditions describe the current conditions of the BackendTLSPolicy.
     //
-    // Implementations should prefer to express TLSConnectionPolicy
-    // conditions using the `TLSConnectionPolicyConditionType` and
-    // `TLSConnectionPolicyConditionReason` constants so that 
+    // Implementations should prefer to express BackendTLSPolicy
+    // conditions using the `BackendTLSPolicyConditionType` and
+    // `BackendTLSPolicyConditionReason` constants so that
     // operators and tools can converge on a common vocabulary to 
-    // describe TLSConnectionPolicy state.
+    // describe BackendTLSPolicy state.
     // Known condition types are:
     // 
     // * “Accepted”
@@ -417,17 +415,17 @@ type TLSConnectionPolicyStatus struct {
     Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// TLSConnectionPolicyConditionType is the type of a condition used
-// as a signal by TLSConnectionPolicy.  This type should be used with
-// the TLSConnectionPolicyStatus.Conditions field.
-type TLSConnectionPolicyConditionType string
+// BackendTLSPolicyConditionType is the type of a condition used
+// as a signal by BackendTLSPolicy.  This type should be used with
+// the BackendTLSPolicyStatus.Conditions field.
+type BackendTLSPolicyConditionType string
 
-//  TLSConnectionPolicyConditionReason is a reason that explains why a
-// particular TLSConnectionPolicyConditionType was generated.
-type TLSConnectionPolicyConditionReason string
+//  BackendTLSPolicyConditionReason is a reason that explains why a
+// particular BackendTLSPolicyConditionType was generated.
+type BackendTLSPolicyConditionReason string
 
 const (
-    // This condition indicates that the TLSConnectionPolicy has been
+    // This condition indicates that the BackendTLSPolicy has been
     // accepted as valid.
     // Possible reason for this condition to be True is:
     //
@@ -437,30 +435,30 @@ const (
     //
     // * “Invalid”
     // * “Pending”
-    TLSConnectionPolicyConditionAccepted TLSConnectionPolicyConditionType = “Accepted”
+    BackendTLSPolicyConditionAccepted BackendTLSPolicyConditionType = “Accepted”
 
     // This reason is used with the “Accepted” condition when the condition is true.
-    TLSConnectionPolicyReasonAccepted TLSConnectionPolicyConditionReason = “Valid”
+    BackendTLSPolicyReasonAccepted BackendTLSPolicyConditionReason = “Valid”
 
-    // This reason is used with the “Accepted” condition when the TLSConnectionPolicy is invalid,
+    // This reason is used with the “Accepted” condition when the BackendTLSPolicy is invalid,
     // e.g. use of a CertRef that crosses namespace boundaries.
-    TLSConnectionPolicyReasonInvalid TLSConnectionPolicyConditionReason = “Invalid”
+    BackendTLSPolicyReasonInvalid BackendTLSPolicyConditionReason = “Invalid”
 
-    // This reason is used with the “Accepted” condition when the TLSConnectionPolicy is pending validation.
-    TLSConnectionPolicyReasonPending TLSConnectionPolicyConditionReason = “Pending”
+    // This reason is used with the “Accepted” condition when the BackendTLSPolicy is pending validation.
+    BackendTLSPolicyReasonPending BackendTLSPolicyConditionReason = “Pending”
 )
 ```
 
 ## How a client behaves
 
-This table describes the effect that a TLSConnectionPolicy has on a Route.  There are only two cases where the
-TLSConnectionPolicy will signal a Route to connect to a backend using TLS, an HTTPRoute with a backend that is targeted
-by a TLSConnectionPolicy, either with or without listener TLS configured.  (There are a few other cases where it may be
+This table describes the effect that a BackendTLSPolicy has on a Route.  There are only two cases where the
+BackendTLSPolicy will signal a Route to connect to a backend using TLS, an HTTPRoute with a backend that is targeted
+by a BackendTLSPolicy, either with or without listener TLS configured.  (There are a few other cases where it may be
 possible, but is implementation dependent.)
 
-Every implementation that claims supports for TLSConnectionPolicy should document for which Routes it is being implemented.
+Every implementation that claims supports for BackendTLSPolicy should document for which Routes it is being implemented.
 
-| Route Type | Gateway Config             | Backend is targeted by a TLSConnectionPolicy? | Connect to backend  with TLS? |
+| Route Type | Gateway Config             | Backend is targeted by a BackendTLSPolicy? | Connect to backend  with TLS? |
 |------------|----------------------------|-----------------------------------------------|-------------------------------|
 | HTTPRoute  | Listener tls               | Yes                                           | **Yes**                       |
 | HTTPRoute  | No listener tls            | Yes                                           | **Yes**                       |
@@ -494,7 +492,7 @@ reverse proxy. This is shown as **bolded** additions in step 6 below.
 4. Optionally, the reverse proxy can perform request header and/or path matching based on match rules of the HTTPRoute.
 5. Optionally, the reverse proxy can modify the request, i.e. add/remove headers, based on filter rules of the HTTPRoute.
 6. Lastly, the reverse proxy **optionally performs a TLS handshake** and forwards the request to one or more objects,
-i.e. Service, in the cluster based on backendRefs rules of the HTTPRoute **and TLSTargetRef of the TLSConnectionPolicy**.
+i.e. Service, in the cluster based on backendRefs rules of the HTTPRoute **and TLSTargetRef of the BackendTLSPolicy**.
 
 ## Alternatives
 Most alternatives are enumerated in the section on the history of backend TLS above.  A couple of additional
@@ -611,7 +609,7 @@ likely look very similar to Route status.
 See [comment](https://github.com/kubernetes-sigs/gateway-api/pull/2113#issuecomment-1696127092).
 3. Rob Scott [wanted to note](https://github.com/kubernetes-sigs/gateway-api/pull/2113#issuecomment-1696127092) that
 when this graduates to the standard channel, implementations of HTTPRoute may also be
-required to watch the TLSConnectionPolicy. If one of these policies is attached to a Service targeted by an HTTPRoute,
+required to watch the BackendTLSPolicy. If one of these policies is attached to a Service targeted by an HTTPRoute,
 the implementation would be required to fully implement the policy or mark the backend invalid.
 
 ## References

--- a/geps/gep-1897.md
+++ b/geps/gep-1897.md
@@ -169,6 +169,7 @@ based on established security requirements.
 Not covered here, but possible to add would be additional configuration options mentioned in [SIG-NET Gateway API: TLS
 to the K8s.Service/Backend](https://docs.google.com/document/d/1RTYh2brg_vLX9o3pTcrWxtZSsf8Y5NQvIG52lpFcZlo).  All of
 these are currently implementation-dependent, with the following recommended defaults:
+
 - Server Name Indication: enables passing of the server name through server name indication, in the TLS transaction, to
 assist with selection of certificates when several hosts share the same IP address. (default to enabled)
 - Subject Alternative Name certificates: enable the use of a single certificate that can serve multiple domains.

--- a/geps/gep-1897.md
+++ b/geps/gep-1897.md
@@ -152,7 +152,7 @@ Route resource, we can reuse the same TLSConnectionPolicy for all the different 
 For the use case where certificates are stored in their own namespace, users may create Secrets and use ReferenceGrants
 for a TLSConnectionPolicy-to-Secret binding.
 
-In the API defined here, the definition of TrustedCACertRefs follows a convention established by TLSRoute in
+In the API defined here, the definition of TrustedCACertRefs follows a convention established by the CertificateRefs field on Gateway in
 https://github.com/kubernetes-sigs/gateway-api/blob/18e79909f7310aafc625ba7c862dfcc67b385250/apis/v1beta1/gateway_types.go#L340
 
 One of the areas of concern for this API is that we need to indicate how and when the API implementations should use the

--- a/geps/gep-1897.md
+++ b/geps/gep-1897.md
@@ -16,7 +16,7 @@ so in order to drive resolution this GEP focuses only on this single piece of fu
 1. The solution must satisfy the following use case: the backend pod has its own
 certificate and the gateway implementation client needs to know how to connect to the
 backend pod. (Use case #4 in [Gateway API TLS Use Cases](#references))
-2. In terms of the Gateway API personas, only the application developer persona in this
+2. In terms of the Gateway API personas, only the application developer persona applies in this
 solution. The application developer should control the gateway to backend TLS settings,
 not the cluster operator, as requiring a cluster operator to manage certificate renewals
 and revocations would be extremely cumbersome.
@@ -153,7 +153,7 @@ For the use case where certificates are stored in their own namespace, users may
 for a TLSConnectionPolicy-to-Secret binding.
 
 In the API defined here, the definition of TrustedCACertRefs follows a convention established by TLSRoute in
-https://github.com/kubernetes-sigs/gateway-api/blob/main/apis/v1beta1/gateway_types.go#L340
+https://github.com/kubernetes-sigs/gateway-api/blob/18e79909f7310aafc625ba7c862dfcc67b385250/apis/v1beta1/gateway_types.go#L340
 
 One of the areas of concern for this API is that we need to indicate how and when the API implementations should use the
 backend destination certificate authority.  This solution proposes, as introduced in
@@ -169,9 +169,6 @@ based on established security requirements.
 Not covered here, but possible to add would be additional configuration options mentioned in [SIG-NET Gateway API: TLS
 to the K8s.Service/Backend](https://docs.google.com/document/d/1RTYh2brg_vLX9o3pTcrWxtZSsf8Y5NQvIG52lpFcZlo).  All of
 these are currently implementation-dependent, with the following recommended defaults:
-- Visibility: the visibility level could be all or none, indicating that if the connection failed due to validation
-failures, it would drop the connection silently if the visibility level were none, and report an error if the visibility
-level were all.  This is left as implementation-dependent.
 - Server Name Indication: enables passing of the server name through server name indication, in the TLS transaction, to
 assist with selection of certificates when several hosts share the same IP address. (default to enabled)
 - Subject Alternative Name certificates: enable the use of a single certificate that can serve multiple domains.
@@ -428,14 +425,19 @@ certificate with SANs.
 ## References
 
 [Gateway API TLS Use Cases](https://docs.google.com/document/d/17sctu2uMJtHmJTGtBi_awGB0YzoCLodtR6rUNmKMCs8/edit#heading=h.cxuq8vo8pcxm)
-https://gateway-api.sigs.k8s.io/geps/gep-713/
-https://gateway-api.sigs.k8s.io/references/policy-attachment/
-https://gateway-api.sigs.k8s.io/v1alpha2/guides/tls/
-https://docs.nginx.com/nginx-ingress-controller/configuration/policy-resource/#egressmtls
-[SIG-NET[Gateway API]: TLS to the K8s.Service/Backend](https://docs.google.com/document/d/1RTYh2brg_vLX9o3pTcrWxtZSsf8Y5NQvIG52lpFcZlo)
-https://serverfault.com/questions/807959/what-is-the-difference-between-san-and-sni-ssl-certificates
+
 [GEP-713: Metaresources and PolicyAttachment](https://gateway-api.sigs.k8s.io/geps/gep-713/)
+
 [Policy Attachment](https://gateway-api.sigs.k8s.io/references/policy-attachment/#direct-policy-attachment)
+
+[Gateway API TLS](https://gateway-api.sigs.k8s.io/v1alpha2/guides/tls/)
+
+[SIG-NET Gateway API: TLS to the K8s.Service/Backend](https://docs.google.com/document/d/1RTYh2brg_vLX9o3pTcrWxtZSsf8Y5NQvIG52lpFcZlo)
+
+[SAN vs SNI](https://serverfault.com/questions/807959/what-is-the-difference-between-san-and-sni-ssl-certificates)
+
 [RFC4346 TLS 1.1](https://datatracker.ietf.org/doc/html/rfc4346#appendix-A.5)
+
 [RFC 5246 TLS 1.2](https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5)
+
 [RFC 8446 TLS 1.3](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.4)

--- a/geps/gep-1897.md
+++ b/geps/gep-1897.md
@@ -143,12 +143,11 @@ This GEP is the outcome of the TLS use case #4 in
 ## API
 
 To allow the gateway client to know how to connect to the backend pod, when the backend pod has its own
-certificate, we implement a metaresource named `TLSConnectionPolicy`, that is previously mentioned as an example in
-[GEP-713: Metaresources and PolicyAttachment](https://gateway-api.sigs.k8s.io/geps/gep-713/), and as a hypothetical in the
-[Policy Attachment](https://gateway-api.sigs.k8s.io/references/policy-attachment/#direct-policy-attachment)
-documentation.
+certificate, we implement a metaresource named `TLSConnectionPolicy`, that was previously introduced as a
+hypothetical Direct Policy Attachment example in
+[GEP-713: Metaresources and PolicyAttachment](https://gateway-api.sigs.k8s.io/geps/gep-713/).
 
-In this document, because naming is hard, we chose to retain the
+In this document, and because naming is hard, we chose to retain the
 name TLSConnectionPolicy to advertise alignment with a previously discussed naming choice, but a new name may be
 substituted without blocking acceptance of the content of the API change.
 
@@ -203,24 +202,25 @@ In an upcoming [extension](https://github.com/kubernetes-sigs/gateway-api/issues
 _may_ also choose to include `SectionName` and/or `Port` in the TargetRef following the same mechanics as `ParentRef`.
 
 TLSConnectionPolicySpec contains the `TargetRef` and `TLS` fields.  The `TLS` field is a `TLSConnectionPolicyConfig` and
-contains `CertRefs`, `CACertRefs`, and  `Hostname`.
+contains `CertRefs`, `StandardCerts`, and `Hostname`.
 The names of the fields were chosen to facilitate discussion, but may be substituted without blocking acceptance of the
 content of the API change.
 
-The `TrustedCA` contains the `CertRefs` and `CACertRefs` fields. CertRefs is a slice of
+The `CertRefs` and `StandardCerts` fields are both optional, but one of them must be set for a valid TLS configuration.
+CertRefs is a slice of
 named config maps, each containing a single cert. We originally proposed to follow the convention established by the
 [CertificateRefs field on Gateway](https://github.com/kubernetes-sigs/gateway-api/blob/18e79909f7310aafc625ba7c862dfcc67b385250/apis/v1beta1/gateway_types.go#L340)
 , but the CertificateRef requires both a tls.key and tls.crt and a certificate reference only requires the tls.crt.
-CACertRefs is an optional enum that allows users to specify whether to use the set of CA certificates trusted by the
-Gateway (CACertRefs specfied as "system"), or to use the existing CertRefs (CACertRefs specfied as "").  The use
+StandardCerts is an optional enum that allows users to specify whether to use the set of CA certificates trusted by the
+Gateway (StandardCerts specfied as "System"), or to use the existing CertRefs (StandardCerts specfied as "").  The use
 and definition of system certificates is implementation-dependent, and the intent is that these certificates are obtained
 from the underlying operating system. CertRefs contains one or more (up to 64) references to Kubernetes objects that
 contain PEM-encoded TLS certificates, which are used to establish a TLS handshake between the gateway and backend pod.
 References to a resource in a different namespace are invalid.
-If CertRefs is unspecified, then CACertRefs must be set to "system" for a valid configuration.
-If CACertRefs is unspecified, then CertRefs must be specified with at least one entry for a valid configuration.
-If CACertRefs is "system" and there are no system trusted certificates or the implementation doesn't define system
-trusted certificates, then a TLS connection must fail.
+If CertRefs is unspecified, then StandardCerts must be set to "System" for a valid configuration.
+If StandardCerts is unspecified, then CertRefs must be specified with at least one entry for a valid configuration.
+If StandardCerts is set to "System" and there are no system trusted certificates or the implementation doesn't define system
+trusted certificates, then the associated TLS connection must fail.
 
 The `Hostname` field is required and is to be used to configure the SNI the Gateway should use to connect to the backend.
 Implementations must validate that at least one name in the certificate served by the backend matches this field.
@@ -267,24 +267,30 @@ type TLSConnectionPolicySpec struct {
 }
 
 // TLSConnectionPolicyConfig contains TLS connection policy configuration.
+// +kubebuilder:validation:XValidation:message="must not contain both CertRefs and StandardCerts",rule="(has(self.certRefs) && size(self.certRefs > 0) && has(self.standardCerts) && self.standardCerts != "")"
+// +kubebuilder:validation:XValidation:message="must specify either CertRefs or StandardCerts",rule="!(has(self.certRefs) && size(self.certRefs > 0) || has(self.standardCerts) && self.standardCerts != "")"
 type TLSConnectionPolicyConfig struct {
     // CertRefs contains one or more references to
     // Kubernetes objects that contain PEM-encoded TLS certificates,
     // which are used to establish a TLS handshake between the gateway
     // and backend pod.
     //
-    // If the CertRefs is empty, then the system trusted
+    // If CertRefs is empty or unspecified, then StandardCerts must
+    // be specified.  Only one of CertRefs or StandardCerts may be
+    // specified, not both.
+    //
+    // If CertRefs is empty or unspecified, then system trusted
     // certificates should be used. If there are none, or the
     // implementation doesn't define system trusted certificates,
     // then a TLS connection must fail.
+    //
+    // References to a resource in a different namespace are
+    // invalid.
     //
     // A single CertRef to a Kubernetes ConfigMap has "Core"
     // support.  Implementations MAY choose to support attaching
     // multiple certificates to a backend, but this behavior is
     // implementation-specific.
-    //
-    // References to a resource in a different namespace are 
-    // invalid.
     // 
     // Support: Core - An optional single reference to a Kubernetes
     // ConfigMapName.
@@ -296,19 +302,22 @@ type TLSConnectionPolicyConfig struct {
     // +optional
     CertRefs []ConfigMapName `json:”certRefs,omitempty”`
 
-    // CACertRefs specifies whether system CA certificates may
+    // StandardCerts specifies whether system CA certificates may
     // be used in the TLS handshake between the gateway and
     // backend pod.
     // 
-    // If CACertRefs is unspecified or set to "", then CertRefs must
+    // If StandardCerts is unspecified or set to "", then CertRefs must
     // be specified with at least one entry for a valid configuration.
+    // If StandardCerts is unspecified or set to "", then CertRefs must
+    // be specified.  Only one of CertRefs or StandardCerts may be
+    // specified, not both.
     //
-    // If CACertRefs is set to "system", then the system trusted
+    // StandardCerts must be set to "System" when CertRefs is unspecified.
+    //
+    // If StandardCerts is set to "System", then the system trusted
     // certificates should be used. If there are none, or the
     // implementation doesn't define system trusted certificates,
     // then a TLS connection must fail.
-    //
-    // CACertRefs must be set to "system" when CertRefs is unspecified.
     //
     // Support: Core - An optional value to specify whether to use
     // system certificates or not.
@@ -317,7 +326,8 @@ type TLSConnectionPolicyConfig struct {
     // for usable system certs, may be ignored. Service mesh may ignore.)
     //
     // +optional
-    CACertRefs CACertRefType `json:"caCertRefs,omitempty"`
+    // kubebuilder:default=""
+    StandardCerts StandardCertType `json:"standardCerts"`
 
     // Hostname is the Server Name Indication that the Gateway uses to
     // connect to the backend.  It represents the fully qualified domain
@@ -325,25 +335,24 @@ type TLSConnectionPolicyConfig struct {
     // IP addresses are not allowed. Each label of the FQDN must consist
     // of lower case alphanumeric characters or '-', and must start and
     // end with an alphanumeric character.  No other punctuation is allowed.
+    // Wildcard domain names are specifically disallowed.
     //
     // It specifies the hostname that may authenticate, and must be in the
     // certificate served by the matching backend.
     //
     // Support: Core - A required value used by the Gateway to connect to
     // the backend when a TLSConnectionPolicy is specified.
-    //
-    // +required
     Hostname v1beta1.PreciseHostname `json:"hostname,omitempty"`
 }
 
-// CACertRefType is the type of CA certificate that will be used when
-// the TLS.certRef is unspecified.
+// StandardCertType is the type of CA certificate that will be used when
+// the TLS.certRefs is unspecified.
 // +kubebuilder:validation:Enum=system;""
-type CACertRefType string
+type StandardCertType string
 
 const (
-    CACertRefSystem CACertRefType = "system"
-    CACertRefNone CACertRefType = ""
+    StandardCertSystem StandardCertType = "System"
+    StandardCertNone StandardCertType = ""
 )
 
 // ConfigMapName references a named config map.
@@ -400,7 +409,7 @@ const (
     TLSConnectionPolicyReasonAccepted TLSConnectionPolicyConditionReason = “Valid”
 
     // This reason is used with the “Accepted” condition when the TLSConnectionPolicy is invalid,
-	// e.g. crossing namespace boundaries, or invalid TLSVersions.
+    // e.g. use of a CertRef that crosses namespace boundaries.
     TLSConnectionPolicyReasonInvalid TLSConnectionPolicyConditionReason = “Invalid”
 
     // This reason is used with the “Accepted” condition when the TLSConnectionPolicy is pending validation.

--- a/geps/gep-1897.md
+++ b/geps/gep-1897.md
@@ -1,4 +1,4 @@
-# GEP-1897: TLS from Gateway to Backend for ingress
+# GEP-1897: Explicit Backend TLS Connection Configuration
 
 * Issue: [#1897](https://github.com/kubernetes-sigs/gateway-api/issues/1897)
 * Status: Provisional
@@ -10,6 +10,12 @@ dataplane to the backend (backend TLS termination), and intends to satisfy the s
 use case “As a client implementation of Gateway API, I need to know how to connect to
 a backend pod that has its own certificate”. TLS configuration can be a nebulous topic,
 so in order to drive resolution this GEP focuses only on this single piece of functionality.
+
+Furthermore, for Gateway API to handle the case where the service or backend owner is doing their own TLS, _and_
+the service or backend owner wants to validate the clients connecting to it, two things need to happen:
+
+- The service or backend owner has to provide a method for the Gateway owner to retrieve a certificate.
+- Gateway API has to provide a way for the Gateway to configure and apply the validation options.
 
 ## Immediate Goals
 
@@ -31,11 +37,12 @@ controlplane, i.e. the hop between gateway and backend.
 1. [TCPRoute](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute) and
 [GRPCRoute](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRoute) use cases
 are not addressed here, because at this point in time these two route types are not graduated to beta.
-2. Mutual TLS (mTLS) use cases are not thoroughly addressed here because we have tried and failed in the past to
-generalize around mTLS, and the treatment of mTLS should be taken outside the context of the hop between gateway and
-backend.
-3. Service mesh use cases are not addressed here because the main concern is the controlplane hop between gateway
-and backend, which is only one part of the picture in a service mesh.
+2. Mutual TLS (mTLS) use cases are intentionally out of scope for this GEP because this GEP does not address the case
+where connections to TLS are implicitly configured on behalf of the user, such as in Service Mesh.  It is about the
+case where an application developer needs to explicitly express that they expect TLS when there is no automatic,
+implicit configuration of that.
+3. Service mesh use cases are not addressed here because this GEP is specifically concerned with the connection between
+Gateways and Backends, not Service to Service.  Service mesh use cases should ignore TLSConnectionPolicy.
 
 ## Non-Goals
 
@@ -142,14 +149,28 @@ This metaresource is named TLSConnectionPolicy.  In this document, because namin
 name TLSConnectionPolicy to advertise alignment with a previously discussed naming choice, but a new name may be
 substituted without blocking acceptance of the content of the API change.
 
-The selection of the applicable Gateway API persona is important in the design of this proposal, because each
-persona is assigned a role which handles specific Gateway API resources.  TLSConnectionPolicy is used by the application
-developer Gateway API persona to convey client certificate settings used in the TLS handshake from Gateway to backend,
-because this persona handles resources involved with application access and configuration, such as Routes and Services.
-Choosing any other role would move the application-related responsibility from the application developer role to that
-role, which violates the role-oriented design principle of Gateway API. As mentioned in Non-goal #7, providing a
-mechanism for the cluster operator gateway role to override gateway to backend TLS settings is not covered here, but can
-be addressed in a future update should the need arise.
+The selection of the applicable Gateway API persona is important in the design of TLSConnectionPolicy, because it provides
+a way to explicitly describe the _expectations_ of the connection to the application.  TLSConnectionPolicy is configured
+by the application developer Gateway API persona to signal what the application developer _expects_ in connections to
+the application, from a TLS perspective.  Only the application developer can know what the application expects, so it is
+important that this configuration be managed by that persona.
+
+During the course of discussion of this proposal, we did consider allowing the cluster operator persona to have some access
+to Gateway cert validation, but as mentioned, TLSConnectionPolicy is used primarily to signal what the application
+developer expects in the connection.  Granting this expectation to any other role would blur the lines between role
+responsibilities, which violates the role-oriented design principle of Gateway API. As mentioned in Non-goal #7,
+providing a mechanism for the cluster operator gateway role to override gateway to backend TLS settings is not covered
+by this proposal, but should be addressed in a future update.  One idea is to use two types: ApplicationTLSConnectionPolicy,
+and GatewayTLSConnectionPolicy, where the application developer is responsible for the former, the cluster operator is
+responsible for the latter, and the cluster operator may configure whether certain settings may be overridden by
+application developers.
+
+Using the viewpoint of the application running inside the Pods, the TLSConnectionPolicy should contain configuration
+for these use cases of the Gateway as a TLS Client:
+
+- An explicit signal that TLS should be used by this connection.
+- Which Certificate Authority (CA) to use, whether the system bundled CA, an internal CA, or self-signed.
+- TLS version to expect.  This allows implementations to introduce features to disallow or force certain TLS versions.
 
 TLSConnectionPolicy is defined as a Direct Policy Attachment without defaults or overrides, applied to a Service that
 accesses the backend in question, where the TLSConnectionPolicy resides in the same namespace as the Service it is
@@ -225,6 +246,9 @@ type TLSConnectionPolicy struct {
 type TLSConnectionPolicySpec struct {
     // TargetRef identifies an API object to apply policy to.
     // Services are the only valid API target references.
+    // Note that this config applies to the entire referenced resource
+    // by default, but this default may change in the future to provide
+    // a more granular application of the policy.
     TargetRef gatewayv1a2.PolicyTargetReference `json:"targetRef"`
 
     // TLS contains TLS connection policy configuration.
@@ -259,8 +283,55 @@ type TLSConnectionPolicyConfig struct {
     //
     // +kubebuilder:validation:MaxItems=64
     // +optional
-    TrustedCACertRefs []ConfigMapName `json:”trustedCACertRefs”`
+    TrustedCACertRefs []ConfigMapName `json:”trustedCACertRefs,omitempty”`
+
+    // AllowedSANs are the Subject Alternative Names that are allowed for
+    // this TLS connection.  It represents the hostnames that may
+    // authenticate, and must be in the received certificate.
+    //
+    // If AllowedSANs is set, then an implementation must validate that
+    // the certificate provided by the pod represents a SAN in its list.
+    //
+    // If AllowedSANs is empty, then any SAN is allowed.
+    //
+    // +kubebuilder:validation:MaxItems=1024
+    // +optional
+    AllowedSANs []string `json:"allowedSans,omitempty"`
+
+    // TLSVersions represent the expected TLS version, which can be
+    // used to establish a TLS handshake between the gateway and
+    // backend pod, and can also be used by implementations to
+    // enforce TLS version minimums.
+    //
+    // If the TLSVersions is set, then the implementation must use the
+    // given TLSVersions if they are allowed.  If none of the TLSVersions
+    // are allowed, then the TLS Connection must fail.  E.g. if a TLSVersions
+    // contains 1.2 and 1.3, but an implementation only allows 1.3, then it
+    // must use 1.3.
+    //
+    // If the TLSVersions is empty, then an implementation may choose
+    // to apply a self-determined TLSVersion.
+    //
+    // Support: Core - An optional TLS Version that must be used.
+    //
+    // Support: Implementation-specific (self-determined default TLSVersion
+    // may be used)
+    //
+    // +kubebuilder:validation:MaxItems=3
+    // +optional
+    TLSVersions []TLSVersionType `json:"tlsVersions,omitempty"`
 }
+
+// TLSVersionType is the type of a TLS version used in TLS connection policy.
+// This type should be used with the TLSConnectionPolicy.TLSVersions field.
+// +kubebuilder:validation:Enum=1.1;1.2;1.3
+type TLSVersionType string
+
+const (
+    TLSVersion1.1 TLSVersionType = "1.1"
+    TLSVersion1.2 TLSVersionType = "1.2"
+    TLSVersion1.3 TLSVersionType = "1.3"
+)
 
 // ConfigMapName references a named config map.
 type ConfigMapName struct {
@@ -315,7 +386,8 @@ const (
     // This reason is used with the “Accepted” condition when the condition is true.
     TLSConnectionPolicyReasonAccepted TLSConnectionPolicyConditionReason = “Valid”
 
-    // This reason is used with the “Accepted” condition when the TLSConnectionPolicy is invalid, e.g. crossing namespace boundaries.
+    // This reason is used with the “Accepted” condition when the TLSConnectionPolicy is invalid,
+	// e.g. crossing namespace boundaries, or invalid TLSVersions.
     TLSConnectionPolicyReasonInvalid TLSConnectionPolicyConditionReason = “Invalid”
 
     // This reason is used with the “Accepted” condition when the TLSConnectionPolicy is pending validation.
@@ -328,8 +400,9 @@ const (
 This table describes the effect that a TLSConnectionPolicy has on a Route.  There are only two cases where the
 TLSConnectionPolicy will signal a Route to connect to a backend using TLS, an HTTPRoute with a backend that is targeted
 by a TLSConnectionPolicy, either with or without listener TLS configured.  (There are a few other cases where it may be
-possible, but is purposely marked “not supported” due to a desire for less confusion on the assigned purpose of each of
-the protocol-affiliated types of Routes.)
+possible, but is implementation dependent.)
+
+Every implementation that claims supports for TLSConnectionPolicy should document for which Routes it is being implemented.
 
 | Route Type | Gateway Config             | Backend is targeted by a TLSConnectionPolicy? | Connect to backend  with TLS? |
 |------------|----------------------------|-----------------------------------------------|-------------------------------|
@@ -338,18 +411,21 @@ the protocol-affiliated types of Routes.)
 | HTTPRoute  | Listener tls               | No                                            | No                            |
 | HTTPRoute  | No listener tls            | No                                            | No                            |
 | TLSRoute   | Listener Mode: Passthrough | Yes                                           | No                            |
-| TLSRoute   | Listener Mode: Terminate   | Yes                                           | Not supported                 |
+| TLSRoute   | Listener Mode: Terminate   | Yes                                           | Implementation-dependent      |
 | TLSRoute   | Listener Mode: Passthrough | No                                            | No                            |
 | TLSRoute   | Listener Mode: Terminate   | No                                            | No                            |
-| TCPRoute   | Listener TLS               | Yes                                           | Not supported                 |
-| TCPRoute   | No listener TLS            | Yes                                           | Not supported                 |
+| TCPRoute   | Listener TLS               | Yes                                           | Implementation-dependent      |
+| TCPRoute   | No listener TLS            | Yes                                           | Implementation-dependent      |
 | TCPRoute   | Listener TLS               | No                                            | No                            |
 | TCPRoute   | No listener TLS            | No                                            | No                            |
-| UDPRoute   | Listener TLS               | N/A                                           | No                            |
-| UDPRoute   | No listener TLS            | N/A                                           | No                            |
-| UDPRoute   | Listener TLS               | N/A                                           | No                            |
-| UDPRoute   | No listener TLS            | N/A                                           | No                            |
-| GRPCRoute  | N/A                        | N/A                                           | No                            |
+| UDPRoute   | Listener TLS               | Yes                                           | No                            |
+| UDPRoute   | No listener TLS            | Yes                                           | No                            |
+| UDPRoute   | Listener TLS               | No                                            | No                            |
+| UDPRoute   | No listener TLS            | No                                            | No                            |
+| GRPCRoute  | Listener TLS               | Yes                                           | Implementation-dependent      |
+| GRPCRoute  | No Listener TLS            | Yes                                           | Implementation-dependent      |
+| GRPCRoute  | Listener TLS               | No                                            | No                            |
+| GRPCRoute  | No Listener TLS            | No                                            | No                            |
 
 ## Request Flow
 
@@ -447,9 +523,16 @@ or some other means - so gateway added headers can be trusted, amongst other thi
 proposal, which centers around application developer persona resources such as HTTPRoute and Service.
 3. Costin mentioned we need to answer the question - is configuring the connection to a backend and TLS
 something the route author decides - or the backend owner?  Same for SAN (Subject Alternative Name) certificates.
-The use of SAN certificates and the use of SNI, as a part of TLS, can be implementation-dependent, though the
-application can still reject any request or certificate that it doesn’t support, including requests with SNI or a
-certificate with SANs.
+The backend owner is the application developer, and the route owner will have to collaborate with the application
+developer to provide the appropriate configuration for TLS.  The implementation would need to take the certificate
+provided by the application and verify that it satisfies the requirements of the route-as-client, including SAN
+information.  Sometimes the backend owner and route owner are the same entity.
+4. Rob Scott is interested in extending the TargetRef to optionally include port, since we are targetting the entirety
+of a Service. See the discussion in https://github.com/kubernetes-sigs/gateway-api/pull/2113/files#r1231594914,
+and follow up issue in https://github.com/kubernetes-sigs/gateway-api/issues/2147
+5. Michael Pleshakov asked about conflicts that could arise when multiple implementations are running in a cluster.
+This is a gap in our policy attachment model that needs to be addressed.  See the discussion in
+https://github.com/kubernetes-sigs/gateway-api/pull/2113/files#r1235750540.
 
 ## References
 

--- a/geps/gep-1897.md
+++ b/geps/gep-1897.md
@@ -27,11 +27,12 @@ solution. The application developer should control the gateway to backend TLS se
 not the cluster operator, as requiring a cluster operator to manage certificate renewals
 and revocations would be extremely cumbersome.
 3. The solution should consider client certificate settings used in the TLS handshake **from
-Gateway to backend**, such as TLS versions and cipher suites. (Use case #5 in [Gateway API TLS Use Cases](#references))
+Gateway to backend**, such as server name indication, trusted certificates,
+and CA certificates.
 
 ## Longer Term Goals
 
-These are worthy goals, but may need a different GEP for proper attention.  This GEP is concerned entirely with the
+These are worthy goals, but deserve a different GEP for proper attention.  This GEP is concerned entirely with the
 controlplane, i.e. the hop between gateway and backend.
 
 1. [TCPRoute](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute) and
@@ -53,11 +54,12 @@ These are worthy goals, but will not be covered by this GEP.
 1. Changes to the existing mechanisms for edge or passthrough TLS termination
 2. Providing a mechanism to decorate multiple route instances
 3. TLSRoute use cases
-4. UDPRoute use cases 
-5. Controlling certificates used by more than one workload (#6 in [Gateway API TLS Use Cases](#references))
-6. Client certificate settings used in TLS **from external clients to the
+4. UDPRoute use cases
+5. Controlling TLS versions or cipher suites used in TLS handshakes. (Use case #5 in [Gateway API TLS Use Cases](#references))
+6. Controlling certificates used by more than one workload (#6 in [Gateway API TLS Use Cases](#references))
+7. Client certificate settings used in TLS **from external clients to the
 Listener** (#7 in [Gateway API TLS Use Cases](#references))
-7. Providing a mechanism for the cluster operator to override gateway to backend TLS settings.
+8. Providing a mechanism for the cluster operator to override gateway to backend TLS settings.
 
 ## Already Solved TLS Use Cases
 
@@ -78,20 +80,19 @@ has its own certificate and the gateway client needs to know how to connect to t
 ![image depicting TLS termination types](images/1897-TLStermtypes.png "TLS termination types")
 
 Gateway API is missing a mechanism for separately providing the details for the backend TLS handshake,
-including:
+including (but not limited to):
 
-* use of TLS
-* destination CA (certificate authority) or CA bundle
-* SANs for validating upstream service (server authentication)
-* client certificate of the gateway (client authentication)
+* intent to use TLS on the backend hop
+* client certificate of the gateway
+* system certificates to use in the absence of client certificates
 
 ## Purpose - why do we want to do this?
 
 This proposal is _very_ tightly scoped because we have tried and failed to address this well-known
 gap in the API specification. The lack of support for this fundamental concept is holding back
 Gateway API adoption by users that require a solution to the use case. One of the recurring themes
-that has held up the prior art has been interest related to service mesh and as such this proposal
-focuses only on the ingress use case to avoid contention there.  Another reason for the tight scope
+that has held up the prior art has been interest related to service mesh, and as such this proposal
+focuses explicitly on the ingress use case in the initial round.  Another reason for the tight scope
 is that we have been too focused on a generic representation of everything that TLS can do, which
 covers too much ground to address in a single GEP.
 
@@ -136,13 +137,13 @@ was followed by intense discussion and closed in favor of a downsize in scope.
 
 In January 2023 we closed GEP-1282 and began a new discussion on enumerating TLS use cases in
 [Gateway API TLS Use Cases](#references), for the purposes of a clear definition and separation of concerns.
-This GEP is the outcome of the TLS use cases #4 and #5 in
-[Gateway API TLS Use Cases](#references) as mentioned in the Goals section above.
+This GEP is the outcome of the TLS use case #4 in
+[Gateway API TLS Use Cases](#references) as mentioned in the Immediate Goals section above.
 
 ## API
 
 To allow the gateway client to know how to connect to the backend pod, when the backend pod has its own
-certificate, we implement a metaresource named `TLSConnectionPolicy`, that is already mentioned as an example in
+certificate, we implement a metaresource named `TLSConnectionPolicy`, that is previously mentioned as an example in
 [GEP-713: Metaresources and PolicyAttachment](https://gateway-api.sigs.k8s.io/geps/gep-713/), and as a hypothetical in the
 [Policy Attachment](https://gateway-api.sigs.k8s.io/references/policy-attachment/#direct-policy-attachment)
 documentation.
@@ -160,25 +161,27 @@ important that this configuration be managed by that persona.
 During the course of discussion of this proposal, we did consider allowing the cluster operator persona to have some access
 to Gateway cert validation, but as mentioned, TLSConnectionPolicy is used primarily to signal what the application
 developer expects in the connection.  Granting this expectation to any other role would blur the lines between role
-responsibilities, which violates the role-oriented design principle of Gateway API. As mentioned in Non-goal #7,
+responsibilities, which compromises the role-oriented design principle of Gateway API. As mentioned in Non-goal #8,
 providing a mechanism for the cluster operator gateway role to override gateway to backend TLS settings is not covered
 by this proposal, but should be addressed in a future update.  One idea is to use two types: ApplicationTLSConnectionPolicy,
 and GatewayTLSConnectionPolicy, where the application developer is responsible for the former, the cluster operator is
 responsible for the latter, and the cluster operator may configure whether certain settings may be overridden by
 application developers.
 
-Using the viewpoint of the application running inside the Pods, the TLSConnectionPolicy should contain configuration
-for these use cases of the Gateway as a TLS Client:
+The TLSConnectionPolicy must contain these configuration items to allow the Gateway to operate successfully
+as a TLS Client:
 
 - An explicit signal that TLS should be used by this connection.
-- Which Certificate Authority (CA) to use, whether the system bundled CA, an internal CA, or self-signed.
-- TLS version to expect.  This allows implementations to introduce features to disallow or force certain TLS versions.
+- A hostname the Gateway should use to connect to the backend.
+- A reference to one or more certificates to use in the TLS handshake, signed by a CA or self-signed.
+- An indication that system certificates may be used.
 
 TLSConnectionPolicy is defined as a Direct Policy Attachment without defaults or overrides, applied to a Service that
 accesses the backend in question, where the TLSConnectionPolicy resides in the same namespace as the Service it is
 applied to.  The TLSConnectionPolicy and the Service must reside in the same namespace in order to prevent the
-complications involved with sharing trust across namespace boundaries.  By choosing the Service resource rather than the
-Route resource, we can reuse the same TLSConnectionPolicy for all the different Routes that might point to this Service.
+complications involved with sharing trust across namespace boundaries.  We chose the Service resource as a target,
+rather than the Route resource, so that we can reuse the same TLSConnectionPolicy for all the different Routes that
+might point to this Service.
 For the use case where certificates are stored in their own namespace, users may create Secrets and use ReferenceGrants
 for a TLSConnectionPolicy-to-Secret binding.  Implementations must respect a ReferenceGrant for cross-namespace Secret
 sharing to TLSConnectionPolicy, even if they don't for other cross-namespace sharing.
@@ -188,8 +191,7 @@ backend destination certificate authority.  This solution proposes, as introduce
 [GEP-713](https://gateway-api.sigs.k8s.io/geps/gep-713/), that the implementation
 should watch the connections to a specified TargetRef (Service), and if the Service matches a TLSConnectionPolicy, then
 assume the connection is TLS, and verify that the TargetRef’s certificate can be validated by the client (Gateway) using
-the provided trusted CA certificates, subject alternative names, and TLS versions, before the connection is made.
-On the question of how to signal
+the provided certificates and hostname before the connection is made. On the question of how to signal
 that there was a failure in the certificate validation, this is left up to the implementation to return a response error
 that is appropriate, such as one of the HTTP error codes: 400 (Bad Request), 401 (Unauthorized), 403 (Forbidden), or
 other signal that makes the failure sufficiently clear to the requester without revealing too much about the transaction,
@@ -197,42 +199,43 @@ based on established security requirements.
 
 All policy resources must include `TargetRef` with the fields specified
 [here](https://github.com/kubernetes-sigs/gateway-api/blob/a33a934af9ec6997b34fd9b00d2ecd13d143e48b/apis/v1alpha2/policy_types.go#L24-L41).
-In an upcoming extension to TargetRef, policy resources _may_ also choose to include `SectionName` and/or `Port` in the
-TargetRef following the same mechanics as `ParentRef`.
+In an upcoming [extension](https://github.com/kubernetes-sigs/gateway-api/issues/2147) to TargetRef, policy resources
+_may_ also choose to include `SectionName` and/or `Port` in the TargetRef following the same mechanics as `ParentRef`.
 
-TLSConnectionPolicySpec includes `TargetRef` and `TLS` fields.  The `TLS` field is a `TLSConnectionPolicyConfig` and
-contains `TrustedCACertRefs`, `AllowedSANs`, and `TLSVersions` to describe the fields that implementations may cover.
+TLSConnectionPolicySpec contains the `TargetRef` and `TLS` fields.  The `TLS` field is a `TLSConnectionPolicyConfig` and
+contains `CertRefs`, `CACertRefs`, and  `Hostname`.
 The names of the fields were chosen to facilitate discussion, but may be substituted without blocking acceptance of the
 content of the API change.
 
-In the API defined here, the `TrustedCACertRefs` is a slice of named config maps containing a single cert. We originally
-proposed to follow the convention established by the
+The `TrustedCA` contains the `CertRefs` and `CACertRefs` fields. CertRefs is a slice of
+named config maps, each containing a single cert. We originally proposed to follow the convention established by the
 [CertificateRefs field on Gateway](https://github.com/kubernetes-sigs/gateway-api/blob/18e79909f7310aafc625ba7c862dfcc67b385250/apis/v1beta1/gateway_types.go#L340)
-, but the CertificateRef requires both a tls.key and tls.crt and a `TrustedCACertRef` really only requires a tls.crt.
-`TrustedCACertRefs` contains one or more (up to 64) references to Kubernetes objects that contain PEM-encoded TLS certificates,
-which are used to establish a TLS handshake between the gateway and backend pod.  If empty, then the system trusted
-certificates should be used.  If there are no system trusted certificates or the implementation doesn't define system
-trusted certificates, then a TLS connection must fail when the field is empty.  References to a resource in a
-different namespace are invalid.
+, but the CertificateRef requires both a tls.key and tls.crt and a certificate reference only requires the tls.crt.
+CACertRefs is an optional enum that allows users to specify whether to use the set of CA certificates trusted by the
+Gateway (CACertRefs specfied as "system"), or to use the existing CertRefs (CACertRefs specfied as "").  The use
+and definition of system certificates is implementation-dependent, and the intent is that these certificates are obtained
+from the underlying operating system. CertRefs contains one or more (up to 64) references to Kubernetes objects that
+contain PEM-encoded TLS certificates, which are used to establish a TLS handshake between the gateway and backend pod.
+References to a resource in a different namespace are invalid.
+If CertRefs is unspecified, then CACertRefs must be set to "system" for a valid configuration.
+If CACertRefs is unspecified, then CertRefs must be specified with at least one entry for a valid configuration.
+If CACertRefs is "system" and there are no system trusted certificates or the implementation doesn't define system
+trusted certificates, then a TLS connection must fail.
 
-TLSConnectionPolicySpec supports the configuration of Subject Alternative Name certificates via the `AllowedSANs` field.
-One or more (up to 64) subject alternative names may be declared.  SAN certificates allow authentication with a single
-certificate that can serve multiple domain
-names that are intended to represent the same endpoint.  For example, these five SAN hosts: example.com, 
-www.example.com, example.net, IPv4 x.x.x.x, and IPv6 x.x.x.x.x.x.x.x all resolve to the same endpoint. If `AllowedSANs`
-is set, then an implementation must validate that the backend pod-provided certificate represents a SAN in its list.
-If empty, then TLS fails.  In the future, we will define more specific ways to handle the case of an empty `AllowedSANs`
-list.
+The `Hostname` field is required and is to be used to configure the SNI the Gateway should use to connect to the backend.
+Implementations must validate that at least one name in the certificate served by the backend matches this field.
+We originally proposed using a list of allowed Subject Alternative Names, but determined that this was [not needed in
+the first round](https://github.com/kubernetes-sigs/gateway-api/pull/2113#issuecomment-1696127092),
+but may be added in the future.
 
-Finally, TLSConnectionPolicy allows the configuration of expected TLS versions via the `TLSVersions` field.
-TLS versions specify one or more (up to 3) TLS versions that the connection may use.  If the `TLSVersions` field is set,
-then the implementation must use the given versions if they are allowed.  If none of the versions are allowed, then the
-TLS connection must fail.  If no TLS versions are specified, then an implementation may choose to apply a self-determined
-default version.
+We originally proposed allowing the configuration of expected TLS versions, but determined that this was [not needed in
+the first round](https://github.com/kubernetes-sigs/gateway-api/pull/2113#issuecomment-1696127092).
 
 Thus, the following additions would be made to the Gateway API:
 
 ```go
+import "sigs.k8s.io/gateway-api/apis/v1beta1"
+
 // TLSConnectionPolicy provides a way to publish TLS configuration
 // that enables a gateway client to connect to a backend pod.
 type TLSConnectionPolicy struct {
@@ -265,17 +268,17 @@ type TLSConnectionPolicySpec struct {
 
 // TLSConnectionPolicyConfig contains TLS connection policy configuration.
 type TLSConnectionPolicyConfig struct {
-    // TrustedCACertRefs contains one or more references to
+    // CertRefs contains one or more references to
     // Kubernetes objects that contain PEM-encoded TLS certificates,
     // which are used to establish a TLS handshake between the gateway
     // and backend pod.
     //
-    // If the TrustedCACertRefs is empty, then the system trusted
+    // If the CertRefs is empty, then the system trusted
     // certificates should be used. If there are none, or the
     // implementation doesn't define system trusted certificates,
     // then a TLS connection must fail.
     //
-    // A single TrustedCACertRef to a Kubernetes ConfigMap has "Core"
+    // A single CertRef to a Kubernetes ConfigMap has "Core"
     // support.  Implementations MAY choose to support attaching
     // multiple certificates to a backend, but this behavior is
     // implementation-specific.
@@ -291,54 +294,56 @@ type TLSConnectionPolicyConfig struct {
     //
     // +kubebuilder:validation:MaxItems=64
     // +optional
-    TrustedCACertRefs []ConfigMapName `json:”trustedCACertRefs,omitempty”`
+    CertRefs []ConfigMapName `json:”certRefs,omitempty”`
 
-    // AllowedSANs are the Subject Alternative Names that are allowed for
-    // this TLS connection.  It represents the hostnames that may
-    // authenticate, and must be in the received certificate.
+    // CACertRefs specifies whether system CA certificates may
+    // be used in the TLS handshake between the gateway and
+    // backend pod.
+    // 
+    // If CACertRefs is unspecified or set to "", then CertRefs must
+    // be specified with at least one entry for a valid configuration.
     //
-    // If AllowedSANs is set, then an implementation must validate that
-    // the certificate provided by the pod represents a SAN in its list.
+    // If CACertRefs is set to "system", then the system trusted
+    // certificates should be used. If there are none, or the
+    // implementation doesn't define system trusted certificates,
+    // then a TLS connection must fail.
     //
-    // If AllowedSANs is empty, then a TLS connection must fail.
+    // CACertRefs must be set to "system" when CertRefs is unspecified.
     //
-    // +kubebuilder:validation:MaxItems=64
+    // Support: Core - An optional value to specify whether to use
+    // system certificates or not.
+    //
+    // Support: Implementation-specific (In the absence of support
+    // for usable system certs, may be ignored. Service mesh may ignore.)
+    //
     // +optional
-    AllowedSANs []string `json:"allowedSans,omitempty"`
+    CACertRefs CACertRefType `json:"caCertRefs,omitempty"`
 
-    // TLSVersions represent the expected TLS version, which can be
-    // used to establish a TLS handshake between the gateway and
-    // backend pod, and can also be used by implementations to
-    // enforce TLS version minimums.
+    // Hostname is the Server Name Indication that the Gateway uses to
+    // connect to the backend.  It represents the fully qualified domain
+    // name of a network host, as defined by RFC1123 - except that numeric
+    // IP addresses are not allowed. Each label of the FQDN must consist
+    // of lower case alphanumeric characters or '-', and must start and
+    // end with an alphanumeric character.  No other punctuation is allowed.
     //
-    // If the TLSVersions is set, then the implementation must use the
-    // given TLSVersions if they are allowed.  If none of the TLSVersions
-    // are allowed, then the TLS Connection must fail.  E.g. if a TLSVersions
-    // contains 1.2 and 1.3, but an implementation only allows 1.3, then it
-    // must use 1.3.
+    // It specifies the hostname that may authenticate, and must be in the
+    // certificate served by the matching backend.
     //
-    // If the TLSVersions is empty, then an implementation may choose
-    // to apply a self-determined TLSVersion.
+    // Support: Core - A required value used by the Gateway to connect to
+    // the backend when a TLSConnectionPolicy is specified.
     //
-    // Support: Core - An optional TLS Version that must be used.
-    //
-    // Support: Implementation-specific (self-determined default TLSVersion
-    // may be used)
-    //
-    // +kubebuilder:validation:MaxItems=3
-    // +optional
-    TLSVersions []TLSVersionType `json:"tlsVersions,omitempty"`
+    // +required
+    Hostname v1beta1.PreciseHostname `json:"hostname,omitempty"`
 }
 
-// TLSVersionType is the type of a TLS version used in TLS connection policy.
-// This type should be used with the TLSConnectionPolicy.TLSVersions field.
-// +kubebuilder:validation:Enum=1.1;1.2;1.3
-type TLSVersionType string
+// CACertRefType is the type of CA certificate that will be used when
+// the TLS.certRef is unspecified.
+// +kubebuilder:validation:Enum=system;""
+type CACertRefType string
 
 const (
-    VersionTLS11 TLSVersionType = "1.1"
-    VersionTLS12 TLSVersionType = "1.2"
-    VersionTLS13 TLSVersionType = "1.3"
+    CACertRefSystem CACertRefType = "system"
+    CACertRefNone CACertRefType = ""
 )
 
 // ConfigMapName references a named config map.
@@ -518,29 +523,53 @@ Ref: [EgressMTLS](https://docs.nginx.com/nginx-ingress-controller/configuration/
 
 Ref: [IngressMTLS](https://docs.nginx.com/nginx-ingress-controller/configuration/policy-resource/#ingressmtls)
 
-## Open Questions
+## Answered Questions
 
-This section is to record issues that were requested for discussion in the API section before this GEP moves
-out of `Provisional` status.
+Q. Bowei recommended that we mention the approach of cross-namespace referencing between Route and Service.
+Be explicit about using the standard rules with respect to attaching policies to resources.
 
-1. Bowei recommended that we mention the approach of cross-namespace referencing between Route and Service.
-Be explicit about using the standard rules with respect to attaching policies to resources.  This is mentioned in the
+A. This is mentioned in the
 API section.
-2. Costin recommended that Gateway SHOULD authenticate with either a JWT with audience or client cert
-or some other means - so gateway added headers can be trusted, amongst other things.  This is out of scope for this
+
+Q. Costin recommended that Gateway SHOULD authenticate with either a JWT with audience or client cert
+or some other means - so gateway added headers can be trusted, amongst other things.
+
+A. This is out of scope for this
 proposal, which centers around application developer persona resources such as HTTPRoute and Service.
-3. Costin mentioned we need to answer the question - is configuring the connection to a backend and TLS
-something the route author decides - or the backend owner?  Same for SAN (Subject Alternative Name) certificates.
+
+Q. Costin mentioned we need to answer the question - is configuring the connection to a backend and TLS
+something the route author decides - or the backend owner?
+
+A. This is decided by the application developer persona,
+which would more likely, but not exclusively, be the backend owner.
+
+Q.Costin continued, same for SAN (Subject Alternative Name) certificates.
 The backend owner is the application developer, and the route owner will have to collaborate with the application
 developer to provide the appropriate configuration for TLS.  The implementation would need to take the certificate
 provided by the application and verify that it satisfies the requirements of the route-as-client, including SAN
 information.  Sometimes the backend owner and route owner are the same entity.
-4. Rob Scott is interested in extending the TargetRef to optionally include port, since we are targetting the entirety
+
+A. This was most recently addressed by
+adding hostname for SNI and removing allowed SANs.
+
+## Graduation Criteria
+
+This section is to record issues that were requested for discussion in the API section before this GEP graduates
+out of `Provisional` status.
+
+1. Rob Scott is interested in extending the TargetRef to optionally include port, since we are targetting the entirety
 of a Service. See the discussion in https://github.com/kubernetes-sigs/gateway-api/pull/2113/files#r1231594914,
 and follow up issue in https://github.com/kubernetes-sigs/gateway-api/issues/2147
-5. Michael Pleshakov asked about conflicts that could arise when multiple implementations are running in a cluster.
+2. Michael Pleshakov asked about conflicts that could arise when multiple implementations are running in a cluster.
 This is a gap in our policy attachment model that needs to be addressed.  See the discussion in
-https://github.com/kubernetes-sigs/gateway-api/pull/2113/files#r1235750540.
+https://github.com/kubernetes-sigs/gateway-api/pull/2113/files#r1235750540. Graduating this GEP to implementable
+requires an update to the Policy GEP to define how status can be nested to support multiple implementations. This will
+likely look very similar to Route status.
+See [comment](https://github.com/kubernetes-sigs/gateway-api/pull/2113#issuecomment-1696127092).
+3. Rob Scott [wanted to note](https://github.com/kubernetes-sigs/gateway-api/pull/2113#issuecomment-1696127092) that
+when this graduates to the standard channel, implementations of HTTPRoute may also be
+required to watch the TLSConnectionPolicy. If one of these policies is attached to a Service targeted by an HTTPRoute,
+the implementation would be required to fully implement the policy or mark the backend invalid.
 
 ## References
 
@@ -555,9 +584,3 @@ https://github.com/kubernetes-sigs/gateway-api/pull/2113/files#r1235750540.
 [SIG-NET Gateway API: TLS to the K8s.Service/Backend](https://docs.google.com/document/d/1RTYh2brg_vLX9o3pTcrWxtZSsf8Y5NQvIG52lpFcZlo)
 
 [SAN vs SNI](https://serverfault.com/questions/807959/what-is-the-difference-between-san-and-sni-ssl-certificates)
-
-[RFC4346 TLS 1.1](https://datatracker.ietf.org/doc/html/rfc4346#appendix-A.5)
-
-[RFC 5246 TLS 1.2](https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5)
-
-[RFC 8446 TLS 1.3](https://datatracker.ietf.org/doc/html/rfc8446#appendix-B.4)

--- a/geps/gep-1897.md
+++ b/geps/gep-1897.md
@@ -213,6 +213,7 @@ named config maps, each containing a single cert. We originally proposed to foll
 , but the CertificateRef requires both a tls.key and tls.crt and a certificate reference only requires the tls.crt.
 StandardCerts is an optional enum that allows users to specify whether to use the set of CA certificates trusted by the
 Gateway (StandardCerts specfied as "System"), or to use the existing CertRefs (StandardCerts specfied as "").  The use
+
 and definition of system certificates is implementation-dependent, and the intent is that these certificates are obtained
 from the underlying operating system. CertRefs contains one or more (up to 64) references to Kubernetes objects that
 contain PEM-encoded TLS certificates, which are used to establish a TLS handshake between the gateway and backend pod.
@@ -287,20 +288,22 @@ type TLSConnectionPolicyConfig struct {
     // References to a resource in a different namespace are
     // invalid.
     //
-    // A single CertRef to a Kubernetes ConfigMap has "Core"
+    // A single CertRef to a Kubernetes ConfigMap kind has "Core"
     // support.  Implementations MAY choose to support attaching
     // multiple certificates to a backend, but this behavior is
-    // implementation-specific.
+    // implementation-specific.  Also implementation-specific is
+    // a CertRef of other object kinds, e.g. Secret.
     // 
     // Support: Core - An optional single reference to a Kubernetes
-    // ConfigMapName.
+    // ConfigMap.
     //
     // Support: Implementation-specific (No reference, more than one
-    // reference, or other resource types; service mesh may ignore.)
+    // reference, or resource types other than ConfigMaps.
+    // Service mesh may ignore.)
     //
     // +kubebuilder:validation:MaxItems=64
     // +optional
-    CertRefs []ConfigMapName `json:”certRefs,omitempty”`
+    CertRefs []ConfigMapObjectReference `json:”certRefs,omitempty”`
 
     // StandardCerts specifies whether system CA certificates may
     // be used in the TLS handshake between the gateway and
@@ -326,8 +329,7 @@ type TLSConnectionPolicyConfig struct {
     // for usable system certs, may be ignored. Service mesh may ignore.)
     //
     // +optional
-    // kubebuilder:default=""
-    StandardCerts StandardCertType `json:"standardCerts"`
+    StandardCerts *StandardCertType `json:"standardCerts,omitempty"`
 
     // Hostname is the Server Name Indication that the Gateway uses to
     // connect to the backend.  It represents the fully qualified domain
@@ -347,19 +349,51 @@ type TLSConnectionPolicyConfig struct {
 
 // StandardCertType is the type of CA certificate that will be used when
 // the TLS.certRefs is unspecified.
-// +kubebuilder:validation:Enum=system;""
+// +kubebuilder:validation:Enum=System
 type StandardCertType string
 
 const (
     StandardCertSystem StandardCertType = "System"
-    StandardCertNone StandardCertType = ""
 )
 
-// ConfigMapName references a named config map.
-type ConfigMapName struct {
-    // name is the metadata.name of the referenced config map.
+// ConfigMapObjectReference identifies a named config map.
+//
+// The API object must be valid in the cluster; the Group and Kind must
+// be registered in the cluster for this reference to be valid.
+//
+// References to objects with invalid Group and Kind are not valid, and must
+// be rejected by the implementation, with appropriate Conditions set
+// on the containing object.
+type ConfigMapObjectReference struct {
+    // Group is the group of the referent.  For example, "gateway.networking.k8s.io".
+    // When unspecified or empty string, core API group is inferred.
+    //
+    // +optional
+    // +kubebuilder:default=""
+    Group *Group `json:"group"`
+
+    // Kind is the kind of the referent.  For example, "ConfigMap".
+    //
+    // +optional
+    // +kubebuilder:default=ConfigMap
+    Kind *Kind `json:"kind"`
+
+    // Name is the metadata.name of the referenced config map.
     // +kubebuilder:validation:Required
-    Name string `json"name"`
+    Name ObjectName `json"name"`
+
+    // Namespace is the namespace of the config map. When unspecified, the local
+    // namespace is inferred.
+    //
+    // Note that when a namespace different than the local namespace is specified,
+    // a ReferenceGrant object is required in the referent namespace to allow that
+    // namespace's owner to accept the reference. See the ReferenceGrant
+    // documentation for details.
+    //
+    // Support: Core
+    //
+    // +optional
+    Namespace *Namespace `json:"namespace,omitempty"`
 }
 
 // TLSConnectionPolicyStatus defines the observed state of TLSConnectionPolicy.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**

/kind gep

**What this PR does / why we need it**:

This PR adds the API details for GEP-1897 TLS from Gateway to Backend for ingress.  GEP-1897 has already had the questions answered - what do we want to do, and why do we want to do this.  This update attempts to answer - how do we do this.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1897

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
