### PR TITLE
Adds API to GEP-91: Client Certificate Validation

### DIFF
--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -72,11 +72,11 @@ spec:
       - kind: Secret
         group: ""
         name: foo-example-com-cert
-    clientValidation:
-      caCertificateRefs:
-      - kind: ConfigMap
-        group: ""
-        name: foo-example-com-ca-cert
+      clientValidation:
+        caCertificateRefs:
+        - kind: ConfigMap
+          group: ""
+          name: foo-example-com-ca-cert
 ```
 
 ## References

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -88,7 +88,7 @@ type GatewayTLSConfig struct {
 
 // FrontendTLSValidation holds configuration information that can be used to validate
 // the frontend initiating the TLS connection
-type FrontendTLSValidationContext struct {
+type FrontendTLSValidation struct {
     // CACertificateRefs contains one or more references to
     // Kubernetes objects that contain TLS certificates of
     // the Certificate Authorities that can be used
@@ -99,8 +99,8 @@ type FrontendTLSValidationContext struct {
     // Implementations MAY choose to support attaching multiple CA certificates to
     // a Listener, but this behavior is implementation-specific.
     //
-    // Support: Core - An optional single reference to a single Kubernetes Secret
-    // and to a single Kubernetes ConfigMap with the CA certificate in a key named `ca.crt`.
+    // Support: Core - A single reference to a single Kubernetes ConfigMap
+    // with the CA certificate in a key named `ca.crt`.
     //
     // Support: Implementation-specific (More than one reference, or other kinds
     // of resources).

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -71,7 +71,7 @@ type ClientValidationContext struct {
     //
     // +kubebuilder:validation:MaxItems=8
     // +optional
-    CACertificateRefs []corev1.ObjectReference `json:”caCertificateRefs,omitempty”`
+    CACertificateRefs []SecretObjectReference `json:”caCertificateRefs,omitempty”`
 }
 
 ```

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -51,7 +51,8 @@ type ClientValidationContext struct {
     // the Certificate Authorities that can be used
     // as a trust anchor to validate the certificates presented by the client.
     //
-    // A single CA certificate reference to a Kubernetes ConfigMap kind has "Core" support.
+    // A single CA certificate reference to a Kubernetes ConfigMap or Secret kind
+    // has "Core" support.
     // Implementations MAY choose to support attaching multiple CA certificates to
     // a Listener, but this behavior is implementation-specific.
     //

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -56,8 +56,8 @@ type ClientValidationContext struct {
     // Implementations MAY choose to support attaching multiple CA certificates to
     // a Listener, but this behavior is implementation-specific.
     //
-    // Support: Core - An optional single reference to a Kubernetes Secret and ConfigMap,
-    // with the CA certificate in a key named `ca.crt`.
+    // Support: Core - An optional single reference to a single Kubernetes Secret
+    // and to a single Kubernetes ConfigMap with the CA certificate in a key named `ca.crt`.
     //
     // Support: Implementation-specific (More than one reference, or other kinds
     // of resources).

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -38,10 +38,43 @@ This table highlights the support. Please feel free to add any missing implement
 * Introduce a `FrontendValidation` field of type `FrontendTLSValidation` within [GatewayTLSConfig][] that can be used to validate the peer (frontend) with which the TLS connection is being made.
 * Introduce a `caCertificateRefs` field within `FrontendTLSValidation` that can be used to specify a list of CA Certificates that can be used as a trust anchor to validate the certificates presented by the client.
 * This new field is mutually exclusive with the [BackendTLSPolicy][] configuation which is used to validate the TLS certificate presented by the backend peer on the connection between the Gateway and the backend, and this GEP is adding support for validating the TLS certificate presented by the frontend client on the connection between the Gateway and the frontend. Both these configurations can coexist at the same time without affecting one another.
+* Also introduce a `ObjectReference` structure that can be used to specify `caCertificateRefs` references.
 
 #### GO
 
 ```go
+// ObjectReference identifies an API object including its namespace.
+//
+// The API object must be valid in the cluster; the Group and Kind must
+// be registered in the cluster for this reference to be valid.
+//
+// References to objects with invalid Group and Kind are not valid, and must
+// be rejected by the implementation, with appropriate Conditions set
+// on the containing object.
+type ObjectReference struct {
+	// Group is the group of the referent. For example, "gateway.networking.k8s.io".
+	// When unspecified or empty string, core API group is inferred.
+	Group Group `json:"group"`
+
+	// Kind is kind of the referent. For example "ConfigMap" or "Service".
+	Kind Kind `json:"kind"`
+
+	// Name is the name of the referent.
+	Name ObjectName `json:"name"`
+
+	// Namespace is the namespace of the referenced object. When unspecified, the local
+	// namespace is inferred.
+	//
+	// Note that when a namespace different than the local namespace is specified,
+	// a ReferenceGrant object is required in the referent namespace to allow that
+	// namespace's owner to accept the reference. See the ReferenceGrant
+	// documentation for details.
+	//
+	// Support: Core
+	//
+	// +optional
+	Namespace *Namespace `json:"namespace,omitempty"`
+}
 
 type GatewayTLSConfig struct {
     ......
@@ -80,7 +113,7 @@ type FrontendTLSValidationContext struct {
     //
     // +kubebuilder:validation:MaxItems=8
     // +kubebuilder:validation:MinItems=1
-    CACertificateRefs []SecretObjectReference `json:"caCertificateRefs,omitempty"`
+    CACertificateRefs []ObjectReference `json:"caCertificateRefs,omitempty"`
 }
 
 ```

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -99,7 +99,7 @@ type FrontendTLSValidation struct {
     // Implementations MAY choose to support attaching multiple CA certificates to
     // a Listener, but this behavior is implementation-specific.
     //
-    // Support: Core - A single reference to a single Kubernetes ConfigMap
+    // Support: Core - A single reference to a Kubernetes ConfigMap
     // with the CA certificate in a key named `ca.crt`.
     //
     // Support: Implementation-specific (More than one reference, or other kinds

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -10,6 +10,21 @@
 This GEP proposes a way to validate the TLS certificate presented by the downstream client to the server
 (Gateway Listener in this case) during a [TLS Handshake Protocol][].
 
+### Existing support in Implementations
+
+This feature is widely supported in implementations that support Gateway API.
+This table highlights the support. Please feel free to add any missing implementations not mentioned below.
+
+| Implementation | Support       |
+|----------------|------------|
+| Apache APISIX  | [ApisixTls.Client.CASecret](https://apisix.apache.org/docs/ingress-controller/tutorials/mtls/#mutual-authentication)      |
+| Contour        | [HTTPProxy.Spec.VirtualHost.Tls.ClientValidation.CASecret](https://projectcontour.io/docs/v1.17.1/config/tls-termination/)      |
+| Emissary Ingress| [TlSContext.Spec.Secret](https://www.getambassador.io/docs/emissary/latest/topics/running/tls/mtls)     |
+| Gloo Edge      | [VirtualService.Spec.SSLConfig.SecretRef](https://docs.solo.io/gloo-edge/latest/guides/security/tls/server_tls/#configuring-downstream-mtls-in-a-virtual-service)      |
+| Istio          | [Gateway.Spec.Servers.TLS.Mode](https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/#configure-a-mutual-tls-ingress-gateway)      |
+| Kong           | [mTLS Plugin](https://docs.konghq.com/hub/kong-inc/mtls-auth/)      |
+| Traefik        | [TLSOption.Spec.ClientAuth](https://doc.traefik.io/traefik/https/tls/#client-authentication-mtls)    |
+
 ## Goals
 - Define an API field to specify the CA Certificate within the Gateway Listener configuration that can be used as a trust anchor to validate the certificates presented by the client. This use case has been been highlighted in the [Gateway API TLS Use Cases][] document under point 7.
 

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -10,7 +10,13 @@
 This GEP proposes a way to validate the TLS certificate presented by the downstream client to the server
 (Gateway Listener in this case) during a [TLS Handshake Protocol][].
 
-### Existing support in Implementations
+## Goals
+- Define an API field to specify the CA Certificate within the Gateway Listener configuration that can be used as a trust anchor to validate the certificates presented by the client. This use case has been been highlighted in the [Gateway API TLS Use Cases][] document under point 7.
+
+## Non-Goals
+- Define other fields that can be used to verify the client certificate such as the Certificate Hash or Subject Alt Name. 
+
+## Existing support in Implementations
 
 This feature is widely supported in implementations that support Gateway API.
 This table highlights the support. Please feel free to add any missing implementations not mentioned below.
@@ -24,12 +30,6 @@ This table highlights the support. Please feel free to add any missing implement
 | Istio          | [Gateway.Spec.Servers.TLS.Mode](https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/#configure-a-mutual-tls-ingress-gateway)      |
 | Kong           | [mTLS Plugin](https://docs.konghq.com/hub/kong-inc/mtls-auth/)      |
 | Traefik        | [TLSOption.Spec.ClientAuth](https://doc.traefik.io/traefik/https/tls/#client-authentication-mtls)    |
-
-## Goals
-- Define an API field to specify the CA Certificate within the Gateway Listener configuration that can be used as a trust anchor to validate the certificates presented by the client. This use case has been been highlighted in the [Gateway API TLS Use Cases][] document under point 7.
-
-## Non-Goals
-- Define other fields that can be used to verify the client certificate such as the Certificate Hash or Subject Alt Name. 
 
 ### API
 

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -14,7 +14,7 @@ This GEP proposes a way to validate the TLS certificate presented by the downstr
 - Define an API field to specify the CA Certificate within the Gateway Listener configuration that can be used as a trust anchor to validate the certificates presented by the client. This use case has been been highlighted in the [Gateway API TLS Use Cases][] document under point 7.
 
 ## Non-Goals
-- Define other fields that can be used to verify the client certificate such as the Certificate Hash or Subject Alt Name. 
+- Define other fields that can be used to verify the client certificate such as the Certificate Hash. 
 
 ## Existing support in Implementations
 
@@ -37,8 +37,6 @@ This table highlights the support. Please feel free to add any missing implement
 to the Gateway.
 * Introduce a `caCertificateRefs` field within `ClientValidationContext` that can be used to specify a list of CA Certificates that
 can be used as a trust anchor to validate the certificates presented by the client.
-* Add CEL validation to ensure that `caCertificateRefs` cannot be empty. This validation will be removed once more fields are added
-into `clientValidation`.
 * This new field is mutually exclusive with the [BackendTLSPolicy][] configuation which is used to validate the TLS certificate presented by the peer on the connection between the Gateway and the backend, and this GEP is adding support for validating the TLS certificate presented by the peer on the connection between the Gateway and the downstream client.
 
 #### GO
@@ -70,8 +68,15 @@ type ClientValidationContext struct {
     // "RefNotPermitted" reason.
     //
     // +kubebuilder:validation:MaxItems=8
-    // +optional
+    // +kubebuilder:validation:MinItems=1
     CACertificateRefs []SecretObjectReference `json:”caCertificateRefs,omitempty”`
+    // SubjectAltNames contains one or more alternate names to verify
+    // the subject identity in the certificate presented by the client.
+    //
+    // Support: Core
+    //
+    // +optional
+    SubjectAltNames []string `json:"subjectAltNames,omitempty"`
 }
 
 ```

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -38,6 +38,7 @@ to the Gateway.
 * Introduce a `caCertificateRefs` field within `ClientValidationContext` that can be used to specify a list of CA Certificates that
 can be used as a trust anchor to validate the certificates presented by the client.
 * This new field is mutually exclusive with the [BackendTLSPolicy][] configuation which is used to validate the TLS certificate presented by the peer on the connection between the Gateway and the backend, and this GEP is adding support for validating the TLS certificate presented by the peer on the connection between the Gateway and the downstream client.
+* Introduce an optional `subjectAltNames` field within `ClientValidationContext` that can be used to specify one or more alternate names to verify the subject identity in the certificate presented by the client. The maximum number of alternate names that can be specified is implementation defined.
 
 #### GO
 
@@ -77,6 +78,7 @@ type ClientValidationContext struct {
     // Support: Core
     //
     // +optional
+    // +kubebuilder:validation:MinItems=1
     SubjectAltNames []string `json:"subjectAltNames,omitempty"`
 }
 

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -16,7 +16,69 @@ This GEP proposes a way to validate the TLS certificate presented by the downstr
 ## Non-Goals
 - Define other fields that can be used to verify the client certificate such as the Certificate Hash or Subject Alt Name. 
 
+### API
+
+* Introduce a `clientValidation` field with [Gateway.Tls][] that can be used to validate the client intiating the TLS connection
+to the Gateway
+* Introduce a `caCerficateRefs` field within `clientValidation` that can be used to specify a list of CA Certificates that
+can be used as a trusted anchor to validate the certificates presented by the client
+
+#### GO
+
+```go
+// ClientValidationContext holds configuration that can be used to validate the client intiating the TLS connection
+// to the Gateway.
+// By default, no client specific configuration is validated.
+type ClientValidationContext struct {
+    // CACertificateRefs contains one or more references to
+    // Kubernetes objects that contain TLS certificates of
+    // the Certificate Authorities that can be used to
+    // as a trusted anchor to validate the certificates presented by the client.
+    //
+	// A single CACertificateRef to a Kubernetes ConfigMap with a key called `ca.crt`
+    // has "Core" support.
+	// Implementations MAY choose to support attaching multiple certificates to
+	// a Listener, but this behavior is implementation-specific.
+	//
+	// References to a resource in different namespace are invalid.
+	// When invalid, "ResolvedRefs" condition MUST be set to False for this listener with the
+	// "RefNotPermitted" reason.
+    //
+    // +kubebuilder:validation:MaxItems=64
+    // +optional
+    CACertificateRefs []LocalObjectReference `json:”caCertificateRefs,omitempty”`
+}
+
+```
+
+#### YAML
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: mtls-basic
+spec:
+  gatewayClassName: acme-lb
+  listeners:
+  - name: foo-https
+    protocol: HTTPS
+    port: 443
+    hostname: foo.example.com
+    tls:
+      certificateRefs:
+      - kind: Secret
+        group: ""
+        name: foo-example-com-cert
+    clientValidation:
+      caCertificateRefs:
+      - kind: ConfigMap
+        group: ""
+        name: foo-example-com-ca-cert
+```
+
 ## References
 
 [TLS Handshake Protocol]: https://www.rfc-editor.org/rfc/rfc5246#section-7.4
 [Certificate Path Validation]: https://www.rfc-editor.org/rfc/rfc5280#section-6
+[Gateway.TLS]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.GatewayTLSConfig

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -1,7 +1,7 @@
 # GEP-91: Client Certificate Validation for TLS terminating at the Gateway Listener
 
 * Issue: [#91](https://github.com/kubernetes-sigs/gateway-api/issues/91)
-* Status: Provisional
+* Status: Implementable 
 
 (See definitions in [GEP Status][/contributing/gep#status].)
 

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -1,7 +1,7 @@
 # GEP-91: Client Certificate Validation for TLS terminating at the Gateway Listener
 
 * Issue: [#91](https://github.com/kubernetes-sigs/gateway-api/issues/91)
-* Status: Implementable 
+* Status: Implementable
 
 (See definitions in [GEP Status][/contributing/gep#status].)
 
@@ -11,10 +11,11 @@ This GEP proposes a way to validate the TLS certificate presented by the downstr
 (Gateway Listener in this case) during a [TLS Handshake Protocol][].
 
 ## Goals
-- Define an API field to specify the CA Certificate within the Gateway Listener configuration that can be used as a trust anchor to validate the certificates presented by the client. This use case has been been highlighted in the [Gateway API TLS Use Cases][] document under point 7.
+
+* Define an API field to specify the CA Certificate within the Gateway Listener configuration that can be used as a trust anchor to validate the certificates presented by the client. This use case has been highlighted in the [TLS Configuration GEP][] under segment 1 and in the [Gateway API TLS Use Cases][] document under point 7.
 
 ## Non-Goals
-- Define other fields that can be used to verify the client certificate such as the Certificate Hash. 
+* Define other fields that can be used to verify the client certificate such as the Certificate Hash.
 
 ## Existing support in Implementations
 
@@ -30,37 +31,36 @@ This table highlights the support. Please feel free to add any missing implement
 | Istio          | [Gateway.Spec.Servers.TLS.Mode](https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/#configure-a-mutual-tls-ingress-gateway)      |
 | Kong           | [mTLS Plugin](https://docs.konghq.com/hub/kong-inc/mtls-auth/)      |
 | Traefik        | [TLSOption.Spec.ClientAuth](https://doc.traefik.io/traefik/https/tls/#client-authentication-mtls)    |
+| NGINX Ingress Controller | [ingressMTLS](https://docs.nginx.com/nginx-ingress-controller/configuration/policy-resource/#ingressmtls)    |
 
 ### API
 
-* Introduce a `Client` field of type `TLSClientContext` within [GatewayTLSConfig][] to hold TLS configuration specific to the client.
-* Introduce a `Validation` field of type `TLSValidationContext` within the `Client` field that can be used to validate the peer with which the TLS connection is being made.
-to the Gateway.
-* Introduce a `caCertificateRefs` field within `ValidationContext` that can be used to specify a list of CA Certificates that
-can be used as a trust anchor to validate the certificates presented by the client.
-* This new field is mutually exclusive with the [BackendTLSPolicy][] configuation which is used to validate the TLS certificate presented by the peer on the connection between the Gateway and the backend, and this GEP is adding support for validating the TLS certificate presented by the peer on the connection between the Gateway and the downstream client.
-* Introduce an optional `subjectAltNames` field within `ClientValidationContext` that can be used to specify one or more alternate names to verify the subject identity in the certificate presented by the client. The maximum number of alternate names that can be specified is implementation defined.
+* Introduce a `FrontendValidation` field of type `FrontEndTLSValidationContext` within [GatewayTLSConfig][] that can be used to validate the peer(frontend) with which the TLS connection is being made.
+* Introduce a `caCertificateRefs` field within `FrontEndTLSValidationContext` that can be used to specify a list of CA Certificates that can be used as a trust anchor to validate the certificates presented by the client.
+* This new field is mutually exclusive with the [BackendTLSPolicy][] configuation which is used to validate the TLS certificate presented by the peer on the connection between the Gateway and the backend, and this GEP is adding support for validating the TLS certificate presented by the peer on the connection between the Gateway and the frontend (downstream client).
 
 #### GO
 
 ```go
-// TLSClientContext holds configuration specific to the client initiating the TLS connection.
-type TLSClientContext struct {
-    // Validation holds configuration around validating the client initiating the TLS connection.
-    //
-    // +optional
-    Validation *TLSValidationContext `json:"validation,omitempty"`
+
+type GatewayTLSConfig struct {
+......
+    // FrontendValidation holds configuration for validating the frontend (client).
+    // Setting this field will require clients to send a client certificate
+    // required for validation. In browsers this may result in a dialog appearing 
+    // that requests a user to specify the client certificate.
+    // The maximum depth of a certificate chain accepted in verification is Implementation specific.
+    FrontendValidation *FrontEndTLSValidationContext `json:"frontEndValidation,omitempty"`
 }
 
-
-// TLSValidationContext holds configuration that can be used to validate the peer in the TLS connection
-type TLSValidationContext struct {
+// FrontEndTLSValidationContext holds configuration that can be used to validate the frontend in the TLS connection
+type FrontEndTLSValidationContext struct {
     // CACertificateRefs contains one or more references to
     // Kubernetes objects that contain TLS certificates of
     // the Certificate Authorities that can be used
     // as a trust anchor to validate the certificates presented by the client.
     //
-    // A single CA certificate reference to a Kubernetes ConfigMap or Secret kind
+    // A single CA certificate reference to a Kubernetes ConfigMap
     // has "Core" support.
     // Implementations MAY choose to support attaching multiple CA certificates to
     // a Listener, but this behavior is implementation-specific.
@@ -80,14 +80,6 @@ type TLSValidationContext struct {
     // +kubebuilder:validation:MaxItems=8
     // +kubebuilder:validation:MinItems=1
     CACertificateRefs []SecretObjectReference `json:"caCertificateRefs,omitempty"`
-    // SubjectAltNames contains one or more alternate names to verify
-    // the subject identity in the certificate presented by the client.
-    //
-    // Support: Core
-    //
-    // +optional
-    // +kubebuilder:validation:MinItems=1
-    SubjectAltNames []string `json:"subjectAltNames,omitempty"`
 }
 
 ```
@@ -111,12 +103,11 @@ spec:
       - kind: Secret
         group: ""
         name: foo-example-com-cert
-      client:
-        validation:
-          caCertificateRefs:
-          - kind: ConfigMap
-            group: ""
-            name: foo-example-com-ca-cert
+      frontEndValidation:
+        caCertificateRefs:
+        - kind: ConfigMap
+          group: ""
+          name: foo-example-com-ca-cert
 ```
 
 ## Deferred
@@ -124,7 +115,10 @@ spec:
 This section highlights use cases that may be covered in a future iteration of this GEP
 
 * Using system CA certificates as the trust anchor to validate the certificates presented by the client.
-* Supporting a permissive TLS mode where untrusted clients are allowed in, useful for debugging and migrating to strict TLS.
+* Supporting a mode where validating client certficates is optional, useful for debugging and migrating to strict TLS.
+* Supporting an optional `subjectAltNames` field within `ClientValidationContext` that can be used to specify one or more alternate names to verify the subject identity in the certificate presented by the client. This field falls under authorization and will be revisited when authorization is tackled as a whole in the project.
+* Specifying the verification depth in the client certificates chain
+
 
 ## References
 
@@ -132,4 +126,5 @@ This section highlights use cases that may be covered in a future iteration of t
 [Certificate Path Validation]: https://www.rfc-editor.org/rfc/rfc5280#section-6
 [GatewayTLSConfig]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.GatewayTLSConfig
 [BackendTLSPolicy]: https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/
+[TLS Configuration GEP]: https://gateway-api.sigs.k8s.io/geps/gep-2907/
 [Gateway API TLS Use Cases]: https://docs.google.com/document/d/17sctu2uMJtHmJTGtBi_awGB0YzoCLodtR6rUNmKMCs8/edit?pli=1#heading=h.cxuq8vo8pcxm

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -57,7 +57,7 @@ type ClientValidationContext struct {
     // Implementations MAY choose to support attaching multiple CA certificates to
     // a Listener, but this behavior is implementation-specific.
     //
-    // Support: Core - An optional single reference to a Kubernetes ConfigMap,
+    // Support: Core - An optional single reference to a Kubernetes Secret and ConfigMap,
     // with the CA certificate in a key named `ca.crt`.
     //
     // Support: Implementation-specific (More than one reference, or other kinds

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -11,7 +11,7 @@ This GEP proposes a way to validate the TLS certificate presented by the downstr
 (Gateway Listener in this case) during a [TLS Handshake Protocol][].
 
 ## Goals
-- Define an API field to specify the CA Certificate within the Gateway Listener configuration that can be used as a trust anchor to validate the certificates presented by the client.
+- Define an API field to specify the CA Certificate within the Gateway Listener configuration that can be used as a trust anchor to validate the certificates presented by the client. This use case has been been highlighted in the [Gateway API TLS Use Cases][] document under point 7.
 
 ## Non-Goals
 - Define other fields that can be used to verify the client certificate such as the Certificate Hash or Subject Alt Name. 
@@ -89,3 +89,4 @@ spec:
 [TLS Handshake Protocol]: https://www.rfc-editor.org/rfc/rfc5246#section-7.4
 [Certificate Path Validation]: https://www.rfc-editor.org/rfc/rfc5280#section-6
 [GatewayTLSConfig]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.GatewayTLSConfig
+[Gateway API TLS Use Cases]: https://docs.google.com/document/d/17sctu2uMJtHmJTGtBi_awGB0YzoCLodtR6rUNmKMCs8/edit?pli=1#heading=h.cxuq8vo8pcxm

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -22,6 +22,9 @@ This GEP proposes a way to validate the TLS certificate presented by the downstr
 to the Gateway.
 * Introduce a `caCertificateRefs` field within `ClientValidationContext` that can be used to specify a list of CA Certificates that
 can be used as a trust anchor to validate the certificates presented by the client.
+* Add CEL validation to ensure that `caCertificateRefs` cannot be empty. This validation will be removed once more fields are added
+into `clientValidation`.
+* This new field is mutually exclusive with the [BackendTLSPolicy][] configuation which is used to validate the TLS certificate presented by the peer on the connection between the Gateway and the backend, and this GEP is adding support for validating the TLS certificate presented by the peer on the connection between the Gateway and the downstream client.
 
 #### GO
 
@@ -32,10 +35,10 @@ can be used as a trust anchor to validate the certificates presented by the clie
 type ClientValidationContext struct {
     // CACertificateRefs contains one or more references to
     // Kubernetes objects that contain TLS certificates of
-    // the Certificate Authorities that can be used to
+    // the Certificate Authorities that can be used
     // as a trust anchor to validate the certificates presented by the client.
     //
-    // A single CACertRef to a Kubernetes ConfigMap kind has "Core" support.
+    // A single CA certificate reference to a Kubernetes ConfigMap kind has "Core" support.
     // Implementations MAY choose to support attaching multiple CA certificates to
     // a Listener, but this behavior is implementation-specific.
     //
@@ -45,7 +48,7 @@ type ClientValidationContext struct {
     // Support: Implementation-specific (More than one reference, or other kinds
     // of resources).
     //
-    // References to a resource in different namespace are invalid UNLESS there
+    // References to a resource in a different namespace are invalid UNLESS there
     // is a ReferenceGrant in the target namespace that allows the certificate
     // to be attached. If a ReferenceGrant does not allow this reference, the
     // "ResolvedRefs" condition MUST be set to False for this listener with the
@@ -84,9 +87,16 @@ spec:
           name: foo-example-com-ca-cert
 ```
 
+## Deferred
+
+This section highlights use cases that may be covered in a future iteration of this GEP
+
+* Using system CA certificates as the trust anchor to validate the certificates presented by the client.
+
 ## References
 
 [TLS Handshake Protocol]: https://www.rfc-editor.org/rfc/rfc5246#section-7.4
 [Certificate Path Validation]: https://www.rfc-editor.org/rfc/rfc5280#section-6
-[GatewayTLSConfig]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.GatewayTLSConfig
+[GatewayTLSConfig]: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.GatewayTLSConfig
+[BackendTLSPolicy]: https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/
 [Gateway API TLS Use Cases]: https://docs.google.com/document/d/17sctu2uMJtHmJTGtBi_awGB0YzoCLodtR6rUNmKMCs8/edit?pli=1#heading=h.cxuq8vo8pcxm

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -35,18 +35,20 @@ type ClientValidationContext struct {
     // the Certificate Authorities that can be used to
     // as a trusted anchor to validate the certificates presented by the client.
     //
-	// A single CACertificateRef to a Kubernetes ConfigMap with a key called `ca.crt`
+    // A single CACertificateRef to a Kubernetes ConfigMap with a key called `ca.crt`
     // has "Core" support.
-	// Implementations MAY choose to support attaching multiple certificates to
-	// a Listener, but this behavior is implementation-specific.
-	//
-	// References to a resource in different namespace are invalid.
-	// When invalid, "ResolvedRefs" condition MUST be set to False for this listener with the
-	// "RefNotPermitted" reason.
+    // Implementations MAY choose to support attaching multiple certificates to
+    // a Listener, but this behavior is implementation-specific.
+    //
+    // References to a resource in different namespace are invalid UNLESS there
+    // is a ReferenceGrant in the target namespace that allows the certificate
+    // to be attached. If a ReferenceGrant does not allow this reference, the
+    // "ResolvedRefs" condition MUST be set to False for this listener with the
+    // "RefNotPermitted" reason.
     //
     // +kubebuilder:validation:MaxItems=64
     // +optional
-    CACertificateRefs []LocalObjectReference `json:”caCertificateRefs,omitempty”`
+    CACertificateRefs []corev1.ObjectReference `json:”caCertificateRefs,omitempty”`
 }
 
 ```


### PR DESCRIPTION
**What type of PR is this?**

/kind gep


**What this PR does / why we need it**:
**What**
Defines an API in GEP-91 to support Client Certificate Validation for TLS Terminating at the Gateway
using a CA Certificate as a trusted anchor.

**Why**
Allows the platform admin configuring the Gateway resource to only select trusted clients to connect to the Gateway

Relates to https://github.com/kubernetes-sigs/gateway-api/issues/91 & https://github.com/kubernetes-sigs/gateway-api/issues/2110