### PR TITLE
docs(conformance): mention network policies

### DIFF
--- a/site-src/concepts/conformance.md
+++ b/site-src/concepts/conformance.md
@@ -169,7 +169,7 @@ go test ./conformance/... --run TestConformance/<ShortName>
 #### Network Policies
 
 In clusters that use [Container Network Interface (CNI) plugins][network_plugins]
-which which enforce network policies some conformance tests might require custom
+which enforce network policies some conformance tests might require custom
 [`NetworkPolicy`][netpol] resources to be added to the cluster in order to allow
 the traffic to reach the required destinations.
 

--- a/site-src/concepts/conformance.md
+++ b/site-src/concepts/conformance.md
@@ -166,6 +166,19 @@ feature) to run a very specific test by name. This can be done using the
 go test ./conformance/... --run TestConformance/<ShortName>
 ```
 
+#### Network Policies
+
+In clusters that use [Container Network Interface (CNI) plugins][network_plugins]
+which which enforce network policies some conformance tests might require custom
+[`NetworkPolicy`][netpol] resources to be added to the cluster in order to allow
+the traffic to reach the required destinations.
+
+Users are expected to add those required network policies so that their
+implementations pass those tests.
+
+[network_plugins]: https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
+[netpol]: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+
 ## Contributing to Conformance
 
 Many implementations run conformance tests as part of their full e2e test suite.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**

/kind documentation
/area conformance

**What this PR does / why we need it**:

This PR explicitly mentions that users are expected to provide required [NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) when running conformance tests in cluster with CNI plugins installed that enforce those policies.

**Which issue(s) this PR fixes**:

Related discussion: https://github.com/kubernetes-sigs/gateway-api/discussions/2137

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
