### PR TITLE
conformance: remove RESTClient in suite.Options, use interface where possible

### DIFF
--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -28,7 +28,6 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
@@ -60,7 +59,6 @@ func TestConformance(t *testing.T) {
 
 	cSuite := suite.New(suite.Options{
 		Client:     client,
-		RESTClient: clientset.CoreV1().RESTClient().(*rest.RESTClient),
 		RestConfig: cfg,
 		// This clientset is needed in addition to the client only because
 		// controller-runtime client doesn't support non CRUD sub-resources yet (https://github.com/kubernetes-sigs/controller-runtime/issues/452).

--- a/conformance/utils/echo/pod.go
+++ b/conformance/utils/echo/pod.go
@@ -42,7 +42,7 @@ type MeshPod struct {
 	Name      string
 	Namespace string
 	Address   string
-	rc        *rest.RESTClient
+	rc        rest.Interface
 	rcfg      *rest.Config
 }
 
@@ -171,7 +171,7 @@ func ConnectToAppInNamespace(t *testing.T, s *suite.ConformanceTestSuite, app Me
 		Name:      podName,
 		Namespace: podNamespace,
 		Address:   pod.Status.PodIP,
-		rc:        s.RESTClient,
+		rc:        s.Clientset.CoreV1().RESTClient(),
 		rcfg:      s.RestConfig,
 	}
 }

--- a/conformance/utils/suite/experimental_suite.go
+++ b/conformance/utils/suite/experimental_suite.go
@@ -151,7 +151,6 @@ func NewExperimentalConformanceTestSuite(s ExperimentalConformanceOptions) (*Exp
 	suite.ConformanceTestSuite = ConformanceTestSuite{
 		Client:           s.Client,
 		Clientset:        s.Clientset,
-		RESTClient:       s.RESTClient,
 		RestConfig:       s.RestConfig,
 		RoundTripper:     roundTripper,
 		GatewayClassName: s.GatewayClassName,

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -57,7 +57,6 @@ type ConformanceTestSuite struct {
 type Options struct {
 	Client           client.Client
 	Clientset        clientset.Interface
-	RESTClient       *rest.RESTClient
 	RestConfig       *rest.Config
 	GatewayClassName string
 	Debug            bool
@@ -111,7 +110,6 @@ func New(s Options) *ConformanceTestSuite {
 	suite := &ConformanceTestSuite{
 		Client:           s.Client,
 		Clientset:        s.Clientset,
-		RESTClient:       s.RESTClient,
 		RestConfig:       s.RestConfig,
 		RoundTripper:     roundTripper,
 		GatewayClassName: s.GatewayClassName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**

/kind cleanup
/area conformance

**What this PR does / why we need it**:

Simplifies the `suite.Options` interface, we can use the `Clientset` to get a `RESTClient`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
