### PR TITLE
Bumping go version to 1.20 to match upstream Kubernetes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/gateway-api
 
-go 1.19
+go 1.20
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This bumps the go version to 1.20 to match upstream Kubernetes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
