### PR TITLE
docs: update signet in owner aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,8 +4,8 @@
 aliases:
   # Reference: https://github.com/kubernetes/org/blob/main/OWNERS_ALIASES
   sig-network-leads:
-    - caseydavenport
-    - dcbw
+    - mikezappa87
+    - shaneutt
     - thockin
 
   # Reference: https://github.com/kubernetes/org/blob/main/config/kubernetes-sigs/sig-network/teams.yaml


### PR DESCRIPTION
While I was looking at this file today, I noticed we were out of date with the source at https://github.com/kubernetes/org/blob/main/OWNERS_ALIASES