### PR TITLE
UnsupportedRoutabilty Reason should only apply to the Accepted Condition

### DIFF
--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -177,7 +177,7 @@ type GatewayInfrastructure struct {
 	// specifies otherwise.
 	//
 	// If a Gateway is mutated but does not support the desired routability it MUST set the `Accepted`
-	// and `Programmed` conditions to `False` with `Reason` set to `UnsupportedRoutability`.
+	// condition to `False` with `Reason` set to `UnsupportedRoutability`.
 	//
 	// +optional
 	Routability *GatewayRoutability `json:"routability,omitempty"`
@@ -690,7 +690,7 @@ const (
 	// address exhaustion, address not yet allocated, or a named address not being found.
 	GatewayReasonAddressNotAssigned GatewayConditionReason = "AddressNotAssigned"
 
-	// This reason is used with "Programmed" and "Accepted" conditions when
+	// This reason is used with the "Accepted" conditions when
 	// desired routability is not able to be fulfilled by the implementation
 	GatewayUnsupportedRoutability GatewayConditionReason = "UnsupportedRoutability"
 )
@@ -712,6 +712,7 @@ const (
 	// * "NotReconciled"
 	// * "UnsupportedAddress"
 	// * "ListenersNotValid"
+	// * "UnsupportedRoutability"
 	//
 	// Possible reasons for this condition to be Unknown are:
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -132,8 +132,8 @@ spec:
                       expectation should be that changes to this field are not supported
                       unless an implementation specifies otherwise. \n If a Gateway
                       is mutated but does not support the desired routability it MUST
-                      set the `Accepted` and `Programmed` conditions to `False` with
-                      `Reason` set to `UnsupportedRoutability`."
+                      set the `Accepted` condition to `False` with `Reason` set to
+                      `UnsupportedRoutability`."
                     maxLength: 253
                     minLength: 1
                     pattern: ^Public|Private|Cluster|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-_]+$
@@ -911,8 +911,8 @@ spec:
                       expectation should be that changes to this field are not supported
                       unless an implementation specifies otherwise. \n If a Gateway
                       is mutated but does not support the desired routability it MUST
-                      set the `Accepted` and `Programmed` conditions to `False` with
-                      `Reason` set to `UnsupportedRoutability`."
+                      set the `Accepted` condition to `False` with `Reason` set to
+                      `UnsupportedRoutability`."
                     maxLength: 253
                     minLength: 1
                     pattern: ^Public|Private|Cluster|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-_]+$

--- a/geps/gep-1651.md
+++ b/geps/gep-1651.md
@@ -73,9 +73,9 @@ for more details.
 Implementations MAY prevent end-users from updating the `routability` value of a Gateway. If
 updates are allowed the semantics and behaviour will depend on the underlying implementation.
 
-If a Gateway is mutated but does not support the desired routability it MUST set the conditions
-`Accepted`, `Programmed` to `False` with `Reason` set to `UnsupportedRoutability`. Implementations
-MAY choose to leave the old Gateway running with the previous generation's configuration.
+If a Gateway is mutated but does not support the desired routability it MUST set the `Accepted` condition
+to `False` with `Reason` set to `UnsupportedRoutability`. Implementations MAY choose to leave the old
+Gateway running with the previous generation's configuration.
 
 ### Go
 
@@ -136,7 +136,7 @@ type GatewayInfrastructure struct {
   // Implementations MAY prevent end-users from updating the routability value of a Gateway.
   // If updates are allowed the semantics and behaviour will depend on the underlying implementation.
   // If a Gateway is mutated but does not support the desired routability it MUST set `Accepted` 
-  // and  `Programmed` conditions to `False` with `Reason` set to `UnsupportedRoutability`.
+  // condition to `False` with `Reason` set to `UnsupportedRoutability`.
   //
   // It is RECOMMENDED that in-cluster gateways SHOULD NOT support 'Private' routability.
   // Kubernetes doesn't have a concept of 'Private' routability for Services. In the future this may


### PR DESCRIPTION
/gep
/kind cleanup


**What this PR does / why we need it**:
This changes the UnsupportedRoutability Reason to only apply to the `Accepted` condition. This matches `UnsupportedAddress`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/2229

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
