### PR TITLE
Check ResolvedRefs condition in Gateway conformance tests

### DIFF
--- a/conformance/tests/gateway-modify-listeners.go
+++ b/conformance/tests/gateway-modify-listeners.go
@@ -87,11 +87,18 @@ var GatewayModifyListeners = suite.ConformanceTest{
 						Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
 						Kind:  v1beta1.Kind("HTTPRoute"),
 					}},
-					Conditions: []metav1.Condition{{
-						Type:   string(v1beta1.ListenerConditionAccepted),
-						Status: metav1.ConditionTrue,
-						Reason: "", // any reason
-					}},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1beta1.ListenerConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+						{
+							Type:   string(v1beta1.ListenerConditionResolvedRefs),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+					},
 					AttachedRoutes: 1,
 				},
 				{
@@ -100,11 +107,18 @@ var GatewayModifyListeners = suite.ConformanceTest{
 						Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
 						Kind:  v1beta1.Kind("HTTPRoute"),
 					}},
-					Conditions: []metav1.Condition{{
-						Type:   string(v1beta1.ListenerConditionAccepted),
-						Status: metav1.ConditionTrue,
-						Reason: "", // any reason
-					}},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1beta1.ListenerConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+						{
+							Type:   string(v1beta1.ListenerConditionResolvedRefs),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+					},
 					AttachedRoutes: 1,
 				},
 			}
@@ -161,11 +175,18 @@ var GatewayModifyListeners = suite.ConformanceTest{
 						Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
 						Kind:  v1beta1.Kind("HTTPRoute"),
 					}},
-					Conditions: []metav1.Condition{{
-						Type:   string(v1beta1.ListenerConditionAccepted),
-						Status: metav1.ConditionTrue,
-						Reason: "", // any reason
-					}},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1beta1.ListenerConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+						{
+							Type:   string(v1beta1.ListenerConditionResolvedRefs),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+					},
 					AttachedRoutes: 1,
 				},
 			}

--- a/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go
+++ b/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go
@@ -55,6 +55,11 @@ var GatewaySecretReferenceGrantAllInNamespace = suite.ConformanceTest{
 						Status: metav1.ConditionTrue,
 						Reason: string(v1beta1.ListenerReasonProgrammed),
 					},
+					{
+						Type:   string(v1beta1.ListenerConditionResolvedRefs),
+						Status: metav1.ConditionTrue,
+						Reason: "", // any reason
+					},
 				},
 				AttachedRoutes: 0,
 			}}

--- a/conformance/tests/gateway-secret-reference-grant-specific.go
+++ b/conformance/tests/gateway-secret-reference-grant-specific.go
@@ -55,6 +55,11 @@ var GatewaySecretReferenceGrantSpecific = suite.ConformanceTest{
 						Status: metav1.ConditionTrue,
 						Reason: string(v1beta1.ListenerReasonProgrammed),
 					},
+					{
+						Type:   string(v1beta1.ListenerConditionResolvedRefs),
+						Status: metav1.ConditionTrue,
+						Reason: "", // any reason
+					},
 				},
 				AttachedRoutes: 0,
 			}}

--- a/conformance/tests/gateway-with-attached-routes.go
+++ b/conformance/tests/gateway-with-attached-routes.go
@@ -47,11 +47,18 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 					Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
 					Kind:  v1beta1.Kind("HTTPRoute"),
 				}},
-				Conditions: []metav1.Condition{{
-					Type:   string(v1beta1.ListenerConditionAccepted),
-					Status: metav1.ConditionTrue,
-					Reason: "", // any reason
-				}},
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(v1beta1.ListenerConditionAccepted),
+						Status: metav1.ConditionTrue,
+						Reason: "", // any reason
+					},
+					{
+						Type:   string(v1beta1.ListenerConditionResolvedRefs),
+						Status: metav1.ConditionTrue,
+						Reason: "", // any reason
+					},
+				},
 				AttachedRoutes: 1,
 			}}
 
@@ -66,11 +73,18 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 					Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
 					Kind:  v1beta1.Kind("HTTPRoute"),
 				}},
-				Conditions: []metav1.Condition{{
-					Type:   string(v1beta1.ListenerConditionAccepted),
-					Status: metav1.ConditionTrue,
-					Reason: "", // any reason
-				}},
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(v1beta1.ListenerConditionAccepted),
+						Status: metav1.ConditionTrue,
+						Reason: "", // any reason
+					},
+					{
+						Type:   string(v1beta1.ListenerConditionResolvedRefs),
+						Status: metav1.ConditionTrue,
+						Reason: "", // any reason
+					},
+				},
 				AttachedRoutes: 2,
 			}}
 
@@ -97,11 +111,18 @@ var GatewayWithAttachedRoutesWithPort8080 = suite.ConformanceTest{
 						Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
 						Kind:  v1beta1.Kind("HTTPRoute"),
 					}},
-					Conditions: []metav1.Condition{{
-						Type:   string(v1beta1.ListenerConditionAccepted),
-						Status: metav1.ConditionTrue,
-						Reason: "", // any reason
-					}},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1beta1.ListenerConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+						{
+							Type:   string(v1beta1.ListenerConditionResolvedRefs),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+					},
 					AttachedRoutes: 0,
 				},
 				{
@@ -110,11 +131,18 @@ var GatewayWithAttachedRoutesWithPort8080 = suite.ConformanceTest{
 						Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
 						Kind:  v1beta1.Kind("HTTPRoute"),
 					}},
-					Conditions: []metav1.Condition{{
-						Type:   string(v1beta1.ListenerConditionAccepted),
-						Status: metav1.ConditionTrue,
-						Reason: "", // any reason
-					}},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1beta1.ListenerConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+						{
+							Type:   string(v1beta1.ListenerConditionResolvedRefs),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+					},
 					AttachedRoutes: 1,
 				},
 			}

--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -39,6 +39,10 @@ type TimeoutConfig struct {
 	// Max value for conformant implementation: None
 	GatewayStatusMustHaveListeners time.Duration
 
+	// GatewayListenersMustHaveCondition represents the maximum time for a Gateway to have all listeners with a specific condition.
+	// Max value for conformant implementation: None
+	GatewayListenersMustHaveCondition time.Duration
+
 	// GWCMustBeAccepted represents the maximum time for a GatewayClass to have an Accepted condition set to true.
 	// Max value for conformant implementation: None
 	GWCMustBeAccepted time.Duration
@@ -91,22 +95,23 @@ type TimeoutConfig struct {
 // DefaultTimeoutConfig populates a TimeoutConfig with the default values.
 func DefaultTimeoutConfig() TimeoutConfig {
 	return TimeoutConfig{
-		CreateTimeout:                  60 * time.Second,
-		DeleteTimeout:                  10 * time.Second,
-		GetTimeout:                     10 * time.Second,
-		GatewayMustHaveAddress:         180 * time.Second,
-		GatewayStatusMustHaveListeners: 60 * time.Second,
-		GWCMustBeAccepted:              180 * time.Second,
-		HTTPRouteMustNotHaveParents:    60 * time.Second,
-		HTTPRouteMustHaveCondition:     60 * time.Second,
-		TLSRouteMustHaveCondition:      60 * time.Second,
-		RouteMustHaveParents:           60 * time.Second,
-		ManifestFetchTimeout:           10 * time.Second,
-		MaxTimeToConsistency:           30 * time.Second,
-		NamespacesMustBeReady:          300 * time.Second,
-		RequestTimeout:                 10 * time.Second,
-		LatestObservedGenerationSet:    60 * time.Second,
-		RequiredConsecutiveSuccesses:   3,
+		CreateTimeout:                     60 * time.Second,
+		DeleteTimeout:                     10 * time.Second,
+		GetTimeout:                        10 * time.Second,
+		GatewayMustHaveAddress:            180 * time.Second,
+		GatewayStatusMustHaveListeners:    60 * time.Second,
+		GatewayListenersMustHaveCondition: 60 * time.Second,
+		GWCMustBeAccepted:                 180 * time.Second,
+		HTTPRouteMustNotHaveParents:       60 * time.Second,
+		HTTPRouteMustHaveCondition:        60 * time.Second,
+		TLSRouteMustHaveCondition:         60 * time.Second,
+		RouteMustHaveParents:              60 * time.Second,
+		ManifestFetchTimeout:              10 * time.Second,
+		MaxTimeToConsistency:              30 * time.Second,
+		NamespacesMustBeReady:             300 * time.Second,
+		RequestTimeout:                    10 * time.Second,
+		LatestObservedGenerationSet:       60 * time.Second,
+		RequiredConsecutiveSuccesses:      3,
 	}
 }
 
@@ -126,6 +131,9 @@ func SetupTimeoutConfig(timeoutConfig *TimeoutConfig) {
 	}
 	if timeoutConfig.GatewayStatusMustHaveListeners == 0 {
 		timeoutConfig.GatewayStatusMustHaveListeners = defaultTimeoutConfig.GatewayStatusMustHaveListeners
+	}
+	if timeoutConfig.GatewayListenersMustHaveCondition == 0 {
+		timeoutConfig.GatewayListenersMustHaveCondition = defaultTimeoutConfig.GatewayListenersMustHaveCondition
 	}
 	if timeoutConfig.GWCMustBeAccepted == 0 {
 		timeoutConfig.GWCMustBeAccepted = defaultTimeoutConfig.GWCMustBeAccepted

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -303,6 +303,11 @@ func GatewayAndHTTPRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutCo
 						Status: metav1.ConditionTrue,
 						Reason: string(v1beta1.RouteReasonAccepted),
 					},
+					{
+						Type:   string(v1beta1.ListenerConditionResolvedRefs),
+						Status: metav1.ConditionTrue,
+						Reason: "", // any reason
+					},
 				},
 			})
 		}

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -267,9 +267,12 @@ func MeshNamespacesMustBeReady(t *testing.T, c client.Client, timeoutConfig conf
 	require.NoErrorf(t, waitErr, "error waiting for %s namespaces to be ready", strings.Join(namespaces, ", "))
 }
 
-// GatewayAndHTTPRoutesMustBeAccepted waits until the specified Gateway has an IP
-// address assigned to it and the Route has a ParentRef referring to the
-// Gateway. The test will fail if these conditions are not met before the
+// GatewayAndHTTPRoutesMustBeAccepted waits until:
+// 1. The specified Gateway has an IP address assigned to it.
+// 2. The route has a ParentRef referring to the Gateway.
+// 3. All the gateway's listeners have the ListenerConditionResolvedRefs set to true.
+//
+// The test will fail if these conditions are not met before the
 // timeouts.
 func GatewayAndHTTPRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, controllerName string, gw GatewayRef, routeNNs ...types.NamespacedName) string {
 	t.Helper()
@@ -297,22 +300,23 @@ func GatewayAndHTTPRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutCo
 					SectionName: listener,
 				},
 				ControllerName: v1beta1.GatewayController(controllerName),
-				Conditions: []metav1.Condition{
-					{
-						Type:   string(v1beta1.RouteConditionAccepted),
-						Status: metav1.ConditionTrue,
-						Reason: string(v1beta1.RouteReasonAccepted),
-					},
-					{
-						Type:   string(v1beta1.ListenerConditionResolvedRefs),
-						Status: metav1.ConditionTrue,
-						Reason: "", // any reason
-					},
-				},
+				Conditions: []metav1.Condition{{
+					Type:   string(v1beta1.RouteConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: string(v1beta1.RouteReasonAccepted),
+				}},
 			})
 		}
 		HTTPRouteMustHaveParents(t, c, timeoutConfig, routeNN, parents, namespaceRequired)
 	}
+
+	resolvedRefsCondition := metav1.Condition{
+		Type:   string(v1beta1.ListenerConditionResolvedRefs),
+		Status: metav1.ConditionTrue,
+		Reason: "", // any reason
+	}
+
+	GatewayListenersMustHaveCondition(t, c, timeoutConfig, gw.NamespacedName, resolvedRefsCondition)
 
 	return gwAddr
 }
@@ -350,6 +354,29 @@ func WaitForGatewayAddress(t *testing.T, client client.Client, timeoutConfig con
 	})
 	require.NoErrorf(t, waitErr, "error waiting for Gateway to have at least one IP address in status")
 	return net.JoinHostPort(ipAddr, port), waitErr
+}
+
+// GatewayListenersMustHaveCondition checks if every listener of the specified gateway has a
+// certain condition.
+func GatewayListenersMustHaveCondition(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, gwName types.NamespacedName, condition metav1.Condition) {
+	t.Helper()
+
+	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.GatewayListenersMustHaveCondition, true, func(ctx context.Context) (bool, error) {
+		var gw v1beta1.Gateway
+		if err := client.Get(ctx, gwName, &gw); err != nil {
+			return false, fmt.Errorf("error fetching Gateway: %w", err)
+		}
+
+		for _, listener := range gw.Status.Listeners {
+			if !findConditionInList(t, listener.Conditions, condition.Type, string(condition.Status), condition.Reason) {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+
+	require.NoErrorf(t, waitErr, "error waiting for Gateway status to have a Condition matching expectations on all listeners")
 }
 
 // GatewayMustHaveZeroRoutes validates that the gateway has zero routes attached.  The status


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind test
/area conformance

**What this PR does / why we need it**:
Checks the `ListenerConditionResolvedRefs` value. This is needed to ensure that its value is always set, no matter if the `ConditionStatus` is true, or false.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1315 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
None
```
