### PR TITLE
Expand and clarify Listeners definition

### DIFF
--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -130,8 +130,8 @@ type GatewaySpec struct {
 	// matches. For example, `"foo.example.com"` takes precedence over
 	// `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
 	//
-	// Implementations MAY collapse separate Gateways onto a single set of
-	// Addresses if the Listeners across all Gateways are compatible.
+	// Implementations MAY merge separate Gateways onto a single set of
+	// Addresses if all Listeners across all Gateways are compatible.
 	//
 	// Support: Core
 	//

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -127,7 +127,8 @@ type GatewaySpec struct {
 	// to least specific Hostname values to find the correct set of Routes.
 	// Exact matches must be processed before wildcard matches, and wildcard
 	// matches must be processed before fallback (empty Hostname value)
-	// matches.
+	// matches. For example, `"foo.example.com"` takes precedence over
+	// `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
 	//
 	// Implementations MAY collapse separate Gateways onto a single set of
 	// Addresses if the Listeners across all Gateways are compatible.

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -85,38 +85,52 @@ type GatewaySpec struct {
 	//
 	// Port and protocol combinations not listed above are considered Extended.
 	//
-	// An implementation MAY group Listeners by Port and then collapse each
-	// group of Listeners into a single Listener if the implementation
-	// determines that the Listeners in the group are "compatible". An
-	// implementation MAY also group together and collapse compatible
-	// Listeners belonging to different Gateways.
+	// A Gateway's Listeners are considered "compatible" if:
 	//
-	// For example, an implementation might consider Listeners to be
-	// compatible with each other if all of the following conditions are
-	// met:
+	// 1. The implementation can serve them in compliance with the Addresses
+	//    requirement that all Listeners are available on all assigned
+	//    addresses.
+	// 2. No Listeners sharing the same Port share the same Hostname value,
+	//    including the empty value, if this would prevent the implementation
+	//    from matching an inbound request to a specific Listener.
 	//
-	// 1. Either each Listener within the group specifies the "HTTP"
-	//    Protocol or each Listener within the group specifies either
-	//    the "HTTPS" or "TLS" Protocol.
+	// Compatible combinations in Extended support are expected to vary across
+	// implementations. A combination that is compatible for one implementation
+	// may not be compatible for another.
 	//
-	// 2. Each Listener within the group specifies a Hostname that is unique
-	//    within the group.
+	// If this field specifies multiple Listeners that are not compatible, the
+	// implementation MUST raise a true "Conflicted" condition in the Listener
+	// Status.
 	//
-	// 3. As a special case, one Listener within a group may omit Hostname,
-	//    in which case this Listener matches when no other Listener
-	//    matches.
+	// Implementations MAY choose to still accept a Gateway with conflicted
+	// Listeners if they accept a partial Listener set that contains no
+	// incompatible Listeners. They MUST set a "ListenersNotValid" condition
+	// the Gateway Status when the Gateway contains incompatible Listeners
+	// whether or not they accept the Gateway.
 	//
-	// If the implementation does collapse compatible Listeners, the
-	// hostname provided in the incoming client request MUST be
-	// matched to a Listener to find the correct set of Routes.
-	// The incoming hostname MUST be matched using the Hostname
-	// field for each Listener in order of most to least specific.
-	// That is, exact matches must be processed before wildcard
+	// For example, the following Listener scenarios may be compatible
+	// depending on implementation capabilities:
+	//
+	// 1. Multiple Listeners with the same Port that all use the "HTTP"
+	//    Protocol that all have unique Hostname values.
+	// 2. Multiple Listeners with the same Port that use either the "HTTPS" or
+	//    "TLS" Protocol that all have unique Hostname values.
+	// 3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
+	//    with the same Protocol has the same Port value.
+	//
+	// An implementation that cannot serve both TCP and UDP listens on the same
+	// address, or cannot mix HTTPS and generic TLS listens on the same port
+	// would not consider those cases compatible.
+	//
+	// Implementations using the Hostname value to select between same-Port
+	// Listeners MUST match inbound request hostnames from the most specific
+	// to least specific Hostname values to find the correct set of Routes.
+	// Exact matches must be processed before wildcard matches, and wildcard
+	// matches must be processed before fallback (empty Hostname value)
 	// matches.
 	//
-	// If this field specifies multiple Listeners that have the same
-	// Port value but are not compatible, the implementation must raise
-	// a "Conflicted" condition in the Listener status.
+	// Implementations MAY collapse separate Gateways onto a single set of
+	// Addresses if the Listeners across all Gateways are compatible.
 	//
 	// Support: Core
 	//

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -132,6 +132,13 @@ type GatewaySpec struct {
 	// matches. For example, `"foo.example.com"` takes precedence over
 	// `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
 	//
+	// Implementations SHOULD NOT match requests to less specific Listeners if
+	// they exhaust attached routes on a more specific Listener. For example, a
+	// request for `subdomain.example.com/path` SHOULD NOT match an HTTPRoute
+	// attached to a Listener with Hostname `*.example.com` if there is a
+	// Listener with with Hostname `subdomain.example.com`, even if no routes
+	// on the second Listener match.
+	//
 	// Implementations MAY merge separate Gateways onto a single set of
 	// Addresses if all Listeners across all Gateways are compatible.
 	//

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -132,13 +132,6 @@ type GatewaySpec struct {
 	// matches. For example, `"foo.example.com"` takes precedence over
 	// `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
 	//
-	// Implementations SHOULD NOT match requests to less specific Listeners if
-	// they exhaust attached routes on a more specific Listener. For example, a
-	// request for `subdomain.example.com/path` SHOULD NOT match an HTTPRoute
-	// attached to a Listener with Hostname `*.example.com` if there is a
-	// Listener with with Hostname `subdomain.example.com`, even if no routes
-	// on the second Listener match.
-	//
 	// Implementations MAY merge separate Gateways onto a single set of
 	// Addresses if all Listeners across all Gateways are compatible.
 	//

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -99,8 +99,8 @@ type GatewaySpec struct {
 	// may not be compatible for another.
 	//
 	// If this field specifies multiple Listeners that are not compatible, the
-	// implementation MUST raise a true "Conflicted" condition in the Listener
-	// Status.
+	// implementation MUST set the "Conflicted" condition in the Listener
+	// Status to "True".
 	//
 	// Implementations MAY choose to still accept a Gateway with conflicted
 	// Listeners if they accept a partial Listener set that contains no
@@ -118,7 +118,7 @@ type GatewaySpec struct {
 	// 3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
 	//    with the same Protocol has the same Port value.
 	//
-	// An implementation that cannot serve both TCP and UDP listens on the same
+	// An implementation that cannot serve both TCP and UDP listeners on the same
 	// address, or cannot mix HTTPS and generic TLS listens on the same port
 	// would not consider those cases compatible.
 	//

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -90,9 +90,11 @@ type GatewaySpec struct {
 	// 1. The implementation can serve them in compliance with the Addresses
 	//    requirement that all Listeners are available on all assigned
 	//    addresses.
-	// 2. No Listeners sharing the same Port share the same Hostname value,
-	//    including the empty value, if this would prevent the implementation
-	//    from matching an inbound request to a specific Listener.
+	// 2. The implementation can match inbound requests to a single distinct
+	//    Listener. When multiple Listeners share values for fields (for
+	//    example, two Listeners with the same Port value), the implementation
+	//    can can match requests to only one of the Listeners using other
+	//    Listener fields.
 	//
 	// Compatible combinations in Extended support are expected to vary across
 	// implementations. A combination that is compatible for one implementation

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -143,24 +143,25 @@ spec:
                   above are considered Extended. \n A Gateway's Listeners are considered
                   \"compatible\" if: \n 1. The implementation can serve them in compliance
                   with the Addresses requirement that all Listeners are available
-                  on all assigned addresses. 2. No Listeners sharing the same Port
-                  share the same Hostname value, including the empty value, if this
-                  would prevent the implementation from matching an inbound request
-                  to a specific Listener. \n Compatible combinations in Extended support
-                  are expected to vary across implementations. A combination that
-                  is compatible for one implementation may not be compatible for another.
-                  \n If this field specifies multiple Listeners that are not compatible,
-                  the implementation MUST set the \"Conflicted\" condition in the
-                  Listener Status to \"True\". \n Implementations MAY choose to still
-                  accept a Gateway with conflicted Listeners if they accept a partial
-                  Listener set that contains no incompatible Listeners. They MUST
-                  set a \"ListenersNotValid\" condition the Gateway Status when the
-                  Gateway contains incompatible Listeners whether or not they accept
-                  the Gateway. \n For example, the following Listener scenarios may
-                  be compatible depending on implementation capabilities: \n 1. Multiple
-                  Listeners with the same Port that all use the \"HTTP\" Protocol
-                  that all have unique Hostname values. 2. Multiple Listeners with
-                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
+                  on all assigned addresses. 2. The implementation can match inbound
+                  requests to a single distinct Listener. When multiple Listeners
+                  share values for fields (for example, two Listeners with the same
+                  Port value), the implementation can can match requests to only one
+                  of the Listeners using other Listener fields. \n Compatible combinations
+                  in Extended support are expected to vary across implementations.
+                  A combination that is compatible for one implementation may not
+                  be compatible for another. \n If this field specifies multiple Listeners
+                  that are not compatible, the implementation MUST set the \"Conflicted\"
+                  condition in the Listener Status to \"True\". \n Implementations
+                  MAY choose to still accept a Gateway with conflicted Listeners if
+                  they accept a partial Listener set that contains no incompatible
+                  Listeners. They MUST set a \"ListenersNotValid\" condition the Gateway
+                  Status when the Gateway contains incompatible Listeners whether
+                  or not they accept the Gateway. \n For example, the following Listener
+                  scenarios may be compatible depending on implementation capabilities:
+                  \n 1. Multiple Listeners with the same Port that all use the \"HTTP\"
+                  Protocol that all have unique Hostname values. 2. Multiple Listeners
+                  with the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
                   that all have unique Hostname values. 3. A mixture of \"TCP\" and
                   \"UDP\" Protocol Listeners, where no Listener with the same Protocol
                   has the same Port value. \n An implementation that cannot serve
@@ -935,24 +936,25 @@ spec:
                   above are considered Extended. \n A Gateway's Listeners are considered
                   \"compatible\" if: \n 1. The implementation can serve them in compliance
                   with the Addresses requirement that all Listeners are available
-                  on all assigned addresses. 2. No Listeners sharing the same Port
-                  share the same Hostname value, including the empty value, if this
-                  would prevent the implementation from matching an inbound request
-                  to a specific Listener. \n Compatible combinations in Extended support
-                  are expected to vary across implementations. A combination that
-                  is compatible for one implementation may not be compatible for another.
-                  \n If this field specifies multiple Listeners that are not compatible,
-                  the implementation MUST set the \"Conflicted\" condition in the
-                  Listener Status to \"True\". \n Implementations MAY choose to still
-                  accept a Gateway with conflicted Listeners if they accept a partial
-                  Listener set that contains no incompatible Listeners. They MUST
-                  set a \"ListenersNotValid\" condition the Gateway Status when the
-                  Gateway contains incompatible Listeners whether or not they accept
-                  the Gateway. \n For example, the following Listener scenarios may
-                  be compatible depending on implementation capabilities: \n 1. Multiple
-                  Listeners with the same Port that all use the \"HTTP\" Protocol
-                  that all have unique Hostname values. 2. Multiple Listeners with
-                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
+                  on all assigned addresses. 2. The implementation can match inbound
+                  requests to a single distinct Listener. When multiple Listeners
+                  share values for fields (for example, two Listeners with the same
+                  Port value), the implementation can can match requests to only one
+                  of the Listeners using other Listener fields. \n Compatible combinations
+                  in Extended support are expected to vary across implementations.
+                  A combination that is compatible for one implementation may not
+                  be compatible for another. \n If this field specifies multiple Listeners
+                  that are not compatible, the implementation MUST set the \"Conflicted\"
+                  condition in the Listener Status to \"True\". \n Implementations
+                  MAY choose to still accept a Gateway with conflicted Listeners if
+                  they accept a partial Listener set that contains no incompatible
+                  Listeners. They MUST set a \"ListenersNotValid\" condition the Gateway
+                  Status when the Gateway contains incompatible Listeners whether
+                  or not they accept the Gateway. \n For example, the following Listener
+                  scenarios may be compatible depending on implementation capabilities:
+                  \n 1. Multiple Listeners with the same Port that all use the \"HTTP\"
+                  Protocol that all have unique Hostname values. 2. Multiple Listeners
+                  with the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
                   that all have unique Hostname values. 3. A mixture of \"TCP\" and
                   \"UDP\" Protocol Listeners, where no Listener with the same Protocol
                   has the same Port value. \n An implementation that cannot serve

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -174,14 +174,9 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations SHOULD NOT match
-                  requests to less specific Listeners if they exhaust attached routes
-                  on a more specific Listener. For example, a request for `subdomain.example.com/path`
-                  SHOULD NOT match an HTTPRoute attached to a Listener with Hostname
-                  `*.example.com` if there is a Listener with with Hostname `subdomain.example.com`,
-                  even if no routes on the second Listener match. \n Implementations
-                  MAY merge separate Gateways onto a single set of Addresses if all
-                  Listeners across all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Implementations MAY merge separate
+                  Gateways onto a single set of Addresses if all Listeners across
+                  all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -972,14 +967,9 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations SHOULD NOT match
-                  requests to less specific Listeners if they exhaust attached routes
-                  on a more specific Listener. For example, a request for `subdomain.example.com/path`
-                  SHOULD NOT match an HTTPRoute attached to a Listener with Hostname
-                  `*.example.com` if there is a Listener with with Hostname `subdomain.example.com`,
-                  even if no routes on the second Listener match. \n Implementations
-                  MAY merge separate Gateways onto a single set of Addresses if all
-                  Listeners across all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Implementations MAY merge separate
+                  Gateways onto a single set of Addresses if all Listeners across
+                  all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -174,9 +174,14 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations MAY merge separate
-                  Gateways onto a single set of Addresses if all Listeners across
-                  all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Implementations SHOULD NOT match
+                  requests to less specific Listeners if they exhaust attached routes
+                  on a more specific Listener. For example, a request for `subdomain.example.com/path`
+                  SHOULD NOT match an HTTPRoute attached to a Listener with Hostname
+                  `*.example.com` if there is a Listener with with Hostname `subdomain.example.com`,
+                  even if no routes on the second Listener match. \n Implementations
+                  MAY merge separate Gateways onto a single set of Addresses if all
+                  Listeners across all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -967,9 +972,14 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations MAY merge separate
-                  Gateways onto a single set of Addresses if all Listeners across
-                  all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Implementations SHOULD NOT match
+                  requests to less specific Listeners if they exhaust attached routes
+                  on a more specific Listener. For example, a request for `subdomain.example.com/path`
+                  SHOULD NOT match an HTTPRoute attached to a Listener with Hostname
+                  `*.example.com` if there is a Listener with with Hostname `subdomain.example.com`,
+                  even if no routes on the second Listener match. \n Implementations
+                  MAY merge separate Gateways onto a single set of Addresses if all
+                  Listeners across all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -140,28 +140,40 @@ spec:
                   the TLS Conformance Profile, the below combinations of port and
                   protocol are considered Core and MUST be supported: \n 1. Port:
                   443, Protocol: TLS \n Port and protocol combinations not listed
-                  above are considered Extended. \n An implementation MAY group Listeners
-                  by Port and then collapse each group of Listeners into a single
-                  Listener if the implementation determines that the Listeners in
-                  the group are \"compatible\". An implementation MAY also group together
-                  and collapse compatible Listeners belonging to different Gateways.
-                  \n For example, an implementation might consider Listeners to be
-                  compatible with each other if all of the following conditions are
-                  met: \n 1. Either each Listener within the group specifies the \"HTTP\"
-                  Protocol or each Listener within the group specifies either the
-                  \"HTTPS\" or \"TLS\" Protocol. \n 2. Each Listener within the group
-                  specifies a Hostname that is unique within the group. \n 3. As a
-                  special case, one Listener within a group may omit Hostname, in
-                  which case this Listener matches when no other Listener matches.
-                  \n If the implementation does collapse compatible Listeners, the
-                  hostname provided in the incoming client request MUST be matched
-                  to a Listener to find the correct set of Routes. The incoming hostname
-                  MUST be matched using the Hostname field for each Listener in order
-                  of most to least specific. That is, exact matches must be processed
-                  before wildcard matches. \n If this field specifies multiple Listeners
-                  that have the same Port value but are not compatible, the implementation
-                  must raise a \"Conflicted\" condition in the Listener status. \n
-                  Support: Core"
+                  above are considered Extended. \n A Gateway's Listeners are considered
+                  \"compatible\" if: \n 1. The implementation can serve them in compliance
+                  with the Addresses requirement that all Listeners are available
+                  on all assigned addresses. 2. No Listeners sharing the same Port
+                  share the same Hostname value, including the empty value, if this
+                  would prevent the implementation from matching an inbound request
+                  to a specific Listener. \n Compatible combinations in Extended support
+                  are expected to vary across implementations. A combination that
+                  is compatible for one implementation may not be compatible for another.
+                  \n If this field specifies multiple Listeners that are not compatible,
+                  the implementation MUST raise a true \"Conflicted\" condition in
+                  the Listener Status. \n Implementations MAY choose to still accept
+                  a Gateway with conflicted Listeners if they accept a partial Listener
+                  set that contains no incompatible Listeners. They MUST set a \"ListenersNotValid\"
+                  condition the Gateway Status when the Gateway contains incompatible
+                  Listeners whether or not they accept the Gateway. \n For example,
+                  the following Listener scenarios may be compatible depending on
+                  implementation capabilities: \n 1. Multiple Listeners with the same
+                  Port that all use the \"HTTP\" Protocol that all have unique Hostname
+                  values. 2. Multiple Listeners with the same Port that use either
+                  the \"HTTPS\" or \"TLS\" Protocol that all have unique Hostname
+                  values. 3. A mixture of \"TCP\" and \"UDP\" Protocol Listeners,
+                  where no Listener with the same Protocol has the same Port value.
+                  \n An implementation that cannot serve both TCP and UDP listens
+                  on the same address, or cannot mix HTTPS and generic TLS listens
+                  on the same port would not consider those cases compatible. \n Implementations
+                  using the Hostname value to select between same-Port Listeners MUST
+                  match inbound request hostnames from the most specific to least
+                  specific Hostname values to find the correct set of Routes. Exact
+                  matches must be processed before wildcard matches, and wildcard
+                  matches must be processed before fallback (empty Hostname value)
+                  matches. \n Implementations MAY collapse separate Gateways onto
+                  a single set of Addresses if the Listeners across all Gateways are
+                  compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -918,28 +930,40 @@ spec:
                   the TLS Conformance Profile, the below combinations of port and
                   protocol are considered Core and MUST be supported: \n 1. Port:
                   443, Protocol: TLS \n Port and protocol combinations not listed
-                  above are considered Extended. \n An implementation MAY group Listeners
-                  by Port and then collapse each group of Listeners into a single
-                  Listener if the implementation determines that the Listeners in
-                  the group are \"compatible\". An implementation MAY also group together
-                  and collapse compatible Listeners belonging to different Gateways.
-                  \n For example, an implementation might consider Listeners to be
-                  compatible with each other if all of the following conditions are
-                  met: \n 1. Either each Listener within the group specifies the \"HTTP\"
-                  Protocol or each Listener within the group specifies either the
-                  \"HTTPS\" or \"TLS\" Protocol. \n 2. Each Listener within the group
-                  specifies a Hostname that is unique within the group. \n 3. As a
-                  special case, one Listener within a group may omit Hostname, in
-                  which case this Listener matches when no other Listener matches.
-                  \n If the implementation does collapse compatible Listeners, the
-                  hostname provided in the incoming client request MUST be matched
-                  to a Listener to find the correct set of Routes. The incoming hostname
-                  MUST be matched using the Hostname field for each Listener in order
-                  of most to least specific. That is, exact matches must be processed
-                  before wildcard matches. \n If this field specifies multiple Listeners
-                  that have the same Port value but are not compatible, the implementation
-                  must raise a \"Conflicted\" condition in the Listener status. \n
-                  Support: Core"
+                  above are considered Extended. \n A Gateway's Listeners are considered
+                  \"compatible\" if: \n 1. The implementation can serve them in compliance
+                  with the Addresses requirement that all Listeners are available
+                  on all assigned addresses. 2. No Listeners sharing the same Port
+                  share the same Hostname value, including the empty value, if this
+                  would prevent the implementation from matching an inbound request
+                  to a specific Listener. \n Compatible combinations in Extended support
+                  are expected to vary across implementations. A combination that
+                  is compatible for one implementation may not be compatible for another.
+                  \n If this field specifies multiple Listeners that are not compatible,
+                  the implementation MUST raise a true \"Conflicted\" condition in
+                  the Listener Status. \n Implementations MAY choose to still accept
+                  a Gateway with conflicted Listeners if they accept a partial Listener
+                  set that contains no incompatible Listeners. They MUST set a \"ListenersNotValid\"
+                  condition the Gateway Status when the Gateway contains incompatible
+                  Listeners whether or not they accept the Gateway. \n For example,
+                  the following Listener scenarios may be compatible depending on
+                  implementation capabilities: \n 1. Multiple Listeners with the same
+                  Port that all use the \"HTTP\" Protocol that all have unique Hostname
+                  values. 2. Multiple Listeners with the same Port that use either
+                  the \"HTTPS\" or \"TLS\" Protocol that all have unique Hostname
+                  values. 3. A mixture of \"TCP\" and \"UDP\" Protocol Listeners,
+                  where no Listener with the same Protocol has the same Port value.
+                  \n An implementation that cannot serve both TCP and UDP listens
+                  on the same address, or cannot mix HTTPS and generic TLS listens
+                  on the same port would not consider those cases compatible. \n Implementations
+                  using the Hostname value to select between same-Port Listeners MUST
+                  match inbound request hostnames from the most specific to least
+                  specific Hostname values to find the correct set of Routes. Exact
+                  matches must be processed before wildcard matches, and wildcard
+                  matches must be processed before fallback (empty Hostname value)
+                  matches. \n Implementations MAY collapse separate Gateways onto
+                  a single set of Addresses if the Listeners across all Gateways are
+                  compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -173,8 +173,8 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations MAY collapse separate
-                  Gateways onto a single set of Addresses if the Listeners across
+                  takes precedence over `\"\"`. \n Implementations MAY merge separate
+                  Gateways onto a single set of Addresses if all Listeners across
                   all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
@@ -965,8 +965,8 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations MAY collapse separate
-                  Gateways onto a single set of Addresses if the Listeners across
+                  takes precedence over `\"\"`. \n Implementations MAY merge separate
+                  Gateways onto a single set of Addresses if all Listeners across
                   all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -150,30 +150,32 @@ spec:
                   are expected to vary across implementations. A combination that
                   is compatible for one implementation may not be compatible for another.
                   \n If this field specifies multiple Listeners that are not compatible,
-                  the implementation MUST raise a true \"Conflicted\" condition in
-                  the Listener Status. \n Implementations MAY choose to still accept
-                  a Gateway with conflicted Listeners if they accept a partial Listener
-                  set that contains no incompatible Listeners. They MUST set a \"ListenersNotValid\"
-                  condition the Gateway Status when the Gateway contains incompatible
-                  Listeners whether or not they accept the Gateway. \n For example,
-                  the following Listener scenarios may be compatible depending on
-                  implementation capabilities: \n 1. Multiple Listeners with the same
-                  Port that all use the \"HTTP\" Protocol that all have unique Hostname
-                  values. 2. Multiple Listeners with the same Port that use either
-                  the \"HTTPS\" or \"TLS\" Protocol that all have unique Hostname
-                  values. 3. A mixture of \"TCP\" and \"UDP\" Protocol Listeners,
-                  where no Listener with the same Protocol has the same Port value.
-                  \n An implementation that cannot serve both TCP and UDP listens
-                  on the same address, or cannot mix HTTPS and generic TLS listens
-                  on the same port would not consider those cases compatible. \n Implementations
-                  using the Hostname value to select between same-Port Listeners MUST
-                  match inbound request hostnames from the most specific to least
-                  specific Hostname values to find the correct set of Routes. Exact
-                  matches must be processed before wildcard matches, and wildcard
-                  matches must be processed before fallback (empty Hostname value)
-                  matches. \n Implementations MAY collapse separate Gateways onto
-                  a single set of Addresses if the Listeners across all Gateways are
-                  compatible. \n Support: Core"
+                  the implementation MUST set the \"Conflicted\" condition in the
+                  Listener Status to \"True\". \n Implementations MAY choose to still
+                  accept a Gateway with conflicted Listeners if they accept a partial
+                  Listener set that contains no incompatible Listeners. They MUST
+                  set a \"ListenersNotValid\" condition the Gateway Status when the
+                  Gateway contains incompatible Listeners whether or not they accept
+                  the Gateway. \n For example, the following Listener scenarios may
+                  be compatible depending on implementation capabilities: \n 1. Multiple
+                  Listeners with the same Port that all use the \"HTTP\" Protocol
+                  that all have unique Hostname values. 2. Multiple Listeners with
+                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
+                  that all have unique Hostname values. 3. A mixture of \"TCP\" and
+                  \"UDP\" Protocol Listeners, where no Listener with the same Protocol
+                  has the same Port value. \n An implementation that cannot serve
+                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
+                  and generic TLS listens on the same port would not consider those
+                  cases compatible. \n Implementations using the Hostname value to
+                  select between same-Port Listeners MUST match inbound request hostnames
+                  from the most specific to least specific Hostname values to find
+                  the correct set of Routes. Exact matches must be processed before
+                  wildcard matches, and wildcard matches must be processed before
+                  fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
+                  takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
+                  takes precedence over `\"\"`. \n Implementations MAY collapse separate
+                  Gateways onto a single set of Addresses if the Listeners across
+                  all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -940,30 +942,32 @@ spec:
                   are expected to vary across implementations. A combination that
                   is compatible for one implementation may not be compatible for another.
                   \n If this field specifies multiple Listeners that are not compatible,
-                  the implementation MUST raise a true \"Conflicted\" condition in
-                  the Listener Status. \n Implementations MAY choose to still accept
-                  a Gateway with conflicted Listeners if they accept a partial Listener
-                  set that contains no incompatible Listeners. They MUST set a \"ListenersNotValid\"
-                  condition the Gateway Status when the Gateway contains incompatible
-                  Listeners whether or not they accept the Gateway. \n For example,
-                  the following Listener scenarios may be compatible depending on
-                  implementation capabilities: \n 1. Multiple Listeners with the same
-                  Port that all use the \"HTTP\" Protocol that all have unique Hostname
-                  values. 2. Multiple Listeners with the same Port that use either
-                  the \"HTTPS\" or \"TLS\" Protocol that all have unique Hostname
-                  values. 3. A mixture of \"TCP\" and \"UDP\" Protocol Listeners,
-                  where no Listener with the same Protocol has the same Port value.
-                  \n An implementation that cannot serve both TCP and UDP listens
-                  on the same address, or cannot mix HTTPS and generic TLS listens
-                  on the same port would not consider those cases compatible. \n Implementations
-                  using the Hostname value to select between same-Port Listeners MUST
-                  match inbound request hostnames from the most specific to least
-                  specific Hostname values to find the correct set of Routes. Exact
-                  matches must be processed before wildcard matches, and wildcard
-                  matches must be processed before fallback (empty Hostname value)
-                  matches. \n Implementations MAY collapse separate Gateways onto
-                  a single set of Addresses if the Listeners across all Gateways are
-                  compatible. \n Support: Core"
+                  the implementation MUST set the \"Conflicted\" condition in the
+                  Listener Status to \"True\". \n Implementations MAY choose to still
+                  accept a Gateway with conflicted Listeners if they accept a partial
+                  Listener set that contains no incompatible Listeners. They MUST
+                  set a \"ListenersNotValid\" condition the Gateway Status when the
+                  Gateway contains incompatible Listeners whether or not they accept
+                  the Gateway. \n For example, the following Listener scenarios may
+                  be compatible depending on implementation capabilities: \n 1. Multiple
+                  Listeners with the same Port that all use the \"HTTP\" Protocol
+                  that all have unique Hostname values. 2. Multiple Listeners with
+                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
+                  that all have unique Hostname values. 3. A mixture of \"TCP\" and
+                  \"UDP\" Protocol Listeners, where no Listener with the same Protocol
+                  has the same Port value. \n An implementation that cannot serve
+                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
+                  and generic TLS listens on the same port would not consider those
+                  cases compatible. \n Implementations using the Hostname value to
+                  select between same-Port Listeners MUST match inbound request hostnames
+                  from the most specific to least specific Hostname values to find
+                  the correct set of Routes. Exact matches must be processed before
+                  wildcard matches, and wildcard matches must be processed before
+                  fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
+                  takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
+                  takes precedence over `\"\"`. \n Implementations MAY collapse separate
+                  Gateways onto a single set of Addresses if the Listeners across
+                  all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -143,24 +143,25 @@ spec:
                   above are considered Extended. \n A Gateway's Listeners are considered
                   \"compatible\" if: \n 1. The implementation can serve them in compliance
                   with the Addresses requirement that all Listeners are available
-                  on all assigned addresses. 2. No Listeners sharing the same Port
-                  share the same Hostname value, including the empty value, if this
-                  would prevent the implementation from matching an inbound request
-                  to a specific Listener. \n Compatible combinations in Extended support
-                  are expected to vary across implementations. A combination that
-                  is compatible for one implementation may not be compatible for another.
-                  \n If this field specifies multiple Listeners that are not compatible,
-                  the implementation MUST set the \"Conflicted\" condition in the
-                  Listener Status to \"True\". \n Implementations MAY choose to still
-                  accept a Gateway with conflicted Listeners if they accept a partial
-                  Listener set that contains no incompatible Listeners. They MUST
-                  set a \"ListenersNotValid\" condition the Gateway Status when the
-                  Gateway contains incompatible Listeners whether or not they accept
-                  the Gateway. \n For example, the following Listener scenarios may
-                  be compatible depending on implementation capabilities: \n 1. Multiple
-                  Listeners with the same Port that all use the \"HTTP\" Protocol
-                  that all have unique Hostname values. 2. Multiple Listeners with
-                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
+                  on all assigned addresses. 2. The implementation can match inbound
+                  requests to a single distinct Listener. When multiple Listeners
+                  share values for fields (for example, two Listeners with the same
+                  Port value), the implementation can can match requests to only one
+                  of the Listeners using other Listener fields. \n Compatible combinations
+                  in Extended support are expected to vary across implementations.
+                  A combination that is compatible for one implementation may not
+                  be compatible for another. \n If this field specifies multiple Listeners
+                  that are not compatible, the implementation MUST set the \"Conflicted\"
+                  condition in the Listener Status to \"True\". \n Implementations
+                  MAY choose to still accept a Gateway with conflicted Listeners if
+                  they accept a partial Listener set that contains no incompatible
+                  Listeners. They MUST set a \"ListenersNotValid\" condition the Gateway
+                  Status when the Gateway contains incompatible Listeners whether
+                  or not they accept the Gateway. \n For example, the following Listener
+                  scenarios may be compatible depending on implementation capabilities:
+                  \n 1. Multiple Listeners with the same Port that all use the \"HTTP\"
+                  Protocol that all have unique Hostname values. 2. Multiple Listeners
+                  with the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
                   that all have unique Hostname values. 3. A mixture of \"TCP\" and
                   \"UDP\" Protocol Listeners, where no Listener with the same Protocol
                   has the same Port value. \n An implementation that cannot serve
@@ -935,24 +936,25 @@ spec:
                   above are considered Extended. \n A Gateway's Listeners are considered
                   \"compatible\" if: \n 1. The implementation can serve them in compliance
                   with the Addresses requirement that all Listeners are available
-                  on all assigned addresses. 2. No Listeners sharing the same Port
-                  share the same Hostname value, including the empty value, if this
-                  would prevent the implementation from matching an inbound request
-                  to a specific Listener. \n Compatible combinations in Extended support
-                  are expected to vary across implementations. A combination that
-                  is compatible for one implementation may not be compatible for another.
-                  \n If this field specifies multiple Listeners that are not compatible,
-                  the implementation MUST set the \"Conflicted\" condition in the
-                  Listener Status to \"True\". \n Implementations MAY choose to still
-                  accept a Gateway with conflicted Listeners if they accept a partial
-                  Listener set that contains no incompatible Listeners. They MUST
-                  set a \"ListenersNotValid\" condition the Gateway Status when the
-                  Gateway contains incompatible Listeners whether or not they accept
-                  the Gateway. \n For example, the following Listener scenarios may
-                  be compatible depending on implementation capabilities: \n 1. Multiple
-                  Listeners with the same Port that all use the \"HTTP\" Protocol
-                  that all have unique Hostname values. 2. Multiple Listeners with
-                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
+                  on all assigned addresses. 2. The implementation can match inbound
+                  requests to a single distinct Listener. When multiple Listeners
+                  share values for fields (for example, two Listeners with the same
+                  Port value), the implementation can can match requests to only one
+                  of the Listeners using other Listener fields. \n Compatible combinations
+                  in Extended support are expected to vary across implementations.
+                  A combination that is compatible for one implementation may not
+                  be compatible for another. \n If this field specifies multiple Listeners
+                  that are not compatible, the implementation MUST set the \"Conflicted\"
+                  condition in the Listener Status to \"True\". \n Implementations
+                  MAY choose to still accept a Gateway with conflicted Listeners if
+                  they accept a partial Listener set that contains no incompatible
+                  Listeners. They MUST set a \"ListenersNotValid\" condition the Gateway
+                  Status when the Gateway contains incompatible Listeners whether
+                  or not they accept the Gateway. \n For example, the following Listener
+                  scenarios may be compatible depending on implementation capabilities:
+                  \n 1. Multiple Listeners with the same Port that all use the \"HTTP\"
+                  Protocol that all have unique Hostname values. 2. Multiple Listeners
+                  with the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
                   that all have unique Hostname values. 3. A mixture of \"TCP\" and
                   \"UDP\" Protocol Listeners, where no Listener with the same Protocol
                   has the same Port value. \n An implementation that cannot serve

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -174,14 +174,9 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations SHOULD NOT match
-                  requests to less specific Listeners if they exhaust attached routes
-                  on a more specific Listener. For example, a request for `subdomain.example.com/path`
-                  SHOULD NOT match an HTTPRoute attached to a Listener with Hostname
-                  `*.example.com` if there is a Listener with with Hostname `subdomain.example.com`,
-                  even if no routes on the second Listener match. \n Implementations
-                  MAY merge separate Gateways onto a single set of Addresses if all
-                  Listeners across all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Implementations MAY merge separate
+                  Gateways onto a single set of Addresses if all Listeners across
+                  all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -972,14 +967,9 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations SHOULD NOT match
-                  requests to less specific Listeners if they exhaust attached routes
-                  on a more specific Listener. For example, a request for `subdomain.example.com/path`
-                  SHOULD NOT match an HTTPRoute attached to a Listener with Hostname
-                  `*.example.com` if there is a Listener with with Hostname `subdomain.example.com`,
-                  even if no routes on the second Listener match. \n Implementations
-                  MAY merge separate Gateways onto a single set of Addresses if all
-                  Listeners across all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Implementations MAY merge separate
+                  Gateways onto a single set of Addresses if all Listeners across
+                  all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -174,9 +174,14 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations MAY merge separate
-                  Gateways onto a single set of Addresses if all Listeners across
-                  all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Implementations SHOULD NOT match
+                  requests to less specific Listeners if they exhaust attached routes
+                  on a more specific Listener. For example, a request for `subdomain.example.com/path`
+                  SHOULD NOT match an HTTPRoute attached to a Listener with Hostname
+                  `*.example.com` if there is a Listener with with Hostname `subdomain.example.com`,
+                  even if no routes on the second Listener match. \n Implementations
+                  MAY merge separate Gateways onto a single set of Addresses if all
+                  Listeners across all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -967,9 +972,14 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations MAY merge separate
-                  Gateways onto a single set of Addresses if all Listeners across
-                  all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Implementations SHOULD NOT match
+                  requests to less specific Listeners if they exhaust attached routes
+                  on a more specific Listener. For example, a request for `subdomain.example.com/path`
+                  SHOULD NOT match an HTTPRoute attached to a Listener with Hostname
+                  `*.example.com` if there is a Listener with with Hostname `subdomain.example.com`,
+                  even if no routes on the second Listener match. \n Implementations
+                  MAY merge separate Gateways onto a single set of Addresses if all
+                  Listeners across all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -140,28 +140,40 @@ spec:
                   the TLS Conformance Profile, the below combinations of port and
                   protocol are considered Core and MUST be supported: \n 1. Port:
                   443, Protocol: TLS \n Port and protocol combinations not listed
-                  above are considered Extended. \n An implementation MAY group Listeners
-                  by Port and then collapse each group of Listeners into a single
-                  Listener if the implementation determines that the Listeners in
-                  the group are \"compatible\". An implementation MAY also group together
-                  and collapse compatible Listeners belonging to different Gateways.
-                  \n For example, an implementation might consider Listeners to be
-                  compatible with each other if all of the following conditions are
-                  met: \n 1. Either each Listener within the group specifies the \"HTTP\"
-                  Protocol or each Listener within the group specifies either the
-                  \"HTTPS\" or \"TLS\" Protocol. \n 2. Each Listener within the group
-                  specifies a Hostname that is unique within the group. \n 3. As a
-                  special case, one Listener within a group may omit Hostname, in
-                  which case this Listener matches when no other Listener matches.
-                  \n If the implementation does collapse compatible Listeners, the
-                  hostname provided in the incoming client request MUST be matched
-                  to a Listener to find the correct set of Routes. The incoming hostname
-                  MUST be matched using the Hostname field for each Listener in order
-                  of most to least specific. That is, exact matches must be processed
-                  before wildcard matches. \n If this field specifies multiple Listeners
-                  that have the same Port value but are not compatible, the implementation
-                  must raise a \"Conflicted\" condition in the Listener status. \n
-                  Support: Core"
+                  above are considered Extended. \n A Gateway's Listeners are considered
+                  \"compatible\" if: \n 1. The implementation can serve them in compliance
+                  with the Addresses requirement that all Listeners are available
+                  on all assigned addresses. 2. No Listeners sharing the same Port
+                  share the same Hostname value, including the empty value, if this
+                  would prevent the implementation from matching an inbound request
+                  to a specific Listener. \n Compatible combinations in Extended support
+                  are expected to vary across implementations. A combination that
+                  is compatible for one implementation may not be compatible for another.
+                  \n If this field specifies multiple Listeners that are not compatible,
+                  the implementation MUST raise a true \"Conflicted\" condition in
+                  the Listener Status. \n Implementations MAY choose to still accept
+                  a Gateway with conflicted Listeners if they accept a partial Listener
+                  set that contains no incompatible Listeners. They MUST set a \"ListenersNotValid\"
+                  condition the Gateway Status when the Gateway contains incompatible
+                  Listeners whether or not they accept the Gateway. \n For example,
+                  the following Listener scenarios may be compatible depending on
+                  implementation capabilities: \n 1. Multiple Listeners with the same
+                  Port that all use the \"HTTP\" Protocol that all have unique Hostname
+                  values. 2. Multiple Listeners with the same Port that use either
+                  the \"HTTPS\" or \"TLS\" Protocol that all have unique Hostname
+                  values. 3. A mixture of \"TCP\" and \"UDP\" Protocol Listeners,
+                  where no Listener with the same Protocol has the same Port value.
+                  \n An implementation that cannot serve both TCP and UDP listens
+                  on the same address, or cannot mix HTTPS and generic TLS listens
+                  on the same port would not consider those cases compatible. \n Implementations
+                  using the Hostname value to select between same-Port Listeners MUST
+                  match inbound request hostnames from the most specific to least
+                  specific Hostname values to find the correct set of Routes. Exact
+                  matches must be processed before wildcard matches, and wildcard
+                  matches must be processed before fallback (empty Hostname value)
+                  matches. \n Implementations MAY collapse separate Gateways onto
+                  a single set of Addresses if the Listeners across all Gateways are
+                  compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -918,28 +930,40 @@ spec:
                   the TLS Conformance Profile, the below combinations of port and
                   protocol are considered Core and MUST be supported: \n 1. Port:
                   443, Protocol: TLS \n Port and protocol combinations not listed
-                  above are considered Extended. \n An implementation MAY group Listeners
-                  by Port and then collapse each group of Listeners into a single
-                  Listener if the implementation determines that the Listeners in
-                  the group are \"compatible\". An implementation MAY also group together
-                  and collapse compatible Listeners belonging to different Gateways.
-                  \n For example, an implementation might consider Listeners to be
-                  compatible with each other if all of the following conditions are
-                  met: \n 1. Either each Listener within the group specifies the \"HTTP\"
-                  Protocol or each Listener within the group specifies either the
-                  \"HTTPS\" or \"TLS\" Protocol. \n 2. Each Listener within the group
-                  specifies a Hostname that is unique within the group. \n 3. As a
-                  special case, one Listener within a group may omit Hostname, in
-                  which case this Listener matches when no other Listener matches.
-                  \n If the implementation does collapse compatible Listeners, the
-                  hostname provided in the incoming client request MUST be matched
-                  to a Listener to find the correct set of Routes. The incoming hostname
-                  MUST be matched using the Hostname field for each Listener in order
-                  of most to least specific. That is, exact matches must be processed
-                  before wildcard matches. \n If this field specifies multiple Listeners
-                  that have the same Port value but are not compatible, the implementation
-                  must raise a \"Conflicted\" condition in the Listener status. \n
-                  Support: Core"
+                  above are considered Extended. \n A Gateway's Listeners are considered
+                  \"compatible\" if: \n 1. The implementation can serve them in compliance
+                  with the Addresses requirement that all Listeners are available
+                  on all assigned addresses. 2. No Listeners sharing the same Port
+                  share the same Hostname value, including the empty value, if this
+                  would prevent the implementation from matching an inbound request
+                  to a specific Listener. \n Compatible combinations in Extended support
+                  are expected to vary across implementations. A combination that
+                  is compatible for one implementation may not be compatible for another.
+                  \n If this field specifies multiple Listeners that are not compatible,
+                  the implementation MUST raise a true \"Conflicted\" condition in
+                  the Listener Status. \n Implementations MAY choose to still accept
+                  a Gateway with conflicted Listeners if they accept a partial Listener
+                  set that contains no incompatible Listeners. They MUST set a \"ListenersNotValid\"
+                  condition the Gateway Status when the Gateway contains incompatible
+                  Listeners whether or not they accept the Gateway. \n For example,
+                  the following Listener scenarios may be compatible depending on
+                  implementation capabilities: \n 1. Multiple Listeners with the same
+                  Port that all use the \"HTTP\" Protocol that all have unique Hostname
+                  values. 2. Multiple Listeners with the same Port that use either
+                  the \"HTTPS\" or \"TLS\" Protocol that all have unique Hostname
+                  values. 3. A mixture of \"TCP\" and \"UDP\" Protocol Listeners,
+                  where no Listener with the same Protocol has the same Port value.
+                  \n An implementation that cannot serve both TCP and UDP listens
+                  on the same address, or cannot mix HTTPS and generic TLS listens
+                  on the same port would not consider those cases compatible. \n Implementations
+                  using the Hostname value to select between same-Port Listeners MUST
+                  match inbound request hostnames from the most specific to least
+                  specific Hostname values to find the correct set of Routes. Exact
+                  matches must be processed before wildcard matches, and wildcard
+                  matches must be processed before fallback (empty Hostname value)
+                  matches. \n Implementations MAY collapse separate Gateways onto
+                  a single set of Addresses if the Listeners across all Gateways are
+                  compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -173,8 +173,8 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations MAY collapse separate
-                  Gateways onto a single set of Addresses if the Listeners across
+                  takes precedence over `\"\"`. \n Implementations MAY merge separate
+                  Gateways onto a single set of Addresses if all Listeners across
                   all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
@@ -965,8 +965,8 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations MAY collapse separate
-                  Gateways onto a single set of Addresses if the Listeners across
+                  takes precedence over `\"\"`. \n Implementations MAY merge separate
+                  Gateways onto a single set of Addresses if all Listeners across
                   all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -150,30 +150,32 @@ spec:
                   are expected to vary across implementations. A combination that
                   is compatible for one implementation may not be compatible for another.
                   \n If this field specifies multiple Listeners that are not compatible,
-                  the implementation MUST raise a true \"Conflicted\" condition in
-                  the Listener Status. \n Implementations MAY choose to still accept
-                  a Gateway with conflicted Listeners if they accept a partial Listener
-                  set that contains no incompatible Listeners. They MUST set a \"ListenersNotValid\"
-                  condition the Gateway Status when the Gateway contains incompatible
-                  Listeners whether or not they accept the Gateway. \n For example,
-                  the following Listener scenarios may be compatible depending on
-                  implementation capabilities: \n 1. Multiple Listeners with the same
-                  Port that all use the \"HTTP\" Protocol that all have unique Hostname
-                  values. 2. Multiple Listeners with the same Port that use either
-                  the \"HTTPS\" or \"TLS\" Protocol that all have unique Hostname
-                  values. 3. A mixture of \"TCP\" and \"UDP\" Protocol Listeners,
-                  where no Listener with the same Protocol has the same Port value.
-                  \n An implementation that cannot serve both TCP and UDP listens
-                  on the same address, or cannot mix HTTPS and generic TLS listens
-                  on the same port would not consider those cases compatible. \n Implementations
-                  using the Hostname value to select between same-Port Listeners MUST
-                  match inbound request hostnames from the most specific to least
-                  specific Hostname values to find the correct set of Routes. Exact
-                  matches must be processed before wildcard matches, and wildcard
-                  matches must be processed before fallback (empty Hostname value)
-                  matches. \n Implementations MAY collapse separate Gateways onto
-                  a single set of Addresses if the Listeners across all Gateways are
-                  compatible. \n Support: Core"
+                  the implementation MUST set the \"Conflicted\" condition in the
+                  Listener Status to \"True\". \n Implementations MAY choose to still
+                  accept a Gateway with conflicted Listeners if they accept a partial
+                  Listener set that contains no incompatible Listeners. They MUST
+                  set a \"ListenersNotValid\" condition the Gateway Status when the
+                  Gateway contains incompatible Listeners whether or not they accept
+                  the Gateway. \n For example, the following Listener scenarios may
+                  be compatible depending on implementation capabilities: \n 1. Multiple
+                  Listeners with the same Port that all use the \"HTTP\" Protocol
+                  that all have unique Hostname values. 2. Multiple Listeners with
+                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
+                  that all have unique Hostname values. 3. A mixture of \"TCP\" and
+                  \"UDP\" Protocol Listeners, where no Listener with the same Protocol
+                  has the same Port value. \n An implementation that cannot serve
+                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
+                  and generic TLS listens on the same port would not consider those
+                  cases compatible. \n Implementations using the Hostname value to
+                  select between same-Port Listeners MUST match inbound request hostnames
+                  from the most specific to least specific Hostname values to find
+                  the correct set of Routes. Exact matches must be processed before
+                  wildcard matches, and wildcard matches must be processed before
+                  fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
+                  takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
+                  takes precedence over `\"\"`. \n Implementations MAY collapse separate
+                  Gateways onto a single set of Addresses if the Listeners across
+                  all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -940,30 +942,32 @@ spec:
                   are expected to vary across implementations. A combination that
                   is compatible for one implementation may not be compatible for another.
                   \n If this field specifies multiple Listeners that are not compatible,
-                  the implementation MUST raise a true \"Conflicted\" condition in
-                  the Listener Status. \n Implementations MAY choose to still accept
-                  a Gateway with conflicted Listeners if they accept a partial Listener
-                  set that contains no incompatible Listeners. They MUST set a \"ListenersNotValid\"
-                  condition the Gateway Status when the Gateway contains incompatible
-                  Listeners whether or not they accept the Gateway. \n For example,
-                  the following Listener scenarios may be compatible depending on
-                  implementation capabilities: \n 1. Multiple Listeners with the same
-                  Port that all use the \"HTTP\" Protocol that all have unique Hostname
-                  values. 2. Multiple Listeners with the same Port that use either
-                  the \"HTTPS\" or \"TLS\" Protocol that all have unique Hostname
-                  values. 3. A mixture of \"TCP\" and \"UDP\" Protocol Listeners,
-                  where no Listener with the same Protocol has the same Port value.
-                  \n An implementation that cannot serve both TCP and UDP listens
-                  on the same address, or cannot mix HTTPS and generic TLS listens
-                  on the same port would not consider those cases compatible. \n Implementations
-                  using the Hostname value to select between same-Port Listeners MUST
-                  match inbound request hostnames from the most specific to least
-                  specific Hostname values to find the correct set of Routes. Exact
-                  matches must be processed before wildcard matches, and wildcard
-                  matches must be processed before fallback (empty Hostname value)
-                  matches. \n Implementations MAY collapse separate Gateways onto
-                  a single set of Addresses if the Listeners across all Gateways are
-                  compatible. \n Support: Core"
+                  the implementation MUST set the \"Conflicted\" condition in the
+                  Listener Status to \"True\". \n Implementations MAY choose to still
+                  accept a Gateway with conflicted Listeners if they accept a partial
+                  Listener set that contains no incompatible Listeners. They MUST
+                  set a \"ListenersNotValid\" condition the Gateway Status when the
+                  Gateway contains incompatible Listeners whether or not they accept
+                  the Gateway. \n For example, the following Listener scenarios may
+                  be compatible depending on implementation capabilities: \n 1. Multiple
+                  Listeners with the same Port that all use the \"HTTP\" Protocol
+                  that all have unique Hostname values. 2. Multiple Listeners with
+                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
+                  that all have unique Hostname values. 3. A mixture of \"TCP\" and
+                  \"UDP\" Protocol Listeners, where no Listener with the same Protocol
+                  has the same Port value. \n An implementation that cannot serve
+                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
+                  and generic TLS listens on the same port would not consider those
+                  cases compatible. \n Implementations using the Hostname value to
+                  select between same-Port Listeners MUST match inbound request hostnames
+                  from the most specific to least specific Hostname values to find
+                  the correct set of Routes. Exact matches must be processed before
+                  wildcard matches, and wildcard matches must be processed before
+                  fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
+                  takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
+                  takes precedence over `\"\"`. \n Implementations MAY collapse separate
+                  Gateways onto a single set of Addresses if the Listeners across
+                  all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

From the attached issue, `Listeners` was unclear regarding what "compatible" meant, in particular that it was more whether the implementation could serve that Listener set on the same addresses while being able to match inbound requests to a single Listener only.

Updates the `GatewaySpec.Listeners` documentation to:

- Separate the definition of and examples for "compatible". Previously "compatible" wasn't clearly defined: we said what implmentations could do with compatible Listeners and provided an example that might be compatible depending on implmentation capabilities. The definition wasn't formal, and was only implied by the surrounding language.
- Move the "same port, different hostname" rule into the definition of "compatible".
- Reference the Addresses MUST in the "compatible" definition.
- Explicitly state that the examples are not normative and may not be compatible depending on implementation capabilities.
- Split the HTTP and HTTPS/TLS examples and add a mixed TCP/UDP example.
- Reword the Hostname matching MUST language to be specific to Hostname matching. Previously, it applied to all same-Port Listeners, and a narrow and pedantic interpretation would preclude TCP and UDP Listeners on the same port unless they used hostname matching, which they can't (because their routes don't have hostnames).
- Expand the Condition usage to apply to all compatibility cases (instead of just same port) and add language about the Gateway-level Condition.
- Use "collapsing" language only in reference to using the same address set across Gateways. Collapsing Listeners _within_ a Gateway didn't really make sense, as those Listeners remained distinct in configuration and status. For example, an HTTPS Listener and TLS Listener on the same port weren't collapsed in any meaningful sense--HTTPRoutes and TLSRoutes would still contribute to the appropriate Listener's `attachedRoutes` separately, not to a hypothetical single combined Listener.

There were two remaining areas of confusion that I didn't have perfect answers to. I've covered those in [a separate comment](https://github.com/kubernetes-sigs/gateway-api/pull/2288#issuecomment-1674091371).

**Which issue(s) this PR fixes**:

Fixes #2274 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```