### PR TITLE
ci(linter): enable several linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,8 @@
 run:
   timeout: 10m
   issues-exit-code: 1
+  max-issues-per-linter: 0
+  max-same-issues: 0
   tests: true
   skip-dirs-use-default: true
   modules-download-mode: readonly
@@ -9,13 +11,20 @@ run:
 linters:
   fast: false
   enable:
-  - gofmt
-  - goimports
-  - revive
-  - govet
-  - gomodguard
-  - misspell
+  - errcheck
   - exportloopref
+  - gocritic
+  - gofumpt
+  - goimports
+  - gomodguard
+  - gosec
+  - govet
+  - misspell
+  - revive
+  - unconvert
+  - unparam
+  - unused
+  - whitespace
   disable:
   - scopelint
   disable-all: false

--- a/apis/v1alpha2/validation/common.go
+++ b/apis/v1alpha2/validation/common.go
@@ -23,11 +23,9 @@ import (
 	gatewayvalidationv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1/validation"
 )
 
-var (
-	// validateParentRefs validates ParentRefs SectionName must be set and uique
-	// when ParentRefs includes 2 or more references to the same parent
-	validateParentRefs = gatewayvalidationv1b1.ValidateParentRefs
-)
+// validateParentRefs validates ParentRefs SectionName must be set and uique
+// when ParentRefs includes 2 or more references to the same parent
+var validateParentRefs = gatewayvalidationv1b1.ValidateParentRefs
 
 // validateBackendRefServicePort validates whether or not a port was specified
 // for a backendRef which refers to a corev1.Service, asserting that the port

--- a/apis/v1beta1/validation/common.go
+++ b/apis/v1beta1/validation/common.go
@@ -41,7 +41,7 @@ func ValidateParentRefs(parentRefs []gatewayv1b1.ParentReference, path *field.Pa
 	}
 	parentRefsSectionMap := make(map[sameKindParentRefs]sets.Set[parentQualifier])
 	for i, p := range parentRefs {
-		targetParentRefs := sameKindParentRefs{name: p.Name, namespace: *new(gatewayv1b1.Namespace), kind: *new(gatewayv1b1.Kind)}
+		targetParentRefs := sameKindParentRefs{name: p.Name, namespace: gatewayv1b1.Namespace(""), kind: gatewayv1b1.Kind("")}
 		pq := parentQualifier{}
 		if p.Namespace != nil {
 			targetParentRefs.namespace = *p.Namespace

--- a/apis/v1beta1/validation/common_test.go
+++ b/apis/v1beta1/validation/common_test.go
@@ -25,7 +25,7 @@ import (
 	gatewayv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-var path = *new(field.Path)
+var path = field.Path{}
 
 func TestValidateParentRefs(t *testing.T) {
 	namespace := gatewayv1b1.Namespace("example-namespace")

--- a/conformance/tests/gateway-modify-listeners.go
+++ b/conformance/tests/gateway-modify-listeners.go
@@ -43,7 +43,6 @@ var GatewayModifyListeners = suite.ConformanceTest{
 	},
 	Manifests: []string{"tests/gateway-modify-listeners.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
-
 		t.Run("should be able to add a listener that then becomes available for routing traffic", func(t *testing.T) {
 			gwNN := types.NamespacedName{Name: "gateway-add-listener", Namespace: "gateway-conformance-infra"}
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
@@ -93,7 +92,7 @@ var GatewayModifyListeners = suite.ConformanceTest{
 					Conditions: []metav1.Condition{{
 						Type:   string(v1beta1.ListenerConditionAccepted),
 						Status: metav1.ConditionTrue,
-						Reason: "", //any reason
+						Reason: "", // any reason
 					}},
 					AttachedRoutes: 1,
 				},
@@ -106,7 +105,7 @@ var GatewayModifyListeners = suite.ConformanceTest{
 					Conditions: []metav1.Condition{{
 						Type:   string(v1beta1.ListenerConditionAccepted),
 						Status: metav1.ConditionTrue,
-						Reason: "", //any reason
+						Reason: "", // any reason
 					}},
 					AttachedRoutes: 1,
 				},
@@ -165,7 +164,7 @@ var GatewayModifyListeners = suite.ConformanceTest{
 					Conditions: []metav1.Condition{{
 						Type:   string(v1beta1.ListenerConditionAccepted),
 						Status: metav1.ConditionTrue,
-						Reason: "", //any reason
+						Reason: "", // any reason
 					}},
 					AttachedRoutes: 1,
 				},

--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -42,7 +42,6 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 	},
 	Manifests: []string{"tests/gateway-observed-generation-bump.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
-
 		gwNN := types.NamespacedName{Name: "gateway-observed-generation-bump", Namespace: "gateway-conformance-infra"}
 
 		t.Run("observedGeneration should increment", func(t *testing.T) {

--- a/conformance/tests/gateway-with-attached-routes.go
+++ b/conformance/tests/gateway-with-attached-routes.go
@@ -50,7 +50,7 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 				Conditions: []metav1.Condition{{
 					Type:   string(v1beta1.ListenerConditionAccepted),
 					Status: metav1.ConditionTrue,
-					Reason: "", //any reason
+					Reason: "", // any reason
 				}},
 				AttachedRoutes: 1,
 			}}
@@ -69,7 +69,7 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 				Conditions: []metav1.Condition{{
 					Type:   string(v1beta1.ListenerConditionAccepted),
 					Status: metav1.ConditionTrue,
-					Reason: "", //any reason
+					Reason: "", // any reason
 				}},
 				AttachedRoutes: 2,
 			}}

--- a/conformance/tests/httproute-invalid-backendref-nonexistent.go
+++ b/conformance/tests/httproute-invalid-backendref-nonexistent.go
@@ -66,6 +66,5 @@ var HTTPRouteInvalidNonExistentBackendRef = suite.ConformanceTest{
 				Response: http.Response{StatusCode: 500},
 			})
 		})
-
 	},
 }

--- a/conformance/tests/httproute-invalid-backendref-unknown-kind.go
+++ b/conformance/tests/httproute-invalid-backendref-unknown-kind.go
@@ -67,6 +67,5 @@ var HTTPRouteInvalidBackendRefUnknownKind = suite.ConformanceTest{
 				Response: http.Response{StatusCode: 500},
 			})
 		})
-
 	},
 }

--- a/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go
@@ -49,7 +49,6 @@ var HTTPRouteInvalidCrossNamespaceBackendRef = suite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		t.Run("HTTPRoute with a cross-namespace BackendRef and no ReferenceGrant has a ResolvedRefs Condition with status False and Reason RefNotPermitted", func(t *testing.T) {
-
 			resolvedRefsCond := metav1.Condition{
 				Type:   string(v1beta1.RouteConditionResolvedRefs),
 				Status: metav1.ConditionFalse,
@@ -68,6 +67,5 @@ var HTTPRouteInvalidCrossNamespaceBackendRef = suite.ConformanceTest{
 				Response: http.Response{StatusCode: 500},
 			})
 		})
-
 	},
 }

--- a/conformance/tests/httproute-partially-invalid-via-reference-grant.go
+++ b/conformance/tests/httproute-partially-invalid-via-reference-grant.go
@@ -49,7 +49,6 @@ var HTTPRoutePartiallyInvalidViaInvalidReferenceGrant = suite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, s.Client, s.TimeoutConfig, s.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
 		t.Run("HTTPRoute with BackendRef in another namespace and no ReferenceGrant covering the Service has a ResolvedRefs Condition with status False and Reason RefNotPermitted", func(t *testing.T) {
-
 			resolvedRefsCond := metav1.Condition{
 				Type:   string(v1beta1.RouteConditionResolvedRefs),
 				Status: metav1.ConditionFalse,
@@ -80,6 +79,5 @@ var HTTPRoutePartiallyInvalidViaInvalidReferenceGrant = suite.ConformanceTest{
 				Namespace: "gateway-conformance-app-backend",
 			})
 		})
-
 	},
 }

--- a/conformance/tests/httproute-path-match-order.go
+++ b/conformance/tests/httproute-path-match-order.go
@@ -45,31 +45,32 @@ var HTTPRoutePathMatchOrder = suite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
-		testCases := []http.ExpectedResponse{{
-			Request:   http.Request{Path: "/match/exact/one"},
-			Backend:   "infra-backend-v3",
-			Namespace: ns,
-		}, {
-			Request:   http.Request{Path: "/match/exact"},
-			Backend:   "infra-backend-v2",
-			Namespace: ns,
-		}, {
-			Request:   http.Request{Path: "/match"},
-			Backend:   "infra-backend-v1",
-			Namespace: ns,
-		}, {
-			Request:   http.Request{Path: "/match/prefix/one/any"},
-			Backend:   "infra-backend-v2",
-			Namespace: ns,
-		}, {
-			Request:   http.Request{Path: "/match/prefix/any"},
-			Backend:   "infra-backend-v1",
-			Namespace: ns,
-		}, {
-			Request:   http.Request{Path: "/match/any"},
-			Backend:   "infra-backend-v3",
-			Namespace: ns,
-		},
+		testCases := []http.ExpectedResponse{
+			{
+				Request:   http.Request{Path: "/match/exact/one"},
+				Backend:   "infra-backend-v3",
+				Namespace: ns,
+			}, {
+				Request:   http.Request{Path: "/match/exact"},
+				Backend:   "infra-backend-v2",
+				Namespace: ns,
+			}, {
+				Request:   http.Request{Path: "/match"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			}, {
+				Request:   http.Request{Path: "/match/prefix/one/any"},
+				Backend:   "infra-backend-v2",
+				Namespace: ns,
+			}, {
+				Request:   http.Request{Path: "/match/prefix/any"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			}, {
+				Request:   http.Request{Path: "/match/any"},
+				Backend:   "infra-backend-v3",
+				Namespace: ns,
+			},
 		}
 
 		for i := range testCases {

--- a/conformance/tests/httproute-redirect-host-and-status.go
+++ b/conformance/tests/httproute-redirect-host-and-status.go
@@ -46,31 +46,32 @@ var HTTPRouteRedirectHostAndStatus = suite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
-		testCases := []http.ExpectedResponse{{
-			Request: http.Request{
-				Path:             "/hostname-redirect",
-				UnfollowRedirect: true,
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Path:             "/hostname-redirect",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Host: "example.org",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path:             "/host-and-status",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 301,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Host: "example.org",
+				},
+				Namespace: ns,
 			},
-			Response: http.Response{
-				StatusCode: 302,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Host: "example.org",
-			},
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path:             "/host-and-status",
-				UnfollowRedirect: true,
-			},
-			Response: http.Response{
-				StatusCode: 301,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Host: "example.org",
-			},
-			Namespace: ns,
-		},
 		}
 		for i := range testCases {
 			// Declare tc here to avoid loop variable

--- a/conformance/tests/httproute-redirect-path.go
+++ b/conformance/tests/httproute-redirect-path.go
@@ -47,81 +47,82 @@ var HTTPRouteRedirectPath = suite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
-		testCases := []http.ExpectedResponse{{
-			Request: http.Request{
-				Path:             "/original-prefix/lemon",
-				UnfollowRedirect: true,
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Path:             "/original-prefix/lemon",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Path: "/replacement-prefix/lemon",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path:             "/full/path/original",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Path: "/full-path-replacement",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path:             "/path-and-host",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Host: "example.org",
+					Path: "/replacement-prefix",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path:             "/path-and-status",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 301,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Path: "/replacement-prefix",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path:             "/full-path-and-host",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Host: "example.org",
+					Path: "/replacement-full",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path:             "/full-path-and-status",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 301,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Path: "/replacement-full",
+				},
+				Namespace: ns,
 			},
-			Response: http.Response{
-				StatusCode: 302,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Path: "/replacement-prefix/lemon",
-			},
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path:             "/full/path/original",
-				UnfollowRedirect: true,
-			},
-			Response: http.Response{
-				StatusCode: 302,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Path: "/full-path-replacement",
-			},
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path:             "/path-and-host",
-				UnfollowRedirect: true,
-			},
-			Response: http.Response{
-				StatusCode: 302,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Host: "example.org",
-				Path: "/replacement-prefix",
-			},
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path:             "/path-and-status",
-				UnfollowRedirect: true,
-			},
-			Response: http.Response{
-				StatusCode: 301,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Path: "/replacement-prefix",
-			},
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path:             "/full-path-and-host",
-				UnfollowRedirect: true,
-			},
-			Response: http.Response{
-				StatusCode: 302,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Host: "example.org",
-				Path: "/replacement-full",
-			},
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path:             "/full-path-and-status",
-				UnfollowRedirect: true,
-			},
-			Response: http.Response{
-				StatusCode: 301,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Path: "/replacement-full",
-			},
-			Namespace: ns,
-		},
 		}
 		for i := range testCases {
 			// Declare tc here to avoid loop variable

--- a/conformance/tests/httproute-redirect-port-and-scheme.go
+++ b/conformance/tests/httproute-redirect-port-and-scheme.go
@@ -59,7 +59,7 @@ var HTTPRouteRedirectPortAndScheme = suite.ConformanceTest{
 		gwAddr443 := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
-		certNN := types.NamespacedName{Name: "tls-validity-checks-certificate", Namespace: string(ns)}
+		certNN := types.NamespacedName{Name: "tls-validity-checks-certificate", Namespace: ns}
 		cPem, keyPem, err := GetTLSSecret(suite.Client, certNN)
 		if err != nil {
 			t.Fatalf("unexpected error finding TLS secret: %v", err)

--- a/conformance/tests/httproute-redirect-port.go
+++ b/conformance/tests/httproute-redirect-port.go
@@ -47,57 +47,58 @@ var HTTPRouteRedirectPort = suite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
-		testCases := []http.ExpectedResponse{{
-			Request: http.Request{
-				Path:             "/port",
-				UnfollowRedirect: true,
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Path:             "/port",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Port: "8083",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path:             "/port-and-host",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Host: "example.org",
+					Port: "8083",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path:             "/port-and-status",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 301,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Port: "8083",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path:             "/port-and-host-and-status",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Port: "8083",
+					Host: "example.org",
+				},
+				Namespace: ns,
 			},
-			Response: http.Response{
-				StatusCode: 302,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Port: "8083",
-			},
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path:             "/port-and-host",
-				UnfollowRedirect: true,
-			},
-			Response: http.Response{
-				StatusCode: 302,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Host: "example.org",
-				Port: "8083",
-			},
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path:             "/port-and-status",
-				UnfollowRedirect: true,
-			},
-			Response: http.Response{
-				StatusCode: 301,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Port: "8083",
-			},
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path:             "/port-and-host-and-status",
-				UnfollowRedirect: true,
-			},
-			Response: http.Response{
-				StatusCode: 302,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Port: "8083",
-				Host: "example.org",
-			},
-			Namespace: ns,
-		},
 		}
 		for i := range testCases {
 			// Declare tc here to avoid loop variable

--- a/conformance/tests/httproute-redirect-scheme.go
+++ b/conformance/tests/httproute-redirect-scheme.go
@@ -47,57 +47,58 @@ var HTTPRouteRedirectScheme = suite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
-		testCases := []http.ExpectedResponse{{
-			Request: http.Request{
-				Path:             "/scheme",
-				UnfollowRedirect: true,
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Path:             "/scheme",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "https",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path:             "/scheme-and-host",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Host:   "example.org",
+					Scheme: "https",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path:             "/scheme-and-status",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 301,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "https",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path:             "/scheme-and-host-and-status",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "https",
+					Host:   "example.org",
+				},
+				Namespace: ns,
 			},
-			Response: http.Response{
-				StatusCode: 302,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Scheme: "https",
-			},
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path:             "/scheme-and-host",
-				UnfollowRedirect: true,
-			},
-			Response: http.Response{
-				StatusCode: 302,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Host:   "example.org",
-				Scheme: "https",
-			},
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path:             "/scheme-and-status",
-				UnfollowRedirect: true,
-			},
-			Response: http.Response{
-				StatusCode: 301,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Scheme: "https",
-			},
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path:             "/scheme-and-host-and-status",
-				UnfollowRedirect: true,
-			},
-			Response: http.Response{
-				StatusCode: 302,
-			},
-			RedirectRequest: &roundtripper.RedirectRequest{
-				Scheme: "https",
-				Host:   "example.org",
-			},
-			Namespace: ns,
-		},
 		}
 		for i := range testCases {
 			// Declare tc here to avoid loop variable

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -271,7 +271,6 @@ func CompareRequest(t *testing.T, req *roundtripper.Request, cReq *roundtripper.
 				} else if strings.Join(actualVal, ",") != expectedVal {
 					return fmt.Errorf("expected %s header to be set to %s, got %s", name, expectedVal, strings.Join(actualVal, ","))
 				}
-
 			}
 		}
 
@@ -366,7 +365,6 @@ func CompareRequest(t *testing.T, req *roundtripper.Request, cReq *roundtripper.
 
 // GetTestCaseName gets the user-defined test case name or generates one from expected response to a given request.
 func (er *ExpectedResponse) GetTestCaseName(i int) string {
-
 	// If TestCase name is provided then use that or else generate one.
 	if er.TestCaseName != "" {
 		return er.TestCaseName

--- a/conformance/utils/http/mirror.go
+++ b/conformance/utils/http/mirror.go
@@ -53,7 +53,6 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset *client
 			}
 		}
 		return mirrored
-
 	}, 60*time.Second, time.Second, "Mirrored request log wasn't found")
 
 	t.Log("Mirrored request log found")

--- a/conformance/utils/kubernetes/certificate.go
+++ b/conformance/utils/kubernetes/certificate.go
@@ -79,7 +79,6 @@ func generateRSACert(hosts []string, keyOut, certOut io.Writer) error {
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
-
 	if err != nil {
 		return fmt.Errorf("failed to generate serial number: %w", err)
 	}
@@ -107,7 +106,6 @@ func generateRSACert(hosts []string, keyOut, certOut io.Writer) error {
 	}
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
-
 	if err != nil {
 		return fmt.Errorf("failed to create certificate: %w", err)
 	}

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -356,7 +356,6 @@ func HTTPRouteMustHaveNoAcceptedParents(t *testing.T, client client.Client, time
 	var actual []v1beta1.RouteParentStatus
 	emptyChecked := false
 	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.HTTPRouteMustNotHaveParents, true, func(ctx context.Context) (bool, error) {
-
 		route := &v1beta1.HTTPRoute{}
 		err := client.Get(ctx, routeName, route)
 		if err != nil {
@@ -461,7 +460,6 @@ func parentsForRouteMatch(t *testing.T, routeName types.NamespacedName, expected
 			return false
 		}
 		if !reflect.DeepEqual(aParent.ParentRef.Group, eParent.ParentRef.Group) {
-
 			t.Logf("Route %s/%s expected ParentReference.Group to be %v, got %v", routeName.Namespace, routeName.Name, eParent.ParentRef.Group, aParent.ParentRef.Group)
 			return false
 		}
@@ -529,7 +527,6 @@ func HTTPRouteMustHaveCondition(t *testing.T, client client.Client, timeoutConfi
 		var conditionFound bool
 		for _, parent := range parents {
 			if err := ConditionsHaveLatestObservedGeneration(route, parent.Conditions); err != nil {
-
 				t.Logf("HTTPRoute(parentRef=%v) %v", parentRefToString(parent.ParentRef), err)
 				return false, nil
 			}

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -89,11 +89,12 @@ func New(s Options) *ConformanceTestSuite {
 		roundTripper = &roundtripper.DefaultRoundTripper{Debug: s.Debug, TimeoutConfig: s.TimeoutConfig}
 	}
 
-	if s.EnableAllSupportedFeatures == true {
+	switch {
+	case s.EnableAllSupportedFeatures == true:
 		s.SupportedFeatures = AllFeatures
-	} else if s.SupportedFeatures == nil {
+	case s.SupportedFeatures == nil:
 		s.SupportedFeatures = StandardCoreFeatures
-	} else {
+	default:
 		for feature := range StandardCoreFeatures {
 			s.SupportedFeatures.Insert(feature)
 		}

--- a/pkg/admission/server.go
+++ b/pkg/admission/server.go
@@ -151,7 +151,6 @@ func ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleValidation(request admission.AdmissionRequest) (*admission.AdmissionResponse, error) {
-
 	var (
 		response     admission.AdmissionResponse
 		deserializer = codecs.UniversalDeserializer()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
