### PR TITLE
ResponseHeaderModifier is already standard since the version now is 0.7+

### DIFF
--- a/geps/gep-1323.md
+++ b/geps/gep-1323.md
@@ -1,7 +1,7 @@
 # GEP 1323: Response Header Filter
 
 * Issue: [#1323](https://github.com/kubernetes-sigs/gateway-api/issues/1323)
-* Status: Experimental
+* Status: Standard
 
 > **Note**: This GEP is exempt from the [Probationary Period][expprob] rules of
 > our GEP overview as it existed before those rules did, and so it has been

--- a/site-src/guides/http-header-modifier.md
+++ b/site-src/guides/http-header-modifier.md
@@ -43,12 +43,6 @@ Using the example above would remove the `x-request-id` header from the HTTP req
 
 ### HTTP Response Header Modifier
 
-!!! info "Experimental Channel"
-
-    The `ResponseHeaderModifier` filter described below is currently only included in the
-    "Experimental" channel of Gateway API. Starting in v0.7.0, this
-    feature will graduate to the "Standard" channel.
-
 Just like editing request headers can be useful, the same goes for response headers. For example, it allows teams to add/remove cookies for only a certain backend, which can help in identifying certain users that were redirected to that backend previously.
 
 Another potential use case could be when you have a frontend that needs to know whether it’s talking to a stable or a beta version of the backend server, in order to render different UI or adapt its response parsing accordingly.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind documentation

**What this PR does / why we need it**:
Update gep-1323

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
