### PR TITLE
live update site when geps are changed

### DIFF
--- a/hack/make-docs.sh
+++ b/hack/make-docs.sh
@@ -30,10 +30,6 @@ run::sed() {
 esac
 }
 
-# Move GEPs to site-src
-rm -rf site-src/geps
-cp -r geps site-src/geps
-
 # Ensure site dir exists
 mkdir -p site
 # Generate docs with mkdocs

--- a/hack/mkdocs-copy-geps.py
+++ b/hack/mkdocs-copy-geps.py
@@ -1,3 +1,17 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import shutil
 import logging
 from mkdocs import plugins

--- a/hack/mkdocs-copy-geps.py
+++ b/hack/mkdocs-copy-geps.py
@@ -1,0 +1,10 @@
+import shutil
+import logging
+from mkdocs import plugins
+
+log = logging.getLogger('mkdocs')
+
+@plugins.event_priority(100)
+def on_pre_build(config, **kwargs):
+    log.info("copying geps")
+    shutil.copytree("geps","site-src/geps", dirs_exist_ok=True)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,10 @@ repo_url: https://github.com/kubernetes-sigs/gateway-api
 repo_name: kubernetes-sigs/gateway-api
 site_dir: site
 docs_dir: site-src
+hooks:
+- hack/mkdocs-copy-geps.py
+watch:
+- geps
 theme:
   name: material
   icon:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR adds a hook and tweaks the mkdocs build process to copy the geps into the site-src folder. It will also watch the GEPs directory and rebuild when changes occur.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```