### PR TITLE
Add SupportedFeature for port 8080 on Gateway

### DIFF
--- a/apis/v1beta1/validation/gateway_test.go
+++ b/apis/v1beta1/validation/gateway_test.go
@@ -237,7 +237,7 @@ func TestValidateGateway(t *testing.T) {
 				},
 			},
 		},
-		"combination of port and protocol are not unique for each listenr when hostnames not set": {
+		"combination of port and protocol are not unique for each listener when hostnames not set": {
 			mutate: func(gw *gatewayv1b1.Gateway) {
 				gw.Spec.Listeners[0].Name = "foo"
 				gw.Spec.Listeners[0].Protocol = gatewayv1b1.HTTPProtocolType

--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -31,21 +31,6 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
-  name: same-namespace-with-http-listener-on-8080
-  namespace: gateway-conformance-infra
-spec:
-  gatewayClassName: "{GATEWAY_CLASS_NAME}"
-  listeners:
-  - name: http
-    port: 8080
-    protocol: HTTP
-    allowedRoutes:
-      namespaces:
-        from: Same
----
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: Gateway
-metadata:
   name: same-namespace-with-https-listener
   namespace: gateway-conformance-infra
 spec:

--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -39,6 +39,7 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 	Description: "A Gateway in the gateway-conformance-infra namespace should update the observedGeneration in all of its Status.Conditions after an update to the spec",
 	Features: []suite.SupportedFeature{
 		suite.SupportGateway,
+		suite.SupportGatewayPort8080,
 	},
 	Manifests: []string{"tests/gateway-observed-generation-bump.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {

--- a/conformance/tests/httproute-redirect-port-and-scheme.go
+++ b/conformance/tests/httproute-redirect-port-and-scheme.go
@@ -40,6 +40,7 @@ var HTTPRouteRedirectPortAndScheme = suite.ConformanceTest{
 		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRoutePortRedirect,
+		suite.SupportGatewayPort8080,
 	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"

--- a/conformance/tests/httproute-redirect-port-and-scheme.yaml
+++ b/conformance/tests/httproute-redirect-port-and-scheme.yaml
@@ -1,4 +1,19 @@
 apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: same-namespace-with-http-listener-on-8080
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: http
+    port: 8080
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: http-route-for-listener-on-port-80

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -64,6 +64,8 @@ const (
 	//
 	//       See: https://github.com/kubernetes-sigs/gateway-api/issues/1780
 	SupportGatewayClassObservedGenerationBump SupportedFeature = "GatewayClassObservedGenerationBump"
+	// This option indicates that the Gateway can also use port 8080
+	SupportGatewayPort8080 SupportedFeature = "GatewayPort8080"
 )
 
 // StandardExtendedFeatures are extra generic features that implementations may
@@ -73,6 +75,7 @@ const (
 // See: https://github.com/kubernetes-sigs/gateway-api/issues/1891
 var StandardExtendedFeatures = sets.New(
 	SupportGatewayClassObservedGenerationBump,
+	SupportGatewayPort8080,
 ).Insert(StandardCoreFeatures.UnsortedList()...)
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?** /kind test /area conformance 
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:
Conformance tests only use ports 80 and 443 in base manifests.  This PR removed the Gateway w/ port 8080 in the base.yaml manifest, adds it to the tests yaml that was using it, and adds a `SupportedFeature` for port 8080

**Which issue(s) this PR fixes**: 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #https://github.com/kubernetes-sigs/gateway-api/issues/2094

**Does this PR introduce a user-facing change?**: 
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
