### PR TITLE
conformance: Ignore state of terminating pods

### DIFF
--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -220,7 +220,8 @@ func NamespacesMustBeReady(t *testing.T, c client.Client, timeoutConfig config.T
 			}
 			for _, pod := range podList.Items {
 				if !findPodConditionInList(t, pod.Status.Conditions, "Ready", "True") &&
-					pod.Status.Phase != v1.PodSucceeded {
+					pod.Status.Phase != v1.PodSucceeded &&
+					pod.DeletionTimestamp == nil {
 					t.Logf("%s/%s Pod not ready yet", ns, pod.Name)
 					return false, nil
 				}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup
/kind test
/kind flake
/area conformance

**What this PR does / why we need it**:

In NamespacesMustBeReady helper that checks if all pods in a namespace are ready, used to gate test runs to ensure we're not making requests to backends that are still coming up, etc.

As tests create/delete Gateways (and associated infrastructure components, e.g. control/data planes) in commonly used namespaces, there are often Terminating pods that the helper waits for, which significantly increases test runtime and causes timeouts.

Instead, if a pod has a deletion timestamp, indicating it is being shut down, we ignore that when checking the pods in a namespace.

**Which issue(s) this PR fixes**:

Fixes #2102

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
