### PR TITLE
conformance: Remove already deleted option RestClient

### DIFF
--- a/conformance/experimental_conformance_test.go
+++ b/conformance/experimental_conformance_test.go
@@ -104,7 +104,6 @@ func testExperimentalConformance(t *testing.T) {
 		suite.ExperimentalConformanceOptions{
 			Options: suite.Options{
 				Client:     mgrClient,
-				RESTClient: k8sClientset.CoreV1().RESTClient().(*rest.RESTClient),
 				RestConfig: cfg,
 				// This clientset is needed in addition to the client only because
 				// controller-runtime client doesn't support non CRUD sub-resources yet (https://github.com/kubernetes-sigs/controller-runtime/issues/452).


### PR DESCRIPTION
**What this PR does / why we need it**:

To avoid compile issue if the experiment tag is enabled.

**Which issue(s) this PR fixes**:

The below PR remove RestClient option in suite.Options, but the same is not remove in Conformance Profile file, probably it's overlooked because of the build tag (e.g. experiment).

Relates: #2241

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
