### PR TITLE
Removing concept of resource-level support levels

### DIFF
--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -57,8 +57,6 @@ import (
 // for the affected listener with a reason of "UnsupportedProtocol".
 // Implementations MAY also accept HTTP/2 connections with an upgrade from
 // HTTP/1, i.e. without prior knowledge.
-//
-// Support: Extended
 type GRPCRoute struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha2/referencegrant_types.go
+++ b/apis/v1alpha2/referencegrant_types.go
@@ -48,8 +48,6 @@ import (
 // support ReferenceGrant MUST NOT permit cross-namespace references which have
 // no grant, and MUST respond to the removal of a grant by revoking the access
 // that the grant allowed.
-//
-// Support: Core
 type ReferenceGrant v1beta1.ReferenceGrant
 
 // +kubebuilder:object:root=true

--- a/apis/v1beta1/referencegrant_types.go
+++ b/apis/v1beta1/referencegrant_types.go
@@ -40,8 +40,6 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // support ReferenceGrant MUST NOT permit cross-namespace references which have
 // no grant, and MUST respond to the removal of a grant by revoking the access
 // that the grant allowed.
-//
-// Support: Core
 type ReferenceGrant struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -48,7 +48,7 @@ spec:
           If the implementation does not support this, then it MUST set the \"Accepted\"
           condition to \"False\" for the affected listener with a reason of \"UnsupportedProtocol\".
           Implementations MAY also accept HTTP/2 connections with an upgrade from
-          HTTP/1, i.e. without prior knowledge. \n Support: Extended"
+          HTTP/1, i.e. without prior knowledge."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
@@ -45,7 +45,7 @@ spec:
           allowing users to assert which cross-namespace object references are permitted.
           Implementations that support ReferenceGrant MUST NOT permit cross-namespace
           references which have no grant, and MUST respond to the removal of a grant
-          by revoking the access that the grant allowed. \n Support: Core"
+          by revoking the access that the grant allowed."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -170,7 +170,7 @@ spec:
           users to assert which cross-namespace object references are permitted. Implementations
           that support ReferenceGrant MUST NOT permit cross-namespace references which
           have no grant, and MUST respond to the removal of a grant by revoking the
-          access that the grant allowed. \n Support: Core"
+          access that the grant allowed."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
@@ -45,7 +45,7 @@ spec:
           allowing users to assert which cross-namespace object references are permitted.
           Implementations that support ReferenceGrant MUST NOT permit cross-namespace
           references which have no grant, and MUST respond to the removal of a grant
-          by revoking the access that the grant allowed. \n Support: Core"
+          by revoking the access that the grant allowed."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -170,7 +170,7 @@ spec:
           users to assert which cross-namespace object references are permitted. Implementations
           that support ReferenceGrant MUST NOT permit cross-namespace references which
           have no grant, and MUST respond to the removal of a grant by revoking the
-          access that the grant allowed. \n Support: Core"
+          access that the grant allowed."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -27,31 +27,23 @@ import "k8s.io/apimachinery/pkg/util/sets"
 type SupportedFeature string
 
 // -----------------------------------------------------------------------------
-// Features - Standard (Core)
+// Features - Gateway Conformance (Core)
 // -----------------------------------------------------------------------------
 
 const (
-	// This option indicates support for ReferenceGrant (core conformance).
-	// Opting out of this requires an implementation to have clearly implemented
-	// and documented equivalent safeguards.
-	SupportReferenceGrant SupportedFeature = "ReferenceGrant"
-	// This option indicates support for Gateway (core conformance).
+	// This option indicates support for Gateway.
 	// Opting out of this is allowed only for GAMMA-only implementations
 	SupportGateway SupportedFeature = "Gateway"
 )
 
-// StandardCoreFeatures are the features that are required to be conformant with
-// the Core API features (e.g. GatewayClass, Gateway, e.t.c.).
-//
-// TODO: we need clarity for standard vs experimental features.
-// See: https://github.com/kubernetes-sigs/gateway-api/issues/1891
-var StandardCoreFeatures = sets.New(
-	SupportReferenceGrant,
+// GatewayCoreFeatures are the features that are required to be conformant with
+// the Gateway resource.
+var GatewayCoreFeatures = sets.New(
 	SupportGateway,
 )
 
 // -----------------------------------------------------------------------------
-// Features - Standard (Extended)
+// Features - Gateway Conformance (Extended)
 // -----------------------------------------------------------------------------
 
 const (
@@ -61,30 +53,23 @@ const (
 
 // StandardExtendedFeatures are extra generic features that implementations may
 // choose to support as an opt-in.
-//
-// TODO: we need clarity for standard vs experimental features.
-// See: https://github.com/kubernetes-sigs/gateway-api/issues/1891
-var StandardExtendedFeatures = sets.New(
+var GatewayExtendedFeatures = sets.New(
 	SupportGatewayPort8080,
-).Insert(StandardCoreFeatures.UnsortedList()...)
+).Insert(GatewayCoreFeatures.UnsortedList()...)
 
 // -----------------------------------------------------------------------------
-// Features - Experimental (Extended)
+// Features - ReferenceGrant Conformance (Core)
 // -----------------------------------------------------------------------------
 
 const (
-	// This option indicates support for Destination Port matching.
-	SupportRouteDestinationPortMatching SupportedFeature = "RouteDestinationPortMatching"
+	// This option indicates support for ReferenceGrant.
+	SupportReferenceGrant SupportedFeature = "ReferenceGrant"
 )
 
-// ExperimentalExtendedFeatures are extra generic features that are currently
-// only available in our experimental release channel, and at an extended
-// support level.
-//
-// TODO: we need clarity for standard vs experimental features.
-// See: https://github.com/kubernetes-sigs/gateway-api/issues/1891
-var ExperimentalExtendedFeatures = sets.New(
-	SupportRouteDestinationPortMatching,
+// ReferenceGrantCoreFeatures includes all SupportedFeatures needed to be
+// conformant with the ReferenceGrant resource.
+var ReferenceGrantCoreFeatures = sets.New(
+	SupportReferenceGrant,
 )
 
 // -----------------------------------------------------------------------------
@@ -97,8 +82,8 @@ const (
 )
 
 // HTTPCoreFeatures includes all SupportedFeatures needed to be conformant with
-// the HTTPRoute.
-var HTTPCoreFeatures = sets.New(
+// the HTTPRoute resource.
+var HTTPRouteCoreFeatures = sets.New(
 	SupportHTTPRoute,
 )
 
@@ -138,7 +123,7 @@ const (
 // HTTPExtendedFeatures includes all the supported features for HTTPRoute
 // conformance and can be used to opt-in to run all HTTPRoute tests, including
 // extended features.
-var HTTPExtendedFeatures = sets.New(
+var HTTPRouteExtendedFeatures = sets.New(
 	SupportHTTPRouteQueryParamMatching,
 	SupportHTTPRouteMethodMatching,
 	SupportHTTPResponseHeaderModification,
@@ -161,7 +146,7 @@ const (
 
 // TLSCoreFeatures includes all the supported features for the TLSRoute API at
 // a Core level of support.
-var TLSCoreFeatures = sets.New(
+var TLSRouteCoreFeatures = sets.New(
 	SupportTLSRoute,
 )
 
@@ -181,6 +166,21 @@ var MeshCoreFeatures = sets.New(
 )
 
 // -----------------------------------------------------------------------------
+// Features - Experimental
+// -----------------------------------------------------------------------------
+
+const (
+	// This option indicates support for Destination Port matching.
+	SupportRouteDestinationPortMatching SupportedFeature = "RouteDestinationPortMatching"
+)
+
+// ExperimentalFeatures are extra generic features that are currently only
+// available in our experimental release channel.
+var ExperimentalFeatures = sets.New(
+	SupportRouteDestinationPortMatching,
+)
+
+// -----------------------------------------------------------------------------
 // Features - Compilations
 // -----------------------------------------------------------------------------
 
@@ -189,9 +189,10 @@ var MeshCoreFeatures = sets.New(
 //
 // NOTE: as new feature sets are added they should be inserted into this set.
 var AllFeatures = sets.New[SupportedFeature]().
-	Insert(StandardExtendedFeatures.UnsortedList()...).
-	Insert(ExperimentalExtendedFeatures.UnsortedList()...).
-	Insert(HTTPCoreFeatures.UnsortedList()...).
-	Insert(HTTPExtendedFeatures.UnsortedList()...).
-	Insert(TLSCoreFeatures.UnsortedList()...).
-	Insert(MeshCoreFeatures.UnsortedList()...)
+	Insert(GatewayExtendedFeatures.UnsortedList()...).
+	Insert(ReferenceGrantCoreFeatures.UnsortedList()...).
+	Insert(HTTPRouteCoreFeatures.UnsortedList()...).
+	Insert(HTTPRouteExtendedFeatures.UnsortedList()...).
+	Insert(TLSRouteCoreFeatures.UnsortedList()...).
+	Insert(MeshCoreFeatures.UnsortedList()...).
+	Insert(ExperimentalFeatures.UnsortedList()...)

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -93,9 +93,9 @@ func New(s Options) *ConformanceTestSuite {
 	case s.EnableAllSupportedFeatures == true:
 		s.SupportedFeatures = AllFeatures
 	case s.SupportedFeatures == nil:
-		s.SupportedFeatures = StandardCoreFeatures
+		s.SupportedFeatures = GatewayCoreFeatures
 	default:
-		for feature := range StandardCoreFeatures {
+		for feature := range GatewayCoreFeatures {
 			s.SupportedFeatures.Insert(feature)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation
/area conformance

**What this PR does / why we need it**:
The concept of conformance levels has gotten rather confusing as we've added both new features and resources. Some resources (GRPCRoute and ReferenceGrant) had conformance levels defined while the rest did not. This does some refactoring to try to make our documentation and lists of conformance features more consistent. This gets us to a point where:

1. Resources don't have support levels, implementations can choose to support whichever set of resources they want
2. Claiming the Support_Resource_ feature when running conformance tests means that you support the resource and all the core features it contains

As a result, the most notable change is that StandardCoreFeatures has been split into two: GatewayCoreFeatures and ReferenceGrantCoreFeatures, this more clearly matches the rest of our feature set. Hopefully this makes sense, but definitely let me know if this is just more confusing.

**Does this PR introduce a user-facing change?**:
```release-note
Conformance Profiles: Some sets of features have been renamed to more closely match the resource they correspond to.
```

/hold 
/cc @LiorLieberman @mlavacca @shaneutt 