### PR TITLE
Fix missing fields in experimental conformance suite setup

### DIFF
--- a/conformance/utils/suite/experimental_suite.go
+++ b/conformance/utils/suite/experimental_suite.go
@@ -152,6 +152,9 @@ func NewExperimentalConformanceTestSuite(s ExperimentalConformanceOptions) (*Exp
 
 	suite.ConformanceTestSuite = ConformanceTestSuite{
 		Client:           s.Client,
+		Clientset:        s.Clientset,
+		RESTClient:       s.RESTClient,
+		RestConfig:       s.RestConfig,
 		RoundTripper:     roundTripper,
 		GatewayClassName: s.GatewayClassName,
 		Debug:            s.Debug,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind test
/area conformance

**What this PR does / why we need it**:

Add missing fields that were not carried over to the experimental conformance reporting suite setup. The k8s clientset especially is required for the mirror tests.

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
