### PR TITLE
Clarify usage of matches with PathPrefixRewrite

### DIFF
--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -855,6 +855,10 @@ type HTTPPathModifier struct {
 	// ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
 	// match the prefix `/abc`, but the path `/abcd` would not.
 	//
+	// ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
+	// Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
+	// the implementation setting the Accepted Condition for the Route to `status: False`.
+	//
 	// Request Path | Prefix Match | Replace Prefix | Modified Path
 	// -------------|--------------|----------------|----------
 	// /foo/bar     | /foo         | /xyz           | /xyz/bar

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -593,8 +593,14 @@ spec:
                                             For example, the paths `/abc`, `/abc/`,
                                             and `/abc/def` would all match the prefix
                                             `/abc`, but the path `/abcd` would not.
-                                            \n Request Path | Prefix Match | Replace
-                                            Prefix | Modified Path -------------|--------------|----------------|----------
+                                            \n ReplacePrefixMatch is only compatible
+                                            with a `PathPrefix` HTTPRouteMatch. Using
+                                            any other HTTPRouteMatch type on the same
+                                            HTTPRouteRule will result in the implementation
+                                            setting the Accepted Condition for the
+                                            Route to `status: False`. \n Request Path
+                                            | Prefix Match | Replace Prefix | Modified
+                                            Path -------------|--------------|----------------|----------
                                             /foo/bar     | /foo         | /xyz           |
                                             /xyz/bar /foo/bar     | /foo         |
                                             /xyz/          | /xyz/bar /foo/bar     |
@@ -875,8 +881,14 @@ spec:
                                             For example, the paths `/abc`, `/abc/`,
                                             and `/abc/def` would all match the prefix
                                             `/abc`, but the path `/abcd` would not.
-                                            \n Request Path | Prefix Match | Replace
-                                            Prefix | Modified Path -------------|--------------|----------------|----------
+                                            \n ReplacePrefixMatch is only compatible
+                                            with a `PathPrefix` HTTPRouteMatch. Using
+                                            any other HTTPRouteMatch type on the same
+                                            HTTPRouteRule will result in the implementation
+                                            setting the Accepted Condition for the
+                                            Route to `status: False`. \n Request Path
+                                            | Prefix Match | Replace Prefix | Modified
+                                            Path -------------|--------------|----------------|----------
                                             /foo/bar     | /foo         | /xyz           |
                                             /xyz/bar /foo/bar     | /foo         |
                                             /xyz/          | /xyz/bar /foo/bar     |
@@ -1284,7 +1296,12 @@ spec:
                                       When specified, a trailing `/` is ignored. For
                                       example, the paths `/abc`, `/abc/`, and `/abc/def`
                                       would all match the prefix `/abc`, but the path
-                                      `/abcd` would not. \n Request Path | Prefix
+                                      `/abcd` would not. \n ReplacePrefixMatch is
+                                      only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same
+                                      HTTPRouteRule will result in the implementation
+                                      setting the Accepted Condition for the Route
+                                      to `status: False`. \n Request Path | Prefix
                                       Match | Replace Prefix | Modified Path -------------|--------------|----------------|----------
                                       /foo/bar     | /foo         | /xyz           |
                                       /xyz/bar /foo/bar     | /foo         | /xyz/
@@ -1546,7 +1563,12 @@ spec:
                                       When specified, a trailing `/` is ignored. For
                                       example, the paths `/abc`, `/abc/`, and `/abc/def`
                                       would all match the prefix `/abc`, but the path
-                                      `/abcd` would not. \n Request Path | Prefix
+                                      `/abcd` would not. \n ReplacePrefixMatch is
+                                      only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same
+                                      HTTPRouteRule will result in the implementation
+                                      setting the Accepted Condition for the Route
+                                      to `status: False`. \n Request Path | Prefix
                                       Match | Replace Prefix | Modified Path -------------|--------------|----------------|----------
                                       /foo/bar     | /foo         | /xyz           |
                                       /xyz/bar /foo/bar     | /foo         | /xyz/
@@ -2627,8 +2649,14 @@ spec:
                                             For example, the paths `/abc`, `/abc/`,
                                             and `/abc/def` would all match the prefix
                                             `/abc`, but the path `/abcd` would not.
-                                            \n Request Path | Prefix Match | Replace
-                                            Prefix | Modified Path -------------|--------------|----------------|----------
+                                            \n ReplacePrefixMatch is only compatible
+                                            with a `PathPrefix` HTTPRouteMatch. Using
+                                            any other HTTPRouteMatch type on the same
+                                            HTTPRouteRule will result in the implementation
+                                            setting the Accepted Condition for the
+                                            Route to `status: False`. \n Request Path
+                                            | Prefix Match | Replace Prefix | Modified
+                                            Path -------------|--------------|----------------|----------
                                             /foo/bar     | /foo         | /xyz           |
                                             /xyz/bar /foo/bar     | /foo         |
                                             /xyz/          | /xyz/bar /foo/bar     |
@@ -2909,8 +2937,14 @@ spec:
                                             For example, the paths `/abc`, `/abc/`,
                                             and `/abc/def` would all match the prefix
                                             `/abc`, but the path `/abcd` would not.
-                                            \n Request Path | Prefix Match | Replace
-                                            Prefix | Modified Path -------------|--------------|----------------|----------
+                                            \n ReplacePrefixMatch is only compatible
+                                            with a `PathPrefix` HTTPRouteMatch. Using
+                                            any other HTTPRouteMatch type on the same
+                                            HTTPRouteRule will result in the implementation
+                                            setting the Accepted Condition for the
+                                            Route to `status: False`. \n Request Path
+                                            | Prefix Match | Replace Prefix | Modified
+                                            Path -------------|--------------|----------------|----------
                                             /foo/bar     | /foo         | /xyz           |
                                             /xyz/bar /foo/bar     | /foo         |
                                             /xyz/          | /xyz/bar /foo/bar     |
@@ -3318,7 +3352,12 @@ spec:
                                       When specified, a trailing `/` is ignored. For
                                       example, the paths `/abc`, `/abc/`, and `/abc/def`
                                       would all match the prefix `/abc`, but the path
-                                      `/abcd` would not. \n Request Path | Prefix
+                                      `/abcd` would not. \n ReplacePrefixMatch is
+                                      only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same
+                                      HTTPRouteRule will result in the implementation
+                                      setting the Accepted Condition for the Route
+                                      to `status: False`. \n Request Path | Prefix
                                       Match | Replace Prefix | Modified Path -------------|--------------|----------------|----------
                                       /foo/bar     | /foo         | /xyz           |
                                       /xyz/bar /foo/bar     | /foo         | /xyz/
@@ -3580,7 +3619,12 @@ spec:
                                       When specified, a trailing `/` is ignored. For
                                       example, the paths `/abc`, `/abc/`, and `/abc/def`
                                       would all match the prefix `/abc`, but the path
-                                      `/abcd` would not. \n Request Path | Prefix
+                                      `/abcd` would not. \n ReplacePrefixMatch is
+                                      only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same
+                                      HTTPRouteRule will result in the implementation
+                                      setting the Accepted Condition for the Route
+                                      to `status: False`. \n Request Path | Prefix
                                       Match | Replace Prefix | Modified Path -------------|--------------|----------------|----------
                                       /foo/bar     | /foo         | /xyz           |
                                       /xyz/bar /foo/bar     | /foo         | /xyz/

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -563,8 +563,14 @@ spec:
                                             For example, the paths `/abc`, `/abc/`,
                                             and `/abc/def` would all match the prefix
                                             `/abc`, but the path `/abcd` would not.
-                                            \n Request Path | Prefix Match | Replace
-                                            Prefix | Modified Path -------------|--------------|----------------|----------
+                                            \n ReplacePrefixMatch is only compatible
+                                            with a `PathPrefix` HTTPRouteMatch. Using
+                                            any other HTTPRouteMatch type on the same
+                                            HTTPRouteRule will result in the implementation
+                                            setting the Accepted Condition for the
+                                            Route to `status: False`. \n Request Path
+                                            | Prefix Match | Replace Prefix | Modified
+                                            Path -------------|--------------|----------------|----------
                                             /foo/bar     | /foo         | /xyz           |
                                             /xyz/bar /foo/bar     | /foo         |
                                             /xyz/          | /xyz/bar /foo/bar     |
@@ -845,8 +851,14 @@ spec:
                                             For example, the paths `/abc`, `/abc/`,
                                             and `/abc/def` would all match the prefix
                                             `/abc`, but the path `/abcd` would not.
-                                            \n Request Path | Prefix Match | Replace
-                                            Prefix | Modified Path -------------|--------------|----------------|----------
+                                            \n ReplacePrefixMatch is only compatible
+                                            with a `PathPrefix` HTTPRouteMatch. Using
+                                            any other HTTPRouteMatch type on the same
+                                            HTTPRouteRule will result in the implementation
+                                            setting the Accepted Condition for the
+                                            Route to `status: False`. \n Request Path
+                                            | Prefix Match | Replace Prefix | Modified
+                                            Path -------------|--------------|----------------|----------
                                             /foo/bar     | /foo         | /xyz           |
                                             /xyz/bar /foo/bar     | /foo         |
                                             /xyz/          | /xyz/bar /foo/bar     |
@@ -1254,7 +1266,12 @@ spec:
                                       When specified, a trailing `/` is ignored. For
                                       example, the paths `/abc`, `/abc/`, and `/abc/def`
                                       would all match the prefix `/abc`, but the path
-                                      `/abcd` would not. \n Request Path | Prefix
+                                      `/abcd` would not. \n ReplacePrefixMatch is
+                                      only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same
+                                      HTTPRouteRule will result in the implementation
+                                      setting the Accepted Condition for the Route
+                                      to `status: False`. \n Request Path | Prefix
                                       Match | Replace Prefix | Modified Path -------------|--------------|----------------|----------
                                       /foo/bar     | /foo         | /xyz           |
                                       /xyz/bar /foo/bar     | /foo         | /xyz/
@@ -1516,7 +1533,12 @@ spec:
                                       When specified, a trailing `/` is ignored. For
                                       example, the paths `/abc`, `/abc/`, and `/abc/def`
                                       would all match the prefix `/abc`, but the path
-                                      `/abcd` would not. \n Request Path | Prefix
+                                      `/abcd` would not. \n ReplacePrefixMatch is
+                                      only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same
+                                      HTTPRouteRule will result in the implementation
+                                      setting the Accepted Condition for the Route
+                                      to `status: False`. \n Request Path | Prefix
                                       Match | Replace Prefix | Modified Path -------------|--------------|----------------|----------
                                       /foo/bar     | /foo         | /xyz           |
                                       /xyz/bar /foo/bar     | /foo         | /xyz/
@@ -2535,8 +2557,14 @@ spec:
                                             For example, the paths `/abc`, `/abc/`,
                                             and `/abc/def` would all match the prefix
                                             `/abc`, but the path `/abcd` would not.
-                                            \n Request Path | Prefix Match | Replace
-                                            Prefix | Modified Path -------------|--------------|----------------|----------
+                                            \n ReplacePrefixMatch is only compatible
+                                            with a `PathPrefix` HTTPRouteMatch. Using
+                                            any other HTTPRouteMatch type on the same
+                                            HTTPRouteRule will result in the implementation
+                                            setting the Accepted Condition for the
+                                            Route to `status: False`. \n Request Path
+                                            | Prefix Match | Replace Prefix | Modified
+                                            Path -------------|--------------|----------------|----------
                                             /foo/bar     | /foo         | /xyz           |
                                             /xyz/bar /foo/bar     | /foo         |
                                             /xyz/          | /xyz/bar /foo/bar     |
@@ -2817,8 +2845,14 @@ spec:
                                             For example, the paths `/abc`, `/abc/`,
                                             and `/abc/def` would all match the prefix
                                             `/abc`, but the path `/abcd` would not.
-                                            \n Request Path | Prefix Match | Replace
-                                            Prefix | Modified Path -------------|--------------|----------------|----------
+                                            \n ReplacePrefixMatch is only compatible
+                                            with a `PathPrefix` HTTPRouteMatch. Using
+                                            any other HTTPRouteMatch type on the same
+                                            HTTPRouteRule will result in the implementation
+                                            setting the Accepted Condition for the
+                                            Route to `status: False`. \n Request Path
+                                            | Prefix Match | Replace Prefix | Modified
+                                            Path -------------|--------------|----------------|----------
                                             /foo/bar     | /foo         | /xyz           |
                                             /xyz/bar /foo/bar     | /foo         |
                                             /xyz/          | /xyz/bar /foo/bar     |
@@ -3226,7 +3260,12 @@ spec:
                                       When specified, a trailing `/` is ignored. For
                                       example, the paths `/abc`, `/abc/`, and `/abc/def`
                                       would all match the prefix `/abc`, but the path
-                                      `/abcd` would not. \n Request Path | Prefix
+                                      `/abcd` would not. \n ReplacePrefixMatch is
+                                      only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same
+                                      HTTPRouteRule will result in the implementation
+                                      setting the Accepted Condition for the Route
+                                      to `status: False`. \n Request Path | Prefix
                                       Match | Replace Prefix | Modified Path -------------|--------------|----------------|----------
                                       /foo/bar     | /foo         | /xyz           |
                                       /xyz/bar /foo/bar     | /foo         | /xyz/
@@ -3488,7 +3527,12 @@ spec:
                                       When specified, a trailing `/` is ignored. For
                                       example, the paths `/abc`, `/abc/`, and `/abc/def`
                                       would all match the prefix `/abc`, but the path
-                                      `/abcd` would not. \n Request Path | Prefix
+                                      `/abcd` would not. \n ReplacePrefixMatch is
+                                      only compatible with a `PathPrefix` HTTPRouteMatch.
+                                      Using any other HTTPRouteMatch type on the same
+                                      HTTPRouteRule will result in the implementation
+                                      setting the Accepted Condition for the Route
+                                      to `status: False`. \n Request Path | Prefix
                                       Match | Replace Prefix | Modified Path -------------|--------------|----------------|----------
                                       /foo/bar     | /foo         | /xyz           |
                                       /xyz/bar /foo/bar     | /foo         | /xyz/


### PR DESCRIPTION
Update PathPrefixRewrite spec to include compatible match types.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:
This PR updates the httproute spec to clarify that PathPrefixRewrite can only be used with a match of type PathPrefix.

**Which issue(s) this PR fixes**:
None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
