### PR TITLE
fix: add check for unrecognized scheme in http redirect request scheme

### DIFF
--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -345,7 +345,7 @@ func CompareRequest(t *testing.T, req *roundtripper.Request, cReq *roundtripper.
 			if strings.ToLower(cRes.RedirectRequest.Scheme) == "https" && gotPort != "443" && gotPort != "" {
 				return fmt.Errorf("for https scheme, expected redirected port to be 443 or not set, got %q", gotPort)
 			}
-			if strings.ToLower(cRes.RedirectRequest.Scheme) != "http" || strings.ToLower(cRes.RedirectRequest.Scheme) == "https" {
+			if strings.ToLower(cRes.RedirectRequest.Scheme) != "http" || strings.ToLower(cRes.RedirectRequest.Scheme) != "https" {
 				t.Logf("Can't validate redirectPort for unrecognized scheme %v", cRes.RedirectRequest.Scheme)
 			}
 		} else if expected.RedirectRequest.Port != gotPort {

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -345,7 +345,9 @@ func CompareRequest(t *testing.T, req *roundtripper.Request, cReq *roundtripper.
 			if strings.ToLower(cRes.RedirectRequest.Scheme) == "https" && gotPort != "443" && gotPort != "" {
 				return fmt.Errorf("for https scheme, expected redirected port to be 443 or not set, got %q", gotPort)
 			}
-			t.Logf("Can't validate redirectPort for unrecognized scheme %v", cRes.RedirectRequest.Scheme)
+			if strings.ToLower(cRes.RedirectRequest.Scheme) != "http" || strings.ToLower(cRes.RedirectRequest.Scheme) == "https" {
+				t.Logf("Can't validate redirectPort for unrecognized scheme %v", cRes.RedirectRequest.Scheme)
+			}
 		} else if expected.RedirectRequest.Port != gotPort {
 			// An expected port was specified in the tests but it didn't match with
 			// gotPort.


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind bug
/area conformance

**What this PR does / why we need it**:

running conformance test `HTTPRouteRedirectPortAndScheme`, will get a wired log in the output even if the redirect scheme is Well-Known. so add some check to ensure this log only be shown if the redirect scheme is a actual unrecognized one.

```
=== CONT  TestGatewayAPIConformance/HTTPRouteRedirectPortAndScheme/http-listener-on-80/1_request_to_'/scheme-nil-and-port-80'_should_receive_a_302
    httproute-redirect-port-and-scheme.go:159: Making GET request to http://172.18.255.200/scheme-nil-and-port-80
Sending Request:
< GET /scheme-nil-and-port-80 HTTP/1.1
< ...

Received Response:
< HTTP/1.1 302 Found
< ...

    http.go:348: Can't validate redirectPort for unrecognized scheme http  ### <<<=== wired log
    http.go:228: Request passed
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
