### PR TITLE
Only require a GatewayClass if the gateway suite is being run

### DIFF
--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -142,14 +142,15 @@ func New(s Options) *ConformanceTestSuite {
 // Setup ensures the base resources required for conformance tests are installed
 // in the cluster. It also ensures that all relevant resources are ready.
 func (suite *ConformanceTestSuite) Setup(t *testing.T) {
-	t.Logf("Test Setup: Ensuring GatewayClass has been accepted")
-	suite.ControllerName = kubernetes.GWCMustHaveAcceptedConditionTrue(t, suite.Client, suite.TimeoutConfig, suite.GatewayClassName)
-
-	suite.Applier.GatewayClass = suite.GatewayClassName
-	suite.Applier.ControllerName = suite.ControllerName
 	suite.Applier.FS = suite.FS
 
 	if suite.SupportedFeatures.Has(SupportGateway) {
+		t.Logf("Test Setup: Ensuring GatewayClass has been accepted")
+		suite.ControllerName = kubernetes.GWCMustHaveAcceptedConditionTrue(t, suite.Client, suite.TimeoutConfig, suite.GatewayClassName)
+
+		suite.Applier.GatewayClass = suite.GatewayClassName
+		suite.Applier.ControllerName = suite.ControllerName
+		
 		t.Logf("Test Setup: Applying base manifests")
 		suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, suite.BaseManifests, suite.Cleanup)
 

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -150,7 +150,7 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 
 		suite.Applier.GatewayClass = suite.GatewayClassName
 		suite.Applier.ControllerName = suite.ControllerName
-		
+
 		t.Logf("Test Setup: Applying base manifests")
 		suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, suite.BaseManifests, suite.Cleanup)
 


### PR DESCRIPTION
/kind test
/area conformance

**What this PR does / why we need it**:

When the conformance tests run, they require that a GatewayClass exists and that it has been accepted.  However, this is not appropriate when testing mesh only conformance because mesh implementations do not necessarily have a GatewayClass.  This change moves the GatewayClass requirement into the Gateway suite so that this is only checked when the Gateway feature is enabled.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
