### PR TITLE
[conformance] Specify group: "" for mesh conformance parentRefs

### DIFF
--- a/conformance/tests/mesh-consumer-route.yaml
+++ b/conformance/tests/mesh-consumer-route.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: gateway-conformance-mesh-consumer
 spec:
   parentRefs:
-  - kind: Service
+  - group: ""
+    kind: Service
     name: echo-v1
     namespace: gateway-conformance-mesh
   rules:

--- a/conformance/tests/mesh-frontend.yaml
+++ b/conformance/tests/mesh-frontend.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: gateway-conformance-mesh
 spec:
   parentRefs:
-  - kind: Service
+  - group: ""
+    kind: Service
     name: echo-v2
   rules:
   - filters:

--- a/conformance/tests/mesh-ports.yaml
+++ b/conformance/tests/mesh-ports.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: gateway-conformance-mesh
 spec:
   parentRefs:
-  - kind: Service
+  - group: ""
+    kind: Service
     name: echo-v1
     port: 80
   rules:
@@ -26,7 +27,8 @@ metadata:
   namespace: gateway-conformance-mesh
 spec:
   parentRefs:
-  - kind: Service
+  - group: ""
+    kind: Service
     name: echo-v2
   rules:
   - filters:

--- a/conformance/tests/mesh-split.yaml
+++ b/conformance/tests/mesh-split.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: gateway-conformance-mesh
 spec:
   parentRefs:
-  - kind: Service
+  - group: ""
+    kind: Service
     name: echo
   rules:
   - matches:


### PR DESCRIPTION
Signed-off-by: flynn@buoyant.io

**What type of PR is this?**

/kind bug
/kind test
/area conformance

**What this PR does / why we need it**:

Many mesh conformance tests specify `parentRefs` with `kind: Service`, but don't specify the `group`. That will default the `group` to `gateway.networking.k8s.io`, which won't work for `kind: Service`.

**Which issue(s) this PR fixes**:

Fixes #2309

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
