### PR TITLE
WIP: Allow specifying NodePort for the Listener ports

### DIFF
--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -128,7 +128,7 @@ type GatewaySpec struct {
 	// +kubebuilder:validation:XValidation:message="tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']",rule="self.all(l, l.protocol in ['HTTP', 'TCP', 'UDP'] ? !has(l.tls) : true)"
 	// +kubebuilder:validation:XValidation:message="hostname must not be specified for protocols ['TCP', 'UDP']",rule="self.all(l, l.protocol in ['TCP', 'UDP']  ? (!has(l.hostname) || l.hostname == '') : true)"
 	// +kubebuilder:validation:XValidation:message="Listener name must be unique within the Gateway",rule="self.all(l1, self.exists_one(l2, l1.name == l2.name))"
-	// +kubebuilder:validation:XValidation:message="Combination of port, protocol and hostname must be unique for each listener",rule="self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname : true)))"
+	// +kubebuilder:validation:XValidation:message="Combination of port, nodeport, protocol and hostname must be unique for each listener",rule="self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.nodeport == l2.nodeport && l1.protocol == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname : true)))"
 	Listeners []Listener `json:"listeners"`
 
 	// Addresses requested for this Gateway. This is optional and behavior can
@@ -207,6 +207,15 @@ type Listener struct {
 	//
 	// Support: Core
 	Port PortNumber `json:"port"`
+
+	// NodePort is the network port on each node where external traffic will be
+	// exposed. Multiple listeners may use the same node port, subject to the
+	// Listener compatibility rules.
+	//
+	// Support: Core
+	//
+	// +optional
+	NodePort PortNumber `json:"nodeport,omitempty"`
 
 	// Protocol specifies the network protocol this listener expects to receive.
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -330,6 +330,15 @@ spec:
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
+                    nodeport:
+                      description: "NodePort is the network port on each node where
+                        external traffic will be exposed. Multiple listeners may use
+                        the same node port, subject to the Listener compatibility
+                        rules. \n Support: Core"
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
                     port:
                       description: "Port is the network port. Multiple listeners may
                         use the same port, subject to the Listener compatibility rules.
@@ -494,11 +503,11 @@ spec:
                     || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
-                - message: Combination of port, protocol and hostname must be unique
-                    for each listener
-                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
-                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
-                    == l2.hostname : true)))'
+                - message: Combination of port, nodeport, protocol and hostname must
+                    be unique for each listener
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.nodeport
+                    == l2.nodeport && l1.protocol == l2.protocol && (has(l1.hostname)
+                    && has(l2.hostname) ? l1.hostname == l2.hostname : true)))'
             required:
             - gatewayClassName
             - listeners
@@ -1108,6 +1117,15 @@ spec:
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
+                    nodeport:
+                      description: "NodePort is the network port on each node where
+                        external traffic will be exposed. Multiple listeners may use
+                        the same node port, subject to the Listener compatibility
+                        rules. \n Support: Core"
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
                     port:
                       description: "Port is the network port. Multiple listeners may
                         use the same port, subject to the Listener compatibility rules.
@@ -1272,11 +1290,11 @@ spec:
                     || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
-                - message: Combination of port, protocol and hostname must be unique
-                    for each listener
-                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
-                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
-                    == l2.hostname : true)))'
+                - message: Combination of port, nodeport, protocol and hostname must
+                    be unique for each listener
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.nodeport
+                    == l2.nodeport && l1.protocol == l2.protocol && (has(l1.hostname)
+                    && has(l2.hostname) ? l1.hostname == l2.hostname : true)))'
             required:
             - gatewayClassName
             - listeners

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -330,6 +330,15 @@ spec:
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
+                    nodeport:
+                      description: "NodePort is the network port on each node where
+                        external traffic will be exposed. Multiple listeners may use
+                        the same node port, subject to the Listener compatibility
+                        rules. \n Support: Core"
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
                     port:
                       description: "Port is the network port. Multiple listeners may
                         use the same port, subject to the Listener compatibility rules.
@@ -494,11 +503,11 @@ spec:
                     || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
-                - message: Combination of port, protocol and hostname must be unique
-                    for each listener
-                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
-                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
-                    == l2.hostname : true)))'
+                - message: Combination of port, nodeport, protocol and hostname must
+                    be unique for each listener
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.nodeport
+                    == l2.nodeport && l1.protocol == l2.protocol && (has(l1.hostname)
+                    && has(l2.hostname) ? l1.hostname == l2.hostname : true)))'
             required:
             - gatewayClassName
             - listeners
@@ -1108,6 +1117,15 @@ spec:
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
+                    nodeport:
+                      description: "NodePort is the network port on each node where
+                        external traffic will be exposed. Multiple listeners may use
+                        the same node port, subject to the Listener compatibility
+                        rules. \n Support: Core"
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
                     port:
                       description: "Port is the network port. Multiple listeners may
                         use the same port, subject to the Listener compatibility rules.
@@ -1272,11 +1290,11 @@ spec:
                     || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
-                - message: Combination of port, protocol and hostname must be unique
-                    for each listener
-                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
-                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
-                    == l2.hostname : true)))'
+                - message: Combination of port, nodeport, protocol and hostname must
+                    be unique for each listener
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.nodeport
+                    == l2.nodeport && l1.protocol == l2.protocol && (has(l1.hostname)
+                    && has(l2.hostname) ? l1.hostname == l2.hostname : true)))'
             required:
             - gatewayClassName
             - listeners


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:
This PR allows users to specify a NodePort instead of a Port in the Listener.

**Which issue(s) this PR fixes**:
Fixes #2321
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add a NodePort field inside the Listener object.
```
