### PR TITLE
Fixing broken presubmits by bumping base image version

### DIFF
--- a/docker/Dockerfile.webhook
+++ b/docker/Dockerfile.webhook
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BUILDPLATFORM=linux/amd64
-FROM --platform=$BUILDPLATFORM golang:1.20 AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.20.5 AS build-env
 RUN mkdir -p /go/src/sig.k8s.io/gateway-api
 WORKDIR /go/src/sig.k8s.io/gateway-api
 COPY  . .


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Presubmits are currently failing ([example](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_gateway-api/2155/pull-gateway-api-verify/1674112294809767936)) with the following error:

```
#3 [internal] load metadata for docker.io/library/golang:1.20
#3 ERROR: failed to copy: httpReadSeeker: failed open: content at https://mirror.gcr.io/v2/library/golang/manifests/sha256:344193a70dc3588452ea39b4a1e465a8d3c91f788ae053f7ee168cebf18e0a50?ns=docker.io not found: not found
#4 [internal] load metadata for gcr.io/distroless/static:nonroot
#4 DONE 0.8s
------
 > [internal] load metadata for docker.io/library/golang:1.20:
------
Dockerfile.webhook:16
--------------------
  14 |     
  15 |     ARG BUILDPLATFORM=linux/amd64
  16 | >>> FROM --platform=$BUILDPLATFORM golang:1.20 AS build-env
  17 |     RUN mkdir -p /go/src/sig.k8s.io/gateway-api
  18 |     WORKDIR /go/src/sig.k8s.io/gateway-api
--------------------
ERROR: failed to solve: golang:1.20: failed to copy: httpReadSeeker: failed open: content at https://mirror.gcr.io/v2/library/golang/manifests/sha256:344193a70dc3588452ea39b4a1e465a8d3c91f788ae053f7ee168cebf18e0a50?ns=docker.io not found: not found
[0;31mTest FAILED: hack/../hack/verify-examples-kind.sh 
```

This PR hopes to understand why that's happening and eventually fix it.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
