### PR TITLE
conformance: fetch Gateway in GatewayMustHaveLatestConditions loop

### DIFF
--- a/conformance/tests/gateway-modify-listeners.go
+++ b/conformance/tests/gateway-modify-listeners.go
@@ -55,7 +55,7 @@ var GatewayModifyListeners = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			// verify that the implementation is tracking the most recent resource changes
-			kubernetes.GatewayMustHaveLatestConditions(t, s.TimeoutConfig, original)
+			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
 
 			all := v1beta1.NamespacesFromAll
 
@@ -114,7 +114,7 @@ var GatewayModifyListeners = suite.ConformanceTest{
 			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
 
 			// verify that the implementation continues to keep up to date with the resource changes we've been making
-			kubernetes.GatewayMustHaveLatestConditions(t, s.TimeoutConfig, updated)
+			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
 
 			require.NotEqual(t, original.Generation, updated.Generation, "generation should change after an update")
 		})
@@ -131,7 +131,7 @@ var GatewayModifyListeners = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			// verify that the implementation is tracking the most recent resource changes
-			kubernetes.GatewayMustHaveLatestConditions(t, s.TimeoutConfig, original)
+			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
 
 			mutate := original.DeepCopy()
 			require.Equalf(t, 2, len(mutate.Spec.Listeners), "the gateway must have 2 listeners")
@@ -173,7 +173,7 @@ var GatewayModifyListeners = suite.ConformanceTest{
 			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
 
 			// verify that the implementation continues to keep up to date with the resource changes we've been making
-			kubernetes.GatewayMustHaveLatestConditions(t, s.TimeoutConfig, updated)
+			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
 
 			require.NotEqual(t, original.Generation, updated.Generation, "generation should change after an update")
 		})

--- a/conformance/tests/gateway-modify-listeners.go
+++ b/conformance/tests/gateway-modify-listeners.go
@@ -50,12 +50,13 @@ var GatewayModifyListeners = suite.ConformanceTest{
 
 			namespaces := []string{"gateway-conformance-infra"}
 			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
-			original := &v1beta1.Gateway{}
-			err := s.Client.Get(ctx, gwNN, original)
-			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			// verify that the implementation is tracking the most recent resource changes
 			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
+
+			original := &v1beta1.Gateway{}
+			err := s.Client.Get(ctx, gwNN, original)
+			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			all := v1beta1.NamespacesFromAll
 
@@ -78,9 +79,6 @@ var GatewayModifyListeners = suite.ConformanceTest{
 
 			// Ensure the generation and observedGeneration sync up
 			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
-			updated := &v1beta1.Gateway{}
-			err = s.Client.Get(ctx, gwNN, updated)
-			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			listeners := []v1beta1.ListenerStatus{
 				{
@@ -116,6 +114,10 @@ var GatewayModifyListeners = suite.ConformanceTest{
 			// verify that the implementation continues to keep up to date with the resource changes we've been making
 			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
 
+			updated := &v1beta1.Gateway{}
+			err = s.Client.Get(ctx, gwNN, updated)
+			require.NoErrorf(t, err, "error getting Gateway: %v", err)
+
 			require.NotEqual(t, original.Generation, updated.Generation, "generation should change after an update")
 		})
 
@@ -126,12 +128,13 @@ var GatewayModifyListeners = suite.ConformanceTest{
 
 			namespaces := []string{"gateway-conformance-infra"}
 			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
-			original := &v1beta1.Gateway{}
-			err := s.Client.Get(ctx, gwNN, original)
-			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			// verify that the implementation is tracking the most recent resource changes
 			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
+
+			original := &v1beta1.Gateway{}
+			err := s.Client.Get(ctx, gwNN, original)
+			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			mutate := original.DeepCopy()
 			require.Equalf(t, 2, len(mutate.Spec.Listeners), "the gateway must have 2 listeners")
@@ -150,9 +153,6 @@ var GatewayModifyListeners = suite.ConformanceTest{
 
 			// Ensure the generation and observedGeneration sync up
 			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
-			updated := &v1beta1.Gateway{}
-			err = s.Client.Get(ctx, gwNN, updated)
-			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			listeners := []v1beta1.ListenerStatus{
 				{
@@ -174,6 +174,10 @@ var GatewayModifyListeners = suite.ConformanceTest{
 
 			// verify that the implementation continues to keep up to date with the resource changes we've been making
 			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
+
+			updated := &v1beta1.Gateway{}
+			err = s.Client.Get(ctx, gwNN, updated)
+			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			require.NotEqual(t, original.Generation, updated.Generation, "generation should change after an update")
 		})

--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -52,12 +52,12 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			namespaces := []string{"gateway-conformance-infra"}
 			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
 
+			// Sanity check
+			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
+
 			original := &v1beta1.Gateway{}
 			err := s.Client.Get(ctx, gwNN, original)
 			require.NoErrorf(t, err, "error getting Gateway: %v", err)
-
-			// Sanity check
-			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
 
 			all := v1beta1.NamespacesFromAll
 
@@ -79,12 +79,12 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			// Ensure the generation and observedGeneration sync up
 			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
 
+			// Sanity check
+			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
+
 			updated := &v1beta1.Gateway{}
 			err = s.Client.Get(ctx, gwNN, updated)
 			require.NoErrorf(t, err, "error getting Gateway: %v", err)
-
-			// Sanity check
-			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
 
 			require.NotEqual(t, original.Generation, updated.Generation, "generation should change after an update")
 		})

--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -57,7 +57,7 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			// Sanity check
-			kubernetes.GatewayMustHaveLatestConditions(t, s.TimeoutConfig, original)
+			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
 
 			all := v1beta1.NamespacesFromAll
 
@@ -84,7 +84,7 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			// Sanity check
-			kubernetes.GatewayMustHaveLatestConditions(t, s.TimeoutConfig, updated)
+			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
 
 			require.NotEqual(t, original.Generation, updated.Generation, "generation should change after an update")
 		})


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
/area conformance

**What this PR does / why we need it**:
Fetches the Gateway from the client each time through
the polling loop in GatewayMustHaveLatestConditions,
so updates to the conditions can be observed.

The current code is checking the same object over and
over again.

**Which issue(s) this PR fixes**:
Updates #1883

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
