### PR TITLE
feat: skip-tests flag added to conformance CLI

### DIFF
--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -52,7 +52,7 @@ func TestConformance(t *testing.T) {
 
 	supportedFeatures := suite.ParseSupportedFeatures(*flags.SupportedFeatures)
 	exemptFeatures := suite.ParseSupportedFeatures(*flags.ExemptFeatures)
-
+	skipTests := suite.ParseSkipTests(*flags.SkipTests)
 	namespaceLabels := suite.ParseNamespaceLabels(*flags.NamespaceLabels)
 
 	t.Logf("Running conformance tests with %s GatewayClass\n cleanup: %t\n debug: %t\n enable all features: %t \n supported features: [%v]\n exempt features: [%v]",
@@ -72,6 +72,7 @@ func TestConformance(t *testing.T) {
 		ExemptFeatures:             exemptFeatures,
 		EnableAllSupportedFeatures: *flags.EnableAllSupportedFeatures,
 		NamespaceLabels:            namespaceLabels,
+		SkipTests:                  skipTests,
 	})
 	cSuite.Setup(t)
 

--- a/conformance/utils/flags/flags.go
+++ b/conformance/utils/flags/flags.go
@@ -28,6 +28,7 @@ var (
 	ShowDebug                  = flag.Bool("debug", false, "Whether to print debug logs")
 	CleanupBaseResources       = flag.Bool("cleanup-base-resources", true, "Whether to cleanup base test resources after the run")
 	SupportedFeatures          = flag.String("supported-features", "", "Supported features included in conformance tests suites")
+	SkipTests                  = flag.String("skip-tests", "", "Comma-separated list of tests to skip")
 	ExemptFeatures             = flag.String("exempt-features", "", "Exempt Features excluded from conformance tests suites")
 	EnableAllSupportedFeatures = flag.Bool("all-features", false, "Whether to enable all supported features for conformance tests")
 	NamespaceLabels            = flag.String("namespace-labels", "", "Comma-separated list of name=value labels to add to test namespaces")

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -261,3 +261,12 @@ func ParseNamespaceLabels(f string) map[string]string {
 	}
 	return res
 }
+
+// ParseSkipTests parses flag arguments and converts the string to
+// []string containing the tests to be skipped.
+func ParseSkipTests(t string) []string {
+	if t == "" {
+		return nil
+	}
+	return strings.Split(t, ",")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind feature
/area conformance

**What this PR does / why we need it**:

The `--skip-tests` flag has been added to the conformance CLI to enable tests opt-out when using it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The `--skip-tests` flag has been added to the conformance CLI to enable tests opt-out when using it.
```
