### PR TITLE
feat: write/log report in suite

### DIFF
--- a/conformance/apis/v1alpha1/conformancereport.go
+++ b/conformance/apis/v1alpha1/conformancereport.go
@@ -71,7 +71,7 @@ type Implementation struct {
 	// addresses.
 	// Rather than Github usernames or email addresses you can provide a URL to the relevant
 	// support pages for the project. Ideally this would be something like the issue creation page
-	// on a repository, but for projects without a publicly exposed repository a general support 
+	// on a repository, but for projects without a publicly exposed repository a general support
 	// page URL can be provided.
 	Contact []string `json:"contact"`
 }

--- a/conformance/experimental_conformance_test.go
+++ b/conformance/experimental_conformance_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package conformance_test
 
 import (
-	"os"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -28,7 +27,6 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -122,6 +120,7 @@ func testExperimentalConformance(t *testing.T) {
 			},
 			Implementation:      *implementation,
 			ConformanceProfiles: conformanceProfiles,
+			ReportOutput:        *flags.ReportOutput,
 		})
 	if err != nil {
 		t.Fatalf("error creating experimental conformance test suite: %v", err)
@@ -129,25 +128,8 @@ func testExperimentalConformance(t *testing.T) {
 
 	cSuite.Setup(t)
 	cSuite.Run(t, tests.ConformanceTests)
-	report, err := cSuite.Report()
+	_, err = cSuite.Report(t)
 	if err != nil {
 		t.Fatalf("error generating conformance profile report: %v", err)
 	}
-	writeReport(t.Logf, *report, *flags.ReportOutput)
-}
-
-func writeReport(logf func(string, ...any), report confv1a1.ConformanceReport, output string) error {
-	rawReport, err := yaml.Marshal(report)
-	if err != nil {
-		return err
-	}
-
-	if output != "" {
-		if err = os.WriteFile(output, rawReport, 0644); err != nil {
-			return err
-		}
-	}
-	logf("Conformance report:\n%s", string(rawReport))
-
-	return nil
 }

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -90,7 +90,7 @@ func New(s Options) *ConformanceTestSuite {
 	}
 
 	switch {
-	case s.EnableAllSupportedFeatures == true:
+	case s.EnableAllSupportedFeatures:
 		s.SupportedFeatures = AllFeatures
 	case s.SupportedFeatures == nil:
 		s.SupportedFeatures = GatewayCoreFeatures


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/area conformance

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/2289

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
support automatically dump report in test suite
```
