### PR TITLE
fix: remove ExemptFeatures in experimental suite

### DIFF
--- a/conformance/utils/suite/experimental_suite.go
+++ b/conformance/utils/suite/experimental_suite.go
@@ -142,6 +142,10 @@ func NewExperimentalConformanceTestSuite(s ExperimentalConformanceOptions) (*Exp
 		}
 	}
 
+	for feature := range s.ExemptFeatures {
+		s.SupportedFeatures.Delete(feature)
+	}
+
 	if s.FS == nil {
 		s.FS = &conformance.Manifests
 	}

--- a/conformance/utils/suite/experimental_suite.go
+++ b/conformance/utils/suite/experimental_suite.go
@@ -122,12 +122,12 @@ func NewExperimentalConformanceTestSuite(s ExperimentalConformanceOptions) (*Exp
 			// the use of a conformance profile implicitly enables any features of
 			// that profile which are supported at a Core level of support.
 			for _, f := range conformanceProfile.CoreFeatures.UnsortedList() {
-				if !s.SupportedFeatures.Has(f) {
+				if !s.SupportedFeatures.Has(f) && !s.ExemptFeatures.Has(f) {
 					s.SupportedFeatures.Insert(f)
 				}
 			}
 			for _, f := range conformanceProfile.ExtendedFeatures.UnsortedList() {
-				if s.SupportedFeatures.Has(f) {
+				if s.SupportedFeatures.Has(f) && !s.ExemptFeatures.Has(f) {
 					if suite.extendedSupportedFeatures[conformanceProfileName] == nil {
 						suite.extendedSupportedFeatures[conformanceProfileName] = sets.New[SupportedFeature]()
 					}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind bug

**What this PR does / why we need it**:

In experimental test suite, we did not remove ExemptFeatures. This makes ExemptFeatures in Options does not work.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/2347

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Remove ExemptFeatures in experimental suite
```
