### PR TITLE
Introduce validations through CEL for Gateway and GatewayClass.

### DIFF
--- a/apis/v1beta1/gatewayclass_types.go
+++ b/apis/v1beta1/gatewayclass_types.go
@@ -78,6 +78,8 @@ type GatewayClassSpec struct {
 	// This field is not mutable and cannot be empty.
 	//
 	// Support: Core
+	//
+	// +kubebuilder:validation:XValidation:message="Value is immutable",rule="self == oldSelf"
 	ControllerName GatewayController `json:"controllerName"`
 
 	// ParametersRef is a reference to a resource that contains the configuration

--- a/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -78,6 +78,9 @@ spec:
                 minLength: 1
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               description:
                 description: Description helps describe a GatewayClass with more details.
                 maxLength: 64
@@ -299,6 +302,9 @@ spec:
                 minLength: 1
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               description:
                 description: Description helps describe a GatewayClass with more details.
                 maxLength: 64

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -95,8 +95,20 @@ spec:
                   required:
                   - value
                   type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must only contain valid characters (matching
+                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? self.value.matches(''^(\\*\\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$''):
+                      true'
                 maxItems: 16
                 type: array
+                x-kubernetes-validations:
+                - message: IPAddress values must be unique
+                  rule: 'self.all(a1, a1.type == ''IPAddress'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
+                - message: Hostname values must be unique
+                  rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
               gatewayClassName:
                 description: GatewayClassName used for this Gateway. This is the name
                   of a GatewayClass resource.
@@ -459,6 +471,11 @@ spec:
                           maxProperties: 16
                           type: object
                       type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs must be set and not empty when TLSModeType
+                          is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 : true'
                   required:
                   - name
                   - port
@@ -470,6 +487,23 @@ spec:
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: tls must be set for protocols ['HTTPS', 'TLS']
+                  rule: 'self.all(l, l.protocol in [''HTTPS'', ''TLS''] ? has(l.tls)
+                    : true)'
+                - message: tls must be empty for protocols ['HTTP', 'TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
+                    !has(l.tls) : true)'
+                - message: hostname must be empty for protocols ['TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                    || l.hostname == '''') : true)'
+                - message: Listener name must be unique within the Gateway
+                  rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
+                - message: Combination of port, protocol and hostname must be unique
+                    for each listener
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
+                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
+                    == l2.hostname : true)))'
             required:
             - gatewayClassName
             - listeners
@@ -840,8 +874,20 @@ spec:
                   required:
                   - value
                   type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must only contain valid characters (matching
+                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? self.value.matches(''^(\\*\\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$''):
+                      true'
                 maxItems: 16
                 type: array
+                x-kubernetes-validations:
+                - message: IPAddress values must be unique
+                  rule: 'self.all(a1, a1.type == ''IPAddress'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
+                - message: Hostname values must be unique
+                  rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
               gatewayClassName:
                 description: GatewayClassName used for this Gateway. This is the name
                   of a GatewayClass resource.
@@ -1204,6 +1250,11 @@ spec:
                           maxProperties: 16
                           type: object
                       type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs must be set and not empty when TLSModeType
+                          is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 : true'
                   required:
                   - name
                   - port
@@ -1215,6 +1266,23 @@ spec:
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: tls must be set for protocols ['HTTPS', 'TLS']
+                  rule: 'self.all(l, l.protocol in [''HTTPS'', ''TLS''] ? has(l.tls)
+                    : true)'
+                - message: tls must be empty for protocols ['HTTP', 'TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
+                    !has(l.tls) : true)'
+                - message: hostname must be empty for protocols ['TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                    || l.hostname == '''') : true)'
+                - message: Listener name must be unique within the Gateway
+                  rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
+                - message: Combination of port, protocol and hostname must be unique
+                    for each listener
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
+                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
+                    == l2.hostname : true)))'
             required:
             - gatewayClassName
             - listeners

--- a/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -78,6 +78,9 @@ spec:
                 minLength: 1
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               description:
                 description: Description helps describe a GatewayClass with more details.
                 maxLength: 64
@@ -278,6 +281,9 @@ spec:
                 minLength: 1
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               description:
                 description: Description helps describe a GatewayClass with more details.
                 maxLength: 64

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -95,8 +95,20 @@ spec:
                   required:
                   - value
                   type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must only contain valid characters (matching
+                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? self.value.matches(''^(\\*\\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$''):
+                      true'
                 maxItems: 16
                 type: array
+                x-kubernetes-validations:
+                - message: IPAddress values must be unique
+                  rule: 'self.all(a1, a1.type == ''IPAddress'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
+                - message: Hostname values must be unique
+                  rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
               gatewayClassName:
                 description: GatewayClassName used for this Gateway. This is the name
                   of a GatewayClass resource.
@@ -435,6 +447,11 @@ spec:
                           maxProperties: 16
                           type: object
                       type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs must be set and not empty when TLSModeType
+                          is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 : true'
                   required:
                   - name
                   - port
@@ -446,6 +463,23 @@ spec:
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: tls must be set for protocols ['HTTPS', 'TLS']
+                  rule: 'self.all(l, l.protocol in [''HTTPS'', ''TLS''] ? has(l.tls)
+                    : true)'
+                - message: tls must be empty for protocols ['HTTP', 'TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
+                    !has(l.tls) : true)'
+                - message: hostname must be empty for protocols ['TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                    || l.hostname == '''') : true)'
+                - message: Listener name must be unique within the Gateway
+                  rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
+                - message: Combination of port, protocol and hostname must be unique
+                    for each listener
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
+                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
+                    == l2.hostname : true)))'
             required:
             - gatewayClassName
             - listeners
@@ -807,8 +841,20 @@ spec:
                   required:
                   - value
                   type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must only contain valid characters (matching
+                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? self.value.matches(''^(\\*\\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$''):
+                      true'
                 maxItems: 16
                 type: array
+                x-kubernetes-validations:
+                - message: IPAddress values must be unique
+                  rule: 'self.all(a1, a1.type == ''IPAddress'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
+                - message: Hostname values must be unique
+                  rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
+                    a2.type == a1.type && a2.value == a1.value) : true )'
               gatewayClassName:
                 description: GatewayClassName used for this Gateway. This is the name
                   of a GatewayClass resource.
@@ -1147,6 +1193,11 @@ spec:
                           maxProperties: 16
                           type: object
                       type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs must be set and not empty when TLSModeType
+                          is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 : true'
                   required:
                   - name
                   - port
@@ -1158,6 +1209,23 @@ spec:
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: tls must be set for protocols ['HTTPS', 'TLS']
+                  rule: 'self.all(l, l.protocol in [''HTTPS'', ''TLS''] ? has(l.tls)
+                    : true)'
+                - message: tls must be empty for protocols ['HTTP', 'TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
+                    !has(l.tls) : true)'
+                - message: hostname must be empty for protocols ['TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                    || l.hostname == '''') : true)'
+                - message: Listener name must be unique within the Gateway
+                  rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
+                - message: Combination of port, protocol and hostname must be unique
+                    for each listener
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
+                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
+                    == l2.hostname : true)))'
             required:
             - gatewayClassName
             - listeners

--- a/hack/cel-validation/gateway_test.go
+++ b/hack/cel-validation/gateway_test.go
@@ -1,0 +1,470 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	gatewayv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidateGateway(t *testing.T) {
+	ctx := context.Background()
+	baseGateway := gatewayv1b1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: gatewayv1b1.GatewaySpec{
+			GatewayClassName: "foo",
+			Listeners: []gatewayv1b1.Listener{
+				{
+					Name:     gatewayv1b1.SectionName("http"),
+					Protocol: gatewayv1b1.HTTPProtocolType,
+					Port:     gatewayv1b1.PortNumber(80),
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		desc       string
+		mutate     func(gw *gatewayv1b1.Gateway)
+		wantErrors []string
+	}{
+		{
+			desc: "tls config present with http protocol",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("http"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(8080),
+						TLS:      &gatewayv1b1.GatewayTLSConfig{},
+					},
+				}
+			},
+			wantErrors: []string{"tls must be empty for protocols ['HTTP', 'TCP', 'UDP']"},
+		},
+		{
+			desc: "tls config present with tcp protocol",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("tcp"),
+						Protocol: gatewayv1b1.TCPProtocolType,
+						Port:     gatewayv1b1.PortNumber(8080),
+						TLS:      &gatewayv1b1.GatewayTLSConfig{},
+					},
+				}
+			},
+			wantErrors: []string{"tls must be empty for protocols ['HTTP', 'TCP', 'UDP']"},
+		},
+		{
+			desc: "tls config not set with https protocol",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("https"),
+						Protocol: gatewayv1b1.HTTPSProtocolType,
+						Port:     gatewayv1b1.PortNumber(8443),
+					},
+				}
+			},
+			wantErrors: []string{"tls must be set for protocols ['HTTPS', 'TLS']"},
+		},
+		{
+			desc: "tls config not set with tls protocol",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("tls"),
+						Protocol: gatewayv1b1.TLSProtocolType,
+						Port:     gatewayv1b1.PortNumber(8443),
+					},
+				}
+			},
+			wantErrors: []string{"tls must be set for protocols ['HTTPS', 'TLS']"},
+		},
+		{
+			desc: "tls config not set with http protocol",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("http"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(8080),
+					},
+				}
+			},
+		},
+		{
+			desc: "tls config not set with tcp protocol",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("tcp"),
+						Protocol: gatewayv1b1.TCPProtocolType,
+						Port:     gatewayv1b1.PortNumber(8080),
+					},
+				}
+			},
+		},
+		{
+			desc: "tls config not set with udp protocol",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("udp"),
+						Protocol: gatewayv1b1.UDPProtocolType,
+						Port:     gatewayv1b1.PortNumber(8080),
+					},
+				}
+			},
+		},
+		{
+			desc: "hostname present with tcp protocol",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				hostname := gatewayv1b1.Hostname("foo")
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("tcp"),
+						Protocol: gatewayv1b1.TCPProtocolType,
+						Port:     gatewayv1b1.PortNumber(8080),
+						Hostname: &hostname,
+					},
+				}
+			},
+			wantErrors: []string{"hostname must be empty for protocols ['TCP', 'UDP']"},
+		},
+		{
+			desc: "hostname present with udp protocol",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				hostname := gatewayv1b1.Hostname("foo")
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("udp"),
+						Protocol: gatewayv1b1.UDPProtocolType,
+						Port:     gatewayv1b1.PortNumber(8080),
+						Hostname: &hostname,
+					},
+				}
+			},
+			wantErrors: []string{"hostname must be empty for protocols ['TCP', 'UDP']"},
+		},
+		{
+			desc: "certificatedRefs not set with https protocol and TLS terminate mode",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				tlsMode := gatewayv1b1.TLSModeType("Terminate")
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("https"),
+						Protocol: gatewayv1b1.HTTPSProtocolType,
+						Port:     gatewayv1b1.PortNumber(8443),
+						TLS: &gatewayv1b1.GatewayTLSConfig{
+							Mode: &tlsMode,
+						},
+					},
+				}
+			},
+			wantErrors: []string{"certificateRefs must be set and not empty when TLSModeType is Terminate"},
+		},
+		{
+			desc: "certificatedRefs not set with tls protocol and TLS terminate mode",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				tlsMode := gatewayv1b1.TLSModeType("Terminate")
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("tls"),
+						Protocol: gatewayv1b1.TLSProtocolType,
+						Port:     gatewayv1b1.PortNumber(8443),
+						TLS: &gatewayv1b1.GatewayTLSConfig{
+							Mode: &tlsMode,
+						},
+					},
+				}
+			},
+			wantErrors: []string{"certificateRefs must be set and not empty when TLSModeType is Terminate"},
+		},
+		{
+			desc: "certificatedRefs set with tls protocol and TLS terminate mode",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				tlsMode := gatewayv1b1.TLSModeType("Terminate")
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("tls"),
+						Protocol: gatewayv1b1.TLSProtocolType,
+						Port:     gatewayv1b1.PortNumber(8443),
+						TLS: &gatewayv1b1.GatewayTLSConfig{
+							Mode: &tlsMode,
+							CertificateRefs: []gatewayv1b1.SecretObjectReference{
+								{Name: gatewayv1b1.ObjectName("foo")},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "names are not unique within the Gateway",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("http"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(80),
+					},
+					{
+						Name:     gatewayv1b1.SectionName("http"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(8000),
+					},
+					{
+						Name:     gatewayv1b1.SectionName("http"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(8080),
+					},
+				}
+			},
+			wantErrors: []string{"Listener name must be unique within the Gateway"},
+		},
+		{
+			desc: "names are unique within the Gateway",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("http-1"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(80),
+					},
+					{
+						Name:     gatewayv1b1.SectionName("http-2"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(8000),
+					},
+					{
+						Name:     gatewayv1b1.SectionName("http-3"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(8080),
+					},
+				}
+			},
+		},
+		{
+			desc: "combination of port, protocol, and hostname are not unique for each listener",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				hostnameFoo := gatewayv1b1.Hostname("foo.com")
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("foo"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(80),
+						Hostname: &hostnameFoo,
+					},
+					{
+						Name:     gatewayv1b1.SectionName("bar"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(80),
+						Hostname: &hostnameFoo,
+					},
+				}
+			},
+			wantErrors: []string{"Combination of port, protocol and hostname must be unique for each listener"},
+		},
+		{
+			desc: "combination of port and protocol are not unique for each listener when hostnames not set",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("foo"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(80),
+					},
+					{
+						Name:     gatewayv1b1.SectionName("bar"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(80),
+					},
+				}
+			},
+			wantErrors: []string{"Combination of port, protocol and hostname must be unique for each listener"},
+		},
+		{
+			desc: "port is unique when protocol and hostname are the same",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				hostnameFoo := gatewayv1b1.Hostname("foo.com")
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("foo"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(80),
+						Hostname: &hostnameFoo,
+					},
+					{
+						Name:     gatewayv1b1.SectionName("bar"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(8000),
+						Hostname: &hostnameFoo,
+					},
+				}
+			},
+		},
+		{
+			desc: "hostname is unique when protocol and port are the same",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				hostnameFoo := gatewayv1b1.Hostname("foo.com")
+				hostnameBar := gatewayv1b1.Hostname("bar.com")
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("foo"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(80),
+						Hostname: &hostnameFoo,
+					},
+					{
+						Name:     gatewayv1b1.SectionName("bar"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(80),
+						Hostname: &hostnameBar,
+					},
+				}
+			},
+		},
+		{
+			desc: "protocol is unique when port and hostname are the same",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				hostnameFoo := gatewayv1b1.Hostname("foo.com")
+				gw.Spec.Listeners = []gatewayv1b1.Listener{
+					{
+						Name:     gatewayv1b1.SectionName("foo"),
+						Protocol: gatewayv1b1.HTTPProtocolType,
+						Port:     gatewayv1b1.PortNumber(8000),
+						Hostname: &hostnameFoo,
+					},
+					{
+						Name:     gatewayv1b1.SectionName("bar"),
+						Protocol: gatewayv1b1.HTTPSProtocolType,
+						Port:     gatewayv1b1.PortNumber(8000),
+						Hostname: &hostnameFoo,
+						TLS: &gatewayv1b1.GatewayTLSConfig{
+							CertificateRefs: []gatewayv1b1.SecretObjectReference{
+								{Name: gatewayv1b1.ObjectName("foo")},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "ip address and hostname in addresses are valid",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Addresses = []gatewayv1b1.GatewayAddress{
+					{
+						Type:  ptrTo(gatewayv1b1.IPAddressType),
+						Value: "1.2.3.4",
+					},
+					{
+						Type:  ptrTo(gatewayv1b1.IPAddressType),
+						Value: "1111:2222:3333:4444::",
+					},
+					{
+						Type:  ptrTo(gatewayv1b1.HostnameAddressType),
+						Value: "foo.bar",
+					},
+				}
+			},
+		},
+		{
+			desc: "ip address and hostname in addresses are invalid",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Addresses = []gatewayv1b1.GatewayAddress{
+					{
+						// TODO(gauravkghildiyal): Figure out a sensible way to check
+						// validity of IP addresses. Admission webhook uses golang IP
+						// parsing which may not be directly translateable to regex matching
+						// in CEL. At the moment, this value will not result in an error.
+						Type:  ptrTo(gatewayv1b1.IPAddressType),
+						Value: "1.2.3.4:8080",
+					},
+					{
+						Type:  ptrTo(gatewayv1b1.HostnameAddressType),
+						Value: "*foo/bar",
+					},
+					{
+						Type:  ptrTo(gatewayv1b1.HostnameAddressType),
+						Value: "12:34:56::",
+					},
+				}
+			},
+			wantErrors: []string{"Hostname value must only contain valid characters (matching ^(\\*\\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)"},
+		},
+		{
+			desc: "duplicate ip address or hostname",
+			mutate: func(gw *gatewayv1b1.Gateway) {
+				gw.Spec.Addresses = []gatewayv1b1.GatewayAddress{
+					{
+						Type:  ptrTo(gatewayv1b1.IPAddressType),
+						Value: "1.2.3.4",
+					},
+					{
+						Type:  ptrTo(gatewayv1b1.IPAddressType),
+						Value: "1.2.3.4",
+					},
+					{
+						Type:  ptrTo(gatewayv1b1.HostnameAddressType),
+						Value: "foo.bar",
+					},
+					{
+						Type:  ptrTo(gatewayv1b1.HostnameAddressType),
+						Value: "foo.bar",
+					},
+				}
+			},
+			wantErrors: []string{"IPAddress values must be unique", "Hostname values must be unique"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			gwc := baseGateway.DeepCopy()
+			gwc.Name = fmt.Sprintf("foo-%v", time.Now().UnixNano())
+
+			tc.mutate(gwc)
+			err := k8sClient.Create(ctx, gwc)
+
+			if (len(tc.wantErrors) != 0) != (err != nil) {
+				t.Fatalf("Unexpected error while creating Gateway; got err=\n%v\n;want error=%v", err, tc.wantErrors != nil)
+			}
+
+			var missingErrorStrings []string
+			for _, wantError := range tc.wantErrors {
+				if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(wantError)) {
+					missingErrorStrings = append(missingErrorStrings, wantError)
+				}
+			}
+			if len(missingErrorStrings) != 0 {
+				t.Errorf("Unexpected error while creating Gateway; got err=\n%v\n;missing strings within error=%q", err, missingErrorStrings)
+			}
+		})
+	}
+}

--- a/hack/cel-validation/gatewayclass_test.go
+++ b/hack/cel-validation/gatewayclass_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	gatewayv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidateGatewayClassUpdate(t *testing.T) {
+	ctx := context.Background()
+	baseGatewayClass := gatewayv1b1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		Spec: gatewayv1b1.GatewayClassSpec{
+			ControllerName: "example.net/gateway-controller",
+		},
+	}
+
+	testCases := []struct {
+		desc           string
+		creationMutate func(gw *gatewayv1b1.GatewayClass)
+		updationMutate func(gw *gatewayv1b1.GatewayClass)
+		wantError      string
+	}{
+		{
+			desc: "cannot upgrade controllerName",
+			creationMutate: func(gwc *gatewayv1b1.GatewayClass) {
+				gwc.Spec.ControllerName = "example.net/gateway-controller-1"
+			},
+			updationMutate: func(gwc *gatewayv1b1.GatewayClass) {
+				gwc.Spec.ControllerName = "example.net/gateway-controller-2"
+			},
+			wantError: "Value is immutable",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			gwc := baseGatewayClass.DeepCopy()
+			gwc.Name = fmt.Sprintf("foo-%v", time.Now().UnixNano())
+
+			tc.creationMutate(gwc)
+			if err := k8sClient.Create(ctx, gwc); err != nil {
+				t.Fatalf("Failed to create GatewayClass: %v", err)
+			}
+			tc.updationMutate(gwc)
+			err := k8sClient.Update(ctx, gwc)
+
+			if (tc.wantError != "") != (err != nil) {
+				t.Fatalf("Unexpected error while updating GatewayClass; got err=\n%v\n;want error=%v", err, tc.wantError != "")
+			}
+			if tc.wantError != "" && !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(tc.wantError)) {
+				t.Fatalf("Unexpected error while updating GatewayClass; got err=\n%v\n;want substring within error=%q", err, tc.wantError)
+			}
+		})
+	}
+}

--- a/hack/cel-validation/main_test.go
+++ b/hack/cel-validation/main_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var k8sClient client.Client
+
+func TestMain(m *testing.M) {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		kubeconfig = path.Join(os.Getenv("HOME"), ".kube/config")
+	}
+
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to get restConfig from BuildConfigFromFlags: %v", err))
+	}
+
+	k8sClient, err = client.New(restConfig, client.Options{})
+	if err != nil {
+		panic(fmt.Sprintf("Error initializing Kubernetes client: %v", err))
+	}
+	v1alpha2.AddToScheme(k8sClient.Scheme())
+	v1beta1.AddToScheme(k8sClient.Scheme())
+
+	os.Exit(m.Run())
+}
+
+func ptrTo[T any](a T) *T {
+	return &a
+}

--- a/hack/run-cel-validation-test.sh
+++ b/hack/run-cel-validation-test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO(https://github.com/kubernetes-sigs/gateway-api/issues/2239): Make this a
+# "verify" script (so that it runs along with the verification presubmit) once
+# we are confident about these tests.
+
+set -eo pipefail
+
+readonly GOFLAGS="-mod=readonly"
+readonly GO111MODULE="on"
+readonly GOPATH="$(mktemp -d)"
+readonly CLUSTER_NAME="verify-gateway-api-validation"
+
+export KUBECONFIG="${GOPATH}/.kubeconfig" # Do not modify the users kube-context by creating a separate kubeconfig
+export GOFLAGS GO111MODULE GOPATH
+export PATH="${GOPATH}/bin:${PATH}"
+
+cleanup() {
+  kind delete cluster --name "${CLUSTER_NAME}" || true
+}
+
+main() {
+  # Install KIND and create a KIND cluster.
+  (cd $GOPATH && go install sigs.k8s.io/kind@v0.20.0)
+  kind create cluster --name "${CLUSTER_NAME}"
+
+  # Install Gateway CRDs.
+  #
+  # It's expected that `make generate` has already been run to generate the
+  # lastest CRD yamls.
+  kubectl apply -k config/crd
+
+  # Run tests.
+  go test -timeout 120s sigs.k8s.io/gateway-api/hack/cel-validation
+
+  cleanup
+}
+
+exit_handler() {
+  if (($? != 0)); then
+    cleanup
+    echo "FAILED"
+    exit 1
+  fi
+}
+
+trap exit_handler EXIT
+
+main "${@}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind feature

**What this PR does / why we need it**:
Add support for CEL based validation for `Gateway` and `GatewayClass`. This allows us to have more complex validations than those supported by the OpenAPIv3 spec without the need of an additional validation webhook. Upcoming PRs will gradually extend this to HTTPRoutes (and other remaining resources) as well.

References:
* https://kubernetes.io/docs/reference/using-api/cel
* https://kubernetes.io/blog/2022/09/23/crd-validation-rules-beta/

Notes for the reviewers:
* The tests included in this PR perform error string comparisons. I understand that this may not be the most ideal choice but it helps establish some confidence that the validations are in fact working correctly.
* Tests aren't currently being run parallely for easier debugging when reading the test output. The tests itself barely take anytime so we may not have the need to run them parallely at the moment.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Introduce validations through CEL for Gateway and GatewayClass.
```
