### PR TITLE
Conformance Profiles (GEP 1709) to Experimental status

### DIFF
--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -2,6 +2,7 @@
 
 * Issue: [#1709](https://github.com/kubernetes-sigs/gateway-api/issues/1709)
 * Status: Prototyping
+* Probationary Period: Re-evaluate in February 2024
 
 ## TLDR
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -11,29 +11,6 @@ when running the conformance test suite. Also add opt-in automated conformance
 reporting to the conformance test suite to report conformance results back to
 the Gateway API project and receive recognition (e.g. badges).
 
-## TODO
-
-The following are items that **MUST** be resolved before we move past the
-`provisioning/prototyping` status:
-
-- We need to think about how we're going to highlight and report on the
-  results for `experimental` features, and make sure this is explicitly
-  written out.
-
-The following are items that **MUST** be resolved before we move past the
-`experimental` status:
-
-- We have been actively [gathering feedback from SIG Arch][sig-arch-feedback].
-  Some time during the `experimental` phase needs to be allowed to continue to
-  engage with SIG Arch and incorporate their feedback into the test suite.
-- We need to sort out how we're going to display conformance results. We want
-  some kind of summarized display of any given implementation's conformance
-  results somewhere on our upstream website (so far the thought has been the
-  [implementations page][impl]). We should look for prior art in Kubernetes
-  SIGs and also reach out to some frontend developers.
-
-[sig-arch-feedback]:https://groups.google.com/g/kubernetes-sig-architecture/c/YjrVZ4NJQiA/m/7Qg7ScddBwAJ
-
 ## Goals
 
 - Add high level profiles which downstream implementations can subscribe to in
@@ -629,6 +606,24 @@ a single route type (`UDPRoute`, in particular as it turns out).
 
 We may consider in the future doing some of these higher level profiles if
 there's a technical reason or strong desire from implementers.
+
+## Graduation Criteria
+
+The following are items that **MUST** be resolved to move this GEP to
+`Standard` status (and before the end of the probationary period):
+
+- [ ] some kind of basic level of display for the report data needs to exist.
+  It's OK for a more robust display layer to be part of a follow-up effort.
+- [ ] initially we were OK with storing reports in the Git repository as files.
+  While this is probably sufficient during the `Experimental` phase, we need to
+  re-evaluate this before `Standard` and see if this remains sufficient or if
+  we want to store the data elsewhere.
+- [ ] We have been actively [gathering feedback from SIG
+  Arch][sig-arch-feedback]. Some time during the `experimental` phase needs to
+  be allowed to continue to engage with SIG Arch and incorporate their feedback
+  into the test suite.
+
+[sig-arch-feedback]:https://groups.google.com/g/kubernetes-sig-architecture/c/YjrVZ4NJQiA/m/7Qg7ScddBwAJ
 
 ## References
 

--- a/geps/gep-1709.md
+++ b/geps/gep-1709.md
@@ -1,7 +1,7 @@
 # GEP-1709: Conformance Profiles
 
 * Issue: [#1709](https://github.com/kubernetes-sigs/gateway-api/issues/1709)
-* Status: Prototyping
+* Status: Experimental
 * Probationary Period: Re-evaluate in February 2024
 
 ## TLDR

--- a/geps/overview.md
+++ b/geps/overview.md
@@ -71,7 +71,8 @@ proposed changes in our API. In some cases, these changes will be documentation
 only, but in most cases, some API changes will also be required. It is important
 that every new feature of the API is marked as "Experimental" when it is
 introduced. Within the API, we use `<gateway:experimental>` tags to denote
-experimental fields.
+experimental fields. Within Golang packages (conformance tests, CLIs, e.t.c.) we
+use the `experimental` Golang build tag to denote experimental functionality.
 
 Some other requirements must be met before marking a GEP `Experimental`:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,8 +89,6 @@ nav:
         - geps/gep-1619.md
         - geps/gep-1897.md
         - geps/gep-1867.md
-      - Prototyping:
-        - geps/gep-1709.md
       - Implementable:
         - geps/gep-1742.md
         - geps/gep-1686.md
@@ -101,6 +99,7 @@ nav:
         - geps/gep-1016.md
         - geps/gep-957.md
         - geps/gep-713.md
+        - geps/gep-1709.md
       - Standard:
         - geps/gep-1364.md
         - geps/gep-1323.md


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind gep

**What this PR does / why we need it**:

In support of #1709 this moves the GEP to `Experimental` status, ready for implementations to start submitting their reports.