### PR TITLE
Use '$(POD_NAMESPACE)' instead of hardcoded namespace

### DIFF
--- a/config/webhook/certificate_config.yaml
+++ b/config/webhook/certificate_config.yaml
@@ -92,8 +92,8 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - create
-        - --host=gateway-api-admission-server,gateway-api-admission-server.gateway-system.svc
-        - --namespace=gateway-system
+        - --host=gateway-api-admission-server,gateway-api-admission-server.$(POD_NAMESPACE).svc
+        - --namespace=$(POD_NAMESPACE)
         - --secret-name=gateway-api-admission
         env:
         - name: POD_NAMESPACE
@@ -139,7 +139,7 @@ spec:
         args:
         - patch
         - --webhook-name=gateway-api-admission
-        - --namespace=gateway-system
+        - --namespace=$(POD_NAMESPACE)
         - --patch-mutating=false
         - --patch-validating=true
         - --secret-name=gateway-api-admission


### PR DESCRIPTION
Properly reads the namespace from the actual deployment

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind regression
-->

**What this PR does / why we need it**:
Do not hardcode the namespace for Pod arguments. The existing 'POD_NAMESPACE' variable suggests that the namespace should have actually been read at runtime. Similar to nginx-ingress in https://github.com/kubernetes/ingress-nginx/blob/d712dd9d92f1f46eab5f55d4643f3a45a7a97f90/charts/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml#L52C15-L52C43

Addtionally, this should enable easier deployments into non default namespaces with (i.e -) kustomize namespace setting

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
* Enable deployments to non-default namespaces
```
