### PR TITLE
conformance: use interface instead of concrete impl for Kubernetes client

### DIFF
--- a/conformance/utils/http/mirror.go
+++ b/conformance/utils/http/mirror.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 )
 
-func ExpectMirroredRequest(t *testing.T, client client.Client, clientset *clientset.Clientset, ns, mirrorPod, path string) {
+func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clientset.Interface, ns, mirrorPod, path string) {
 	if mirrorPod == "" {
 		t.Fatalf("MirroredTo wasn't provided in the testcase, this test should only check http request mirror.")
 	}

--- a/conformance/utils/kubernetes/logs.go
+++ b/conformance/utils/kubernetes/logs.go
@@ -28,7 +28,7 @@ import (
 
 // DumpEchoLogs returns logs of the echoserver pod in
 // in the given namespace and with the given name.
-func DumpEchoLogs(ns, name string, c client.Client, cs *clientset.Clientset) ([][]byte, error) {
+func DumpEchoLogs(ns, name string, c client.Client, cs clientset.Interface) ([][]byte, error) {
 	var logs [][]byte
 
 	pods := new(corev1.PodList)

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -36,7 +36,7 @@ import (
 // conformance tests.
 type ConformanceTestSuite struct {
 	Client            client.Client
-	Clientset         *clientset.Clientset
+	Clientset         clientset.Interface
 	RESTClient        *rest.RESTClient
 	RestConfig        *rest.Config
 	RoundTripper      roundtripper.RoundTripper
@@ -56,7 +56,7 @@ type ConformanceTestSuite struct {
 // Options can be used to initialize a ConformanceTestSuite.
 type Options struct {
 	Client           client.Client
-	Clientset        *clientset.Clientset
+	Clientset        clientset.Interface
 	RESTClient       *rest.RESTClient
 	RestConfig       *rest.Config
 	GatewayClassName string


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Preferred to use interface generally than the concrete implementation

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
