### PR TITLE
apis: document ParentRef functionality for GAMMA

### DIFF
--- a/apis/v1alpha2/referencegrant_types.go
+++ b/apis/v1alpha2/referencegrant_types.go
@@ -36,8 +36,12 @@ import (
 // Additional Reference Grants can be used to add to the set of trusted
 // sources of inbound references for the namespace they are defined within.
 //
-// All cross-namespace references in Gateway API (with the exception of cross-namespace
-// Gateway-route attachment) require a ReferenceGrant.
+// A ReferenceGrant is required for all cross-namespace references in Gateway API
+// (with the exception of cross-namespace Route-Gateway attachment, which is
+// governed by the AllowedRoutes configuration on the Gateway, and cross-namespace
+// Service ParentRefs on a "consumer" mesh Route, which defines routing rules
+// applicable only to workloads in the Route namespace). ReferenceGrants allowing
+// a reference from a Route to a Service are only applicable to BackendRefs.
 //
 // ReferenceGrant is a form of runtime verification allowing users to assert
 // which cross-namespace object references are permitted. Implementations that

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -21,10 +21,14 @@ import (
 )
 
 // ParentReference identifies an API object (usually a Gateway) that can be considered
-// a parent of this resource (usually a route). The only kinds of parent resources
-// with "Core" support are Service (only for implementations supporting the Mesh
-// conformance profile) and Gateway. This API may be extended in the future to
-// support additional kinds of parent resources.
+// a parent of this resource (usually a route). There are two kinds of parent resources
+// with "Core" support:
+//
+// * Gateway (Gateway conformance profile)
+// * Service (Mesh conformance profile)
+//
+// This API may be extended in the future to support additional kinds of parent
+// resources.
 //
 // The API object must be valid in the cluster; the Group and Kind must
 // be registered in the cluster for this reference to be valid.

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -46,11 +46,12 @@ type ParentReference struct {
 
 	// Kind is kind of the referent.
 	//
-	// Support: Core (Gateway)
+	// There are two kinds of parent resources with "Core" support:
 	//
-	// Support: Core (Service - mesh conformance profile only)
+	// * Gateway (Gateway conformance profile)
+	// * Service (Mesh conformance profile)
 	//
-	// Support: Implementation-specific (Other Resources)
+	// Support for other resources is Implementation-Specific.
 	//
 	// +kubebuilder:default=Gateway
 	// +optional

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -85,10 +85,6 @@ type ParentReference struct {
 	// are specified, the name and port of the selected listener must match
 	// both specified values.
 	//
-	// * Service: Port Name. When both Port (experimental) and SectionName
-	// are specified, the name and port of the selected port must match
-	// both specified values.
-	//
 	// Implementations MAY choose to support attaching Routes to other resources.
 	// If that is the case, they MUST clearly document how SectionName is
 	// interpreted.

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -85,7 +85,7 @@ type ParentReference struct {
 	// are specified, the name and port of the selected listener must match
 	// both specified values.
 	//
-	// * Service: Named port. When both Port (experimental) and SectionName
+	// * Service: Port Name. When both Port (experimental) and SectionName
 	// are specified, the name and port of the selected port must match
 	// both specified values.
 	//

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -156,10 +156,13 @@ type CommonRouteSpec struct {
 	// namespace for a "producer" route, or the mesh implementation must support
 	// and allow "consumer" routes for the referenced Service.
 	//
-	// The only kinds of parent resources with "Core" support are Service (only
-	// for implementations supporting the Mesh conformance profile) and Gateway.
+	// There are two kinds of parent resources with "Core" support:
+	//
+	// * Gateway (Gateway conformance profile)
+	// * Service (Mesh conformance profile)
+	//
 	// This API may be extended in the future to support additional kinds of parent
-	// resources such as one of the route kinds.
+	// resources.
 	//
 	// It is invalid to reference an identical parent more than once. It is
 	// valid to reference multiple distinct sections within the same parent

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -63,10 +63,11 @@ type ParentReference struct {
 	//
 	// ParentRefs from a Route to a Service in the same namespace are "producer"
 	// routes, which apply default routing rules to inbound connections from
-	// any namespace to the Service. ParentRefs from a Route to a Service in a
-	// different namespace are "consumer" routes, and these routing rules are
-	// only applied to outbound connections to the Service from the same
-	// namespace as the Route.
+	// any namespace to the Service.
+	//
+	// ParentRefs from a Route to a Service in a different namespace are
+	// "consumer" routes, and these routing rules are only applied to outbound
+	// connections to the Service from the same namespace as the Route.
 	//
 	// Support: Core
 	//

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -67,7 +67,9 @@ type ParentReference struct {
 	//
 	// ParentRefs from a Route to a Service in a different namespace are
 	// "consumer" routes, and these routing rules are only applied to outbound
-	// connections to the Service from the same namespace as the Route.
+	// connections originating from the same namespace as the Route, for which
+	// the intended destination of the connections are a Service targeted as a
+	// ParentRef of the Route.
 	//
 	// Support: Core
 	//
@@ -173,10 +175,13 @@ type CommonRouteSpec struct {
 	//
 	// ParentRefs from a Route to a Service in the same namespace are "producer"
 	// routes, which apply default routing rules to inbound connections from
-	// any namespace to the Service. ParentRefs from a Route to a Service in a
-	// different namespace are "consumer" routes, and these routing rules are
-	// only applied to outbound connections to the Service from the same
-	// namespace as the Route.
+	// any namespace to the Service.
+	//
+	// ParentRefs from a Route to a Service in a different namespace are
+	// "consumer" routes, and these routing rules are only applied to outbound
+	// connections originating from the same namespace as the Route, for which
+	// the intended destination of the connections are a Service targeted as a
+	// ParentRef of the Route.
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=32

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -154,7 +154,10 @@ type CommonRouteSpec struct {
 	// the Gateway needs to allow attachment from Routes of this kind and
 	// namespace. For Services, that means the Service must either be in the same
 	// namespace for a "producer" route, or the mesh implementation must support
-	// and allow "consumer" routes for the referenced Service.
+	// and allow "consumer" routes for the referenced Service. ReferenceGrant is
+	// not applicable for governing ParentRefs to Services - it is not possible to
+	// create a "producer" route for a Service in a different namespace from the
+	// Route.
 	//
 	// There are two kinds of parent resources with "Core" support:
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -130,40 +130,40 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n The only kinds of parent resources
-                  with \"Core\" support are Service (only for implementations supporting
-                  the Mesh conformance profile) and Gateway. This API may be extended
-                  in the future to support additional kinds of parent resources such
-                  as one of the route kinds. \n It is invalid to reference an identical
-                  parent more than once. It is valid to reference multiple distinct
-                  sections within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. \n There are two kinds of parent
+                  resources with \"Core\" support: \n * Gateway (Gateway conformance
+                  profile) * Service (Mesh conformance profile) \n This API may be
+                  extended in the future to support additional kinds of parent resources.
+                  \n It is invalid to reference an identical parent more than once.
+                  It is valid to reference multiple distinct sections within the same
+                  parent resource, such as two separate Listeners on the same Gateway
+                  or two separate ports on the same Service. \n It is possible to
+                  separately reference multiple distinct objects that may be collapsed
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kinds of parent resources with \"Core\" support
-                    are Service (only for implementations supporting the Mesh conformance
-                    profile) and Gateway. This API may be extended in the future to
-                    support additional kinds of parent resources. \n The API object
-                    must be valid in the cluster; the Group and Kind must be registered
-                    in the cluster for this reference to be valid."
+                    a route). There are two kinds of parent resources with \"Core\"
+                    support: \n * Gateway (Gateway conformance profile) * Service
+                    (Mesh conformance profile) \n This API may be extended in the
+                    future to support additional kinds of parent resources. \n The
+                    API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -177,9 +177,10 @@ spec:
                       type: string
                     kind:
                       default: Gateway
-                      description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Core (Service - mesh conformance profile
-                        only) \n Support: Implementation-specific (Other Resources)"
+                      description: "Kind is kind of the referent. \n There are two
+                        kinds of parent resources with \"Core\" support: \n * Gateway
+                        (Gateway conformance profile) * Service (Mesh conformance
+                        profile) \n Support for other resources is Implementation-Specific."
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1421,10 +1422,11 @@ spec:
                           type: string
                         kind:
                           default: Gateway
-                          description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Core (Service - mesh conformance
-                            profile only) \n Support: Implementation-specific (Other
-                            Resources)"
+                          description: "Kind is kind of the referent. \n There are
+                            two kinds of parent resources with \"Core\" support: \n
+                            * Gateway (Gateway conformance profile) * Service (Mesh
+                            conformance profile) \n Support for other resources is
+                            Implementation-Specific."
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -130,31 +130,34 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n There are two kinds of parent
-                  resources with \"Core\" support: \n * Gateway (Gateway conformance
-                  profile) * Service (Mesh conformance profile) \n This API may be
-                  extended in the future to support additional kinds of parent resources.
-                  \n It is invalid to reference an identical parent more than once.
-                  It is valid to reference multiple distinct sections within the same
-                  parent resource, such as two separate Listeners on the same Gateway
-                  or two separate ports on the same Service. \n It is possible to
-                  separately reference multiple distinct objects that may be collapsed
-                  by an implementation. For example, some implementations may choose
-                  to merge compatible Gateway Listeners together. If that is the case,
-                  the list of routes attached to those resources should also be merged.
-                  \n Note that for ParentRefs that cross namespace boundaries, there
-                  are specific rules. Cross-namespace references are only valid if
-                  they are explicitly allowed by something in the namespace they are
-                  referring to. For example, Gateway has the AllowedRoutes field,
-                  and ReferenceGrant provides a generic way to enable other kinds
-                  of cross-namespace reference. \n ParentRefs from a Route to a Service
-                  in the same namespace are \"producer\" routes, which apply default
-                  routing rules to inbound connections from any namespace to the Service.
-                  \n ParentRefs from a Route to a Service in a different namespace
-                  are \"consumer\" routes, and these routing rules are only applied
-                  to outbound connections originating from the same namespace as the
-                  Route, for which the intended destination of the connections are
-                  a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. ReferenceGrant is not applicable
+                  for governing ParentRefs to Services - it is not possible to create
+                  a \"producer\" route for a Service in a different namespace from
+                  the Route. \n There are two kinds of parent resources with \"Core\"
+                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
+                  conformance profile) \n This API may be extended in the future to
+                  support additional kinds of parent resources. \n It is invalid to
+                  reference an identical parent more than once. It is valid to reference
+                  multiple distinct sections within the same parent resource, such
+                  as two separate Listeners on the same Gateway or two separate ports
+                  on the same Service. \n It is possible to separately reference multiple
+                  distinct objects that may be collapsed by an implementation. For
+                  example, some implementations may choose to merge compatible Gateway
+                  Listeners together. If that is the case, the list of routes attached
+                  to those resources should also be merged. \n Note that for ParentRefs
+                  that cross namespace boundaries, there are specific rules. Cross-namespace
+                  references are only valid if they are explicitly allowed by something
+                  in the namespace they are referring to. For example, Gateway has
+                  the AllowedRoutes field, and ReferenceGrant provides a generic way
+                  to enable other kinds of cross-namespace reference. \n ParentRefs
+                  from a Route to a Service in the same namespace are \"producer\"
+                  routes, which apply default routing rules to inbound connections
+                  from any namespace to the Service. \n ParentRefs from a Route to
+                  a Service in a different namespace are \"consumer\" routes, and
+                  these routing rules are only applied to outbound connections originating
+                  from the same namespace as the Route, for which the intended destination
+                  of the connections are a Service targeted as a ParentRef of the
+                  Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -201,7 +201,7 @@ spec:
                         \n ParentRefs from a Route to a Service in the same namespace
                         are \"producer\" routes, which apply default routing rules
                         to inbound connections from any namespace to the Service.
-                        ParentRefs from a Route to a Service in a different namespace
+                        \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
                         applied to outbound connections to the Service from the same
                         namespace as the Route. \n Support: Core"
@@ -245,22 +245,19 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n * Service: Named port. When both Port
-                        (experimental) and SectionName are specified, the name and
-                        port of the selected port must match both specified values.
-                        \n Implementations MAY choose to support attaching Routes
-                        to other resources. If that is the case, they MUST clearly
-                        document how SectionName is interpreted. \n When unspecified
-                        (empty string), this will reference the entire resource. For
-                        the purpose of status, an attachment is considered successful
-                        if at least one section in the parent resource accepts it.
-                        For example, Gateway listeners can restrict which Routes can
-                        attach to them by Route kind, namespace, or hostname. If 1
-                        of 2 Gateway listeners accept attachment from the referencing
-                        Route, the Route MUST be considered successfully attached.
-                        If no Gateway listeners accept attachment from this Route,
-                        the Route MUST be considered detached from the Gateway. \n
-                        Support: Core"
+                        specified values. \n Implementations MAY choose to support
+                        attaching Routes to other resources. If that is the case,
+                        they MUST clearly document how SectionName is interpreted.
+                        \n When unspecified (empty string), this will reference the
+                        entire resource. For the purpose of status, an attachment
+                        is considered successful if at least one section in the parent
+                        resource accepts it. For example, Gateway listeners can restrict
+                        which Routes can attach to them by Route kind, namespace,
+                        or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the Route MUST be considered detached from the Gateway.
+                        \n Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -1447,8 +1444,8 @@ spec:
                             reference. \n ParentRefs from a Route to a Service in
                             the same namespace are \"producer\" routes, which apply
                             default routing rules to inbound connections from any
-                            namespace to the Service. ParentRefs from a Route to a
-                            Service in a different namespace are \"consumer\" routes,
+                            namespace to the Service. \n ParentRefs from a Route to
+                            a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
                             to the Service from the same namespace as the Route. \n
                             Support: Core"
@@ -1494,12 +1491,9 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n * Service: Named
-                            port. When both Port (experimental) and SectionName are
-                            specified, the name and port of the selected port must
-                            match both specified values. \n Implementations MAY choose
-                            to support attaching Routes to other resources. If that
-                            is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n Implementations MAY
+                            choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -127,13 +127,18 @@ spec:
                   that a Route wants to be attached to. Note that the referenced parent
                   resource needs to allow this for the attachment to be complete.
                   For Gateways, that means the Gateway needs to allow attachment from
-                  Routes of this kind and namespace. \n The only kind of parent resource
-                  with \"Core\" support is Gateway. This API may be extended in the
-                  future to support additional kinds of parent resources such as one
-                  of the route kinds. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as 2 Listeners within a Gateway.
-                  \n It is possible to separately reference multiple distinct objects
+                  Routes of this kind and namespace. For Services, that means the
+                  Service must either be in the same namespace for a \"producer\"
+                  route, or the mesh implementation must support and allow \"consumer\"
+                  routes for the referenced Service. \n The only kinds of parent resources
+                  with \"Core\" support are Service (only for implementations supporting
+                  the Mesh conformance profile) and Gateway. This API may be extended
+                  in the future to support additional kinds of parent resources such
+                  as one of the route kinds. \n It is invalid to reference an identical
+                  parent more than once. It is valid to reference multiple distinct
+                  sections within the same parent resource, such as two separate Listeners
+                  on the same Gateway or two separate ports on the same Service. \n
+                  It is possible to separately reference multiple distinct objects
                   that may be collapsed by an implementation. For example, some implementations
                   may choose to merge compatible Gateway Listeners together. If that
                   is the case, the list of routes attached to those resources should
@@ -141,16 +146,23 @@ spec:
                   boundaries, there are specific rules. Cross-namespace references
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable any other
-                  kind of cross-namespace reference."
+                  field, and ReferenceGrant provides a generic way to enable other
+                  kinds of cross-namespace reference. \n ParentRefs from a Route to
+                  a Service in the same namespace are \"producer\" routes, which apply
+                  default routing rules to inbound connections from any namespace
+                  to the Service. ParentRefs from a Route to a Service in a different
+                  namespace are \"consumer\" routes, and these routing rules are only
+                  applied to outbound connections to the Service from the same namespace
+                  as the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kind of parent resource with \"Core\" support
-                    is Gateway. This API may be extended in the future to support
-                    additional kinds of parent resources, such as HTTPRoute. \n The
-                    API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid."
+                    a route). The only kinds of parent resources with \"Core\" support
+                    are Service (only for implementations supporting the Mesh conformance
+                    profile) and Gateway. This API may be extended in the future to
+                    support additional kinds of parent resources. \n The API object
+                    must be valid in the cluster; the Group and Kind must be registered
+                    in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -165,7 +177,8 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Implementation-specific (Other Resources)"
+                        (Gateway) \n Support: Core (Service - mesh conformance profile
+                        only) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -185,7 +198,13 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n Support: Core"
+                        \n ParentRefs from a Route to a Service in the same namespace
+                        are \"producer\" routes, which apply default routing rules
+                        to inbound connections from any namespace to the Service.
+                        ParentRefs from a Route to a Service in a different namespace
+                        are \"consumer\" routes, and these routing rules are only
+                        applied to outbound connections to the Service from the same
+                        namespace as the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -200,18 +219,22 @@ spec:
                         a Route must apply to a specific port as opposed to a listener(s)
                         whose port(s) may be changed. When both Port and SectionName
                         are specified, the name and port of the selected listener
-                        must match both specified values. \n Implementations MAY choose
-                        to support other parent resources. Implementations supporting
-                        other types of parent resources MUST clearly document how/if
-                        Port is interpreted. \n For the purpose of status, an attachment
-                        is considered successful as long as the parent resource accepts
-                        it partially. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Extended \n <gateway:experimental>"
+                        must match both specified values. \n When the parent resource
+                        is a Service, this targets a specific port in the Service
+                        spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified
+                        values. \n Implementations MAY choose to support other parent
+                        resources. Implementations supporting other types of parent
+                        resources MUST clearly document how/if Port is interpreted.
+                        \n For the purpose of status, an attachment is considered
+                        successful as long as the parent resource accepts it partially.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Extended \n <gateway:experimental>"
                       format: int32
                       maximum: 65535
                       minimum: 1
@@ -222,19 +245,22 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n Implementations MAY choose to support
-                        attaching Routes to other resources. If that is the case,
-                        they MUST clearly document how SectionName is interpreted.
-                        \n When unspecified (empty string), this will reference the
-                        entire resource. For the purpose of status, an attachment
-                        is considered successful if at least one section in the parent
-                        resource accepts it. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Core"
+                        specified values. \n * Service: Named port. When both Port
+                        (experimental) and SectionName are specified, the name and
+                        port of the selected port must match both specified values.
+                        \n Implementations MAY choose to support attaching Routes
+                        to other resources. If that is the case, they MUST clearly
+                        document how SectionName is interpreted. \n When unspecified
+                        (empty string), this will reference the entire resource. For
+                        the purpose of status, an attachment is considered successful
+                        if at least one section in the parent resource accepts it.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -1396,7 +1422,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Core (Gateway) \n Support: Core (Service - mesh conformance
+                            profile only) \n Support: Implementation-specific (Other
                             Resources)"
                           maxLength: 63
                           minLength: 1
@@ -1417,7 +1444,14 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n Support: Core"
+                            reference. \n ParentRefs from a Route to a Service in
+                            the same namespace are \"producer\" routes, which apply
+                            default routing rules to inbound connections from any
+                            namespace to the Service. ParentRefs from a Route to a
+                            Service in a different namespace are \"consumer\" routes,
+                            and these routing rules are only applied to outbound connections
+                            to the Service from the same namespace as the Route. \n
+                            Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -1433,8 +1467,12 @@ spec:
                             a specific port as opposed to a listener(s) whose port(s)
                             may be changed. When both Port and SectionName are specified,
                             the name and port of the selected listener must match
-                            both specified values. \n Implementations MAY choose to
-                            support other parent resources. Implementations supporting
+                            both specified values. \n When the parent resource is
+                            a Service, this targets a specific port in the Service
+                            spec. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support other parent resources. Implementations supporting
                             other types of parent resources MUST clearly document
                             how/if Port is interpreted. \n For the purpose of status,
                             an attachment is considered successful as long as the
@@ -1456,9 +1494,12 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n Implementations MAY
-                            choose to support attaching Routes to other resources.
-                            If that is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n * Service: Named
+                            port. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support attaching Routes to other resources. If that
+                            is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -150,10 +150,11 @@ spec:
                   kinds of cross-namespace reference. \n ParentRefs from a Route to
                   a Service in the same namespace are \"producer\" routes, which apply
                   default routing rules to inbound connections from any namespace
-                  to the Service. ParentRefs from a Route to a Service in a different
+                  to the Service. \n ParentRefs from a Route to a Service in a different
                   namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections to the Service from the same namespace
-                  as the Route."
+                  applied to outbound connections originating from the same namespace
+                  as the Route, for which the intended destination of the connections
+                  are a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -203,8 +204,10 @@ spec:
                         to inbound connections from any namespace to the Service.
                         \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
-                        applied to outbound connections to the Service from the same
-                        namespace as the Route. \n Support: Core"
+                        applied to outbound connections originating from the same
+                        namespace as the Route, for which the intended destination
+                        of the connections are a Service targeted as a ParentRef of
+                        the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -1447,8 +1450,10 @@ spec:
                             namespace to the Service. \n ParentRefs from a Route to
                             a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
-                            to the Service from the same namespace as the Route. \n
-                            Support: Core"
+                            originating from the same namespace as the Route, for
+                            which the intended destination of the connections are
+                            a Service targeted as a ParentRef of the Route. \n Support:
+                            Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -114,13 +114,18 @@ spec:
                   that a Route wants to be attached to. Note that the referenced parent
                   resource needs to allow this for the attachment to be complete.
                   For Gateways, that means the Gateway needs to allow attachment from
-                  Routes of this kind and namespace. \n The only kind of parent resource
-                  with \"Core\" support is Gateway. This API may be extended in the
-                  future to support additional kinds of parent resources such as one
-                  of the route kinds. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as 2 Listeners within a Gateway.
-                  \n It is possible to separately reference multiple distinct objects
+                  Routes of this kind and namespace. For Services, that means the
+                  Service must either be in the same namespace for a \"producer\"
+                  route, or the mesh implementation must support and allow \"consumer\"
+                  routes for the referenced Service. \n The only kinds of parent resources
+                  with \"Core\" support are Service (only for implementations supporting
+                  the Mesh conformance profile) and Gateway. This API may be extended
+                  in the future to support additional kinds of parent resources such
+                  as one of the route kinds. \n It is invalid to reference an identical
+                  parent more than once. It is valid to reference multiple distinct
+                  sections within the same parent resource, such as two separate Listeners
+                  on the same Gateway or two separate ports on the same Service. \n
+                  It is possible to separately reference multiple distinct objects
                   that may be collapsed by an implementation. For example, some implementations
                   may choose to merge compatible Gateway Listeners together. If that
                   is the case, the list of routes attached to those resources should
@@ -128,16 +133,23 @@ spec:
                   boundaries, there are specific rules. Cross-namespace references
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable any other
-                  kind of cross-namespace reference."
+                  field, and ReferenceGrant provides a generic way to enable other
+                  kinds of cross-namespace reference. \n ParentRefs from a Route to
+                  a Service in the same namespace are \"producer\" routes, which apply
+                  default routing rules to inbound connections from any namespace
+                  to the Service. ParentRefs from a Route to a Service in a different
+                  namespace are \"consumer\" routes, and these routing rules are only
+                  applied to outbound connections to the Service from the same namespace
+                  as the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kind of parent resource with \"Core\" support
-                    is Gateway. This API may be extended in the future to support
-                    additional kinds of parent resources, such as HTTPRoute. \n The
-                    API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid."
+                    a route). The only kinds of parent resources with \"Core\" support
+                    are Service (only for implementations supporting the Mesh conformance
+                    profile) and Gateway. This API may be extended in the future to
+                    support additional kinds of parent resources. \n The API object
+                    must be valid in the cluster; the Group and Kind must be registered
+                    in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -152,7 +164,8 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Implementation-specific (Other Resources)"
+                        (Gateway) \n Support: Core (Service - mesh conformance profile
+                        only) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -172,7 +185,13 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n Support: Core"
+                        \n ParentRefs from a Route to a Service in the same namespace
+                        are \"producer\" routes, which apply default routing rules
+                        to inbound connections from any namespace to the Service.
+                        ParentRefs from a Route to a Service in a different namespace
+                        are \"consumer\" routes, and these routing rules are only
+                        applied to outbound connections to the Service from the same
+                        namespace as the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -187,18 +206,22 @@ spec:
                         a Route must apply to a specific port as opposed to a listener(s)
                         whose port(s) may be changed. When both Port and SectionName
                         are specified, the name and port of the selected listener
-                        must match both specified values. \n Implementations MAY choose
-                        to support other parent resources. Implementations supporting
-                        other types of parent resources MUST clearly document how/if
-                        Port is interpreted. \n For the purpose of status, an attachment
-                        is considered successful as long as the parent resource accepts
-                        it partially. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Extended \n <gateway:experimental>"
+                        must match both specified values. \n When the parent resource
+                        is a Service, this targets a specific port in the Service
+                        spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified
+                        values. \n Implementations MAY choose to support other parent
+                        resources. Implementations supporting other types of parent
+                        resources MUST clearly document how/if Port is interpreted.
+                        \n For the purpose of status, an attachment is considered
+                        successful as long as the parent resource accepts it partially.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Extended \n <gateway:experimental>"
                       format: int32
                       maximum: 65535
                       minimum: 1
@@ -209,19 +232,22 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n Implementations MAY choose to support
-                        attaching Routes to other resources. If that is the case,
-                        they MUST clearly document how SectionName is interpreted.
-                        \n When unspecified (empty string), this will reference the
-                        entire resource. For the purpose of status, an attachment
-                        is considered successful if at least one section in the parent
-                        resource accepts it. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Core"
+                        specified values. \n * Service: Named port. When both Port
+                        (experimental) and SectionName are specified, the name and
+                        port of the selected port must match both specified values.
+                        \n Implementations MAY choose to support attaching Routes
+                        to other resources. If that is the case, they MUST clearly
+                        document how SectionName is interpreted. \n When unspecified
+                        (empty string), this will reference the entire resource. For
+                        the purpose of status, an attachment is considered successful
+                        if at least one section in the parent resource accepts it.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -1912,7 +1938,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Core (Gateway) \n Support: Core (Service - mesh conformance
+                            profile only) \n Support: Implementation-specific (Other
                             Resources)"
                           maxLength: 63
                           minLength: 1
@@ -1933,7 +1960,14 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n Support: Core"
+                            reference. \n ParentRefs from a Route to a Service in
+                            the same namespace are \"producer\" routes, which apply
+                            default routing rules to inbound connections from any
+                            namespace to the Service. ParentRefs from a Route to a
+                            Service in a different namespace are \"consumer\" routes,
+                            and these routing rules are only applied to outbound connections
+                            to the Service from the same namespace as the Route. \n
+                            Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -1949,8 +1983,12 @@ spec:
                             a specific port as opposed to a listener(s) whose port(s)
                             may be changed. When both Port and SectionName are specified,
                             the name and port of the selected listener must match
-                            both specified values. \n Implementations MAY choose to
-                            support other parent resources. Implementations supporting
+                            both specified values. \n When the parent resource is
+                            a Service, this targets a specific port in the Service
+                            spec. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support other parent resources. Implementations supporting
                             other types of parent resources MUST clearly document
                             how/if Port is interpreted. \n For the purpose of status,
                             an attachment is considered successful as long as the
@@ -1972,9 +2010,12 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n Implementations MAY
-                            choose to support attaching Routes to other resources.
-                            If that is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n * Service: Named
+                            port. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support attaching Routes to other resources. If that
+                            is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least
@@ -2102,13 +2143,18 @@ spec:
                   that a Route wants to be attached to. Note that the referenced parent
                   resource needs to allow this for the attachment to be complete.
                   For Gateways, that means the Gateway needs to allow attachment from
-                  Routes of this kind and namespace. \n The only kind of parent resource
-                  with \"Core\" support is Gateway. This API may be extended in the
-                  future to support additional kinds of parent resources such as one
-                  of the route kinds. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as 2 Listeners within a Gateway.
-                  \n It is possible to separately reference multiple distinct objects
+                  Routes of this kind and namespace. For Services, that means the
+                  Service must either be in the same namespace for a \"producer\"
+                  route, or the mesh implementation must support and allow \"consumer\"
+                  routes for the referenced Service. \n The only kinds of parent resources
+                  with \"Core\" support are Service (only for implementations supporting
+                  the Mesh conformance profile) and Gateway. This API may be extended
+                  in the future to support additional kinds of parent resources such
+                  as one of the route kinds. \n It is invalid to reference an identical
+                  parent more than once. It is valid to reference multiple distinct
+                  sections within the same parent resource, such as two separate Listeners
+                  on the same Gateway or two separate ports on the same Service. \n
+                  It is possible to separately reference multiple distinct objects
                   that may be collapsed by an implementation. For example, some implementations
                   may choose to merge compatible Gateway Listeners together. If that
                   is the case, the list of routes attached to those resources should
@@ -2116,16 +2162,23 @@ spec:
                   boundaries, there are specific rules. Cross-namespace references
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable any other
-                  kind of cross-namespace reference."
+                  field, and ReferenceGrant provides a generic way to enable other
+                  kinds of cross-namespace reference. \n ParentRefs from a Route to
+                  a Service in the same namespace are \"producer\" routes, which apply
+                  default routing rules to inbound connections from any namespace
+                  to the Service. ParentRefs from a Route to a Service in a different
+                  namespace are \"consumer\" routes, and these routing rules are only
+                  applied to outbound connections to the Service from the same namespace
+                  as the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kind of parent resource with \"Core\" support
-                    is Gateway. This API may be extended in the future to support
-                    additional kinds of parent resources, such as HTTPRoute. \n The
-                    API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid."
+                    a route). The only kinds of parent resources with \"Core\" support
+                    are Service (only for implementations supporting the Mesh conformance
+                    profile) and Gateway. This API may be extended in the future to
+                    support additional kinds of parent resources. \n The API object
+                    must be valid in the cluster; the Group and Kind must be registered
+                    in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -2140,7 +2193,8 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Implementation-specific (Other Resources)"
+                        (Gateway) \n Support: Core (Service - mesh conformance profile
+                        only) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -2160,7 +2214,13 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n Support: Core"
+                        \n ParentRefs from a Route to a Service in the same namespace
+                        are \"producer\" routes, which apply default routing rules
+                        to inbound connections from any namespace to the Service.
+                        ParentRefs from a Route to a Service in a different namespace
+                        are \"consumer\" routes, and these routing rules are only
+                        applied to outbound connections to the Service from the same
+                        namespace as the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -2175,18 +2235,22 @@ spec:
                         a Route must apply to a specific port as opposed to a listener(s)
                         whose port(s) may be changed. When both Port and SectionName
                         are specified, the name and port of the selected listener
-                        must match both specified values. \n Implementations MAY choose
-                        to support other parent resources. Implementations supporting
-                        other types of parent resources MUST clearly document how/if
-                        Port is interpreted. \n For the purpose of status, an attachment
-                        is considered successful as long as the parent resource accepts
-                        it partially. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Extended \n <gateway:experimental>"
+                        must match both specified values. \n When the parent resource
+                        is a Service, this targets a specific port in the Service
+                        spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified
+                        values. \n Implementations MAY choose to support other parent
+                        resources. Implementations supporting other types of parent
+                        resources MUST clearly document how/if Port is interpreted.
+                        \n For the purpose of status, an attachment is considered
+                        successful as long as the parent resource accepts it partially.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Extended \n <gateway:experimental>"
                       format: int32
                       maximum: 65535
                       minimum: 1
@@ -2197,19 +2261,22 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n Implementations MAY choose to support
-                        attaching Routes to other resources. If that is the case,
-                        they MUST clearly document how SectionName is interpreted.
-                        \n When unspecified (empty string), this will reference the
-                        entire resource. For the purpose of status, an attachment
-                        is considered successful if at least one section in the parent
-                        resource accepts it. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Core"
+                        specified values. \n * Service: Named port. When both Port
+                        (experimental) and SectionName are specified, the name and
+                        port of the selected port must match both specified values.
+                        \n Implementations MAY choose to support attaching Routes
+                        to other resources. If that is the case, they MUST clearly
+                        document how SectionName is interpreted. \n When unspecified
+                        (empty string), this will reference the entire resource. For
+                        the purpose of status, an attachment is considered successful
+                        if at least one section in the parent resource accepts it.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -3900,7 +3967,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Core (Gateway) \n Support: Core (Service - mesh conformance
+                            profile only) \n Support: Implementation-specific (Other
                             Resources)"
                           maxLength: 63
                           minLength: 1
@@ -3921,7 +3989,14 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n Support: Core"
+                            reference. \n ParentRefs from a Route to a Service in
+                            the same namespace are \"producer\" routes, which apply
+                            default routing rules to inbound connections from any
+                            namespace to the Service. ParentRefs from a Route to a
+                            Service in a different namespace are \"consumer\" routes,
+                            and these routing rules are only applied to outbound connections
+                            to the Service from the same namespace as the Route. \n
+                            Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -3937,8 +4012,12 @@ spec:
                             a specific port as opposed to a listener(s) whose port(s)
                             may be changed. When both Port and SectionName are specified,
                             the name and port of the selected listener must match
-                            both specified values. \n Implementations MAY choose to
-                            support other parent resources. Implementations supporting
+                            both specified values. \n When the parent resource is
+                            a Service, this targets a specific port in the Service
+                            spec. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support other parent resources. Implementations supporting
                             other types of parent resources MUST clearly document
                             how/if Port is interpreted. \n For the purpose of status,
                             an attachment is considered successful as long as the
@@ -3960,9 +4039,12 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n Implementations MAY
-                            choose to support attaching Routes to other resources.
-                            If that is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n * Service: Named
+                            port. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support attaching Routes to other resources. If that
+                            is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -137,10 +137,11 @@ spec:
                   kinds of cross-namespace reference. \n ParentRefs from a Route to
                   a Service in the same namespace are \"producer\" routes, which apply
                   default routing rules to inbound connections from any namespace
-                  to the Service. ParentRefs from a Route to a Service in a different
+                  to the Service. \n ParentRefs from a Route to a Service in a different
                   namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections to the Service from the same namespace
-                  as the Route."
+                  applied to outbound connections originating from the same namespace
+                  as the Route, for which the intended destination of the connections
+                  are a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -190,8 +191,10 @@ spec:
                         to inbound connections from any namespace to the Service.
                         \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
-                        applied to outbound connections to the Service from the same
-                        namespace as the Route. \n Support: Core"
+                        applied to outbound connections originating from the same
+                        namespace as the Route, for which the intended destination
+                        of the connections are a Service targeted as a ParentRef of
+                        the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -1963,8 +1966,10 @@ spec:
                             namespace to the Service. \n ParentRefs from a Route to
                             a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
-                            to the Service from the same namespace as the Route. \n
-                            Support: Core"
+                            originating from the same namespace as the Route, for
+                            which the intended destination of the connections are
+                            a Service targeted as a ParentRef of the Route. \n Support:
+                            Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -2160,10 +2165,11 @@ spec:
                   kinds of cross-namespace reference. \n ParentRefs from a Route to
                   a Service in the same namespace are \"producer\" routes, which apply
                   default routing rules to inbound connections from any namespace
-                  to the Service. ParentRefs from a Route to a Service in a different
+                  to the Service. \n ParentRefs from a Route to a Service in a different
                   namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections to the Service from the same namespace
-                  as the Route."
+                  applied to outbound connections originating from the same namespace
+                  as the Route, for which the intended destination of the connections
+                  are a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -2213,8 +2219,10 @@ spec:
                         to inbound connections from any namespace to the Service.
                         \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
-                        applied to outbound connections to the Service from the same
-                        namespace as the Route. \n Support: Core"
+                        applied to outbound connections originating from the same
+                        namespace as the Route, for which the intended destination
+                        of the connections are a Service targeted as a ParentRef of
+                        the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -3986,8 +3994,10 @@ spec:
                             namespace to the Service. \n ParentRefs from a Route to
                             a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
-                            to the Service from the same namespace as the Route. \n
-                            Support: Core"
+                            originating from the same namespace as the Route, for
+                            which the intended destination of the connections are
+                            a Service targeted as a ParentRef of the Route. \n Support:
+                            Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -117,31 +117,34 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n There are two kinds of parent
-                  resources with \"Core\" support: \n * Gateway (Gateway conformance
-                  profile) * Service (Mesh conformance profile) \n This API may be
-                  extended in the future to support additional kinds of parent resources.
-                  \n It is invalid to reference an identical parent more than once.
-                  It is valid to reference multiple distinct sections within the same
-                  parent resource, such as two separate Listeners on the same Gateway
-                  or two separate ports on the same Service. \n It is possible to
-                  separately reference multiple distinct objects that may be collapsed
-                  by an implementation. For example, some implementations may choose
-                  to merge compatible Gateway Listeners together. If that is the case,
-                  the list of routes attached to those resources should also be merged.
-                  \n Note that for ParentRefs that cross namespace boundaries, there
-                  are specific rules. Cross-namespace references are only valid if
-                  they are explicitly allowed by something in the namespace they are
-                  referring to. For example, Gateway has the AllowedRoutes field,
-                  and ReferenceGrant provides a generic way to enable other kinds
-                  of cross-namespace reference. \n ParentRefs from a Route to a Service
-                  in the same namespace are \"producer\" routes, which apply default
-                  routing rules to inbound connections from any namespace to the Service.
-                  \n ParentRefs from a Route to a Service in a different namespace
-                  are \"consumer\" routes, and these routing rules are only applied
-                  to outbound connections originating from the same namespace as the
-                  Route, for which the intended destination of the connections are
-                  a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. ReferenceGrant is not applicable
+                  for governing ParentRefs to Services - it is not possible to create
+                  a \"producer\" route for a Service in a different namespace from
+                  the Route. \n There are two kinds of parent resources with \"Core\"
+                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
+                  conformance profile) \n This API may be extended in the future to
+                  support additional kinds of parent resources. \n It is invalid to
+                  reference an identical parent more than once. It is valid to reference
+                  multiple distinct sections within the same parent resource, such
+                  as two separate Listeners on the same Gateway or two separate ports
+                  on the same Service. \n It is possible to separately reference multiple
+                  distinct objects that may be collapsed by an implementation. For
+                  example, some implementations may choose to merge compatible Gateway
+                  Listeners together. If that is the case, the list of routes attached
+                  to those resources should also be merged. \n Note that for ParentRefs
+                  that cross namespace boundaries, there are specific rules. Cross-namespace
+                  references are only valid if they are explicitly allowed by something
+                  in the namespace they are referring to. For example, Gateway has
+                  the AllowedRoutes field, and ReferenceGrant provides a generic way
+                  to enable other kinds of cross-namespace reference. \n ParentRefs
+                  from a Route to a Service in the same namespace are \"producer\"
+                  routes, which apply default routing rules to inbound connections
+                  from any namespace to the Service. \n ParentRefs from a Route to
+                  a Service in a different namespace are \"consumer\" routes, and
+                  these routing rules are only applied to outbound connections originating
+                  from the same namespace as the Route, for which the intended destination
+                  of the connections are a Service targeted as a ParentRef of the
+                  Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -2147,31 +2150,34 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n There are two kinds of parent
-                  resources with \"Core\" support: \n * Gateway (Gateway conformance
-                  profile) * Service (Mesh conformance profile) \n This API may be
-                  extended in the future to support additional kinds of parent resources.
-                  \n It is invalid to reference an identical parent more than once.
-                  It is valid to reference multiple distinct sections within the same
-                  parent resource, such as two separate Listeners on the same Gateway
-                  or two separate ports on the same Service. \n It is possible to
-                  separately reference multiple distinct objects that may be collapsed
-                  by an implementation. For example, some implementations may choose
-                  to merge compatible Gateway Listeners together. If that is the case,
-                  the list of routes attached to those resources should also be merged.
-                  \n Note that for ParentRefs that cross namespace boundaries, there
-                  are specific rules. Cross-namespace references are only valid if
-                  they are explicitly allowed by something in the namespace they are
-                  referring to. For example, Gateway has the AllowedRoutes field,
-                  and ReferenceGrant provides a generic way to enable other kinds
-                  of cross-namespace reference. \n ParentRefs from a Route to a Service
-                  in the same namespace are \"producer\" routes, which apply default
-                  routing rules to inbound connections from any namespace to the Service.
-                  \n ParentRefs from a Route to a Service in a different namespace
-                  are \"consumer\" routes, and these routing rules are only applied
-                  to outbound connections originating from the same namespace as the
-                  Route, for which the intended destination of the connections are
-                  a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. ReferenceGrant is not applicable
+                  for governing ParentRefs to Services - it is not possible to create
+                  a \"producer\" route for a Service in a different namespace from
+                  the Route. \n There are two kinds of parent resources with \"Core\"
+                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
+                  conformance profile) \n This API may be extended in the future to
+                  support additional kinds of parent resources. \n It is invalid to
+                  reference an identical parent more than once. It is valid to reference
+                  multiple distinct sections within the same parent resource, such
+                  as two separate Listeners on the same Gateway or two separate ports
+                  on the same Service. \n It is possible to separately reference multiple
+                  distinct objects that may be collapsed by an implementation. For
+                  example, some implementations may choose to merge compatible Gateway
+                  Listeners together. If that is the case, the list of routes attached
+                  to those resources should also be merged. \n Note that for ParentRefs
+                  that cross namespace boundaries, there are specific rules. Cross-namespace
+                  references are only valid if they are explicitly allowed by something
+                  in the namespace they are referring to. For example, Gateway has
+                  the AllowedRoutes field, and ReferenceGrant provides a generic way
+                  to enable other kinds of cross-namespace reference. \n ParentRefs
+                  from a Route to a Service in the same namespace are \"producer\"
+                  routes, which apply default routing rules to inbound connections
+                  from any namespace to the Service. \n ParentRefs from a Route to
+                  a Service in a different namespace are \"consumer\" routes, and
+                  these routing rules are only applied to outbound connections originating
+                  from the same namespace as the Route, for which the intended destination
+                  of the connections are a Service targeted as a ParentRef of the
+                  Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -117,40 +117,40 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n The only kinds of parent resources
-                  with \"Core\" support are Service (only for implementations supporting
-                  the Mesh conformance profile) and Gateway. This API may be extended
-                  in the future to support additional kinds of parent resources such
-                  as one of the route kinds. \n It is invalid to reference an identical
-                  parent more than once. It is valid to reference multiple distinct
-                  sections within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. \n There are two kinds of parent
+                  resources with \"Core\" support: \n * Gateway (Gateway conformance
+                  profile) * Service (Mesh conformance profile) \n This API may be
+                  extended in the future to support additional kinds of parent resources.
+                  \n It is invalid to reference an identical parent more than once.
+                  It is valid to reference multiple distinct sections within the same
+                  parent resource, such as two separate Listeners on the same Gateway
+                  or two separate ports on the same Service. \n It is possible to
+                  separately reference multiple distinct objects that may be collapsed
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kinds of parent resources with \"Core\" support
-                    are Service (only for implementations supporting the Mesh conformance
-                    profile) and Gateway. This API may be extended in the future to
-                    support additional kinds of parent resources. \n The API object
-                    must be valid in the cluster; the Group and Kind must be registered
-                    in the cluster for this reference to be valid."
+                    a route). There are two kinds of parent resources with \"Core\"
+                    support: \n * Gateway (Gateway conformance profile) * Service
+                    (Mesh conformance profile) \n This API may be extended in the
+                    future to support additional kinds of parent resources. \n The
+                    API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -164,9 +164,10 @@ spec:
                       type: string
                     kind:
                       default: Gateway
-                      description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Core (Service - mesh conformance profile
-                        only) \n Support: Implementation-specific (Other Resources)"
+                      description: "Kind is kind of the referent. \n There are two
+                        kinds of parent resources with \"Core\" support: \n * Gateway
+                        (Gateway conformance profile) * Service (Mesh conformance
+                        profile) \n Support for other resources is Implementation-Specific."
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1937,10 +1938,11 @@ spec:
                           type: string
                         kind:
                           default: Gateway
-                          description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Core (Service - mesh conformance
-                            profile only) \n Support: Implementation-specific (Other
-                            Resources)"
+                          description: "Kind is kind of the referent. \n There are
+                            two kinds of parent resources with \"Core\" support: \n
+                            * Gateway (Gateway conformance profile) * Service (Mesh
+                            conformance profile) \n Support for other resources is
+                            Implementation-Specific."
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -2145,40 +2147,40 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n The only kinds of parent resources
-                  with \"Core\" support are Service (only for implementations supporting
-                  the Mesh conformance profile) and Gateway. This API may be extended
-                  in the future to support additional kinds of parent resources such
-                  as one of the route kinds. \n It is invalid to reference an identical
-                  parent more than once. It is valid to reference multiple distinct
-                  sections within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. \n There are two kinds of parent
+                  resources with \"Core\" support: \n * Gateway (Gateway conformance
+                  profile) * Service (Mesh conformance profile) \n This API may be
+                  extended in the future to support additional kinds of parent resources.
+                  \n It is invalid to reference an identical parent more than once.
+                  It is valid to reference multiple distinct sections within the same
+                  parent resource, such as two separate Listeners on the same Gateway
+                  or two separate ports on the same Service. \n It is possible to
+                  separately reference multiple distinct objects that may be collapsed
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kinds of parent resources with \"Core\" support
-                    are Service (only for implementations supporting the Mesh conformance
-                    profile) and Gateway. This API may be extended in the future to
-                    support additional kinds of parent resources. \n The API object
-                    must be valid in the cluster; the Group and Kind must be registered
-                    in the cluster for this reference to be valid."
+                    a route). There are two kinds of parent resources with \"Core\"
+                    support: \n * Gateway (Gateway conformance profile) * Service
+                    (Mesh conformance profile) \n This API may be extended in the
+                    future to support additional kinds of parent resources. \n The
+                    API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -2192,9 +2194,10 @@ spec:
                       type: string
                     kind:
                       default: Gateway
-                      description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Core (Service - mesh conformance profile
-                        only) \n Support: Implementation-specific (Other Resources)"
+                      description: "Kind is kind of the referent. \n There are two
+                        kinds of parent resources with \"Core\" support: \n * Gateway
+                        (Gateway conformance profile) * Service (Mesh conformance
+                        profile) \n Support for other resources is Implementation-Specific."
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -3965,10 +3968,11 @@ spec:
                           type: string
                         kind:
                           default: Gateway
-                          description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Core (Service - mesh conformance
-                            profile only) \n Support: Implementation-specific (Other
-                            Resources)"
+                          description: "Kind is kind of the referent. \n There are
+                            two kinds of parent resources with \"Core\" support: \n
+                            * Gateway (Gateway conformance profile) * Service (Mesh
+                            conformance profile) \n Support for other resources is
+                            Implementation-Specific."
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -188,7 +188,7 @@ spec:
                         \n ParentRefs from a Route to a Service in the same namespace
                         are \"producer\" routes, which apply default routing rules
                         to inbound connections from any namespace to the Service.
-                        ParentRefs from a Route to a Service in a different namespace
+                        \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
                         applied to outbound connections to the Service from the same
                         namespace as the Route. \n Support: Core"
@@ -232,22 +232,19 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n * Service: Named port. When both Port
-                        (experimental) and SectionName are specified, the name and
-                        port of the selected port must match both specified values.
-                        \n Implementations MAY choose to support attaching Routes
-                        to other resources. If that is the case, they MUST clearly
-                        document how SectionName is interpreted. \n When unspecified
-                        (empty string), this will reference the entire resource. For
-                        the purpose of status, an attachment is considered successful
-                        if at least one section in the parent resource accepts it.
-                        For example, Gateway listeners can restrict which Routes can
-                        attach to them by Route kind, namespace, or hostname. If 1
-                        of 2 Gateway listeners accept attachment from the referencing
-                        Route, the Route MUST be considered successfully attached.
-                        If no Gateway listeners accept attachment from this Route,
-                        the Route MUST be considered detached from the Gateway. \n
-                        Support: Core"
+                        specified values. \n Implementations MAY choose to support
+                        attaching Routes to other resources. If that is the case,
+                        they MUST clearly document how SectionName is interpreted.
+                        \n When unspecified (empty string), this will reference the
+                        entire resource. For the purpose of status, an attachment
+                        is considered successful if at least one section in the parent
+                        resource accepts it. For example, Gateway listeners can restrict
+                        which Routes can attach to them by Route kind, namespace,
+                        or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the Route MUST be considered detached from the Gateway.
+                        \n Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -1963,8 +1960,8 @@ spec:
                             reference. \n ParentRefs from a Route to a Service in
                             the same namespace are \"producer\" routes, which apply
                             default routing rules to inbound connections from any
-                            namespace to the Service. ParentRefs from a Route to a
-                            Service in a different namespace are \"consumer\" routes,
+                            namespace to the Service. \n ParentRefs from a Route to
+                            a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
                             to the Service from the same namespace as the Route. \n
                             Support: Core"
@@ -2010,12 +2007,9 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n * Service: Named
-                            port. When both Port (experimental) and SectionName are
-                            specified, the name and port of the selected port must
-                            match both specified values. \n Implementations MAY choose
-                            to support attaching Routes to other resources. If that
-                            is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n Implementations MAY
+                            choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least
@@ -2217,7 +2211,7 @@ spec:
                         \n ParentRefs from a Route to a Service in the same namespace
                         are \"producer\" routes, which apply default routing rules
                         to inbound connections from any namespace to the Service.
-                        ParentRefs from a Route to a Service in a different namespace
+                        \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
                         applied to outbound connections to the Service from the same
                         namespace as the Route. \n Support: Core"
@@ -2261,22 +2255,19 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n * Service: Named port. When both Port
-                        (experimental) and SectionName are specified, the name and
-                        port of the selected port must match both specified values.
-                        \n Implementations MAY choose to support attaching Routes
-                        to other resources. If that is the case, they MUST clearly
-                        document how SectionName is interpreted. \n When unspecified
-                        (empty string), this will reference the entire resource. For
-                        the purpose of status, an attachment is considered successful
-                        if at least one section in the parent resource accepts it.
-                        For example, Gateway listeners can restrict which Routes can
-                        attach to them by Route kind, namespace, or hostname. If 1
-                        of 2 Gateway listeners accept attachment from the referencing
-                        Route, the Route MUST be considered successfully attached.
-                        If no Gateway listeners accept attachment from this Route,
-                        the Route MUST be considered detached from the Gateway. \n
-                        Support: Core"
+                        specified values. \n Implementations MAY choose to support
+                        attaching Routes to other resources. If that is the case,
+                        they MUST clearly document how SectionName is interpreted.
+                        \n When unspecified (empty string), this will reference the
+                        entire resource. For the purpose of status, an attachment
+                        is considered successful if at least one section in the parent
+                        resource accepts it. For example, Gateway listeners can restrict
+                        which Routes can attach to them by Route kind, namespace,
+                        or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the Route MUST be considered detached from the Gateway.
+                        \n Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -3992,8 +3983,8 @@ spec:
                             reference. \n ParentRefs from a Route to a Service in
                             the same namespace are \"producer\" routes, which apply
                             default routing rules to inbound connections from any
-                            namespace to the Service. ParentRefs from a Route to a
-                            Service in a different namespace are \"consumer\" routes,
+                            namespace to the Service. \n ParentRefs from a Route to
+                            a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
                             to the Service from the same namespace as the Route. \n
                             Support: Core"
@@ -4039,12 +4030,9 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n * Service: Named
-                            port. When both Port (experimental) and SectionName are
-                            specified, the name and port of the selected port must
-                            match both specified values. \n Implementations MAY choose
-                            to support attaching Routes to other resources. If that
-                            is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n Implementations MAY
+                            choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least

--- a/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
@@ -35,13 +35,17 @@ spec:
           namespace as the policy. \n Each ReferenceGrant can be used to represent
           a unique trust relationship. Additional Reference Grants can be used to
           add to the set of trusted sources of inbound references for the namespace
-          they are defined within. \n All cross-namespace references in Gateway API
-          (with the exception of cross-namespace Gateway-route attachment) require
-          a ReferenceGrant. \n ReferenceGrant is a form of runtime verification allowing
-          users to assert which cross-namespace object references are permitted. Implementations
-          that support ReferenceGrant MUST NOT permit cross-namespace references which
-          have no grant, and MUST respond to the removal of a grant by revoking the
-          access that the grant allowed. \n Support: Core"
+          they are defined within. \n A ReferenceGrant is required for all cross-namespace
+          references in Gateway API (with the exception of cross-namespace Route-Gateway
+          attachment, which is governed by the AllowedRoutes configuration on the
+          Gateway, and cross-namespace Service ParentRefs on a \"consumer\" mesh Route,
+          which defines routing rules applicable only to workloads in the Route namespace).
+          ReferenceGrants allowing a reference from a Route to a Service are only
+          applicable to BackendRefs. \n ReferenceGrant is a form of runtime verification
+          allowing users to assert which cross-namespace object references are permitted.
+          Implementations that support ReferenceGrant MUST NOT permit cross-namespace
+          references which have no grant, and MUST respond to the removal of a grant
+          by revoking the access that the grant allowed. \n Support: Core"
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -49,13 +49,18 @@ spec:
                   that a Route wants to be attached to. Note that the referenced parent
                   resource needs to allow this for the attachment to be complete.
                   For Gateways, that means the Gateway needs to allow attachment from
-                  Routes of this kind and namespace. \n The only kind of parent resource
-                  with \"Core\" support is Gateway. This API may be extended in the
-                  future to support additional kinds of parent resources such as one
-                  of the route kinds. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as 2 Listeners within a Gateway.
-                  \n It is possible to separately reference multiple distinct objects
+                  Routes of this kind and namespace. For Services, that means the
+                  Service must either be in the same namespace for a \"producer\"
+                  route, or the mesh implementation must support and allow \"consumer\"
+                  routes for the referenced Service. \n The only kinds of parent resources
+                  with \"Core\" support are Service (only for implementations supporting
+                  the Mesh conformance profile) and Gateway. This API may be extended
+                  in the future to support additional kinds of parent resources such
+                  as one of the route kinds. \n It is invalid to reference an identical
+                  parent more than once. It is valid to reference multiple distinct
+                  sections within the same parent resource, such as two separate Listeners
+                  on the same Gateway or two separate ports on the same Service. \n
+                  It is possible to separately reference multiple distinct objects
                   that may be collapsed by an implementation. For example, some implementations
                   may choose to merge compatible Gateway Listeners together. If that
                   is the case, the list of routes attached to those resources should
@@ -63,16 +68,23 @@ spec:
                   boundaries, there are specific rules. Cross-namespace references
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable any other
-                  kind of cross-namespace reference."
+                  field, and ReferenceGrant provides a generic way to enable other
+                  kinds of cross-namespace reference. \n ParentRefs from a Route to
+                  a Service in the same namespace are \"producer\" routes, which apply
+                  default routing rules to inbound connections from any namespace
+                  to the Service. ParentRefs from a Route to a Service in a different
+                  namespace are \"consumer\" routes, and these routing rules are only
+                  applied to outbound connections to the Service from the same namespace
+                  as the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kind of parent resource with \"Core\" support
-                    is Gateway. This API may be extended in the future to support
-                    additional kinds of parent resources, such as HTTPRoute. \n The
-                    API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid."
+                    a route). The only kinds of parent resources with \"Core\" support
+                    are Service (only for implementations supporting the Mesh conformance
+                    profile) and Gateway. This API may be extended in the future to
+                    support additional kinds of parent resources. \n The API object
+                    must be valid in the cluster; the Group and Kind must be registered
+                    in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -87,7 +99,8 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Implementation-specific (Other Resources)"
+                        (Gateway) \n Support: Core (Service - mesh conformance profile
+                        only) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -107,7 +120,13 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n Support: Core"
+                        \n ParentRefs from a Route to a Service in the same namespace
+                        are \"producer\" routes, which apply default routing rules
+                        to inbound connections from any namespace to the Service.
+                        ParentRefs from a Route to a Service in a different namespace
+                        are \"consumer\" routes, and these routing rules are only
+                        applied to outbound connections to the Service from the same
+                        namespace as the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -122,18 +141,22 @@ spec:
                         a Route must apply to a specific port as opposed to a listener(s)
                         whose port(s) may be changed. When both Port and SectionName
                         are specified, the name and port of the selected listener
-                        must match both specified values. \n Implementations MAY choose
-                        to support other parent resources. Implementations supporting
-                        other types of parent resources MUST clearly document how/if
-                        Port is interpreted. \n For the purpose of status, an attachment
-                        is considered successful as long as the parent resource accepts
-                        it partially. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Extended \n <gateway:experimental>"
+                        must match both specified values. \n When the parent resource
+                        is a Service, this targets a specific port in the Service
+                        spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified
+                        values. \n Implementations MAY choose to support other parent
+                        resources. Implementations supporting other types of parent
+                        resources MUST clearly document how/if Port is interpreted.
+                        \n For the purpose of status, an attachment is considered
+                        successful as long as the parent resource accepts it partially.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Extended \n <gateway:experimental>"
                       format: int32
                       maximum: 65535
                       minimum: 1
@@ -144,19 +167,22 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n Implementations MAY choose to support
-                        attaching Routes to other resources. If that is the case,
-                        they MUST clearly document how SectionName is interpreted.
-                        \n When unspecified (empty string), this will reference the
-                        entire resource. For the purpose of status, an attachment
-                        is considered successful if at least one section in the parent
-                        resource accepts it. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Core"
+                        specified values. \n * Service: Named port. When both Port
+                        (experimental) and SectionName are specified, the name and
+                        port of the selected port must match both specified values.
+                        \n Implementations MAY choose to support attaching Routes
+                        to other resources. If that is the case, they MUST clearly
+                        document how SectionName is interpreted. \n When unspecified
+                        (empty string), this will reference the entire resource. For
+                        the purpose of status, an attachment is considered successful
+                        if at least one section in the parent resource accepts it.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -421,7 +447,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Core (Gateway) \n Support: Core (Service - mesh conformance
+                            profile only) \n Support: Implementation-specific (Other
                             Resources)"
                           maxLength: 63
                           minLength: 1
@@ -442,7 +469,14 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n Support: Core"
+                            reference. \n ParentRefs from a Route to a Service in
+                            the same namespace are \"producer\" routes, which apply
+                            default routing rules to inbound connections from any
+                            namespace to the Service. ParentRefs from a Route to a
+                            Service in a different namespace are \"consumer\" routes,
+                            and these routing rules are only applied to outbound connections
+                            to the Service from the same namespace as the Route. \n
+                            Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -458,8 +492,12 @@ spec:
                             a specific port as opposed to a listener(s) whose port(s)
                             may be changed. When both Port and SectionName are specified,
                             the name and port of the selected listener must match
-                            both specified values. \n Implementations MAY choose to
-                            support other parent resources. Implementations supporting
+                            both specified values. \n When the parent resource is
+                            a Service, this targets a specific port in the Service
+                            spec. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support other parent resources. Implementations supporting
                             other types of parent resources MUST clearly document
                             how/if Port is interpreted. \n For the purpose of status,
                             an attachment is considered successful as long as the
@@ -481,9 +519,12 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n Implementations MAY
-                            choose to support attaching Routes to other resources.
-                            If that is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n * Service: Named
+                            port. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support attaching Routes to other resources. If that
+                            is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -123,7 +123,7 @@ spec:
                         \n ParentRefs from a Route to a Service in the same namespace
                         are \"producer\" routes, which apply default routing rules
                         to inbound connections from any namespace to the Service.
-                        ParentRefs from a Route to a Service in a different namespace
+                        \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
                         applied to outbound connections to the Service from the same
                         namespace as the Route. \n Support: Core"
@@ -167,22 +167,19 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n * Service: Named port. When both Port
-                        (experimental) and SectionName are specified, the name and
-                        port of the selected port must match both specified values.
-                        \n Implementations MAY choose to support attaching Routes
-                        to other resources. If that is the case, they MUST clearly
-                        document how SectionName is interpreted. \n When unspecified
-                        (empty string), this will reference the entire resource. For
-                        the purpose of status, an attachment is considered successful
-                        if at least one section in the parent resource accepts it.
-                        For example, Gateway listeners can restrict which Routes can
-                        attach to them by Route kind, namespace, or hostname. If 1
-                        of 2 Gateway listeners accept attachment from the referencing
-                        Route, the Route MUST be considered successfully attached.
-                        If no Gateway listeners accept attachment from this Route,
-                        the Route MUST be considered detached from the Gateway. \n
-                        Support: Core"
+                        specified values. \n Implementations MAY choose to support
+                        attaching Routes to other resources. If that is the case,
+                        they MUST clearly document how SectionName is interpreted.
+                        \n When unspecified (empty string), this will reference the
+                        entire resource. For the purpose of status, an attachment
+                        is considered successful if at least one section in the parent
+                        resource accepts it. For example, Gateway listeners can restrict
+                        which Routes can attach to them by Route kind, namespace,
+                        or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the Route MUST be considered detached from the Gateway.
+                        \n Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -472,8 +469,8 @@ spec:
                             reference. \n ParentRefs from a Route to a Service in
                             the same namespace are \"producer\" routes, which apply
                             default routing rules to inbound connections from any
-                            namespace to the Service. ParentRefs from a Route to a
-                            Service in a different namespace are \"consumer\" routes,
+                            namespace to the Service. \n ParentRefs from a Route to
+                            a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
                             to the Service from the same namespace as the Route. \n
                             Support: Core"
@@ -519,12 +516,9 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n * Service: Named
-                            port. When both Port (experimental) and SectionName are
-                            specified, the name and port of the selected port must
-                            match both specified values. \n Implementations MAY choose
-                            to support attaching Routes to other resources. If that
-                            is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n Implementations MAY
+                            choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -52,40 +52,40 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n The only kinds of parent resources
-                  with \"Core\" support are Service (only for implementations supporting
-                  the Mesh conformance profile) and Gateway. This API may be extended
-                  in the future to support additional kinds of parent resources such
-                  as one of the route kinds. \n It is invalid to reference an identical
-                  parent more than once. It is valid to reference multiple distinct
-                  sections within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. \n There are two kinds of parent
+                  resources with \"Core\" support: \n * Gateway (Gateway conformance
+                  profile) * Service (Mesh conformance profile) \n This API may be
+                  extended in the future to support additional kinds of parent resources.
+                  \n It is invalid to reference an identical parent more than once.
+                  It is valid to reference multiple distinct sections within the same
+                  parent resource, such as two separate Listeners on the same Gateway
+                  or two separate ports on the same Service. \n It is possible to
+                  separately reference multiple distinct objects that may be collapsed
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kinds of parent resources with \"Core\" support
-                    are Service (only for implementations supporting the Mesh conformance
-                    profile) and Gateway. This API may be extended in the future to
-                    support additional kinds of parent resources. \n The API object
-                    must be valid in the cluster; the Group and Kind must be registered
-                    in the cluster for this reference to be valid."
+                    a route). There are two kinds of parent resources with \"Core\"
+                    support: \n * Gateway (Gateway conformance profile) * Service
+                    (Mesh conformance profile) \n This API may be extended in the
+                    future to support additional kinds of parent resources. \n The
+                    API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -99,9 +99,10 @@ spec:
                       type: string
                     kind:
                       default: Gateway
-                      description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Core (Service - mesh conformance profile
-                        only) \n Support: Implementation-specific (Other Resources)"
+                      description: "Kind is kind of the referent. \n There are two
+                        kinds of parent resources with \"Core\" support: \n * Gateway
+                        (Gateway conformance profile) * Service (Mesh conformance
+                        profile) \n Support for other resources is Implementation-Specific."
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -446,10 +447,11 @@ spec:
                           type: string
                         kind:
                           default: Gateway
-                          description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Core (Service - mesh conformance
-                            profile only) \n Support: Implementation-specific (Other
-                            Resources)"
+                          description: "Kind is kind of the referent. \n There are
+                            two kinds of parent resources with \"Core\" support: \n
+                            * Gateway (Gateway conformance profile) * Service (Mesh
+                            conformance profile) \n Support for other resources is
+                            Implementation-Specific."
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -52,31 +52,34 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n There are two kinds of parent
-                  resources with \"Core\" support: \n * Gateway (Gateway conformance
-                  profile) * Service (Mesh conformance profile) \n This API may be
-                  extended in the future to support additional kinds of parent resources.
-                  \n It is invalid to reference an identical parent more than once.
-                  It is valid to reference multiple distinct sections within the same
-                  parent resource, such as two separate Listeners on the same Gateway
-                  or two separate ports on the same Service. \n It is possible to
-                  separately reference multiple distinct objects that may be collapsed
-                  by an implementation. For example, some implementations may choose
-                  to merge compatible Gateway Listeners together. If that is the case,
-                  the list of routes attached to those resources should also be merged.
-                  \n Note that for ParentRefs that cross namespace boundaries, there
-                  are specific rules. Cross-namespace references are only valid if
-                  they are explicitly allowed by something in the namespace they are
-                  referring to. For example, Gateway has the AllowedRoutes field,
-                  and ReferenceGrant provides a generic way to enable other kinds
-                  of cross-namespace reference. \n ParentRefs from a Route to a Service
-                  in the same namespace are \"producer\" routes, which apply default
-                  routing rules to inbound connections from any namespace to the Service.
-                  \n ParentRefs from a Route to a Service in a different namespace
-                  are \"consumer\" routes, and these routing rules are only applied
-                  to outbound connections originating from the same namespace as the
-                  Route, for which the intended destination of the connections are
-                  a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. ReferenceGrant is not applicable
+                  for governing ParentRefs to Services - it is not possible to create
+                  a \"producer\" route for a Service in a different namespace from
+                  the Route. \n There are two kinds of parent resources with \"Core\"
+                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
+                  conformance profile) \n This API may be extended in the future to
+                  support additional kinds of parent resources. \n It is invalid to
+                  reference an identical parent more than once. It is valid to reference
+                  multiple distinct sections within the same parent resource, such
+                  as two separate Listeners on the same Gateway or two separate ports
+                  on the same Service. \n It is possible to separately reference multiple
+                  distinct objects that may be collapsed by an implementation. For
+                  example, some implementations may choose to merge compatible Gateway
+                  Listeners together. If that is the case, the list of routes attached
+                  to those resources should also be merged. \n Note that for ParentRefs
+                  that cross namespace boundaries, there are specific rules. Cross-namespace
+                  references are only valid if they are explicitly allowed by something
+                  in the namespace they are referring to. For example, Gateway has
+                  the AllowedRoutes field, and ReferenceGrant provides a generic way
+                  to enable other kinds of cross-namespace reference. \n ParentRefs
+                  from a Route to a Service in the same namespace are \"producer\"
+                  routes, which apply default routing rules to inbound connections
+                  from any namespace to the Service. \n ParentRefs from a Route to
+                  a Service in a different namespace are \"consumer\" routes, and
+                  these routing rules are only applied to outbound connections originating
+                  from the same namespace as the Route, for which the intended destination
+                  of the connections are a Service targeted as a ParentRef of the
+                  Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -72,10 +72,11 @@ spec:
                   kinds of cross-namespace reference. \n ParentRefs from a Route to
                   a Service in the same namespace are \"producer\" routes, which apply
                   default routing rules to inbound connections from any namespace
-                  to the Service. ParentRefs from a Route to a Service in a different
+                  to the Service. \n ParentRefs from a Route to a Service in a different
                   namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections to the Service from the same namespace
-                  as the Route."
+                  applied to outbound connections originating from the same namespace
+                  as the Route, for which the intended destination of the connections
+                  are a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -125,8 +126,10 @@ spec:
                         to inbound connections from any namespace to the Service.
                         \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
-                        applied to outbound connections to the Service from the same
-                        namespace as the Route. \n Support: Core"
+                        applied to outbound connections originating from the same
+                        namespace as the Route, for which the intended destination
+                        of the connections are a Service targeted as a ParentRef of
+                        the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -472,8 +475,10 @@ spec:
                             namespace to the Service. \n ParentRefs from a Route to
                             a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
-                            to the Service from the same namespace as the Route. \n
-                            Support: Core"
+                            originating from the same namespace as the Route, for
+                            which the intended destination of the connections are
+                            a Service targeted as a ParentRef of the Route. \n Support:
+                            Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -98,40 +98,40 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n The only kinds of parent resources
-                  with \"Core\" support are Service (only for implementations supporting
-                  the Mesh conformance profile) and Gateway. This API may be extended
-                  in the future to support additional kinds of parent resources such
-                  as one of the route kinds. \n It is invalid to reference an identical
-                  parent more than once. It is valid to reference multiple distinct
-                  sections within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. \n There are two kinds of parent
+                  resources with \"Core\" support: \n * Gateway (Gateway conformance
+                  profile) * Service (Mesh conformance profile) \n This API may be
+                  extended in the future to support additional kinds of parent resources.
+                  \n It is invalid to reference an identical parent more than once.
+                  It is valid to reference multiple distinct sections within the same
+                  parent resource, such as two separate Listeners on the same Gateway
+                  or two separate ports on the same Service. \n It is possible to
+                  separately reference multiple distinct objects that may be collapsed
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kinds of parent resources with \"Core\" support
-                    are Service (only for implementations supporting the Mesh conformance
-                    profile) and Gateway. This API may be extended in the future to
-                    support additional kinds of parent resources. \n The API object
-                    must be valid in the cluster; the Group and Kind must be registered
-                    in the cluster for this reference to be valid."
+                    a route). There are two kinds of parent resources with \"Core\"
+                    support: \n * Gateway (Gateway conformance profile) * Service
+                    (Mesh conformance profile) \n This API may be extended in the
+                    future to support additional kinds of parent resources. \n The
+                    API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -145,9 +145,10 @@ spec:
                       type: string
                     kind:
                       default: Gateway
-                      description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Core (Service - mesh conformance profile
-                        only) \n Support: Implementation-specific (Other Resources)"
+                      description: "Kind is kind of the referent. \n There are two
+                        kinds of parent resources with \"Core\" support: \n * Gateway
+                        (Gateway conformance profile) * Service (Mesh conformance
+                        profile) \n Support for other resources is Implementation-Specific."
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -495,10 +496,11 @@ spec:
                           type: string
                         kind:
                           default: Gateway
-                          description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Core (Service - mesh conformance
-                            profile only) \n Support: Implementation-specific (Other
-                            Resources)"
+                          description: "Kind is kind of the referent. \n There are
+                            two kinds of parent resources with \"Core\" support: \n
+                            * Gateway (Gateway conformance profile) * Service (Mesh
+                            conformance profile) \n Support for other resources is
+                            Implementation-Specific."
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -98,31 +98,34 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n There are two kinds of parent
-                  resources with \"Core\" support: \n * Gateway (Gateway conformance
-                  profile) * Service (Mesh conformance profile) \n This API may be
-                  extended in the future to support additional kinds of parent resources.
-                  \n It is invalid to reference an identical parent more than once.
-                  It is valid to reference multiple distinct sections within the same
-                  parent resource, such as two separate Listeners on the same Gateway
-                  or two separate ports on the same Service. \n It is possible to
-                  separately reference multiple distinct objects that may be collapsed
-                  by an implementation. For example, some implementations may choose
-                  to merge compatible Gateway Listeners together. If that is the case,
-                  the list of routes attached to those resources should also be merged.
-                  \n Note that for ParentRefs that cross namespace boundaries, there
-                  are specific rules. Cross-namespace references are only valid if
-                  they are explicitly allowed by something in the namespace they are
-                  referring to. For example, Gateway has the AllowedRoutes field,
-                  and ReferenceGrant provides a generic way to enable other kinds
-                  of cross-namespace reference. \n ParentRefs from a Route to a Service
-                  in the same namespace are \"producer\" routes, which apply default
-                  routing rules to inbound connections from any namespace to the Service.
-                  \n ParentRefs from a Route to a Service in a different namespace
-                  are \"consumer\" routes, and these routing rules are only applied
-                  to outbound connections originating from the same namespace as the
-                  Route, for which the intended destination of the connections are
-                  a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. ReferenceGrant is not applicable
+                  for governing ParentRefs to Services - it is not possible to create
+                  a \"producer\" route for a Service in a different namespace from
+                  the Route. \n There are two kinds of parent resources with \"Core\"
+                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
+                  conformance profile) \n This API may be extended in the future to
+                  support additional kinds of parent resources. \n It is invalid to
+                  reference an identical parent more than once. It is valid to reference
+                  multiple distinct sections within the same parent resource, such
+                  as two separate Listeners on the same Gateway or two separate ports
+                  on the same Service. \n It is possible to separately reference multiple
+                  distinct objects that may be collapsed by an implementation. For
+                  example, some implementations may choose to merge compatible Gateway
+                  Listeners together. If that is the case, the list of routes attached
+                  to those resources should also be merged. \n Note that for ParentRefs
+                  that cross namespace boundaries, there are specific rules. Cross-namespace
+                  references are only valid if they are explicitly allowed by something
+                  in the namespace they are referring to. For example, Gateway has
+                  the AllowedRoutes field, and ReferenceGrant provides a generic way
+                  to enable other kinds of cross-namespace reference. \n ParentRefs
+                  from a Route to a Service in the same namespace are \"producer\"
+                  routes, which apply default routing rules to inbound connections
+                  from any namespace to the Service. \n ParentRefs from a Route to
+                  a Service in a different namespace are \"consumer\" routes, and
+                  these routing rules are only applied to outbound connections originating
+                  from the same namespace as the Route, for which the intended destination
+                  of the connections are a Service targeted as a ParentRef of the
+                  Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -118,10 +118,11 @@ spec:
                   kinds of cross-namespace reference. \n ParentRefs from a Route to
                   a Service in the same namespace are \"producer\" routes, which apply
                   default routing rules to inbound connections from any namespace
-                  to the Service. ParentRefs from a Route to a Service in a different
+                  to the Service. \n ParentRefs from a Route to a Service in a different
                   namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections to the Service from the same namespace
-                  as the Route."
+                  applied to outbound connections originating from the same namespace
+                  as the Route, for which the intended destination of the connections
+                  are a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -171,8 +172,10 @@ spec:
                         to inbound connections from any namespace to the Service.
                         \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
-                        applied to outbound connections to the Service from the same
-                        namespace as the Route. \n Support: Core"
+                        applied to outbound connections originating from the same
+                        namespace as the Route, for which the intended destination
+                        of the connections are a Service targeted as a ParentRef of
+                        the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -521,8 +524,10 @@ spec:
                             namespace to the Service. \n ParentRefs from a Route to
                             a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
-                            to the Service from the same namespace as the Route. \n
-                            Support: Core"
+                            originating from the same namespace as the Route, for
+                            which the intended destination of the connections are
+                            a Service targeted as a ParentRef of the Route. \n Support:
+                            Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -95,13 +95,18 @@ spec:
                   that a Route wants to be attached to. Note that the referenced parent
                   resource needs to allow this for the attachment to be complete.
                   For Gateways, that means the Gateway needs to allow attachment from
-                  Routes of this kind and namespace. \n The only kind of parent resource
-                  with \"Core\" support is Gateway. This API may be extended in the
-                  future to support additional kinds of parent resources such as one
-                  of the route kinds. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as 2 Listeners within a Gateway.
-                  \n It is possible to separately reference multiple distinct objects
+                  Routes of this kind and namespace. For Services, that means the
+                  Service must either be in the same namespace for a \"producer\"
+                  route, or the mesh implementation must support and allow \"consumer\"
+                  routes for the referenced Service. \n The only kinds of parent resources
+                  with \"Core\" support are Service (only for implementations supporting
+                  the Mesh conformance profile) and Gateway. This API may be extended
+                  in the future to support additional kinds of parent resources such
+                  as one of the route kinds. \n It is invalid to reference an identical
+                  parent more than once. It is valid to reference multiple distinct
+                  sections within the same parent resource, such as two separate Listeners
+                  on the same Gateway or two separate ports on the same Service. \n
+                  It is possible to separately reference multiple distinct objects
                   that may be collapsed by an implementation. For example, some implementations
                   may choose to merge compatible Gateway Listeners together. If that
                   is the case, the list of routes attached to those resources should
@@ -109,16 +114,23 @@ spec:
                   boundaries, there are specific rules. Cross-namespace references
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable any other
-                  kind of cross-namespace reference."
+                  field, and ReferenceGrant provides a generic way to enable other
+                  kinds of cross-namespace reference. \n ParentRefs from a Route to
+                  a Service in the same namespace are \"producer\" routes, which apply
+                  default routing rules to inbound connections from any namespace
+                  to the Service. ParentRefs from a Route to a Service in a different
+                  namespace are \"consumer\" routes, and these routing rules are only
+                  applied to outbound connections to the Service from the same namespace
+                  as the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kind of parent resource with \"Core\" support
-                    is Gateway. This API may be extended in the future to support
-                    additional kinds of parent resources, such as HTTPRoute. \n The
-                    API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid."
+                    a route). The only kinds of parent resources with \"Core\" support
+                    are Service (only for implementations supporting the Mesh conformance
+                    profile) and Gateway. This API may be extended in the future to
+                    support additional kinds of parent resources. \n The API object
+                    must be valid in the cluster; the Group and Kind must be registered
+                    in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -133,7 +145,8 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Implementation-specific (Other Resources)"
+                        (Gateway) \n Support: Core (Service - mesh conformance profile
+                        only) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -153,7 +166,13 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n Support: Core"
+                        \n ParentRefs from a Route to a Service in the same namespace
+                        are \"producer\" routes, which apply default routing rules
+                        to inbound connections from any namespace to the Service.
+                        ParentRefs from a Route to a Service in a different namespace
+                        are \"consumer\" routes, and these routing rules are only
+                        applied to outbound connections to the Service from the same
+                        namespace as the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -168,18 +187,22 @@ spec:
                         a Route must apply to a specific port as opposed to a listener(s)
                         whose port(s) may be changed. When both Port and SectionName
                         are specified, the name and port of the selected listener
-                        must match both specified values. \n Implementations MAY choose
-                        to support other parent resources. Implementations supporting
-                        other types of parent resources MUST clearly document how/if
-                        Port is interpreted. \n For the purpose of status, an attachment
-                        is considered successful as long as the parent resource accepts
-                        it partially. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Extended \n <gateway:experimental>"
+                        must match both specified values. \n When the parent resource
+                        is a Service, this targets a specific port in the Service
+                        spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified
+                        values. \n Implementations MAY choose to support other parent
+                        resources. Implementations supporting other types of parent
+                        resources MUST clearly document how/if Port is interpreted.
+                        \n For the purpose of status, an attachment is considered
+                        successful as long as the parent resource accepts it partially.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Extended \n <gateway:experimental>"
                       format: int32
                       maximum: 65535
                       minimum: 1
@@ -190,19 +213,22 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n Implementations MAY choose to support
-                        attaching Routes to other resources. If that is the case,
-                        they MUST clearly document how SectionName is interpreted.
-                        \n When unspecified (empty string), this will reference the
-                        entire resource. For the purpose of status, an attachment
-                        is considered successful if at least one section in the parent
-                        resource accepts it. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Core"
+                        specified values. \n * Service: Named port. When both Port
+                        (experimental) and SectionName are specified, the name and
+                        port of the selected port must match both specified values.
+                        \n Implementations MAY choose to support attaching Routes
+                        to other resources. If that is the case, they MUST clearly
+                        document how SectionName is interpreted. \n When unspecified
+                        (empty string), this will reference the entire resource. For
+                        the purpose of status, an attachment is considered successful
+                        if at least one section in the parent resource accepts it.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -470,7 +496,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Core (Gateway) \n Support: Core (Service - mesh conformance
+                            profile only) \n Support: Implementation-specific (Other
                             Resources)"
                           maxLength: 63
                           minLength: 1
@@ -491,7 +518,14 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n Support: Core"
+                            reference. \n ParentRefs from a Route to a Service in
+                            the same namespace are \"producer\" routes, which apply
+                            default routing rules to inbound connections from any
+                            namespace to the Service. ParentRefs from a Route to a
+                            Service in a different namespace are \"consumer\" routes,
+                            and these routing rules are only applied to outbound connections
+                            to the Service from the same namespace as the Route. \n
+                            Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -507,8 +541,12 @@ spec:
                             a specific port as opposed to a listener(s) whose port(s)
                             may be changed. When both Port and SectionName are specified,
                             the name and port of the selected listener must match
-                            both specified values. \n Implementations MAY choose to
-                            support other parent resources. Implementations supporting
+                            both specified values. \n When the parent resource is
+                            a Service, this targets a specific port in the Service
+                            spec. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support other parent resources. Implementations supporting
                             other types of parent resources MUST clearly document
                             how/if Port is interpreted. \n For the purpose of status,
                             an attachment is considered successful as long as the
@@ -530,9 +568,12 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n Implementations MAY
-                            choose to support attaching Routes to other resources.
-                            If that is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n * Service: Named
+                            port. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support attaching Routes to other resources. If that
+                            is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -169,7 +169,7 @@ spec:
                         \n ParentRefs from a Route to a Service in the same namespace
                         are \"producer\" routes, which apply default routing rules
                         to inbound connections from any namespace to the Service.
-                        ParentRefs from a Route to a Service in a different namespace
+                        \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
                         applied to outbound connections to the Service from the same
                         namespace as the Route. \n Support: Core"
@@ -213,22 +213,19 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n * Service: Named port. When both Port
-                        (experimental) and SectionName are specified, the name and
-                        port of the selected port must match both specified values.
-                        \n Implementations MAY choose to support attaching Routes
-                        to other resources. If that is the case, they MUST clearly
-                        document how SectionName is interpreted. \n When unspecified
-                        (empty string), this will reference the entire resource. For
-                        the purpose of status, an attachment is considered successful
-                        if at least one section in the parent resource accepts it.
-                        For example, Gateway listeners can restrict which Routes can
-                        attach to them by Route kind, namespace, or hostname. If 1
-                        of 2 Gateway listeners accept attachment from the referencing
-                        Route, the Route MUST be considered successfully attached.
-                        If no Gateway listeners accept attachment from this Route,
-                        the Route MUST be considered detached from the Gateway. \n
-                        Support: Core"
+                        specified values. \n Implementations MAY choose to support
+                        attaching Routes to other resources. If that is the case,
+                        they MUST clearly document how SectionName is interpreted.
+                        \n When unspecified (empty string), this will reference the
+                        entire resource. For the purpose of status, an attachment
+                        is considered successful if at least one section in the parent
+                        resource accepts it. For example, Gateway listeners can restrict
+                        which Routes can attach to them by Route kind, namespace,
+                        or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the Route MUST be considered detached from the Gateway.
+                        \n Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -521,8 +518,8 @@ spec:
                             reference. \n ParentRefs from a Route to a Service in
                             the same namespace are \"producer\" routes, which apply
                             default routing rules to inbound connections from any
-                            namespace to the Service. ParentRefs from a Route to a
-                            Service in a different namespace are \"consumer\" routes,
+                            namespace to the Service. \n ParentRefs from a Route to
+                            a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
                             to the Service from the same namespace as the Route. \n
                             Support: Core"
@@ -568,12 +565,9 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n * Service: Named
-                            port. When both Port (experimental) and SectionName are
-                            specified, the name and port of the selected port must
-                            match both specified values. \n Implementations MAY choose
-                            to support attaching Routes to other resources. If that
-                            is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n Implementations MAY
+                            choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -49,13 +49,18 @@ spec:
                   that a Route wants to be attached to. Note that the referenced parent
                   resource needs to allow this for the attachment to be complete.
                   For Gateways, that means the Gateway needs to allow attachment from
-                  Routes of this kind and namespace. \n The only kind of parent resource
-                  with \"Core\" support is Gateway. This API may be extended in the
-                  future to support additional kinds of parent resources such as one
-                  of the route kinds. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as 2 Listeners within a Gateway.
-                  \n It is possible to separately reference multiple distinct objects
+                  Routes of this kind and namespace. For Services, that means the
+                  Service must either be in the same namespace for a \"producer\"
+                  route, or the mesh implementation must support and allow \"consumer\"
+                  routes for the referenced Service. \n The only kinds of parent resources
+                  with \"Core\" support are Service (only for implementations supporting
+                  the Mesh conformance profile) and Gateway. This API may be extended
+                  in the future to support additional kinds of parent resources such
+                  as one of the route kinds. \n It is invalid to reference an identical
+                  parent more than once. It is valid to reference multiple distinct
+                  sections within the same parent resource, such as two separate Listeners
+                  on the same Gateway or two separate ports on the same Service. \n
+                  It is possible to separately reference multiple distinct objects
                   that may be collapsed by an implementation. For example, some implementations
                   may choose to merge compatible Gateway Listeners together. If that
                   is the case, the list of routes attached to those resources should
@@ -63,16 +68,23 @@ spec:
                   boundaries, there are specific rules. Cross-namespace references
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable any other
-                  kind of cross-namespace reference."
+                  field, and ReferenceGrant provides a generic way to enable other
+                  kinds of cross-namespace reference. \n ParentRefs from a Route to
+                  a Service in the same namespace are \"producer\" routes, which apply
+                  default routing rules to inbound connections from any namespace
+                  to the Service. ParentRefs from a Route to a Service in a different
+                  namespace are \"consumer\" routes, and these routing rules are only
+                  applied to outbound connections to the Service from the same namespace
+                  as the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kind of parent resource with \"Core\" support
-                    is Gateway. This API may be extended in the future to support
-                    additional kinds of parent resources, such as HTTPRoute. \n The
-                    API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid."
+                    a route). The only kinds of parent resources with \"Core\" support
+                    are Service (only for implementations supporting the Mesh conformance
+                    profile) and Gateway. This API may be extended in the future to
+                    support additional kinds of parent resources. \n The API object
+                    must be valid in the cluster; the Group and Kind must be registered
+                    in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -87,7 +99,8 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Implementation-specific (Other Resources)"
+                        (Gateway) \n Support: Core (Service - mesh conformance profile
+                        only) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -107,7 +120,13 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n Support: Core"
+                        \n ParentRefs from a Route to a Service in the same namespace
+                        are \"producer\" routes, which apply default routing rules
+                        to inbound connections from any namespace to the Service.
+                        ParentRefs from a Route to a Service in a different namespace
+                        are \"consumer\" routes, and these routing rules are only
+                        applied to outbound connections to the Service from the same
+                        namespace as the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -122,18 +141,22 @@ spec:
                         a Route must apply to a specific port as opposed to a listener(s)
                         whose port(s) may be changed. When both Port and SectionName
                         are specified, the name and port of the selected listener
-                        must match both specified values. \n Implementations MAY choose
-                        to support other parent resources. Implementations supporting
-                        other types of parent resources MUST clearly document how/if
-                        Port is interpreted. \n For the purpose of status, an attachment
-                        is considered successful as long as the parent resource accepts
-                        it partially. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Extended \n <gateway:experimental>"
+                        must match both specified values. \n When the parent resource
+                        is a Service, this targets a specific port in the Service
+                        spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified
+                        values. \n Implementations MAY choose to support other parent
+                        resources. Implementations supporting other types of parent
+                        resources MUST clearly document how/if Port is interpreted.
+                        \n For the purpose of status, an attachment is considered
+                        successful as long as the parent resource accepts it partially.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Extended \n <gateway:experimental>"
                       format: int32
                       maximum: 65535
                       minimum: 1
@@ -144,19 +167,22 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n Implementations MAY choose to support
-                        attaching Routes to other resources. If that is the case,
-                        they MUST clearly document how SectionName is interpreted.
-                        \n When unspecified (empty string), this will reference the
-                        entire resource. For the purpose of status, an attachment
-                        is considered successful if at least one section in the parent
-                        resource accepts it. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Core"
+                        specified values. \n * Service: Named port. When both Port
+                        (experimental) and SectionName are specified, the name and
+                        port of the selected port must match both specified values.
+                        \n Implementations MAY choose to support attaching Routes
+                        to other resources. If that is the case, they MUST clearly
+                        document how SectionName is interpreted. \n When unspecified
+                        (empty string), this will reference the entire resource. For
+                        the purpose of status, an attachment is considered successful
+                        if at least one section in the parent resource accepts it.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -421,7 +447,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Core (Gateway) \n Support: Core (Service - mesh conformance
+                            profile only) \n Support: Implementation-specific (Other
                             Resources)"
                           maxLength: 63
                           minLength: 1
@@ -442,7 +469,14 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n Support: Core"
+                            reference. \n ParentRefs from a Route to a Service in
+                            the same namespace are \"producer\" routes, which apply
+                            default routing rules to inbound connections from any
+                            namespace to the Service. ParentRefs from a Route to a
+                            Service in a different namespace are \"consumer\" routes,
+                            and these routing rules are only applied to outbound connections
+                            to the Service from the same namespace as the Route. \n
+                            Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -458,8 +492,12 @@ spec:
                             a specific port as opposed to a listener(s) whose port(s)
                             may be changed. When both Port and SectionName are specified,
                             the name and port of the selected listener must match
-                            both specified values. \n Implementations MAY choose to
-                            support other parent resources. Implementations supporting
+                            both specified values. \n When the parent resource is
+                            a Service, this targets a specific port in the Service
+                            spec. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support other parent resources. Implementations supporting
                             other types of parent resources MUST clearly document
                             how/if Port is interpreted. \n For the purpose of status,
                             an attachment is considered successful as long as the
@@ -481,9 +519,12 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n Implementations MAY
-                            choose to support attaching Routes to other resources.
-                            If that is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n * Service: Named
+                            port. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support attaching Routes to other resources. If that
+                            is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -123,7 +123,7 @@ spec:
                         \n ParentRefs from a Route to a Service in the same namespace
                         are \"producer\" routes, which apply default routing rules
                         to inbound connections from any namespace to the Service.
-                        ParentRefs from a Route to a Service in a different namespace
+                        \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
                         applied to outbound connections to the Service from the same
                         namespace as the Route. \n Support: Core"
@@ -167,22 +167,19 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n * Service: Named port. When both Port
-                        (experimental) and SectionName are specified, the name and
-                        port of the selected port must match both specified values.
-                        \n Implementations MAY choose to support attaching Routes
-                        to other resources. If that is the case, they MUST clearly
-                        document how SectionName is interpreted. \n When unspecified
-                        (empty string), this will reference the entire resource. For
-                        the purpose of status, an attachment is considered successful
-                        if at least one section in the parent resource accepts it.
-                        For example, Gateway listeners can restrict which Routes can
-                        attach to them by Route kind, namespace, or hostname. If 1
-                        of 2 Gateway listeners accept attachment from the referencing
-                        Route, the Route MUST be considered successfully attached.
-                        If no Gateway listeners accept attachment from this Route,
-                        the Route MUST be considered detached from the Gateway. \n
-                        Support: Core"
+                        specified values. \n Implementations MAY choose to support
+                        attaching Routes to other resources. If that is the case,
+                        they MUST clearly document how SectionName is interpreted.
+                        \n When unspecified (empty string), this will reference the
+                        entire resource. For the purpose of status, an attachment
+                        is considered successful if at least one section in the parent
+                        resource accepts it. For example, Gateway listeners can restrict
+                        which Routes can attach to them by Route kind, namespace,
+                        or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the Route MUST be considered detached from the Gateway.
+                        \n Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -472,8 +469,8 @@ spec:
                             reference. \n ParentRefs from a Route to a Service in
                             the same namespace are \"producer\" routes, which apply
                             default routing rules to inbound connections from any
-                            namespace to the Service. ParentRefs from a Route to a
-                            Service in a different namespace are \"consumer\" routes,
+                            namespace to the Service. \n ParentRefs from a Route to
+                            a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
                             to the Service from the same namespace as the Route. \n
                             Support: Core"
@@ -519,12 +516,9 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n * Service: Named
-                            port. When both Port (experimental) and SectionName are
-                            specified, the name and port of the selected port must
-                            match both specified values. \n Implementations MAY choose
-                            to support attaching Routes to other resources. If that
-                            is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n Implementations MAY
+                            choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -52,40 +52,40 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n The only kinds of parent resources
-                  with \"Core\" support are Service (only for implementations supporting
-                  the Mesh conformance profile) and Gateway. This API may be extended
-                  in the future to support additional kinds of parent resources such
-                  as one of the route kinds. \n It is invalid to reference an identical
-                  parent more than once. It is valid to reference multiple distinct
-                  sections within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. \n There are two kinds of parent
+                  resources with \"Core\" support: \n * Gateway (Gateway conformance
+                  profile) * Service (Mesh conformance profile) \n This API may be
+                  extended in the future to support additional kinds of parent resources.
+                  \n It is invalid to reference an identical parent more than once.
+                  It is valid to reference multiple distinct sections within the same
+                  parent resource, such as two separate Listeners on the same Gateway
+                  or two separate ports on the same Service. \n It is possible to
+                  separately reference multiple distinct objects that may be collapsed
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kinds of parent resources with \"Core\" support
-                    are Service (only for implementations supporting the Mesh conformance
-                    profile) and Gateway. This API may be extended in the future to
-                    support additional kinds of parent resources. \n The API object
-                    must be valid in the cluster; the Group and Kind must be registered
-                    in the cluster for this reference to be valid."
+                    a route). There are two kinds of parent resources with \"Core\"
+                    support: \n * Gateway (Gateway conformance profile) * Service
+                    (Mesh conformance profile) \n This API may be extended in the
+                    future to support additional kinds of parent resources. \n The
+                    API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -99,9 +99,10 @@ spec:
                       type: string
                     kind:
                       default: Gateway
-                      description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Core (Service - mesh conformance profile
-                        only) \n Support: Implementation-specific (Other Resources)"
+                      description: "Kind is kind of the referent. \n There are two
+                        kinds of parent resources with \"Core\" support: \n * Gateway
+                        (Gateway conformance profile) * Service (Mesh conformance
+                        profile) \n Support for other resources is Implementation-Specific."
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -446,10 +447,11 @@ spec:
                           type: string
                         kind:
                           default: Gateway
-                          description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Core (Service - mesh conformance
-                            profile only) \n Support: Implementation-specific (Other
-                            Resources)"
+                          description: "Kind is kind of the referent. \n There are
+                            two kinds of parent resources with \"Core\" support: \n
+                            * Gateway (Gateway conformance profile) * Service (Mesh
+                            conformance profile) \n Support for other resources is
+                            Implementation-Specific."
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -52,31 +52,34 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n There are two kinds of parent
-                  resources with \"Core\" support: \n * Gateway (Gateway conformance
-                  profile) * Service (Mesh conformance profile) \n This API may be
-                  extended in the future to support additional kinds of parent resources.
-                  \n It is invalid to reference an identical parent more than once.
-                  It is valid to reference multiple distinct sections within the same
-                  parent resource, such as two separate Listeners on the same Gateway
-                  or two separate ports on the same Service. \n It is possible to
-                  separately reference multiple distinct objects that may be collapsed
-                  by an implementation. For example, some implementations may choose
-                  to merge compatible Gateway Listeners together. If that is the case,
-                  the list of routes attached to those resources should also be merged.
-                  \n Note that for ParentRefs that cross namespace boundaries, there
-                  are specific rules. Cross-namespace references are only valid if
-                  they are explicitly allowed by something in the namespace they are
-                  referring to. For example, Gateway has the AllowedRoutes field,
-                  and ReferenceGrant provides a generic way to enable other kinds
-                  of cross-namespace reference. \n ParentRefs from a Route to a Service
-                  in the same namespace are \"producer\" routes, which apply default
-                  routing rules to inbound connections from any namespace to the Service.
-                  \n ParentRefs from a Route to a Service in a different namespace
-                  are \"consumer\" routes, and these routing rules are only applied
-                  to outbound connections originating from the same namespace as the
-                  Route, for which the intended destination of the connections are
-                  a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. ReferenceGrant is not applicable
+                  for governing ParentRefs to Services - it is not possible to create
+                  a \"producer\" route for a Service in a different namespace from
+                  the Route. \n There are two kinds of parent resources with \"Core\"
+                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
+                  conformance profile) \n This API may be extended in the future to
+                  support additional kinds of parent resources. \n It is invalid to
+                  reference an identical parent more than once. It is valid to reference
+                  multiple distinct sections within the same parent resource, such
+                  as two separate Listeners on the same Gateway or two separate ports
+                  on the same Service. \n It is possible to separately reference multiple
+                  distinct objects that may be collapsed by an implementation. For
+                  example, some implementations may choose to merge compatible Gateway
+                  Listeners together. If that is the case, the list of routes attached
+                  to those resources should also be merged. \n Note that for ParentRefs
+                  that cross namespace boundaries, there are specific rules. Cross-namespace
+                  references are only valid if they are explicitly allowed by something
+                  in the namespace they are referring to. For example, Gateway has
+                  the AllowedRoutes field, and ReferenceGrant provides a generic way
+                  to enable other kinds of cross-namespace reference. \n ParentRefs
+                  from a Route to a Service in the same namespace are \"producer\"
+                  routes, which apply default routing rules to inbound connections
+                  from any namespace to the Service. \n ParentRefs from a Route to
+                  a Service in a different namespace are \"consumer\" routes, and
+                  these routing rules are only applied to outbound connections originating
+                  from the same namespace as the Route, for which the intended destination
+                  of the connections are a Service targeted as a ParentRef of the
+                  Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -72,10 +72,11 @@ spec:
                   kinds of cross-namespace reference. \n ParentRefs from a Route to
                   a Service in the same namespace are \"producer\" routes, which apply
                   default routing rules to inbound connections from any namespace
-                  to the Service. ParentRefs from a Route to a Service in a different
+                  to the Service. \n ParentRefs from a Route to a Service in a different
                   namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections to the Service from the same namespace
-                  as the Route."
+                  applied to outbound connections originating from the same namespace
+                  as the Route, for which the intended destination of the connections
+                  are a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -125,8 +126,10 @@ spec:
                         to inbound connections from any namespace to the Service.
                         \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
-                        applied to outbound connections to the Service from the same
-                        namespace as the Route. \n Support: Core"
+                        applied to outbound connections originating from the same
+                        namespace as the Route, for which the intended destination
+                        of the connections are a Service targeted as a ParentRef of
+                        the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -472,8 +475,10 @@ spec:
                             namespace to the Service. \n ParentRefs from a Route to
                             a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
-                            to the Service from the same namespace as the Route. \n
-                            Support: Core"
+                            originating from the same namespace as the Route, for
+                            which the intended destination of the connections are
+                            a Service targeted as a ParentRef of the Route. \n Support:
+                            Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -114,13 +114,18 @@ spec:
                   that a Route wants to be attached to. Note that the referenced parent
                   resource needs to allow this for the attachment to be complete.
                   For Gateways, that means the Gateway needs to allow attachment from
-                  Routes of this kind and namespace. \n The only kind of parent resource
-                  with \"Core\" support is Gateway. This API may be extended in the
-                  future to support additional kinds of parent resources such as one
-                  of the route kinds. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as 2 Listeners within a Gateway.
-                  \n It is possible to separately reference multiple distinct objects
+                  Routes of this kind and namespace. For Services, that means the
+                  Service must either be in the same namespace for a \"producer\"
+                  route, or the mesh implementation must support and allow \"consumer\"
+                  routes for the referenced Service. \n The only kinds of parent resources
+                  with \"Core\" support are Service (only for implementations supporting
+                  the Mesh conformance profile) and Gateway. This API may be extended
+                  in the future to support additional kinds of parent resources such
+                  as one of the route kinds. \n It is invalid to reference an identical
+                  parent more than once. It is valid to reference multiple distinct
+                  sections within the same parent resource, such as two separate Listeners
+                  on the same Gateway or two separate ports on the same Service. \n
+                  It is possible to separately reference multiple distinct objects
                   that may be collapsed by an implementation. For example, some implementations
                   may choose to merge compatible Gateway Listeners together. If that
                   is the case, the list of routes attached to those resources should
@@ -128,16 +133,23 @@ spec:
                   boundaries, there are specific rules. Cross-namespace references
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable any other
-                  kind of cross-namespace reference."
+                  field, and ReferenceGrant provides a generic way to enable other
+                  kinds of cross-namespace reference. \n ParentRefs from a Route to
+                  a Service in the same namespace are \"producer\" routes, which apply
+                  default routing rules to inbound connections from any namespace
+                  to the Service. ParentRefs from a Route to a Service in a different
+                  namespace are \"consumer\" routes, and these routing rules are only
+                  applied to outbound connections to the Service from the same namespace
+                  as the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kind of parent resource with \"Core\" support
-                    is Gateway. This API may be extended in the future to support
-                    additional kinds of parent resources, such as HTTPRoute. \n The
-                    API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid."
+                    a route). The only kinds of parent resources with \"Core\" support
+                    are Service (only for implementations supporting the Mesh conformance
+                    profile) and Gateway. This API may be extended in the future to
+                    support additional kinds of parent resources. \n The API object
+                    must be valid in the cluster; the Group and Kind must be registered
+                    in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -152,7 +164,8 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Implementation-specific (Other Resources)"
+                        (Gateway) \n Support: Core (Service - mesh conformance profile
+                        only) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -172,7 +185,13 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n Support: Core"
+                        \n ParentRefs from a Route to a Service in the same namespace
+                        are \"producer\" routes, which apply default routing rules
+                        to inbound connections from any namespace to the Service.
+                        ParentRefs from a Route to a Service in a different namespace
+                        are \"consumer\" routes, and these routing rules are only
+                        applied to outbound connections to the Service from the same
+                        namespace as the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -183,19 +202,22 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n Implementations MAY choose to support
-                        attaching Routes to other resources. If that is the case,
-                        they MUST clearly document how SectionName is interpreted.
-                        \n When unspecified (empty string), this will reference the
-                        entire resource. For the purpose of status, an attachment
-                        is considered successful if at least one section in the parent
-                        resource accepts it. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Core"
+                        specified values. \n * Service: Named port. When both Port
+                        (experimental) and SectionName are specified, the name and
+                        port of the selected port must match both specified values.
+                        \n Implementations MAY choose to support attaching Routes
+                        to other resources. If that is the case, they MUST clearly
+                        document how SectionName is interpreted. \n When unspecified
+                        (empty string), this will reference the entire resource. For
+                        the purpose of status, an attachment is considered successful
+                        if at least one section in the parent resource accepts it.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -1886,7 +1908,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Core (Gateway) \n Support: Core (Service - mesh conformance
+                            profile only) \n Support: Implementation-specific (Other
                             Resources)"
                           maxLength: 63
                           minLength: 1
@@ -1907,7 +1930,14 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n Support: Core"
+                            reference. \n ParentRefs from a Route to a Service in
+                            the same namespace are \"producer\" routes, which apply
+                            default routing rules to inbound connections from any
+                            namespace to the Service. ParentRefs from a Route to a
+                            Service in a different namespace are \"consumer\" routes,
+                            and these routing rules are only applied to outbound connections
+                            to the Service from the same namespace as the Route. \n
+                            Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -1918,9 +1948,12 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n Implementations MAY
-                            choose to support attaching Routes to other resources.
-                            If that is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n * Service: Named
+                            port. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support attaching Routes to other resources. If that
+                            is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least
@@ -2048,13 +2081,18 @@ spec:
                   that a Route wants to be attached to. Note that the referenced parent
                   resource needs to allow this for the attachment to be complete.
                   For Gateways, that means the Gateway needs to allow attachment from
-                  Routes of this kind and namespace. \n The only kind of parent resource
-                  with \"Core\" support is Gateway. This API may be extended in the
-                  future to support additional kinds of parent resources such as one
-                  of the route kinds. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as 2 Listeners within a Gateway.
-                  \n It is possible to separately reference multiple distinct objects
+                  Routes of this kind and namespace. For Services, that means the
+                  Service must either be in the same namespace for a \"producer\"
+                  route, or the mesh implementation must support and allow \"consumer\"
+                  routes for the referenced Service. \n The only kinds of parent resources
+                  with \"Core\" support are Service (only for implementations supporting
+                  the Mesh conformance profile) and Gateway. This API may be extended
+                  in the future to support additional kinds of parent resources such
+                  as one of the route kinds. \n It is invalid to reference an identical
+                  parent more than once. It is valid to reference multiple distinct
+                  sections within the same parent resource, such as two separate Listeners
+                  on the same Gateway or two separate ports on the same Service. \n
+                  It is possible to separately reference multiple distinct objects
                   that may be collapsed by an implementation. For example, some implementations
                   may choose to merge compatible Gateway Listeners together. If that
                   is the case, the list of routes attached to those resources should
@@ -2062,16 +2100,23 @@ spec:
                   boundaries, there are specific rules. Cross-namespace references
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable any other
-                  kind of cross-namespace reference."
+                  field, and ReferenceGrant provides a generic way to enable other
+                  kinds of cross-namespace reference. \n ParentRefs from a Route to
+                  a Service in the same namespace are \"producer\" routes, which apply
+                  default routing rules to inbound connections from any namespace
+                  to the Service. ParentRefs from a Route to a Service in a different
+                  namespace are \"consumer\" routes, and these routing rules are only
+                  applied to outbound connections to the Service from the same namespace
+                  as the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kind of parent resource with \"Core\" support
-                    is Gateway. This API may be extended in the future to support
-                    additional kinds of parent resources, such as HTTPRoute. \n The
-                    API object must be valid in the cluster; the Group and Kind must
-                    be registered in the cluster for this reference to be valid."
+                    a route). The only kinds of parent resources with \"Core\" support
+                    are Service (only for implementations supporting the Mesh conformance
+                    profile) and Gateway. This API may be extended in the future to
+                    support additional kinds of parent resources. \n The API object
+                    must be valid in the cluster; the Group and Kind must be registered
+                    in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -2086,7 +2131,8 @@ spec:
                     kind:
                       default: Gateway
                       description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Implementation-specific (Other Resources)"
+                        (Gateway) \n Support: Core (Service - mesh conformance profile
+                        only) \n Support: Implementation-specific (Other Resources)"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -2106,7 +2152,13 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n Support: Core"
+                        \n ParentRefs from a Route to a Service in the same namespace
+                        are \"producer\" routes, which apply default routing rules
+                        to inbound connections from any namespace to the Service.
+                        ParentRefs from a Route to a Service in a different namespace
+                        are \"consumer\" routes, and these routing rules are only
+                        applied to outbound connections to the Service from the same
+                        namespace as the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -2117,19 +2169,22 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n Implementations MAY choose to support
-                        attaching Routes to other resources. If that is the case,
-                        they MUST clearly document how SectionName is interpreted.
-                        \n When unspecified (empty string), this will reference the
-                        entire resource. For the purpose of status, an attachment
-                        is considered successful if at least one section in the parent
-                        resource accepts it. For example, Gateway listeners can restrict
-                        which Routes can attach to them by Route kind, namespace,
-                        or hostname. If 1 of 2 Gateway listeners accept attachment
-                        from the referencing Route, the Route MUST be considered successfully
-                        attached. If no Gateway listeners accept attachment from this
-                        Route, the Route MUST be considered detached from the Gateway.
-                        \n Support: Core"
+                        specified values. \n * Service: Named port. When both Port
+                        (experimental) and SectionName are specified, the name and
+                        port of the selected port must match both specified values.
+                        \n Implementations MAY choose to support attaching Routes
+                        to other resources. If that is the case, they MUST clearly
+                        document how SectionName is interpreted. \n When unspecified
+                        (empty string), this will reference the entire resource. For
+                        the purpose of status, an attachment is considered successful
+                        if at least one section in the parent resource accepts it.
+                        For example, Gateway listeners can restrict which Routes can
+                        attach to them by Route kind, namespace, or hostname. If 1
+                        of 2 Gateway listeners accept attachment from the referencing
+                        Route, the Route MUST be considered successfully attached.
+                        If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway. \n
+                        Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -3820,7 +3875,8 @@ spec:
                         kind:
                           default: Gateway
                           description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Core (Gateway) \n Support: Core (Service - mesh conformance
+                            profile only) \n Support: Implementation-specific (Other
                             Resources)"
                           maxLength: 63
                           minLength: 1
@@ -3841,7 +3897,14 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n Support: Core"
+                            reference. \n ParentRefs from a Route to a Service in
+                            the same namespace are \"producer\" routes, which apply
+                            default routing rules to inbound connections from any
+                            namespace to the Service. ParentRefs from a Route to a
+                            Service in a different namespace are \"consumer\" routes,
+                            and these routing rules are only applied to outbound connections
+                            to the Service from the same namespace as the Route. \n
+                            Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -3852,9 +3915,12 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n Implementations MAY
-                            choose to support attaching Routes to other resources.
-                            If that is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n * Service: Named
+                            port. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values. \n Implementations MAY choose
+                            to support attaching Routes to other resources. If that
+                            is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -188,7 +188,7 @@ spec:
                         \n ParentRefs from a Route to a Service in the same namespace
                         are \"producer\" routes, which apply default routing rules
                         to inbound connections from any namespace to the Service.
-                        ParentRefs from a Route to a Service in a different namespace
+                        \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
                         applied to outbound connections to the Service from the same
                         namespace as the Route. \n Support: Core"
@@ -202,22 +202,19 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n * Service: Named port. When both Port
-                        (experimental) and SectionName are specified, the name and
-                        port of the selected port must match both specified values.
-                        \n Implementations MAY choose to support attaching Routes
-                        to other resources. If that is the case, they MUST clearly
-                        document how SectionName is interpreted. \n When unspecified
-                        (empty string), this will reference the entire resource. For
-                        the purpose of status, an attachment is considered successful
-                        if at least one section in the parent resource accepts it.
-                        For example, Gateway listeners can restrict which Routes can
-                        attach to them by Route kind, namespace, or hostname. If 1
-                        of 2 Gateway listeners accept attachment from the referencing
-                        Route, the Route MUST be considered successfully attached.
-                        If no Gateway listeners accept attachment from this Route,
-                        the Route MUST be considered detached from the Gateway. \n
-                        Support: Core"
+                        specified values. \n Implementations MAY choose to support
+                        attaching Routes to other resources. If that is the case,
+                        they MUST clearly document how SectionName is interpreted.
+                        \n When unspecified (empty string), this will reference the
+                        entire resource. For the purpose of status, an attachment
+                        is considered successful if at least one section in the parent
+                        resource accepts it. For example, Gateway listeners can restrict
+                        which Routes can attach to them by Route kind, namespace,
+                        or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the Route MUST be considered detached from the Gateway.
+                        \n Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -1933,8 +1930,8 @@ spec:
                             reference. \n ParentRefs from a Route to a Service in
                             the same namespace are \"producer\" routes, which apply
                             default routing rules to inbound connections from any
-                            namespace to the Service. ParentRefs from a Route to a
-                            Service in a different namespace are \"consumer\" routes,
+                            namespace to the Service. \n ParentRefs from a Route to
+                            a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
                             to the Service from the same namespace as the Route. \n
                             Support: Core"
@@ -1948,12 +1945,9 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n * Service: Named
-                            port. When both Port (experimental) and SectionName are
-                            specified, the name and port of the selected port must
-                            match both specified values. \n Implementations MAY choose
-                            to support attaching Routes to other resources. If that
-                            is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n Implementations MAY
+                            choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least
@@ -2155,7 +2149,7 @@ spec:
                         \n ParentRefs from a Route to a Service in the same namespace
                         are \"producer\" routes, which apply default routing rules
                         to inbound connections from any namespace to the Service.
-                        ParentRefs from a Route to a Service in a different namespace
+                        \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
                         applied to outbound connections to the Service from the same
                         namespace as the Route. \n Support: Core"
@@ -2169,22 +2163,19 @@ spec:
                         interpreted as the following: \n * Gateway: Listener Name.
                         When both Port (experimental) and SectionName are specified,
                         the name and port of the selected listener must match both
-                        specified values. \n * Service: Named port. When both Port
-                        (experimental) and SectionName are specified, the name and
-                        port of the selected port must match both specified values.
-                        \n Implementations MAY choose to support attaching Routes
-                        to other resources. If that is the case, they MUST clearly
-                        document how SectionName is interpreted. \n When unspecified
-                        (empty string), this will reference the entire resource. For
-                        the purpose of status, an attachment is considered successful
-                        if at least one section in the parent resource accepts it.
-                        For example, Gateway listeners can restrict which Routes can
-                        attach to them by Route kind, namespace, or hostname. If 1
-                        of 2 Gateway listeners accept attachment from the referencing
-                        Route, the Route MUST be considered successfully attached.
-                        If no Gateway listeners accept attachment from this Route,
-                        the Route MUST be considered detached from the Gateway. \n
-                        Support: Core"
+                        specified values. \n Implementations MAY choose to support
+                        attaching Routes to other resources. If that is the case,
+                        they MUST clearly document how SectionName is interpreted.
+                        \n When unspecified (empty string), this will reference the
+                        entire resource. For the purpose of status, an attachment
+                        is considered successful if at least one section in the parent
+                        resource accepts it. For example, Gateway listeners can restrict
+                        which Routes can attach to them by Route kind, namespace,
+                        or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the Route MUST be considered detached from the Gateway.
+                        \n Support: Core"
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -3900,8 +3891,8 @@ spec:
                             reference. \n ParentRefs from a Route to a Service in
                             the same namespace are \"producer\" routes, which apply
                             default routing rules to inbound connections from any
-                            namespace to the Service. ParentRefs from a Route to a
-                            Service in a different namespace are \"consumer\" routes,
+                            namespace to the Service. \n ParentRefs from a Route to
+                            a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
                             to the Service from the same namespace as the Route. \n
                             Support: Core"
@@ -3915,12 +3906,9 @@ spec:
                             is interpreted as the following: \n * Gateway: Listener
                             Name. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected listener
-                            must match both specified values. \n * Service: Named
-                            port. When both Port (experimental) and SectionName are
-                            specified, the name and port of the selected port must
-                            match both specified values. \n Implementations MAY choose
-                            to support attaching Routes to other resources. If that
-                            is the case, they MUST clearly document how SectionName
+                            must match both specified values. \n Implementations MAY
+                            choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
                             is interpreted. \n When unspecified (empty string), this
                             will reference the entire resource. For the purpose of
                             status, an attachment is considered successful if at least

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -137,10 +137,11 @@ spec:
                   kinds of cross-namespace reference. \n ParentRefs from a Route to
                   a Service in the same namespace are \"producer\" routes, which apply
                   default routing rules to inbound connections from any namespace
-                  to the Service. ParentRefs from a Route to a Service in a different
+                  to the Service. \n ParentRefs from a Route to a Service in a different
                   namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections to the Service from the same namespace
-                  as the Route."
+                  applied to outbound connections originating from the same namespace
+                  as the Route, for which the intended destination of the connections
+                  are a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -190,8 +191,10 @@ spec:
                         to inbound connections from any namespace to the Service.
                         \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
-                        applied to outbound connections to the Service from the same
-                        namespace as the Route. \n Support: Core"
+                        applied to outbound connections originating from the same
+                        namespace as the Route, for which the intended destination
+                        of the connections are a Service targeted as a ParentRef of
+                        the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -1933,8 +1936,10 @@ spec:
                             namespace to the Service. \n ParentRefs from a Route to
                             a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
-                            to the Service from the same namespace as the Route. \n
-                            Support: Core"
+                            originating from the same namespace as the Route, for
+                            which the intended destination of the connections are
+                            a Service targeted as a ParentRef of the Route. \n Support:
+                            Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -2098,10 +2103,11 @@ spec:
                   kinds of cross-namespace reference. \n ParentRefs from a Route to
                   a Service in the same namespace are \"producer\" routes, which apply
                   default routing rules to inbound connections from any namespace
-                  to the Service. ParentRefs from a Route to a Service in a different
+                  to the Service. \n ParentRefs from a Route to a Service in a different
                   namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections to the Service from the same namespace
-                  as the Route."
+                  applied to outbound connections originating from the same namespace
+                  as the Route, for which the intended destination of the connections
+                  are a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -2151,8 +2157,10 @@ spec:
                         to inbound connections from any namespace to the Service.
                         \n ParentRefs from a Route to a Service in a different namespace
                         are \"consumer\" routes, and these routing rules are only
-                        applied to outbound connections to the Service from the same
-                        namespace as the Route. \n Support: Core"
+                        applied to outbound connections originating from the same
+                        namespace as the Route, for which the intended destination
+                        of the connections are a Service targeted as a ParentRef of
+                        the Route. \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -3894,8 +3902,10 @@ spec:
                             namespace to the Service. \n ParentRefs from a Route to
                             a Service in a different namespace are \"consumer\" routes,
                             and these routing rules are only applied to outbound connections
-                            to the Service from the same namespace as the Route. \n
-                            Support: Core"
+                            originating from the same namespace as the Route, for
+                            which the intended destination of the connections are
+                            a Service targeted as a ParentRef of the Route. \n Support:
+                            Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -117,40 +117,40 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n The only kinds of parent resources
-                  with \"Core\" support are Service (only for implementations supporting
-                  the Mesh conformance profile) and Gateway. This API may be extended
-                  in the future to support additional kinds of parent resources such
-                  as one of the route kinds. \n It is invalid to reference an identical
-                  parent more than once. It is valid to reference multiple distinct
-                  sections within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. \n There are two kinds of parent
+                  resources with \"Core\" support: \n * Gateway (Gateway conformance
+                  profile) * Service (Mesh conformance profile) \n This API may be
+                  extended in the future to support additional kinds of parent resources.
+                  \n It is invalid to reference an identical parent more than once.
+                  It is valid to reference multiple distinct sections within the same
+                  parent resource, such as two separate Listeners on the same Gateway
+                  or two separate ports on the same Service. \n It is possible to
+                  separately reference multiple distinct objects that may be collapsed
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kinds of parent resources with \"Core\" support
-                    are Service (only for implementations supporting the Mesh conformance
-                    profile) and Gateway. This API may be extended in the future to
-                    support additional kinds of parent resources. \n The API object
-                    must be valid in the cluster; the Group and Kind must be registered
-                    in the cluster for this reference to be valid."
+                    a route). There are two kinds of parent resources with \"Core\"
+                    support: \n * Gateway (Gateway conformance profile) * Service
+                    (Mesh conformance profile) \n This API may be extended in the
+                    future to support additional kinds of parent resources. \n The
+                    API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -164,9 +164,10 @@ spec:
                       type: string
                     kind:
                       default: Gateway
-                      description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Core (Service - mesh conformance profile
-                        only) \n Support: Implementation-specific (Other Resources)"
+                      description: "Kind is kind of the referent. \n There are two
+                        kinds of parent resources with \"Core\" support: \n * Gateway
+                        (Gateway conformance profile) * Service (Mesh conformance
+                        profile) \n Support for other resources is Implementation-Specific."
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1907,10 +1908,11 @@ spec:
                           type: string
                         kind:
                           default: Gateway
-                          description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Core (Service - mesh conformance
-                            profile only) \n Support: Implementation-specific (Other
-                            Resources)"
+                          description: "Kind is kind of the referent. \n There are
+                            two kinds of parent resources with \"Core\" support: \n
+                            * Gateway (Gateway conformance profile) * Service (Mesh
+                            conformance profile) \n Support for other resources is
+                            Implementation-Specific."
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -2083,40 +2085,40 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n The only kinds of parent resources
-                  with \"Core\" support are Service (only for implementations supporting
-                  the Mesh conformance profile) and Gateway. This API may be extended
-                  in the future to support additional kinds of parent resources such
-                  as one of the route kinds. \n It is invalid to reference an identical
-                  parent more than once. It is valid to reference multiple distinct
-                  sections within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. \n There are two kinds of parent
+                  resources with \"Core\" support: \n * Gateway (Gateway conformance
+                  profile) * Service (Mesh conformance profile) \n This API may be
+                  extended in the future to support additional kinds of parent resources.
+                  \n It is invalid to reference an identical parent more than once.
+                  It is valid to reference multiple distinct sections within the same
+                  parent resource, such as two separate Listeners on the same Gateway
+                  or two separate ports on the same Service. \n It is possible to
+                  separately reference multiple distinct objects that may be collapsed
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
-                    a route). The only kinds of parent resources with \"Core\" support
-                    are Service (only for implementations supporting the Mesh conformance
-                    profile) and Gateway. This API may be extended in the future to
-                    support additional kinds of parent resources. \n The API object
-                    must be valid in the cluster; the Group and Kind must be registered
-                    in the cluster for this reference to be valid."
+                    a route). There are two kinds of parent resources with \"Core\"
+                    support: \n * Gateway (Gateway conformance profile) * Service
+                    (Mesh conformance profile) \n This API may be extended in the
+                    future to support additional kinds of parent resources. \n The
+                    API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid."
                   properties:
                     group:
                       default: gateway.networking.k8s.io
@@ -2130,9 +2132,10 @@ spec:
                       type: string
                     kind:
                       default: Gateway
-                      description: "Kind is kind of the referent. \n Support: Core
-                        (Gateway) \n Support: Core (Service - mesh conformance profile
-                        only) \n Support: Implementation-specific (Other Resources)"
+                      description: "Kind is kind of the referent. \n There are two
+                        kinds of parent resources with \"Core\" support: \n * Gateway
+                        (Gateway conformance profile) * Service (Mesh conformance
+                        profile) \n Support for other resources is Implementation-Specific."
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -3873,10 +3876,11 @@ spec:
                           type: string
                         kind:
                           default: Gateway
-                          description: "Kind is kind of the referent. \n Support:
-                            Core (Gateway) \n Support: Core (Service - mesh conformance
-                            profile only) \n Support: Implementation-specific (Other
-                            Resources)"
+                          description: "Kind is kind of the referent. \n There are
+                            two kinds of parent resources with \"Core\" support: \n
+                            * Gateway (Gateway conformance profile) * Service (Mesh
+                            conformance profile) \n Support for other resources is
+                            Implementation-Specific."
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -117,31 +117,34 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n There are two kinds of parent
-                  resources with \"Core\" support: \n * Gateway (Gateway conformance
-                  profile) * Service (Mesh conformance profile) \n This API may be
-                  extended in the future to support additional kinds of parent resources.
-                  \n It is invalid to reference an identical parent more than once.
-                  It is valid to reference multiple distinct sections within the same
-                  parent resource, such as two separate Listeners on the same Gateway
-                  or two separate ports on the same Service. \n It is possible to
-                  separately reference multiple distinct objects that may be collapsed
-                  by an implementation. For example, some implementations may choose
-                  to merge compatible Gateway Listeners together. If that is the case,
-                  the list of routes attached to those resources should also be merged.
-                  \n Note that for ParentRefs that cross namespace boundaries, there
-                  are specific rules. Cross-namespace references are only valid if
-                  they are explicitly allowed by something in the namespace they are
-                  referring to. For example, Gateway has the AllowedRoutes field,
-                  and ReferenceGrant provides a generic way to enable other kinds
-                  of cross-namespace reference. \n ParentRefs from a Route to a Service
-                  in the same namespace are \"producer\" routes, which apply default
-                  routing rules to inbound connections from any namespace to the Service.
-                  \n ParentRefs from a Route to a Service in a different namespace
-                  are \"consumer\" routes, and these routing rules are only applied
-                  to outbound connections originating from the same namespace as the
-                  Route, for which the intended destination of the connections are
-                  a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. ReferenceGrant is not applicable
+                  for governing ParentRefs to Services - it is not possible to create
+                  a \"producer\" route for a Service in a different namespace from
+                  the Route. \n There are two kinds of parent resources with \"Core\"
+                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
+                  conformance profile) \n This API may be extended in the future to
+                  support additional kinds of parent resources. \n It is invalid to
+                  reference an identical parent more than once. It is valid to reference
+                  multiple distinct sections within the same parent resource, such
+                  as two separate Listeners on the same Gateway or two separate ports
+                  on the same Service. \n It is possible to separately reference multiple
+                  distinct objects that may be collapsed by an implementation. For
+                  example, some implementations may choose to merge compatible Gateway
+                  Listeners together. If that is the case, the list of routes attached
+                  to those resources should also be merged. \n Note that for ParentRefs
+                  that cross namespace boundaries, there are specific rules. Cross-namespace
+                  references are only valid if they are explicitly allowed by something
+                  in the namespace they are referring to. For example, Gateway has
+                  the AllowedRoutes field, and ReferenceGrant provides a generic way
+                  to enable other kinds of cross-namespace reference. \n ParentRefs
+                  from a Route to a Service in the same namespace are \"producer\"
+                  routes, which apply default routing rules to inbound connections
+                  from any namespace to the Service. \n ParentRefs from a Route to
+                  a Service in a different namespace are \"consumer\" routes, and
+                  these routing rules are only applied to outbound connections originating
+                  from the same namespace as the Route, for which the intended destination
+                  of the connections are a Service targeted as a ParentRef of the
+                  Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -2085,31 +2088,34 @@ spec:
                   Routes of this kind and namespace. For Services, that means the
                   Service must either be in the same namespace for a \"producer\"
                   route, or the mesh implementation must support and allow \"consumer\"
-                  routes for the referenced Service. \n There are two kinds of parent
-                  resources with \"Core\" support: \n * Gateway (Gateway conformance
-                  profile) * Service (Mesh conformance profile) \n This API may be
-                  extended in the future to support additional kinds of parent resources.
-                  \n It is invalid to reference an identical parent more than once.
-                  It is valid to reference multiple distinct sections within the same
-                  parent resource, such as two separate Listeners on the same Gateway
-                  or two separate ports on the same Service. \n It is possible to
-                  separately reference multiple distinct objects that may be collapsed
-                  by an implementation. For example, some implementations may choose
-                  to merge compatible Gateway Listeners together. If that is the case,
-                  the list of routes attached to those resources should also be merged.
-                  \n Note that for ParentRefs that cross namespace boundaries, there
-                  are specific rules. Cross-namespace references are only valid if
-                  they are explicitly allowed by something in the namespace they are
-                  referring to. For example, Gateway has the AllowedRoutes field,
-                  and ReferenceGrant provides a generic way to enable other kinds
-                  of cross-namespace reference. \n ParentRefs from a Route to a Service
-                  in the same namespace are \"producer\" routes, which apply default
-                  routing rules to inbound connections from any namespace to the Service.
-                  \n ParentRefs from a Route to a Service in a different namespace
-                  are \"consumer\" routes, and these routing rules are only applied
-                  to outbound connections originating from the same namespace as the
-                  Route, for which the intended destination of the connections are
-                  a Service targeted as a ParentRef of the Route."
+                  routes for the referenced Service. ReferenceGrant is not applicable
+                  for governing ParentRefs to Services - it is not possible to create
+                  a \"producer\" route for a Service in a different namespace from
+                  the Route. \n There are two kinds of parent resources with \"Core\"
+                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
+                  conformance profile) \n This API may be extended in the future to
+                  support additional kinds of parent resources. \n It is invalid to
+                  reference an identical parent more than once. It is valid to reference
+                  multiple distinct sections within the same parent resource, such
+                  as two separate Listeners on the same Gateway or two separate ports
+                  on the same Service. \n It is possible to separately reference multiple
+                  distinct objects that may be collapsed by an implementation. For
+                  example, some implementations may choose to merge compatible Gateway
+                  Listeners together. If that is the case, the list of routes attached
+                  to those resources should also be merged. \n Note that for ParentRefs
+                  that cross namespace boundaries, there are specific rules. Cross-namespace
+                  references are only valid if they are explicitly allowed by something
+                  in the namespace they are referring to. For example, Gateway has
+                  the AllowedRoutes field, and ReferenceGrant provides a generic way
+                  to enable other kinds of cross-namespace reference. \n ParentRefs
+                  from a Route to a Service in the same namespace are \"producer\"
+                  routes, which apply default routing rules to inbound connections
+                  from any namespace to the Service. \n ParentRefs from a Route to
+                  a Service in a different namespace are \"consumer\" routes, and
+                  these routing rules are only applied to outbound connections originating
+                  from the same namespace as the Route, for which the intended destination
+                  of the connections are a Service targeted as a ParentRef of the
+                  Route."
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually

--- a/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
@@ -35,13 +35,17 @@ spec:
           namespace as the policy. \n Each ReferenceGrant can be used to represent
           a unique trust relationship. Additional Reference Grants can be used to
           add to the set of trusted sources of inbound references for the namespace
-          they are defined within. \n All cross-namespace references in Gateway API
-          (with the exception of cross-namespace Gateway-route attachment) require
-          a ReferenceGrant. \n ReferenceGrant is a form of runtime verification allowing
-          users to assert which cross-namespace object references are permitted. Implementations
-          that support ReferenceGrant MUST NOT permit cross-namespace references which
-          have no grant, and MUST respond to the removal of a grant by revoking the
-          access that the grant allowed. \n Support: Core"
+          they are defined within. \n A ReferenceGrant is required for all cross-namespace
+          references in Gateway API (with the exception of cross-namespace Route-Gateway
+          attachment, which is governed by the AllowedRoutes configuration on the
+          Gateway, and cross-namespace Service ParentRefs on a \"consumer\" mesh Route,
+          which defines routing rules applicable only to workloads in the Route namespace).
+          ReferenceGrants allowing a reference from a Route to a Service are only
+          applicable to BackendRefs. \n ReferenceGrant is a form of runtime verification
+          allowing users to assert which cross-namespace object references are permitted.
+          Implementations that support ReferenceGrant MUST NOT permit cross-namespace
+          references which have no grant, and MUST respond to the removal of a grant
+          by revoking the access that the grant allowed. \n Support: Core"
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind documentation
/area mesh

**What this PR does / why we need it**:
Updates API documentation support for ParentRef targeting a Kubernetes Service, as proposed in [GEP-1426](https://gateway-api.sigs.k8s.io/geps/gep-1426/).

**Which issue(s) this PR fixes**:
Fixes #2139
Service port targeting refs #1995 

**Links:**
- https://kubernetes.io/docs/concepts/services-networking/service/

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Adds support for ParentRef targeting a Kubernetes Service resource for mesh implementations.
```
