### PR TITLE
Conformance tweaks for Linkerd and other meshes

### DIFF
--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -53,6 +53,7 @@ func TestConformance(t *testing.T) {
 	exemptFeatures := suite.ParseSupportedFeatures(*flags.ExemptFeatures)
 	skipTests := suite.ParseSkipTests(*flags.SkipTests)
 	namespaceLabels := suite.ParseNamespaceLabels(*flags.NamespaceLabels)
+	namespaceAnnotations := suite.ParseNamespaceAnnotations(*flags.NamespaceAnnotations)
 
 	t.Logf("Running conformance tests with %s GatewayClass\n cleanup: %t\n debug: %t\n enable all features: %t \n supported features: [%v]\n exempt features: [%v]",
 		*flags.GatewayClassName, *flags.CleanupBaseResources, *flags.ShowDebug, *flags.EnableAllSupportedFeatures, *flags.SupportedFeatures, *flags.ExemptFeatures)
@@ -70,6 +71,7 @@ func TestConformance(t *testing.T) {
 		ExemptFeatures:             exemptFeatures,
 		EnableAllSupportedFeatures: *flags.EnableAllSupportedFeatures,
 		NamespaceLabels:            namespaceLabels,
+		NamespaceAnnotations:       namespaceAnnotations,
 		SkipTests:                  skipTests,
 	})
 	cSuite.Setup(t)

--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -52,8 +52,8 @@ func TestConformance(t *testing.T) {
 	supportedFeatures := suite.ParseSupportedFeatures(*flags.SupportedFeatures)
 	exemptFeatures := suite.ParseSupportedFeatures(*flags.ExemptFeatures)
 	skipTests := suite.ParseSkipTests(*flags.SkipTests)
-	namespaceLabels := suite.ParseNamespaceLabels(*flags.NamespaceLabels)
-	namespaceAnnotations := suite.ParseNamespaceAnnotations(*flags.NamespaceAnnotations)
+	namespaceLabels := suite.ParseKeyValuePairs(*flags.NamespaceLabels)
+	namespaceAnnotations := suite.ParseKeyValuePairs(*flags.NamespaceAnnotations)
 
 	t.Logf("Running conformance tests with %s GatewayClass\n cleanup: %t\n debug: %t\n enable all features: %t \n supported features: [%v]\n exempt features: [%v]",
 		*flags.GatewayClassName, *flags.CleanupBaseResources, *flags.ShowDebug, *flags.EnableAllSupportedFeatures, *flags.SupportedFeatures, *flags.ExemptFeatures)

--- a/conformance/experimental_conformance_test.go
+++ b/conformance/experimental_conformance_test.go
@@ -73,8 +73,8 @@ func TestExperimentalConformance(t *testing.T) {
 	supportedFeatures = suite.ParseSupportedFeatures(*flags.SupportedFeatures)
 	exemptFeatures = suite.ParseSupportedFeatures(*flags.ExemptFeatures)
 	skipTests = suite.ParseSkipTests(*flags.SkipTests)
-	namespaceLabels = suite.ParseNamespaceLabels(*flags.NamespaceLabels)
-	namespaceAnnotations = suite.ParseNamespaceAnnotations(*flags.NamespaceAnnotations)
+	namespaceLabels = suite.ParseKeyValuePairs(*flags.NamespaceLabels)
+	namespaceAnnotations = suite.ParseKeyValuePairs(*flags.NamespaceAnnotations)
 
 	// experimental conformance flags
 	conformanceProfiles = suite.ParseConformanceProfiles(*flags.ConformanceProfiles)

--- a/conformance/experimental_conformance_test.go
+++ b/conformance/experimental_conformance_test.go
@@ -39,15 +39,16 @@ import (
 )
 
 var (
-	cfg                 *rest.Config
-	k8sClientset        *kubernetes.Clientset
-	mgrClient           client.Client
-	supportedFeatures   sets.Set[suite.SupportedFeature]
-	exemptFeatures      sets.Set[suite.SupportedFeature]
-	namespaceLabels     map[string]string
-	implementation      *confv1a1.Implementation
-	conformanceProfiles sets.Set[suite.ConformanceProfileName]
-	skipTests           []string
+	cfg                  *rest.Config
+	k8sClientset         *kubernetes.Clientset
+	mgrClient            client.Client
+	supportedFeatures    sets.Set[suite.SupportedFeature]
+	exemptFeatures       sets.Set[suite.SupportedFeature]
+	namespaceLabels      map[string]string
+	namespaceAnnotations map[string]string
+	implementation       *confv1a1.Implementation
+	conformanceProfiles  sets.Set[suite.ConformanceProfileName]
+	skipTests            []string
 )
 
 func TestExperimentalConformance(t *testing.T) {
@@ -73,6 +74,7 @@ func TestExperimentalConformance(t *testing.T) {
 	exemptFeatures = suite.ParseSupportedFeatures(*flags.ExemptFeatures)
 	skipTests = suite.ParseSkipTests(*flags.SkipTests)
 	namespaceLabels = suite.ParseNamespaceLabels(*flags.NamespaceLabels)
+	namespaceAnnotations = suite.ParseNamespaceAnnotations(*flags.NamespaceAnnotations)
 
 	// experimental conformance flags
 	conformanceProfiles = suite.ParseConformanceProfiles(*flags.ConformanceProfiles)
@@ -115,6 +117,7 @@ func testExperimentalConformance(t *testing.T) {
 				ExemptFeatures:             exemptFeatures,
 				EnableAllSupportedFeatures: *flags.EnableAllSupportedFeatures,
 				NamespaceLabels:            namespaceLabels,
+				NamespaceAnnotations:       namespaceAnnotations,
 				SkipTests:                  skipTests,
 			},
 			Implementation:      *implementation,

--- a/conformance/tests/mesh-frontend-hostname.go
+++ b/conformance/tests/mesh-frontend-hostname.go
@@ -33,6 +33,7 @@ var MeshFrontendHostname = suite.ConformanceTest{
 	Description: "Mesh parentRef matches Service IP (not Host)",
 	Features: []suite.SupportedFeature{
 		suite.SupportMesh,
+		suite.SupportHTTPResponseHeaderModification,
 	},
 	Manifests: []string{"tests/mesh-frontend.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {

--- a/conformance/utils/flags/flags.go
+++ b/conformance/utils/flags/flags.go
@@ -32,4 +32,5 @@ var (
 	ExemptFeatures             = flag.String("exempt-features", "", "Exempt Features excluded from conformance tests suites")
 	EnableAllSupportedFeatures = flag.Bool("all-features", false, "Whether to enable all supported features for conformance tests")
 	NamespaceLabels            = flag.String("namespace-labels", "", "Comma-separated list of name=value labels to add to test namespaces")
+	NamespaceAnnotations       = flag.String("namespace-annotations", "", "Comma-separated list of name=value annotations to add to test namespaces")
 )

--- a/conformance/utils/suite/experimental_suite.go
+++ b/conformance/utils/suite/experimental_suite.go
@@ -159,7 +159,8 @@ func NewExperimentalConformanceTestSuite(s ExperimentalConformanceOptions) (*Exp
 		BaseManifests:    s.BaseManifests,
 		MeshManifests:    s.MeshManifests,
 		Applier: kubernetes.Applier{
-			NamespaceLabels: s.NamespaceLabels,
+			NamespaceLabels:      s.NamespaceLabels,
+			NamespaceAnnotations: s.NamespaceAnnotations,
 		},
 		SupportedFeatures: s.SupportedFeatures,
 		TimeoutConfig:     s.TimeoutConfig,

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -182,7 +182,7 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 			"gateway-conformance-app-backend",
 			"gateway-conformance-web-backend",
 		}
-		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, namespaces)
+		kubernetes.MeshNamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, namespaces)
 	}
 }
 

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -55,15 +55,16 @@ type ConformanceTestSuite struct {
 
 // Options can be used to initialize a ConformanceTestSuite.
 type Options struct {
-	Client           client.Client
-	Clientset        clientset.Interface
-	RestConfig       *rest.Config
-	GatewayClassName string
-	Debug            bool
-	RoundTripper     roundtripper.RoundTripper
-	BaseManifests    string
-	MeshManifests    string
-	NamespaceLabels  map[string]string
+	Client               client.Client
+	Clientset            clientset.Interface
+	RestConfig           *rest.Config
+	GatewayClassName     string
+	Debug                bool
+	RoundTripper         roundtripper.RoundTripper
+	BaseManifests        string
+	MeshManifests        string
+	NamespaceLabels      map[string]string
+	NamespaceAnnotations map[string]string
 
 	// CleanupBaseResources indicates whether or not the base test
 	// resources such as Gateways should be cleaned up after the run.
@@ -118,7 +119,8 @@ func New(s Options) *ConformanceTestSuite {
 		BaseManifests:    s.BaseManifests,
 		MeshManifests:    s.MeshManifests,
 		Applier: kubernetes.Applier{
-			NamespaceLabels: s.NamespaceLabels,
+			NamespaceLabels:      s.NamespaceLabels,
+			NamespaceAnnotations: s.NamespaceAnnotations,
 		},
 		SupportedFeatures: s.SupportedFeatures,
 		TimeoutConfig:     s.TimeoutConfig,
@@ -248,6 +250,22 @@ func ParseSupportedFeatures(f string) sets.Set[SupportedFeature] {
 // ParseNamespaceLables parses flag arguments and converts the string to
 // map[string]string containing label key/value pairs.
 func ParseNamespaceLabels(f string) map[string]string {
+	if f == "" {
+		return nil
+	}
+	res := map[string]string{}
+	for _, kv := range strings.Split(f, ",") {
+		parts := strings.Split(kv, "=")
+		if len(parts) == 2 {
+			res[parts[0]] = parts[1]
+		}
+	}
+	return res
+}
+
+// ParseNamespaceAnnotations parses flag arguments and converts the string to
+// map[string]string containing annotation key/value pairs.
+func ParseNamespaceAnnotations(f string) map[string]string {
 	if f == "" {
 		return nil
 	}

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -247,25 +247,9 @@ func ParseSupportedFeatures(f string) sets.Set[SupportedFeature] {
 	return res
 }
 
-// ParseNamespaceLabels parses flag arguments and converts the string to
+// ParseKeyValuePairs parses flag arguments and converts the string to
 // map[string]string containing label key/value pairs.
-func ParseNamespaceLabels(f string) map[string]string {
-	if f == "" {
-		return nil
-	}
-	res := map[string]string{}
-	for _, kv := range strings.Split(f, ",") {
-		parts := strings.Split(kv, "=")
-		if len(parts) == 2 {
-			res[parts[0]] = parts[1]
-		}
-	}
-	return res
-}
-
-// ParseNamespaceAnnotations parses flag arguments and converts the string to
-// map[string]string containing annotation key/value pairs.
-func ParseNamespaceAnnotations(f string) map[string]string {
+func ParseKeyValuePairs(f string) map[string]string {
 	if f == "" {
 		return nil
 	}

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -247,7 +247,7 @@ func ParseSupportedFeatures(f string) sets.Set[SupportedFeature] {
 	return res
 }
 
-// ParseNamespaceLables parses flag arguments and converts the string to
+// ParseNamespaceLabels parses flag arguments and converts the string to
 // map[string]string containing label key/value pairs.
 func ParseNamespaceLabels(f string) map[string]string {
 	if f == "" {

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -47,7 +47,7 @@ func TestParseSupportedFeatures(t *testing.T) {
 	}
 }
 
-func TestParseNamespaceLabels(t *testing.T) {
+func TestParseKeyValuePairs(t *testing.T) {
 	flags := []string{
 		"",
 		"a=b",
@@ -61,7 +61,7 @@ func TestParseNamespaceLabels(t *testing.T) {
 
 	for i, f := range flags {
 		expect := labels[i]
-		got := ParseNamespaceLabels(f)
+		got := ParseKeyValuePairs(f)
 		if !reflect.DeepEqual(got, expect) {
 			t.Errorf("Unexpected labels from flags '%s', expected: %v, got: %v", f, expect, got)
 		}

--- a/site-src/concepts/conformance.md
+++ b/site-src/concepts/conformance.md
@@ -126,13 +126,24 @@ feature and any relevant API features, e.g:
 go test ./conformance/... -args -supported-features=Mesh,Gateway,HTTPRoute
 ```
 
-#### Namespace Labels
+#### Namespace Labels and Annotations
 
-If labels are needed on namespaces used for testing, you can use
-the `-namespace-labels` flag to pass one or more `name=value` labels to
-set on the test namespaces. For mesh testing, this flag can be used if
-an implementation requires labels on namespaces that host mesh workloads,
-for example, to enable sidecar injection.
+If labels are needed on namespaces used for testing, you can use the
+`-namespace-labels` flag to pass one or more `name=value` labels to set on the
+test namespaces. Likewise, `-namespace-annotations` can be used to specify
+annotations to be applied to the test namespaces. For mesh testing, this flag
+can be used if an implementation requires labels on namespaces that host mesh
+workloads, for example, to enable sidecar injection.
+
+As an example, when testing Linkerd, you might run
+
+```shell
+go test ./conformance/... -args \
+   ...
+   -namespace-annotations=linkerd.io/inject=enabled
+```
+
+so that the test namespaces are correctly injected into the mesh.
 
 #### Excluding Tests
 


### PR DESCRIPTION
/kind bug
/area conformance

This PR makes some small changes to allow conformance to work for Linkerd and, most likely, other meshes that don't also provide gateway controllers. Huge props to @adleong for doing most of the heavy lifting on this, weeks ago. :slightly_smiling_face:

Like most nontrivial PRs of mine, it is best reviewed commit by commit.

- Allow `-namespace-annotations` to annotate namespaces created by the tests

    We already had `-namespace-labels` to supply labels on test namespaces. Linkerd needs annotations rather than labels, so we add a new parallel flag to set annotations on test namespaces.

- Document `-namespace-annotations`

    Documentation is in a separate commit.

- comment fix

    This just triggered me so I had to fix it. :slightly_smiling_face:
    
- Split out `MeshNamespacesMustBeReady`, since mesh namespaces don't have Gateways

    If testing a service mesh that doesn't also provide a gateway controller, there won't be any Gateways in the namespace, so this pulls out a separate function to check that the namespace is ready without needing Gateways, and uses it for the namespaces used for mesh testing.

- `MeshFrontendHostname` requires `HTTPResponseHeaderModification`

    The `MeshFrontendHostname` test actually relies on a header modification, but wasn't tagged as such.

**Does this PR introduce a user-facing change?**:

```release-note
Better support mesh-only conformance testing
```
