### PR TITLE
conformance-profiles CLI fixes

### DIFF
--- a/conformance/experimental_conformance_test.go
+++ b/conformance/experimental_conformance_test.go
@@ -75,7 +75,7 @@ func TestExperimentalConformance(t *testing.T) {
 	namespaceLabels = suite.ParseNamespaceLabels(*flags.NamespaceLabels)
 
 	// experimental conformance flags
-	conformanceProfiles := suite.ParseConformanceProfiles(*flags.ConformanceProfiles)
+	conformanceProfiles = suite.ParseConformanceProfiles(*flags.ConformanceProfiles)
 
 	if conformanceProfiles.Len() > 0 {
 		// if some conformance profiles have been set, run the experimental conformance suite...
@@ -131,10 +131,10 @@ func testExperimentalConformance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error generating conformance profile report: %v", err)
 	}
-	writeReport(t.Log, *report, *flags.ReportOutput)
+	writeReport(t.Logf, *report, *flags.ReportOutput)
 }
 
-func writeReport(log func(...any), report confv1a1.ConformanceReport, output string) error {
+func writeReport(logf func(string, ...any), report confv1a1.ConformanceReport, output string) error {
 	rawReport, err := yaml.Marshal(report)
 	if err != nil {
 		return err
@@ -145,7 +145,7 @@ func writeReport(log func(...any), report confv1a1.ConformanceReport, output str
 			return err
 		}
 	}
-	log("Conformance report:\n %s", rawReport)
+	logf("Conformance report:\n %s", string(rawReport))
 
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind bug
/area conformance

**What this PR does / why we need it**:

Minor fixes to correct some bad behaviors and improve the usability of the conformance profiles CLI.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
