### PR TITLE
Improve AttachedRoutes conformance test

### DIFF
--- a/conformance/tests/gateway-with-attached-routes.go
+++ b/conformance/tests/gateway-with-attached-routes.go
@@ -76,5 +76,39 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 
 			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
 		})
+
+		t.Run("Gateway listener should not have route attached if route doesn't exist", func(t *testing.T) {
+			gwNN := types.NamespacedName{Name: "gateway-with-two-listeners-and-one-attached-route", Namespace: "gateway-conformance-infra"}
+			listeners := []v1beta1.ListenerStatus{
+				{
+					Name: v1beta1.SectionName("udp"),
+					SupportedKinds: []v1beta1.RouteGroupKind{{
+						Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
+						Kind:  v1beta1.Kind("UDPRoute"),
+					}},
+					Conditions: []metav1.Condition{{
+						Type:   string(v1beta1.ListenerConditionAccepted),
+						Status: metav1.ConditionTrue,
+						Reason: "", // any reason
+					}},
+					AttachedRoutes: 0,
+				},
+				{
+					Name: v1beta1.SectionName("http"),
+					SupportedKinds: []v1beta1.RouteGroupKind{{
+						Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
+						Kind:  v1beta1.Kind("HTTPRoute"),
+					}},
+					Conditions: []metav1.Condition{{
+						Type:   string(v1beta1.ListenerConditionAccepted),
+						Status: metav1.ConditionTrue,
+						Reason: "", // any reason
+					}},
+					AttachedRoutes: 1,
+				},
+			}
+
+			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
+		})
 	},
 }

--- a/conformance/tests/gateway-with-attached-routes.go
+++ b/conformance/tests/gateway-with-attached-routes.go
@@ -77,7 +77,7 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
 		})
 
-		t.Run("Gateway listener should not have the route attached if the route is not allowed by the listener's protocol", func(t *testing.T) {
+		t.Run("Gateway listener should have attached route by specifying the sectionName", func(t *testing.T) {
 			gwNN := types.NamespacedName{Name: "gateway-with-two-listeners-and-one-attached-route", Namespace: "gateway-conformance-infra"}
 			listeners := []v1beta1.ListenerStatus{
 				{

--- a/conformance/tests/gateway-with-attached-routes.go
+++ b/conformance/tests/gateway-with-attached-routes.go
@@ -77,7 +77,7 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
 		})
 
-		t.Run("Gateway listener should not have route attached if route doesn't exist", func(t *testing.T) {
+		t.Run("Gateway listener should not have the route attached if the route  is not allowed by the listener's protocol", func(t *testing.T) {
 			gwNN := types.NamespacedName{Name: "gateway-with-two-listeners-and-one-attached-route", Namespace: "gateway-conformance-infra"}
 			listeners := []v1beta1.ListenerStatus{
 				{

--- a/conformance/tests/gateway-with-attached-routes.go
+++ b/conformance/tests/gateway-with-attached-routes.go
@@ -77,14 +77,14 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
 		})
 
-		t.Run("Gateway listener should not have the route attached if the route  is not allowed by the listener's protocol", func(t *testing.T) {
+		t.Run("Gateway listener should not have the route attached if the route is not allowed by the listener's protocol", func(t *testing.T) {
 			gwNN := types.NamespacedName{Name: "gateway-with-two-listeners-and-one-attached-route", Namespace: "gateway-conformance-infra"}
 			listeners := []v1beta1.ListenerStatus{
 				{
-					Name: v1beta1.SectionName("udp"),
+					Name: v1beta1.SectionName("http-unattached"),
 					SupportedKinds: []v1beta1.RouteGroupKind{{
 						Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
-						Kind:  v1beta1.Kind("UDPRoute"),
+						Kind:  v1beta1.Kind("HTTPRoute"),
 					}},
 					Conditions: []metav1.Condition{{
 						Type:   string(v1beta1.ListenerConditionAccepted),

--- a/conformance/tests/gateway-with-attached-routes.yaml
+++ b/conformance/tests/gateway-with-attached-routes.yaml
@@ -86,3 +86,53 @@ spec:
   - backendRefs:
     - name: infra-backend-v1
       port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: gateway-with-two-listeners-and-one-attached-route
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: udp
+      port: 8080
+      protocol: UDP
+      allowedRoutes:
+        kinds:
+          - kind: UDPRoute
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              # This label is added automatically as of K8s 1.22
+              # to all namespaces
+              kubernetes.io/metadata.name: gateway-conformance-infra
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              # This label is added automatically as of K8s 1.22
+              # to all namespaces
+              kubernetes.io/metadata.name: gateway-conformance-infra
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: http-route-4
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - kind: Gateway
+      name: gateway-with-two-listeners-and-one-attached-route
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8080

--- a/conformance/tests/gateway-with-attached-routes.yaml
+++ b/conformance/tests/gateway-with-attached-routes.yaml
@@ -95,12 +95,12 @@ metadata:
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
   listeners:
-    - name: udp
+    - name: http-unattached
       port: 8080
-      protocol: UDP
+      protocol: HTTP
       allowedRoutes:
         kinds:
-          - kind: UDPRoute
+          - kind: HTTPRoute
         namespaces:
           from: Selector
           selector:
@@ -132,6 +132,7 @@ spec:
     - kind: Gateway
       name: gateway-with-two-listeners-and-one-attached-route
       namespace: gateway-conformance-infra
+      sectionName: http
   rules:
     - backendRefs:
         - name: infra-backend-v1

--- a/conformance/tests/gateway-with-attached-routes.yaml
+++ b/conformance/tests/gateway-with-attached-routes.yaml
@@ -102,12 +102,7 @@ spec:
       kinds:
       - kind: HTTPRoute
       namespaces:
-        from: Selector
-        selector:
-          matchLabels:
-            # This label is added automatically as of K8s 1.22
-            # to all namespaces
-            kubernetes.io/metadata.name: gateway-conformance-infra
+        from: All
   - name: http
     port: 80
     protocol: HTTP
@@ -115,12 +110,7 @@ spec:
       kinds:
       - kind: HTTPRoute
       namespaces:
-        from: Selector
-        selector:
-          matchLabels:
-            # This label is added automatically as of K8s 1.22
-            # to all namespaces
-            kubernetes.io/metadata.name: gateway-conformance-infra
+        from: All
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute

--- a/conformance/tests/gateway-with-attached-routes.yaml
+++ b/conformance/tests/gateway-with-attached-routes.yaml
@@ -95,32 +95,32 @@ metadata:
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
   listeners:
-    - name: http-unattached
-      port: 8080
-      protocol: HTTP
-      allowedRoutes:
-        kinds:
-          - kind: HTTPRoute
-        namespaces:
-          from: Selector
-          selector:
-            matchLabels:
-              # This label is added automatically as of K8s 1.22
-              # to all namespaces
-              kubernetes.io/metadata.name: gateway-conformance-infra
-    - name: http
-      port: 80
-      protocol: HTTP
-      allowedRoutes:
-        kinds:
-          - kind: HTTPRoute
-        namespaces:
-          from: Selector
-          selector:
-            matchLabels:
-              # This label is added automatically as of K8s 1.22
-              # to all namespaces
-              kubernetes.io/metadata.name: gateway-conformance-infra
+  - name: http-unattached
+    port: 8080
+    protocol: HTTP
+    allowedRoutes:
+      kinds:
+      - kind: HTTPRoute
+      namespaces:
+        from: Selector
+        selector:
+          matchLabels:
+            # This label is added automatically as of K8s 1.22
+            # to all namespaces
+            kubernetes.io/metadata.name: gateway-conformance-infra
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      kinds:
+      - kind: HTTPRoute
+      namespaces:
+        from: Selector
+        selector:
+          matchLabels:
+            # This label is added automatically as of K8s 1.22
+            # to all namespaces
+            kubernetes.io/metadata.name: gateway-conformance-infra
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
@@ -129,11 +129,11 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - kind: Gateway
-      name: gateway-with-two-listeners-and-one-attached-route
-      namespace: gateway-conformance-infra
-      sectionName: http
+  - kind: Gateway
+    name: gateway-with-two-listeners-and-one-attached-route
+    namespace: gateway-conformance-infra
+    sectionName: http
   rules:
-    - backendRefs:
-        - name: infra-backend-v1
-          port: 8080
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind test
/area conformance
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2058 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
