### PR TITLE
feat: Exclude experimental guidance from standard channel CRDs

### DIFF
--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -66,6 +66,7 @@ type ParentReference struct {
 	// Gateway has the AllowedRoutes field, and ReferenceGrant provides a
 	// generic way to enable any other kind of cross-namespace reference.
 	//
+	//<experimental:description>
 	// ParentRefs from a Route to a Service in the same namespace are "producer"
 	// routes, which apply default routing rules to inbound connections from
 	// any namespace to the Service.
@@ -75,6 +76,7 @@ type ParentReference struct {
 	// connections originating from the same namespace as the Route, for which
 	// the intended destination of the connections are a Service targeted as a
 	// ParentRef of the Route.
+	//</experimental:description>
 	//
 	// Support: Core
 	//
@@ -127,9 +129,11 @@ type ParentReference struct {
 	// and SectionName are specified, the name and port of the selected listener
 	// must match both specified values.
 	//
+	//<experimental:description>
 	// When the parent resource is a Service, this targets a specific port in the
 	// Service spec. When both Port (experimental) and SectionName are specified,
 	// the name and port of the selected port must match both specified values.
+	//</experimental:description>
 	//
 	// Implementations MAY choose to support other parent resources.
 	// Implementations supporting other types of parent resources MUST clearly
@@ -167,8 +171,9 @@ type CommonRouteSpec struct {
 	// There are two kinds of parent resources with "Core" support:
 	//
 	// * Gateway (Gateway conformance profile)
+	//<experimental:description>
 	// * Service (Mesh conformance profile, experimental, ClusterIP Services only)
-	//
+	//</experimental:description>
 	// This API may be extended in the future to support additional kinds of parent
 	// resources.
 	//
@@ -189,6 +194,7 @@ type CommonRouteSpec struct {
 	// Gateway has the AllowedRoutes field, and ReferenceGrant provides a
 	// generic way to enable other kinds of cross-namespace reference.
 	//
+	//<experimental:description>
 	// ParentRefs from a Route to a Service in the same namespace are "producer"
 	// routes, which apply default routing rules to inbound connections from
 	// any namespace to the Service.
@@ -198,6 +204,7 @@ type CommonRouteSpec struct {
 	// connections originating from the same namespace as the Route, for which
 	// the intended destination of the connections are a Service targeted as a
 	// ParentRef of the Route.
+	//</experimental:description>
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=32

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -66,7 +66,7 @@ type ParentReference struct {
 	// Gateway has the AllowedRoutes field, and ReferenceGrant provides a
 	// generic way to enable any other kind of cross-namespace reference.
 	//
-	//<experimental:description>
+	//<gateway:experimental:description>
 	// ParentRefs from a Route to a Service in the same namespace are "producer"
 	// routes, which apply default routing rules to inbound connections from
 	// any namespace to the Service.
@@ -76,7 +76,7 @@ type ParentReference struct {
 	// connections originating from the same namespace as the Route, for which
 	// the intended destination of the connections are a Service targeted as a
 	// ParentRef of the Route.
-	//</experimental:description>
+	//</gateway:experimental:description>
 	//
 	// Support: Core
 	//
@@ -129,11 +129,11 @@ type ParentReference struct {
 	// and SectionName are specified, the name and port of the selected listener
 	// must match both specified values.
 	//
-	//<experimental:description>
+	//<gateway:experimental:description>
 	// When the parent resource is a Service, this targets a specific port in the
 	// Service spec. When both Port (experimental) and SectionName are specified,
 	// the name and port of the selected port must match both specified values.
-	//</experimental:description>
+	//</gateway:experimental:description>
 	//
 	// Implementations MAY choose to support other parent resources.
 	// Implementations supporting other types of parent resources MUST clearly
@@ -171,9 +171,9 @@ type CommonRouteSpec struct {
 	// There are two kinds of parent resources with "Core" support:
 	//
 	// * Gateway (Gateway conformance profile)
-	//<experimental:description>
+	//<gateway:experimental:description>
 	// * Service (Mesh conformance profile, experimental, ClusterIP Services only)
-	//</experimental:description>
+	//</gateway:experimental:description>
 	// This API may be extended in the future to support additional kinds of parent
 	// resources.
 	//
@@ -194,7 +194,7 @@ type CommonRouteSpec struct {
 	// Gateway has the AllowedRoutes field, and ReferenceGrant provides a
 	// generic way to enable other kinds of cross-namespace reference.
 	//
-	//<experimental:description>
+	//<gateway:experimental:description>
 	// ParentRefs from a Route to a Service in the same namespace are "producer"
 	// routes, which apply default routing rules to inbound connections from
 	// any namespace to the Service.
@@ -204,7 +204,7 @@ type CommonRouteSpec struct {
 	// connections originating from the same namespace as the Route, for which
 	// the intended destination of the connections are a Service targeted as a
 	// ParentRef of the Route.
-	//</experimental:description>
+	//</gateway:experimental:description>
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=32

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -66,7 +66,7 @@ type ParentReference struct {
 	// Gateway has the AllowedRoutes field, and ReferenceGrant provides a
 	// generic way to enable any other kind of cross-namespace reference.
 	//
-	//<gateway:experimental:description>
+	// <gateway:experimental:description>
 	// ParentRefs from a Route to a Service in the same namespace are "producer"
 	// routes, which apply default routing rules to inbound connections from
 	// any namespace to the Service.
@@ -76,7 +76,7 @@ type ParentReference struct {
 	// connections originating from the same namespace as the Route, for which
 	// the intended destination of the connections are a Service targeted as a
 	// ParentRef of the Route.
-	//</gateway:experimental:description>
+	// </gateway:experimental:description>
 	//
 	// Support: Core
 	//
@@ -129,11 +129,11 @@ type ParentReference struct {
 	// and SectionName are specified, the name and port of the selected listener
 	// must match both specified values.
 	//
-	//<gateway:experimental:description>
+	// <gateway:experimental:description>
 	// When the parent resource is a Service, this targets a specific port in the
 	// Service spec. When both Port (experimental) and SectionName are specified,
 	// the name and port of the selected port must match both specified values.
-	//</gateway:experimental:description>
+	// </gateway:experimental:description>
 	//
 	// Implementations MAY choose to support other parent resources.
 	// Implementations supporting other types of parent resources MUST clearly
@@ -171,9 +171,9 @@ type CommonRouteSpec struct {
 	// There are two kinds of parent resources with "Core" support:
 	//
 	// * Gateway (Gateway conformance profile)
-	//<gateway:experimental:description>
+	// <gateway:experimental:description>
 	// * Service (Mesh conformance profile, experimental, ClusterIP Services only)
-	//</gateway:experimental:description>
+	// </gateway:experimental:description>
 	// This API may be extended in the future to support additional kinds of parent
 	// resources.
 	//
@@ -194,7 +194,7 @@ type CommonRouteSpec struct {
 	// Gateway has the AllowedRoutes field, and ReferenceGrant provides a
 	// generic way to enable other kinds of cross-namespace reference.
 	//
-	//<gateway:experimental:description>
+	// <gateway:experimental:description>
 	// ParentRefs from a Route to a Service in the same namespace are "producer"
 	// routes, which apply default routing rules to inbound connections from
 	// any namespace to the Service.
@@ -204,7 +204,7 @@ type CommonRouteSpec struct {
 	// connections originating from the same namespace as the Route, for which
 	// the intended destination of the connections are a Service targeted as a
 	// ParentRef of the Route.
-	//</gateway:experimental:description>
+	// </gateway:experimental:description>
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=32

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -522,13 +522,7 @@ spec:
                 description: "Addresses lists the IP addresses that have actually
                   been bound to the Gateway. These addresses may differ from the addresses
                   in the Spec, e.g. if the Gateway automatically assigns an address
-                  from a reserved pool. \n Implementations that support GatewayRoutability
-                  MUST include an address that has the same routable semantics as
-                  defined in the Gateway spec. \n Implementations MAY add additional
-                  addresses in status, but they MUST be semantically less than the
-                  scope of the requested scope. For example if a user requests a `Private`
-                  routable Gateway then an additional address MAY have a routability
-                  of `Cluster` but MUST NOT include `Public`."
+                  from a reserved pool. \n "
                 items:
                   description: GatewayStatusAddress describes an address that is bound
                     to a Gateway.
@@ -1306,13 +1300,7 @@ spec:
                 description: "Addresses lists the IP addresses that have actually
                   been bound to the Gateway. These addresses may differ from the addresses
                   in the Spec, e.g. if the Gateway automatically assigns an address
-                  from a reserved pool. \n Implementations that support GatewayRoutability
-                  MUST include an address that has the same routable semantics as
-                  defined in the Gateway spec. \n Implementations MAY add additional
-                  addresses in status, but they MUST be semantically less than the
-                  scope of the requested scope. For example if a user requests a `Private`
-                  routable Gateway then an additional address MAY have a routability
-                  of `Cluster` but MUST NOT include `Public`."
+                  from a reserved pool. \n "
                 items:
                   description: GatewayStatusAddress describes an address that is bound
                     to a Gateway.

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -522,7 +522,13 @@ spec:
                 description: "Addresses lists the IP addresses that have actually
                   been bound to the Gateway. These addresses may differ from the addresses
                   in the Spec, e.g. if the Gateway automatically assigns an address
-                  from a reserved pool. \n "
+                  from a reserved pool. \n Implementations that support GatewayRoutability
+                  MUST include an address that has the same routable semantics as
+                  defined in the Gateway spec. \n Implementations MAY add additional
+                  addresses in status, but they MUST be semantically less than the
+                  scope of the requested scope. For example if a user requests a `Private`
+                  routable Gateway then an additional address MAY have a routability
+                  of `Cluster` but MUST NOT include `Public`."
                 items:
                   description: GatewayStatusAddress describes an address that is bound
                     to a Gateway.
@@ -1300,7 +1306,13 @@ spec:
                 description: "Addresses lists the IP addresses that have actually
                   been bound to the Gateway. These addresses may differ from the addresses
                   in the Spec, e.g. if the Gateway automatically assigns an address
-                  from a reserved pool. \n "
+                  from a reserved pool. \n Implementations that support GatewayRoutability
+                  MUST include an address that has the same routable semantics as
+                  defined in the Gateway spec. \n Implementations MAY add additional
+                  addresses in status, but they MUST be semantically less than the
+                  scope of the requested scope. For example if a user requests a `Private`
+                  routable Gateway then an additional address MAY have a routability
+                  of `Cluster` but MUST NOT include `Public`."
                 items:
                   description: GatewayStatusAddress describes an address that is bound
                     to a Gateway.

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -134,8 +134,8 @@ spec:
                   for governing ParentRefs to Services - it is not possible to create
                   a \"producer\" route for a Service in a different namespace from
                   the Route. \n There are two kinds of parent resources with \"Core\"
-                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
-                  conformance profile, experimental, ClusterIP Services only) \n This
+                  support: \n * Gateway (Gateway conformance profile)  * Service (Mesh
+                  conformance profile, experimental, ClusterIP Services only)  This
                   API may be extended in the future to support additional kinds of
                   parent resources. \n It is invalid to reference an identical parent
                   more than once. It is valid to reference multiple distinct sections
@@ -150,14 +150,14 @@ spec:
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
                   field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
+                  kinds of cross-namespace reference. \n  ParentRefs from a Route
+                  to a Service in the same namespace are \"producer\" routes, which
+                  apply default routing rules to inbound connections from any namespace
                   to the Service. \n ParentRefs from a Route to a Service in a different
                   namespace are \"consumer\" routes, and these routing rules are only
                   applied to outbound connections originating from the same namespace
                   as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  are a Service targeted as a ParentRef of the Route.  \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -205,7 +205,7 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n ParentRefs from a Route to a Service in the same namespace
+                        \n  ParentRefs from a Route to a Service in the same namespace
                         are \"producer\" routes, which apply default routing rules
                         to inbound connections from any namespace to the Service.
                         \n ParentRefs from a Route to a Service in a different namespace
@@ -213,7 +213,7 @@ spec:
                         applied to outbound connections originating from the same
                         namespace as the Route, for which the intended destination
                         of the connections are a Service targeted as a ParentRef of
-                        the Route. \n Support: Core"
+                        the Route.  \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -228,11 +228,11 @@ spec:
                         a Route must apply to a specific port as opposed to a listener(s)
                         whose port(s) may be changed. When both Port and SectionName
                         are specified, the name and port of the selected listener
-                        must match both specified values. \n When the parent resource
+                        must match both specified values. \n  When the parent resource
                         is a Service, this targets a specific port in the Service
                         spec. When both Port (experimental) and SectionName are specified,
                         the name and port of the selected port must match both specified
-                        values. \n Implementations MAY choose to support other parent
+                        values.  \n Implementations MAY choose to support other parent
                         resources. Implementations supporting other types of parent
                         resources MUST clearly document how/if Port is interpreted.
                         \n For the purpose of status, an attachment is considered
@@ -1493,7 +1493,7 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n ParentRefs from a Route to a Service in
+                            reference. \n  ParentRefs from a Route to a Service in
                             the same namespace are \"producer\" routes, which apply
                             default routing rules to inbound connections from any
                             namespace to the Service. \n ParentRefs from a Route to
@@ -1501,7 +1501,7 @@ spec:
                             and these routing rules are only applied to outbound connections
                             originating from the same namespace as the Route, for
                             which the intended destination of the connections are
-                            a Service targeted as a ParentRef of the Route. \n Support:
+                            a Service targeted as a ParentRef of the Route.  \n Support:
                             Core"
                           maxLength: 63
                           minLength: 1
@@ -1518,11 +1518,11 @@ spec:
                             a specific port as opposed to a listener(s) whose port(s)
                             may be changed. When both Port and SectionName are specified,
                             the name and port of the selected listener must match
-                            both specified values. \n When the parent resource is
+                            both specified values. \n  When the parent resource is
                             a Service, this targets a specific port in the Service
                             spec. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected port must
-                            match both specified values. \n Implementations MAY choose
+                            match both specified values.  \n Implementations MAY choose
                             to support other parent resources. Implementations supporting
                             other types of parent resources MUST clearly document
                             how/if Port is interpreted. \n For the purpose of status,

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -121,8 +121,8 @@ spec:
                   for governing ParentRefs to Services - it is not possible to create
                   a \"producer\" route for a Service in a different namespace from
                   the Route. \n There are two kinds of parent resources with \"Core\"
-                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
-                  conformance profile, experimental, ClusterIP Services only) \n This
+                  support: \n * Gateway (Gateway conformance profile)  * Service (Mesh
+                  conformance profile, experimental, ClusterIP Services only)  This
                   API may be extended in the future to support additional kinds of
                   parent resources. \n It is invalid to reference an identical parent
                   more than once. It is valid to reference multiple distinct sections
@@ -137,14 +137,14 @@ spec:
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
                   field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
+                  kinds of cross-namespace reference. \n  ParentRefs from a Route
+                  to a Service in the same namespace are \"producer\" routes, which
+                  apply default routing rules to inbound connections from any namespace
                   to the Service. \n ParentRefs from a Route to a Service in a different
                   namespace are \"consumer\" routes, and these routing rules are only
                   applied to outbound connections originating from the same namespace
                   as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  are a Service targeted as a ParentRef of the Route.  \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -192,7 +192,7 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n ParentRefs from a Route to a Service in the same namespace
+                        \n  ParentRefs from a Route to a Service in the same namespace
                         are \"producer\" routes, which apply default routing rules
                         to inbound connections from any namespace to the Service.
                         \n ParentRefs from a Route to a Service in a different namespace
@@ -200,7 +200,7 @@ spec:
                         applied to outbound connections originating from the same
                         namespace as the Route, for which the intended destination
                         of the connections are a Service targeted as a ParentRef of
-                        the Route. \n Support: Core"
+                        the Route.  \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -215,11 +215,11 @@ spec:
                         a Route must apply to a specific port as opposed to a listener(s)
                         whose port(s) may be changed. When both Port and SectionName
                         are specified, the name and port of the selected listener
-                        must match both specified values. \n When the parent resource
+                        must match both specified values. \n  When the parent resource
                         is a Service, this targets a specific port in the Service
                         spec. When both Port (experimental) and SectionName are specified,
                         the name and port of the selected port must match both specified
-                        values. \n Implementations MAY choose to support other parent
+                        values.  \n Implementations MAY choose to support other parent
                         resources. Implementations supporting other types of parent
                         resources MUST clearly document how/if Port is interpreted.
                         \n For the purpose of status, an attachment is considered
@@ -2309,7 +2309,7 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n ParentRefs from a Route to a Service in
+                            reference. \n  ParentRefs from a Route to a Service in
                             the same namespace are \"producer\" routes, which apply
                             default routing rules to inbound connections from any
                             namespace to the Service. \n ParentRefs from a Route to
@@ -2317,7 +2317,7 @@ spec:
                             and these routing rules are only applied to outbound connections
                             originating from the same namespace as the Route, for
                             which the intended destination of the connections are
-                            a Service targeted as a ParentRef of the Route. \n Support:
+                            a Service targeted as a ParentRef of the Route.  \n Support:
                             Core"
                           maxLength: 63
                           minLength: 1
@@ -2334,11 +2334,11 @@ spec:
                             a specific port as opposed to a listener(s) whose port(s)
                             may be changed. When both Port and SectionName are specified,
                             the name and port of the selected listener must match
-                            both specified values. \n When the parent resource is
+                            both specified values. \n  When the parent resource is
                             a Service, this targets a specific port in the Service
                             spec. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected port must
-                            match both specified values. \n Implementations MAY choose
+                            match both specified values.  \n Implementations MAY choose
                             to support other parent resources. Implementations supporting
                             other types of parent resources MUST clearly document
                             how/if Port is interpreted. \n For the purpose of status,
@@ -2503,8 +2503,8 @@ spec:
                   for governing ParentRefs to Services - it is not possible to create
                   a \"producer\" route for a Service in a different namespace from
                   the Route. \n There are two kinds of parent resources with \"Core\"
-                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
-                  conformance profile, experimental, ClusterIP Services only) \n This
+                  support: \n * Gateway (Gateway conformance profile)  * Service (Mesh
+                  conformance profile, experimental, ClusterIP Services only)  This
                   API may be extended in the future to support additional kinds of
                   parent resources. \n It is invalid to reference an identical parent
                   more than once. It is valid to reference multiple distinct sections
@@ -2519,14 +2519,14 @@ spec:
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
                   field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
+                  kinds of cross-namespace reference. \n  ParentRefs from a Route
+                  to a Service in the same namespace are \"producer\" routes, which
+                  apply default routing rules to inbound connections from any namespace
                   to the Service. \n ParentRefs from a Route to a Service in a different
                   namespace are \"consumer\" routes, and these routing rules are only
                   applied to outbound connections originating from the same namespace
                   as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  are a Service targeted as a ParentRef of the Route.  \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -2574,7 +2574,7 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n ParentRefs from a Route to a Service in the same namespace
+                        \n  ParentRefs from a Route to a Service in the same namespace
                         are \"producer\" routes, which apply default routing rules
                         to inbound connections from any namespace to the Service.
                         \n ParentRefs from a Route to a Service in a different namespace
@@ -2582,7 +2582,7 @@ spec:
                         applied to outbound connections originating from the same
                         namespace as the Route, for which the intended destination
                         of the connections are a Service targeted as a ParentRef of
-                        the Route. \n Support: Core"
+                        the Route.  \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -2597,11 +2597,11 @@ spec:
                         a Route must apply to a specific port as opposed to a listener(s)
                         whose port(s) may be changed. When both Port and SectionName
                         are specified, the name and port of the selected listener
-                        must match both specified values. \n When the parent resource
+                        must match both specified values. \n  When the parent resource
                         is a Service, this targets a specific port in the Service
                         spec. When both Port (experimental) and SectionName are specified,
                         the name and port of the selected port must match both specified
-                        values. \n Implementations MAY choose to support other parent
+                        values.  \n Implementations MAY choose to support other parent
                         resources. Implementations supporting other types of parent
                         resources MUST clearly document how/if Port is interpreted.
                         \n For the purpose of status, an attachment is considered
@@ -4691,7 +4691,7 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n ParentRefs from a Route to a Service in
+                            reference. \n  ParentRefs from a Route to a Service in
                             the same namespace are \"producer\" routes, which apply
                             default routing rules to inbound connections from any
                             namespace to the Service. \n ParentRefs from a Route to
@@ -4699,7 +4699,7 @@ spec:
                             and these routing rules are only applied to outbound connections
                             originating from the same namespace as the Route, for
                             which the intended destination of the connections are
-                            a Service targeted as a ParentRef of the Route. \n Support:
+                            a Service targeted as a ParentRef of the Route.  \n Support:
                             Core"
                           maxLength: 63
                           minLength: 1
@@ -4716,11 +4716,11 @@ spec:
                             a specific port as opposed to a listener(s) whose port(s)
                             may be changed. When both Port and SectionName are specified,
                             the name and port of the selected listener must match
-                            both specified values. \n When the parent resource is
+                            both specified values. \n  When the parent resource is
                             a Service, this targets a specific port in the Service
                             spec. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected port must
-                            match both specified values. \n Implementations MAY choose
+                            match both specified values.  \n Implementations MAY choose
                             to support other parent resources. Implementations supporting
                             other types of parent resources MUST clearly document
                             how/if Port is interpreted. \n For the purpose of status,

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -56,8 +56,8 @@ spec:
                   for governing ParentRefs to Services - it is not possible to create
                   a \"producer\" route for a Service in a different namespace from
                   the Route. \n There are two kinds of parent resources with \"Core\"
-                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
-                  conformance profile, experimental, ClusterIP Services only) \n This
+                  support: \n * Gateway (Gateway conformance profile)  * Service (Mesh
+                  conformance profile, experimental, ClusterIP Services only)  This
                   API may be extended in the future to support additional kinds of
                   parent resources. \n It is invalid to reference an identical parent
                   more than once. It is valid to reference multiple distinct sections
@@ -72,14 +72,14 @@ spec:
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
                   field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
+                  kinds of cross-namespace reference. \n  ParentRefs from a Route
+                  to a Service in the same namespace are \"producer\" routes, which
+                  apply default routing rules to inbound connections from any namespace
                   to the Service. \n ParentRefs from a Route to a Service in a different
                   namespace are \"consumer\" routes, and these routing rules are only
                   applied to outbound connections originating from the same namespace
                   as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  are a Service targeted as a ParentRef of the Route.  \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -127,7 +127,7 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n ParentRefs from a Route to a Service in the same namespace
+                        \n  ParentRefs from a Route to a Service in the same namespace
                         are \"producer\" routes, which apply default routing rules
                         to inbound connections from any namespace to the Service.
                         \n ParentRefs from a Route to a Service in a different namespace
@@ -135,7 +135,7 @@ spec:
                         applied to outbound connections originating from the same
                         namespace as the Route, for which the intended destination
                         of the connections are a Service targeted as a ParentRef of
-                        the Route. \n Support: Core"
+                        the Route.  \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -150,11 +150,11 @@ spec:
                         a Route must apply to a specific port as opposed to a listener(s)
                         whose port(s) may be changed. When both Port and SectionName
                         are specified, the name and port of the selected listener
-                        must match both specified values. \n When the parent resource
+                        must match both specified values. \n  When the parent resource
                         is a Service, this targets a specific port in the Service
                         spec. When both Port (experimental) and SectionName are specified,
                         the name and port of the selected port must match both specified
-                        values. \n Implementations MAY choose to support other parent
+                        values.  \n Implementations MAY choose to support other parent
                         resources. Implementations supporting other types of parent
                         resources MUST clearly document how/if Port is interpreted.
                         \n For the purpose of status, an attachment is considered
@@ -496,7 +496,7 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n ParentRefs from a Route to a Service in
+                            reference. \n  ParentRefs from a Route to a Service in
                             the same namespace are \"producer\" routes, which apply
                             default routing rules to inbound connections from any
                             namespace to the Service. \n ParentRefs from a Route to
@@ -504,7 +504,7 @@ spec:
                             and these routing rules are only applied to outbound connections
                             originating from the same namespace as the Route, for
                             which the intended destination of the connections are
-                            a Service targeted as a ParentRef of the Route. \n Support:
+                            a Service targeted as a ParentRef of the Route.  \n Support:
                             Core"
                           maxLength: 63
                           minLength: 1
@@ -521,11 +521,11 @@ spec:
                             a specific port as opposed to a listener(s) whose port(s)
                             may be changed. When both Port and SectionName are specified,
                             the name and port of the selected listener must match
-                            both specified values. \n When the parent resource is
+                            both specified values. \n  When the parent resource is
                             a Service, this targets a specific port in the Service
                             spec. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected port must
-                            match both specified values. \n Implementations MAY choose
+                            match both specified values.  \n Implementations MAY choose
                             to support other parent resources. Implementations supporting
                             other types of parent resources MUST clearly document
                             how/if Port is interpreted. \n For the purpose of status,

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -102,8 +102,8 @@ spec:
                   for governing ParentRefs to Services - it is not possible to create
                   a \"producer\" route for a Service in a different namespace from
                   the Route. \n There are two kinds of parent resources with \"Core\"
-                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
-                  conformance profile, experimental, ClusterIP Services only) \n This
+                  support: \n * Gateway (Gateway conformance profile)  * Service (Mesh
+                  conformance profile, experimental, ClusterIP Services only)  This
                   API may be extended in the future to support additional kinds of
                   parent resources. \n It is invalid to reference an identical parent
                   more than once. It is valid to reference multiple distinct sections
@@ -118,14 +118,14 @@ spec:
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
                   field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
+                  kinds of cross-namespace reference. \n  ParentRefs from a Route
+                  to a Service in the same namespace are \"producer\" routes, which
+                  apply default routing rules to inbound connections from any namespace
                   to the Service. \n ParentRefs from a Route to a Service in a different
                   namespace are \"consumer\" routes, and these routing rules are only
                   applied to outbound connections originating from the same namespace
                   as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  are a Service targeted as a ParentRef of the Route.  \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -173,7 +173,7 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n ParentRefs from a Route to a Service in the same namespace
+                        \n  ParentRefs from a Route to a Service in the same namespace
                         are \"producer\" routes, which apply default routing rules
                         to inbound connections from any namespace to the Service.
                         \n ParentRefs from a Route to a Service in a different namespace
@@ -181,7 +181,7 @@ spec:
                         applied to outbound connections originating from the same
                         namespace as the Route, for which the intended destination
                         of the connections are a Service targeted as a ParentRef of
-                        the Route. \n Support: Core"
+                        the Route.  \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -196,11 +196,11 @@ spec:
                         a Route must apply to a specific port as opposed to a listener(s)
                         whose port(s) may be changed. When both Port and SectionName
                         are specified, the name and port of the selected listener
-                        must match both specified values. \n When the parent resource
+                        must match both specified values. \n  When the parent resource
                         is a Service, this targets a specific port in the Service
                         spec. When both Port (experimental) and SectionName are specified,
                         the name and port of the selected port must match both specified
-                        values. \n Implementations MAY choose to support other parent
+                        values.  \n Implementations MAY choose to support other parent
                         resources. Implementations supporting other types of parent
                         resources MUST clearly document how/if Port is interpreted.
                         \n For the purpose of status, an attachment is considered
@@ -545,7 +545,7 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n ParentRefs from a Route to a Service in
+                            reference. \n  ParentRefs from a Route to a Service in
                             the same namespace are \"producer\" routes, which apply
                             default routing rules to inbound connections from any
                             namespace to the Service. \n ParentRefs from a Route to
@@ -553,7 +553,7 @@ spec:
                             and these routing rules are only applied to outbound connections
                             originating from the same namespace as the Route, for
                             which the intended destination of the connections are
-                            a Service targeted as a ParentRef of the Route. \n Support:
+                            a Service targeted as a ParentRef of the Route.  \n Support:
                             Core"
                           maxLength: 63
                           minLength: 1
@@ -570,11 +570,11 @@ spec:
                             a specific port as opposed to a listener(s) whose port(s)
                             may be changed. When both Port and SectionName are specified,
                             the name and port of the selected listener must match
-                            both specified values. \n When the parent resource is
+                            both specified values. \n  When the parent resource is
                             a Service, this targets a specific port in the Service
                             spec. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected port must
-                            match both specified values. \n Implementations MAY choose
+                            match both specified values.  \n Implementations MAY choose
                             to support other parent resources. Implementations supporting
                             other types of parent resources MUST clearly document
                             how/if Port is interpreted. \n For the purpose of status,

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -56,8 +56,8 @@ spec:
                   for governing ParentRefs to Services - it is not possible to create
                   a \"producer\" route for a Service in a different namespace from
                   the Route. \n There are two kinds of parent resources with \"Core\"
-                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
-                  conformance profile, experimental, ClusterIP Services only) \n This
+                  support: \n * Gateway (Gateway conformance profile)  * Service (Mesh
+                  conformance profile, experimental, ClusterIP Services only)  This
                   API may be extended in the future to support additional kinds of
                   parent resources. \n It is invalid to reference an identical parent
                   more than once. It is valid to reference multiple distinct sections
@@ -72,14 +72,14 @@ spec:
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
                   field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
+                  kinds of cross-namespace reference. \n  ParentRefs from a Route
+                  to a Service in the same namespace are \"producer\" routes, which
+                  apply default routing rules to inbound connections from any namespace
                   to the Service. \n ParentRefs from a Route to a Service in a different
                   namespace are \"consumer\" routes, and these routing rules are only
                   applied to outbound connections originating from the same namespace
                   as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  are a Service targeted as a ParentRef of the Route.  \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -127,7 +127,7 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n ParentRefs from a Route to a Service in the same namespace
+                        \n  ParentRefs from a Route to a Service in the same namespace
                         are \"producer\" routes, which apply default routing rules
                         to inbound connections from any namespace to the Service.
                         \n ParentRefs from a Route to a Service in a different namespace
@@ -135,7 +135,7 @@ spec:
                         applied to outbound connections originating from the same
                         namespace as the Route, for which the intended destination
                         of the connections are a Service targeted as a ParentRef of
-                        the Route. \n Support: Core"
+                        the Route.  \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -150,11 +150,11 @@ spec:
                         a Route must apply to a specific port as opposed to a listener(s)
                         whose port(s) may be changed. When both Port and SectionName
                         are specified, the name and port of the selected listener
-                        must match both specified values. \n When the parent resource
+                        must match both specified values. \n  When the parent resource
                         is a Service, this targets a specific port in the Service
                         spec. When both Port (experimental) and SectionName are specified,
                         the name and port of the selected port must match both specified
-                        values. \n Implementations MAY choose to support other parent
+                        values.  \n Implementations MAY choose to support other parent
                         resources. Implementations supporting other types of parent
                         resources MUST clearly document how/if Port is interpreted.
                         \n For the purpose of status, an attachment is considered
@@ -496,7 +496,7 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n ParentRefs from a Route to a Service in
+                            reference. \n  ParentRefs from a Route to a Service in
                             the same namespace are \"producer\" routes, which apply
                             default routing rules to inbound connections from any
                             namespace to the Service. \n ParentRefs from a Route to
@@ -504,7 +504,7 @@ spec:
                             and these routing rules are only applied to outbound connections
                             originating from the same namespace as the Route, for
                             which the intended destination of the connections are
-                            a Service targeted as a ParentRef of the Route. \n Support:
+                            a Service targeted as a ParentRef of the Route.  \n Support:
                             Core"
                           maxLength: 63
                           minLength: 1
@@ -521,11 +521,11 @@ spec:
                             a specific port as opposed to a listener(s) whose port(s)
                             may be changed. When both Port and SectionName are specified,
                             the name and port of the selected listener must match
-                            both specified values. \n When the parent resource is
+                            both specified values. \n  When the parent resource is
                             a Service, this targets a specific port in the Service
                             spec. When both Port (experimental) and SectionName are
                             specified, the name and port of the selected port must
-                            match both specified values. \n Implementations MAY choose
+                            match both specified values.  \n Implementations MAY choose
                             to support other parent resources. Implementations supporting
                             other types of parent resources MUST clearly document
                             how/if Port is interpreted. \n For the purpose of status,

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -121,15 +121,14 @@ spec:
                   for governing ParentRefs to Services - it is not possible to create
                   a \"producer\" route for a Service in a different namespace from
                   the Route. \n There are two kinds of parent resources with \"Core\"
-                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
-                  conformance profile, experimental, ClusterIP Services only) \n This
-                  API may be extended in the future to support additional kinds of
-                  parent resources. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
+                  support: \n * Gateway (Gateway conformance profile)  This API may
+                  be extended in the future to support additional kinds of parent
+                  resources. \n It is invalid to reference an identical parent more
+                  than once. It is valid to reference multiple distinct sections within
+                  the same parent resource, such as two separate Listeners on the
+                  same Gateway or two separate ports on the same Service. \n It is
+                  possible to separately reference multiple distinct objects that
+                  may be collapsed by an implementation. For example, some implementations
                   may choose to merge compatible Gateway Listeners together. If that
                   is the case, the list of routes attached to those resources should
                   also be merged. \n Note that for ParentRefs that cross namespace
@@ -137,14 +136,7 @@ spec:
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
                   field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  kinds of cross-namespace reference. \n  \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -192,15 +184,7 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n ParentRefs from a Route to a Service in the same namespace
-                        are \"producer\" routes, which apply default routing rules
-                        to inbound connections from any namespace to the Service.
-                        \n ParentRefs from a Route to a Service in a different namespace
-                        are \"consumer\" routes, and these routing rules are only
-                        applied to outbound connections originating from the same
-                        namespace as the Route, for which the intended destination
-                        of the connections are a Service targeted as a ParentRef of
-                        the Route. \n Support: Core"
+                        \n  \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -2277,16 +2261,7 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n ParentRefs from a Route to a Service in
-                            the same namespace are \"producer\" routes, which apply
-                            default routing rules to inbound connections from any
-                            namespace to the Service. \n ParentRefs from a Route to
-                            a Service in a different namespace are \"consumer\" routes,
-                            and these routing rules are only applied to outbound connections
-                            originating from the same namespace as the Route, for
-                            which the intended destination of the connections are
-                            a Service targeted as a ParentRef of the Route. \n Support:
-                            Core"
+                            reference. \n  \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -2439,15 +2414,14 @@ spec:
                   for governing ParentRefs to Services - it is not possible to create
                   a \"producer\" route for a Service in a different namespace from
                   the Route. \n There are two kinds of parent resources with \"Core\"
-                  support: \n * Gateway (Gateway conformance profile) * Service (Mesh
-                  conformance profile, experimental, ClusterIP Services only) \n This
-                  API may be extended in the future to support additional kinds of
-                  parent resources. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
+                  support: \n * Gateway (Gateway conformance profile)  This API may
+                  be extended in the future to support additional kinds of parent
+                  resources. \n It is invalid to reference an identical parent more
+                  than once. It is valid to reference multiple distinct sections within
+                  the same parent resource, such as two separate Listeners on the
+                  same Gateway or two separate ports on the same Service. \n It is
+                  possible to separately reference multiple distinct objects that
+                  may be collapsed by an implementation. For example, some implementations
                   may choose to merge compatible Gateway Listeners together. If that
                   is the case, the list of routes attached to those resources should
                   also be merged. \n Note that for ParentRefs that cross namespace
@@ -2455,14 +2429,7 @@ spec:
                   are only valid if they are explicitly allowed by something in the
                   namespace they are referring to. For example, Gateway has the AllowedRoutes
                   field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  kinds of cross-namespace reference. \n  \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -2510,15 +2477,7 @@ spec:
                         the namespace they are referring to. For example: Gateway
                         has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
-                        \n ParentRefs from a Route to a Service in the same namespace
-                        are \"producer\" routes, which apply default routing rules
-                        to inbound connections from any namespace to the Service.
-                        \n ParentRefs from a Route to a Service in a different namespace
-                        are \"consumer\" routes, and these routing rules are only
-                        applied to outbound connections originating from the same
-                        namespace as the Route, for which the intended destination
-                        of the connections are a Service targeted as a ParentRef of
-                        the Route. \n Support: Core"
+                        \n  \n Support: Core"
                       maxLength: 63
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -4595,16 +4554,7 @@ spec:
                             in the namespace they are referring to. For example: Gateway
                             has the AllowedRoutes field, and ReferenceGrant provides
                             a generic way to enable any other kind of cross-namespace
-                            reference. \n ParentRefs from a Route to a Service in
-                            the same namespace are \"producer\" routes, which apply
-                            default routing rules to inbound connections from any
-                            namespace to the Service. \n ParentRefs from a Route to
-                            a Service in a different namespace are \"consumer\" routes,
-                            and these routing rules are only applied to outbound connections
-                            originating from the same namespace as the Route, for
-                            which the intended destination of the connections are
-                            a Service targeted as a ParentRef of the Route. \n Support:
-                            Core"
+                            reference. \n  \n Support: Core"
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -207,14 +207,14 @@ func gatewayTweaks(channel string, props map[string]apiext.JSONSchemaProps) map[
 				})
 			}
 		}
-		startTag := "<experimental:description:start>"
-		endTag := "<experimental:description:end>"
+		startTag := "<experimental:description>"
+		endTag := "</experimental:description>"
 		regexPattern := startTag + `(?s:(.*?))` + endTag
-		if channel == "standard" && strings.Contains(jsonProps.Description, "<experimental:description:start>") {
+		if channel == "standard" && strings.Contains(jsonProps.Description, "<experimental:description>") {
 			re := regexp.MustCompile(regexPattern)
 			match := re.FindStringSubmatch(jsonProps.Description)
 			if len(match) != 2 {
-				log.Fatalf("Invalid <experimental:description:start> tag for %s", name)
+				log.Fatalf("Invalid <experimental:description> tag for %s", name)
 			}
 			modifiedDescription := re.ReplaceAllString(jsonProps.Description, "")
 			jsonProps.Description = modifiedDescription

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -207,6 +207,22 @@ func gatewayTweaks(channel string, props map[string]apiext.JSONSchemaProps) map[
 				})
 			}
 		}
+		startTag := "<experimental:description:start>"
+		endTag := "<experimental:description:end>"
+		regexPattern := startTag + `(?s:(.*?))` + endTag
+		if channel == "standard" && strings.Contains(jsonProps.Description, "<experimental:description:start>") {
+			re := regexp.MustCompile(regexPattern)
+			match := re.FindStringSubmatch(jsonProps.Description)
+			if len(match) != 2 {
+				log.Fatalf("Invalid <experimental:description:start> tag for %s", name)
+			}
+			modifiedDescription := re.ReplaceAllString(jsonProps.Description, "")
+			jsonProps.Description = modifiedDescription
+
+		} else {
+			jsonProps.Description = strings.ReplaceAll(jsonProps.Description, startTag, "")
+			jsonProps.Description = strings.ReplaceAll(jsonProps.Description, endTag, "")
+		}
 
 		if numValid < numExpressions {
 			fmt.Printf("Description: %s\n", jsonProps.Description)

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -218,7 +218,6 @@ func gatewayTweaks(channel string, props map[string]apiext.JSONSchemaProps) map[
 			}
 			modifiedDescription := re.ReplaceAllString(jsonProps.Description, "")
 			jsonProps.Description = modifiedDescription
-
 		} else {
 			jsonProps.Description = strings.ReplaceAll(jsonProps.Description, startTag, "")
 			jsonProps.Description = strings.ReplaceAll(jsonProps.Description, endTag, "")

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -207,14 +207,14 @@ func gatewayTweaks(channel string, props map[string]apiext.JSONSchemaProps) map[
 				})
 			}
 		}
-		startTag := "<experimental:description>"
-		endTag := "</experimental:description>"
+		startTag := "<gateway:experimental:description>"
+		endTag := "</gateway:experimental:description>"
 		regexPattern := startTag + `(?s:(.*?))` + endTag
-		if channel == "standard" && strings.Contains(jsonProps.Description, "<experimental:description>") {
+		if channel == "standard" && strings.Contains(jsonProps.Description, "<gateway:experimental:description>") {
 			re := regexp.MustCompile(regexPattern)
 			match := re.FindStringSubmatch(jsonProps.Description)
 			if len(match) != 2 {
-				log.Fatalf("Invalid <experimental:description> tag for %s", name)
+				log.Fatalf("Invalid <gateway:experimental:description> tag for %s", name)
 			}
 			modifiedDescription := re.ReplaceAllString(jsonProps.Description, "")
 			jsonProps.Description = modifiedDescription


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:
This PR adds the feature where we can specifiy the start and end tag to the CRDs description which only need to be there in expremental channel CRDs and exclude from standard channel CRDs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2160

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Excluding experimental guidance in field descriptions from standard CRDs
```
