### PR TITLE
Update GEP-1742 to refer to GEP-2257

### DIFF
--- a/geps/gep-1742.md
+++ b/geps/gep-1742.md
@@ -206,7 +206,7 @@ sequenceDiagram
     participant C as Client
     participant P as Proxy
     participant U as Upstream
-    
+
     C->>P: Connection Started
     activate U
     activate C
@@ -224,7 +224,7 @@ sequenceDiagram
     activate U
     note left of U: timeout queue<br/>(wait for available server)
     deactivate U
-		
+
     P->>U: Connection Started
     activate U
     P->>U: Starts sending Request

--- a/geps/gep-1742.md
+++ b/geps/gep-1742.md
@@ -368,9 +368,11 @@ sequenceDiagram
     U->>C: Connection ended
 ```
 
-Both timeout fields are string duration values as specified by
-[Golang time.ParseDuration](https://pkg.go.dev/time#ParseDuration) and MUST be >= 1ms
-or 0 to disable (no timeout).
+Both timeout fields are [GEP-2257 Duration] values. A zero-valued timeout
+("0s") MUST be interpreted as disabling the timeout; a non-zero-valued timeout
+MUST be >= 1ms.
+
+[GEP-2257 Duration]:/geps/gep-2257/
 
 ### GO
 


### PR DESCRIPTION
**What type of PR is this?**

/kind gep

**What this PR does / why we need it**:

The point of GEP-2257 was to nail down the syntax used for Durations, such as appear in GEP-1742, so... we should probably update GEP-1742 to actually make use of that. 😂

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
