### PR TITLE
Update GAMMA meetings to every other week, per discussion in the GAMMA meeting.

### DIFF
--- a/site-src/contributing/index.md
+++ b/site-src/contributing/index.md
@@ -61,12 +61,12 @@ Being the main meeting for Gateway API, the topics can vary here and often this
 is where new topics and ideas are discussed. However if you're simply
 interested in the ingress use case, this is the common forum for that.
 
-### Mesh Meeting
+### Mesh Meeting (GAMMA)
 
 [GAMMA](/contributing/gamma/) is the initative within Gateway API to use the
 resources provided by Gateway API for service mesh use cases. Meetings happen
-weekly on Tuesdays, alternating between 3pm Pacific Time (23:00 UTC) and 8AM
-Pacific Time (16:00 UTC):
+every other week on Tuesdays, alternating between 3pm Pacific Time (23:00 UTC)
+and 8AM Pacific Time (16:00 UTC):
 
 * [Zoom link](https://zoom.us/j/96951309977)
 * Convert to your timezone: [3pm PT](http://www.thetimezoneconverter.com/?t=15:00&tz=PT%20%28Pacific%20Time%29)/[8am PT](http://www.thetimezoneconverter.com/?t=08:00&tz=PT%20%28Pacific%20Time%29)


### PR DESCRIPTION
Per discussion in the GAMMA meeting, let's meet every other Tuesday.

FTR the next meeting will be 25 July 2023 at 0800 US/Pacific (1100
US/Eastern, 1500 UTC).

Signed-off-by: flynn@buoyant.io

/kind documentation

```release-note
NONE
```
