### PR TITLE
Add Conformance Details section to GEP template

### DIFF
--- a/geps/gep-696.md
+++ b/geps/gep-696.md
@@ -27,6 +27,14 @@ the content into the GEP as online documents are easier to lose
 
 (... details, can point to PR with changes)
 
+## Conformance Details
+
+(This section describes the names to be used for the feature or
+features in conformance tests and profiles.
+
+These should be `CamelCase` names that specify the feature as
+precisely as possible, and are particularly important for
+Extended features, since they may be surfaced to users.)
 
 ## Alternatives
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation
/area conformance

**What this PR does / why we need it**:

This PR adds a "Conformance Details" section to the GEP template, which will encourage us all to ensure that we agree on the names to be used for the feature or features in conformance tests and profiles.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
GEPs now must have a Conformance Details section that specifies the feature's name for conformance purposes.
```
