### PR TITLE
Updating GEP-1742 to clarify timeout formatting

### DIFF
--- a/geps/gep-1742.md
+++ b/geps/gep-1742.md
@@ -206,7 +206,7 @@ sequenceDiagram
     participant C as Client
     participant P as Proxy
     participant U as Upstream
-    
+
     C->>P: Connection Started
     activate U
     activate C
@@ -224,7 +224,7 @@ sequenceDiagram
     activate U
     note left of U: timeout queue<br/>(wait for available server)
     deactivate U
-		
+
     P->>U: Connection Started
     activate U
     P->>U: Starts sending Request
@@ -370,7 +370,7 @@ sequenceDiagram
 
 Both timeout fields are string duration values as specified by
 [Golang time.ParseDuration](https://pkg.go.dev/time#ParseDuration) and MUST be >= 1ms
-or 0 to disable (no timeout).
+and <= 100y.
 
 ### GO
 
@@ -388,8 +388,6 @@ type HTTPRouteRule struct {
 }
 
 // HTTPRouteTimeouts defines timeouts that can be configured for an HTTPRoute.
-// Timeout values are formatted like 1h/1m/1s/1ms as parsed by Golang time.ParseDuration
-// and MUST BE >= 1ms or 0 to disable (no timeout).
 type HTTPRouteTimeouts struct {
 	// Request specifies the duration for processing an HTTP client request after which the
 	// gateway will time out if unable to send a response.
@@ -403,13 +401,22 @@ type HTTPRouteTimeouts struct {
 	// request stream has been received instead of immediately after the transaction is
 	// initiated by the client.
 	//
+	// This value follows a subset of Golang and XML Duration formatting, for example 1m, 1s,
+	// or 1ms. This value MUST BE >= 0 and <= 9999h. When "0" is specified, it indicates that
+	// no timeout should be implemented. If an implementation cannot support the granularity
+	// specified, it MUST round up to the closest value it supports. For example, if 1ms is
+	// specified, and an implementation can only configure timeouts in seconds, it MUST configure
+	// 1 second as the timeout. In the special case of a "0" timeout, the implementation SHOULD
+	// NOT implement a timeout. If that is not possible it MUST configure the maximum timeout
+	// value it supports.
+	//
 	// When this field is unspecified, request timeout behavior is implementation-dependent.
 	//
 	// Support: Extended
 	//
 	// +optional
-	// +kubebuilder:validation:Format=duration
-	Request *metav1.Duration `json:"request,omitempty"`
+	// +kubebuilder:validation:Pattern=^(0|[1-9][0-9]{0,3}(m|s|ms))$
+  Request *metav1.Duration `json:"request,omitempty"`
 
 	// BackendRequest specifies a timeout for an individual request from the gateway
 	// to a backend service. This covers the time from when the request first starts being
@@ -419,14 +426,22 @@ type HTTPRouteTimeouts struct {
 	// may result in more than one call from the gateway to the destination backend service,
 	// for example, if automatic retries are supported.
 	//
-	// Because the Request timeout encompasses the BackendRequest timeout,
-	// the value of BackendRequest defaults to and must be <= the value of Request timeout.
+	// This value follows a subset of Golang and XML Duration formatting, for example 1m, 1s,
+	// or 1ms. This value MUST BE >= 0 and <= 9999h. When "0" is specified, it indicates that
+	// no timeout should be implemented. If an implementation cannot support the granularity
+	// specified, it MUST round up to the closest value it supports. For example, if 1ms is
+	// specified, and an implementation can only configure timeouts in seconds, it MUST configure
+	// 1 second as the timeout. In the special case of a "0" timeout, the implementation SHOULD
+	// NOT implement a timeout. If that is not possible it MUST configure the maximum timeout
+	// value it supports.
+	//
+	// When this field is unspecified, request timeout behavior is implementation-dependent.
 	//
 	// Support: Extended
 	//
 	// +optional
-	// +kubebuilder:validation:Format=duration
-	BackendRequest *metav1.Duration `json:"backendRequest,omitempty"`
+	// +kubebuilder:validation:Pattern=^(0|[1-9][0-9]{0,3}(m|s|ms))$
+	BackendRequest *string `json:"backendRequest,omitempty"`
 }
 ```
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind gep

**What this PR does / why we need it**:
While reviewing the implementation of this GEP, I realized that the upper and lower bounds of these timeout values were not what I expected. This makes the following changes:

**1. Introduces an upper bound of 10 years**
In Kubernetes APIs we _always_ try to have a clear upper and lower bound for fields. This enables implementations to write tests that ensure they can support the min and max values for any field in the API. As far as I can tell, 10 years is lower than all implementations support, but still likely sufficiently high to not be a limiting factor for anyone. Note that our [API versioning guidelines](https://gateway-api.sigs.k8s.io/concepts/versioning/#minor-version-eg-v040-v050) allow us to loosen validation in future releases, but we try to avoid tightening validation wherever possible. This means that we should aim to start with the tightest validation that is reasonable for a feature.

**2. Removes the possibility of setting 0 to mean "no timeout"**
Although both HAProxy and Envoy support 0 as "no timeout", I'm not sure how broadly supportable this concept of an "infinite" timeout would be beyond those two dataplanes. If 0 is really just intended to represent "max timeout", why not define a max timeout supported by the API and suggest users set that if that's really what they want? That feels both more specific and less likely to surprise users. If we ever determine that we really do need a "0" value here, we can loosen validation in the future to support it, but once we've allowed that value it's nearly impossible to undo that.

**3. Clarifies that values should be rounded up to the closest value an implementation can support**
There are likely some implementations that are not going to be able to support the level of granularity supported by Golang's concept of duration. This provides guidance to those implementations for how they should handle this. We likely also will want to add something to status for this in the future, but there's not an obvious condition to attach that to yet.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @frankbu @srodi @candita @shaneutt @howardjohn 
