### PR TITLE
conformance: Make routability tests runnable

### DIFF
--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -176,7 +176,7 @@ type GatewayInfrastructure struct {
 	Routability *GatewayRoutability `json:"routability,omitempty"`
 }
 
-// GatewayRoutablility represents the routability of a Gateway
+// GatewayRoutability represents the routability of a Gateway
 //
 // The pre-defined values listed in this package can be compared semantically.
 // `Public` has a larger scope than `Private`, while `Private` has a larger scope than

--- a/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -224,9 +224,9 @@ spec:
                   MUST populate this list with the GatewayRoutability values that
                   are supported by this GatewayClass. \n <gateway:experimental>"
                 items:
-                  description: "GatewayRoutablility represents the routability of
-                    a Gateway \n The pre-defined values listed in this package can
-                    be compared semantically. `Public` has a larger scope than `Private`,
+                  description: "GatewayRoutability represents the routability of a
+                    Gateway \n The pre-defined values listed in this package can be
+                    compared semantically. `Public` has a larger scope than `Private`,
                     while `Private` has a larger scope than `Cluster`. \n Implementations
                     can define custom routability values by specifying a vendor prefix
                     followed by a slash '/' and a custom name ie. `dev.example.com/my-routability`."
@@ -445,9 +445,9 @@ spec:
                   MUST populate this list with the GatewayRoutability values that
                   are supported by this GatewayClass. \n <gateway:experimental>"
                 items:
-                  description: "GatewayRoutablility represents the routability of
-                    a Gateway \n The pre-defined values listed in this package can
-                    be compared semantically. `Public` has a larger scope than `Private`,
+                  description: "GatewayRoutability represents the routability of a
+                    Gateway \n The pre-defined values listed in this package can be
+                    compared semantically. `Public` has a larger scope than `Private`,
                     while `Private` has a larger scope than `Cluster`. \n Implementations
                     can define custom routability values by specifying a vendor prefix
                     followed by a slash '/' and a custom name ie. `dev.example.com/my-routability`."

--- a/conformance/tests/gateway-routability-default.yaml
+++ b/conformance/tests/gateway-routability-default.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
-  name: gateway-public-routability
+  name: gateway-default-routability
   namespace: gateway-conformance-infra
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -113,6 +113,10 @@ const (
 // See: https://github.com/kubernetes-sigs/gateway-api/issues/1891
 var ExperimentalExtendedFeatures = sets.New(
 	SupportRouteDestinationPortMatching,
+	SupportGatewayClassRoutability,
+	SupportGatewayPublicRoutability,
+	SupportGatewayPrivateRoutability,
+	SupportGatewayClusterRoutability,
 )
 
 // -----------------------------------------------------------------------------

--- a/geps/gep-1651.md
+++ b/geps/gep-1651.md
@@ -81,7 +81,7 @@ MAY choose to leave the old Gateway running with the previous generation's confi
 
 ```go
 
-// GatewayRoutablility represents the routability of a Gateway
+// GatewayRoutability represents the routability of a Gateway
 //
 // The pre-defined values listed in this package can be compared semantically.
 // `Public` has a larger scope than `Private`, while `Private` has a larger scope than


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup
/kind test
/area conformance

**What this PR does / why we need it**:

The new routability tests are not runnable, they are not included in the set of all features and also have various issues

- fix manifest file names
- gateway names/typos
- move to testify require statements to prevent tests to continue to execute when preconditions not met (to prevent panics) and to simplify test logic

Other issues still remain and will be covered in subsequent issues for discussion, this does not make a guarantee the logic of these tests is correct since there is no implementation that supports them yet.

**Which issue(s) this PR fixes**:

Fixes #2204

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
