### PR TITLE
Add IncompatibleFilters reason for Accepted condition

### DIFF
--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -225,6 +225,13 @@ type GRPCRouteRule struct {
 	//
 	// Specifying a core filter multiple times has unspecified or
 	// implementation-specific conformance.
+	//
+	// If an implementation can not support a combinations of filters, they must clearly
+	// document that limitation. In cases where incompatible or unsupported
+	// filters are specified and cause the `Accepted` condition to be set to status
+	// `False`, implementations may use the `IncompatibleFilters` reason to specify
+	// this configuration error.
+	//
 	// Support: Core
 	//
 	// +optional

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -207,8 +207,10 @@ type HTTPRouteRule struct {
 	// All filters are expected to be compatible with each other except for the
 	// URLRewrite and RequestRedirect filters, which may not be combined. If an
 	// implementation can not support other combinations of filters, they must clearly
-	// document that limitation. In all cases where incompatible or unsupported
-	// filters are specified, implementations MUST add a warning condition to status.
+	// document that limitation. In cases where incompatible or unsupported
+	// filters are specified and cause the `Accepted` condition to be set to status
+	// `False`, implementations may use the `IncompatibleFilters` reason to specify
+	// this configuration error.
 	//
 	// Support: Core
 	//

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -252,6 +252,11 @@ const (
 	// reconciled the route.
 	RouteReasonPending RouteConditionReason = "Pending"
 
+	// This reason is used with the "Accepted" condition when there
+	// are incompatible filters present on a route rule (for example if
+	// the URLRewrite and RequestRedirect are both present on an HTTPRoute).
+	RouteReasonIncompatibleFilters RouteConditionReason = "IncompatibleFilters"
+
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the Route.
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -764,7 +764,12 @@ spec:
                         are encouraged to support extended filters. - Implementation-specific
                         custom filters have no API guarantees across implementations.
                         \n Specifying a core filter multiple times has unspecified
-                        or implementation-specific conformance. Support: Core"
+                        or implementation-specific conformance. \n If an implementation
+                        can not support a combinations of filters, they must clearly
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified and cause the `Accepted` condition to
+                        be set to status `False`, implementations may use the `IncompatibleFilters`
+                        reason to specify this configuration error. \n Support: Core"
                       items:
                         description: GRPCRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -979,9 +979,10 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. In all cases where incompatible
-                        or unsupported filters are specified, implementations MUST
-                        add a warning condition to status. \n Support: Core"
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified and cause the `Accepted` condition to
+                        be set to status `False`, implementations may use the `IncompatibleFilters`
+                        reason to specify this configuration error. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -2967,9 +2968,10 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. In all cases where incompatible
-                        or unsupported filters are specified, implementations MUST
-                        add a warning condition to status. \n Support: Core"
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified and cause the `Accepted` condition to
+                        be set to status `False`, implementations may use the `IncompatibleFilters`
+                        reason to specify this configuration error. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -953,9 +953,10 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. In all cases where incompatible
-                        or unsupported filters are specified, implementations MUST
-                        add a warning condition to status. \n Support: Core"
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified and cause the `Accepted` condition to
+                        be set to status `False`, implementations may use the `IncompatibleFilters`
+                        reason to specify this configuration error. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -2887,9 +2888,10 @@ spec:
                         with each other except for the URLRewrite and RequestRedirect
                         filters, which may not be combined. If an implementation can
                         not support other combinations of filters, they must clearly
-                        document that limitation. In all cases where incompatible
-                        or unsupported filters are specified, implementations MUST
-                        add a warning condition to status. \n Support: Core"
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified and cause the `Accepted` condition to
+                        be set to status `False`, implementations may use the `IncompatibleFilters`
+                        reason to specify this configuration error. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.

--- a/site-src/api-types/grpcroute.md
+++ b/site-src/api-types/grpcroute.md
@@ -184,10 +184,11 @@ Conformance levels are defined by the filter type:
 
 Specifying a core filter multiple times has unspecified or custom conformance.
 
-All filters are expected to be compatible with each other. If an implementation
-cannot support other combinations of filters, they must clearly document that
-limitation. In all cases where incompatible or unsupported filters are
-specified, implementations MUST add a warning condition to status.
+If an implementation can not support a combinations of filters, they must clearly
+document that limitation. In cases where incompatible or unsupported
+filters are specified and cause the `Accepted` condition to be set to status
+`False`, implementations may use the `IncompatibleFilters` reason to specify
+this configuration error.
 
 #### BackendRefs (optional)
 

--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -130,8 +130,10 @@ implementation-specific conformance.
 All filters are expected to be compatible with each other except for the
 URLRewrite and RequestRedirect filters, which may not be combined. If an
 implementation can not support other combinations of filters, they must clearly
-document that limitation. In all cases where incompatible or unsupported
-filters are specified, implementations MUST add a warning condition to status.
+document that limitation. In cases where incompatible or unsupported
+filters are specified and cause the `Accepted` condition to be set to status
+`False`, implementations may use the `IncompatibleFilters` reason to specify
+this configuration error.
 
 #### BackendRefs (optional)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind documentation


**What this PR does / why we need it**:

Adds new reason for configuration errors arising from invalid combination of route filters.

Pulled out of https://github.com/kubernetes-sigs/gateway-api/pull/1540 per @robscott 

**Which issue(s) this PR fixes**:

Fixes #1521

**Does this PR introduce a user-facing change?**:

```release-note
Add IncompatibleFilters reason for implementations to specify when a route is invalid due to an invalid combination of route filters.
```
