### PR TITLE
Clarify necessity for implementations to handle GWC .status

### DIFF
--- a/apis/v1beta1/gatewayclass_types.go
+++ b/apis/v1beta1/gatewayclass_types.go
@@ -57,6 +57,9 @@ type GatewayClass struct {
 
 	// Status defines the current state of GatewayClass.
 	//
+	// Implementations MUST populate status on all GatewayClass resources which
+	// specify their controller name.
+	//
 	// +kubebuilder:default={conditions: {{type: "Accepted", status: "Unknown", message: "Waiting for controller", reason: "Waiting", lastTransitionTime: "1970-01-01T00:00:00Z"}}}
 	Status GatewayClassStatus `json:"status,omitempty"`
 }

--- a/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -132,7 +132,9 @@ spec:
                 reason: Waiting
                 status: Unknown
                 type: Accepted
-            description: Status defines the current state of GatewayClass.
+            description: "Status defines the current state of GatewayClass. \n Implementations
+              MUST populate status on all GatewayClass resources which specify their
+              controller name."
             properties:
               conditions:
                 default:
@@ -353,7 +355,9 @@ spec:
                 reason: Waiting
                 status: Unknown
                 type: Accepted
-            description: Status defines the current state of GatewayClass.
+            description: "Status defines the current state of GatewayClass. \n Implementations
+              MUST populate status on all GatewayClass resources which specify their
+              controller name."
             properties:
               conditions:
                 default:

--- a/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -132,7 +132,9 @@ spec:
                 reason: Waiting
                 status: Unknown
                 type: Accepted
-            description: Status defines the current state of GatewayClass.
+            description: "Status defines the current state of GatewayClass. \n Implementations
+              MUST populate status on all GatewayClass resources which specify their
+              controller name."
             properties:
               conditions:
                 default:
@@ -332,7 +334,9 @@ spec:
                 reason: Waiting
                 status: Unknown
                 type: Accepted
-            description: Status defines the current state of GatewayClass.
+            description: "Status defines the current state of GatewayClass. \n Implementations
+              MUST populate status on all GatewayClass resources which specify their
+              controller name."
             properties:
               conditions:
                 default:


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Clarifies that we expect implementations to handle the `.status` for `GatewayClass` resources which carry their `controllerName`.

**Which issue(s) this PR fixes**:

Resolves #1822 in support of #1781.