### PR TITLE
docs: Removed note about path redirect being experimental

### DIFF
--- a/site-src/guides/http-redirect-rewrite.md
+++ b/site-src/guides/http-redirect-rewrite.md
@@ -33,12 +33,6 @@ unchanged.
 
 ### Path redirects
 
-!!! info "Experimental Channel"
-
-    The `Path` field described below is currently only included in the
-    "Experimental" channel of Gateway API. Starting in v0.7.0, this
-    feature will graduate to the "Standard" channel.
-
 Path redirects use an HTTP Path Modifier to replace either entire paths or path
 prefixes. For example, the HTTPRoute below will issue a 302 redirect to all
 `redirect.example` requests whose path begins with `/cayenne` to `/paprika`:


### PR DESCRIPTION
Signed-off-by: Nico Vibert <nicolas.vibert@isovalent.com>

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Removed a reference that this feature will become a Standard feature in v0.7.0. Given that we are approaching v0.8.0, we can probably remove this now.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
