### PR TITLE
Removing broken GAMMA link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,7 +123,6 @@ nav:
     - How to Get Involved: contributing/index.md
     - Developer Guide: contributing/devguide.md
     - Enhancement Requests: contributing/enhancement-requests.md
-    - GAMMA: contributing/gamma.md
     - Contributor Ladder: contributing/contributor-ladder.md
   - Blog:
     - Index: blog/index.md


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
This removes a broken link from the contributing nav. Fortunately any external links to https://gateway-api.sigs.k8s.io/contributing/gamma will continue to work because there's already a redirect in place (thanks @kflynn!). 

**Which issue(s) this PR fixes**:
Fixes #2259

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
