### PR TITLE
Add handling for indistinct ParentRefs with conformance tests

### DIFF
--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -137,27 +137,43 @@ spec:
                   support: \n * Gateway (Gateway conformance profile) * Service (Mesh
                   conformance profile, experimental, ClusterIP Services only) \n This
                   API may be extended in the future to support additional kinds of
-                  parent resources. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  parent resources. \n ParentRefs must be _distinct_. This means either
+                  that: \n * They select different objects.  If this is the case,
+                  then parentRef entries are distinct. In terms of fields, this means
+                  that the multi-part key defined by `group`, `kind`, `namespace`,
+                  and `name` must be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field
+                  used, each ParentRef that selects the same object must set the same
+                  set of optional fields to different values. If one ParentRef sets
+                  a combination of optional fields, all must set the same combination.
+                  \n Some examples: \n * If one ParentRef sets `sectionName`, all
+                  ParentRefs referencing the same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                  object must also set `port`. * If one ParentRef sets `sectionName`
+                  and `port`, all ParentRefs referencing the same object must also
+                  set `sectionName` and `port`. \n It is invalid to reference non-distinct
+                  ParentRefs in the same Route object. In this case, the Route must
+                  have the `Accepted` Condition set to `false`, with a Reason of `ParentsNotDistinct`.
+                  Note that _all_ ParentRefs must be distinct - having one distinct
+                  ParentRef and two indistinct ParentRefs must result in the entire
+                  Route being marked not `Accepted`, for example. \n It is possible
+                  to separately reference multiple distinct objects that may be merged
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route. \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -124,27 +124,43 @@ spec:
                   support: \n * Gateway (Gateway conformance profile) * Service (Mesh
                   conformance profile, experimental, ClusterIP Services only) \n This
                   API may be extended in the future to support additional kinds of
-                  parent resources. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  parent resources. \n ParentRefs must be _distinct_. This means either
+                  that: \n * They select different objects.  If this is the case,
+                  then parentRef entries are distinct. In terms of fields, this means
+                  that the multi-part key defined by `group`, `kind`, `namespace`,
+                  and `name` must be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field
+                  used, each ParentRef that selects the same object must set the same
+                  set of optional fields to different values. If one ParentRef sets
+                  a combination of optional fields, all must set the same combination.
+                  \n Some examples: \n * If one ParentRef sets `sectionName`, all
+                  ParentRefs referencing the same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                  object must also set `port`. * If one ParentRef sets `sectionName`
+                  and `port`, all ParentRefs referencing the same object must also
+                  set `sectionName` and `port`. \n It is invalid to reference non-distinct
+                  ParentRefs in the same Route object. In this case, the Route must
+                  have the `Accepted` Condition set to `false`, with a Reason of `ParentsNotDistinct`.
+                  Note that _all_ ParentRefs must be distinct - having one distinct
+                  ParentRef and two indistinct ParentRefs must result in the entire
+                  Route being marked not `Accepted`, for example. \n It is possible
+                  to separately reference multiple distinct objects that may be merged
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route. \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -2523,27 +2539,43 @@ spec:
                   support: \n * Gateway (Gateway conformance profile) * Service (Mesh
                   conformance profile, experimental, ClusterIP Services only) \n This
                   API may be extended in the future to support additional kinds of
-                  parent resources. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  parent resources. \n ParentRefs must be _distinct_. This means either
+                  that: \n * They select different objects.  If this is the case,
+                  then parentRef entries are distinct. In terms of fields, this means
+                  that the multi-part key defined by `group`, `kind`, `namespace`,
+                  and `name` must be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field
+                  used, each ParentRef that selects the same object must set the same
+                  set of optional fields to different values. If one ParentRef sets
+                  a combination of optional fields, all must set the same combination.
+                  \n Some examples: \n * If one ParentRef sets `sectionName`, all
+                  ParentRefs referencing the same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                  object must also set `port`. * If one ParentRef sets `sectionName`
+                  and `port`, all ParentRefs referencing the same object must also
+                  set `sectionName` and `port`. \n It is invalid to reference non-distinct
+                  ParentRefs in the same Route object. In this case, the Route must
+                  have the `Accepted` Condition set to `false`, with a Reason of `ParentsNotDistinct`.
+                  Note that _all_ ParentRefs must be distinct - having one distinct
+                  ParentRef and two indistinct ParentRefs must result in the entire
+                  Route being marked not `Accepted`, for example. \n It is possible
+                  to separately reference multiple distinct objects that may be merged
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route. \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -59,27 +59,43 @@ spec:
                   support: \n * Gateway (Gateway conformance profile) * Service (Mesh
                   conformance profile, experimental, ClusterIP Services only) \n This
                   API may be extended in the future to support additional kinds of
-                  parent resources. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  parent resources. \n ParentRefs must be _distinct_. This means either
+                  that: \n * They select different objects.  If this is the case,
+                  then parentRef entries are distinct. In terms of fields, this means
+                  that the multi-part key defined by `group`, `kind`, `namespace`,
+                  and `name` must be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field
+                  used, each ParentRef that selects the same object must set the same
+                  set of optional fields to different values. If one ParentRef sets
+                  a combination of optional fields, all must set the same combination.
+                  \n Some examples: \n * If one ParentRef sets `sectionName`, all
+                  ParentRefs referencing the same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                  object must also set `port`. * If one ParentRef sets `sectionName`
+                  and `port`, all ParentRefs referencing the same object must also
+                  set `sectionName` and `port`. \n It is invalid to reference non-distinct
+                  ParentRefs in the same Route object. In this case, the Route must
+                  have the `Accepted` Condition set to `false`, with a Reason of `ParentsNotDistinct`.
+                  Note that _all_ ParentRefs must be distinct - having one distinct
+                  ParentRef and two indistinct ParentRefs must result in the entire
+                  Route being marked not `Accepted`, for example. \n It is possible
+                  to separately reference multiple distinct objects that may be merged
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route. \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -105,27 +105,43 @@ spec:
                   support: \n * Gateway (Gateway conformance profile) * Service (Mesh
                   conformance profile, experimental, ClusterIP Services only) \n This
                   API may be extended in the future to support additional kinds of
-                  parent resources. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  parent resources. \n ParentRefs must be _distinct_. This means either
+                  that: \n * They select different objects.  If this is the case,
+                  then parentRef entries are distinct. In terms of fields, this means
+                  that the multi-part key defined by `group`, `kind`, `namespace`,
+                  and `name` must be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field
+                  used, each ParentRef that selects the same object must set the same
+                  set of optional fields to different values. If one ParentRef sets
+                  a combination of optional fields, all must set the same combination.
+                  \n Some examples: \n * If one ParentRef sets `sectionName`, all
+                  ParentRefs referencing the same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                  object must also set `port`. * If one ParentRef sets `sectionName`
+                  and `port`, all ParentRefs referencing the same object must also
+                  set `sectionName` and `port`. \n It is invalid to reference non-distinct
+                  ParentRefs in the same Route object. In this case, the Route must
+                  have the `Accepted` Condition set to `false`, with a Reason of `ParentsNotDistinct`.
+                  Note that _all_ ParentRefs must be distinct - having one distinct
+                  ParentRef and two indistinct ParentRefs must result in the entire
+                  Route being marked not `Accepted`, for example. \n It is possible
+                  to separately reference multiple distinct objects that may be merged
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route. \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -59,27 +59,43 @@ spec:
                   support: \n * Gateway (Gateway conformance profile) * Service (Mesh
                   conformance profile, experimental, ClusterIP Services only) \n This
                   API may be extended in the future to support additional kinds of
-                  parent resources. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  parent resources. \n ParentRefs must be _distinct_. This means either
+                  that: \n * They select different objects.  If this is the case,
+                  then parentRef entries are distinct. In terms of fields, this means
+                  that the multi-part key defined by `group`, `kind`, `namespace`,
+                  and `name` must be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field
+                  used, each ParentRef that selects the same object must set the same
+                  set of optional fields to different values. If one ParentRef sets
+                  a combination of optional fields, all must set the same combination.
+                  \n Some examples: \n * If one ParentRef sets `sectionName`, all
+                  ParentRefs referencing the same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                  object must also set `port`. * If one ParentRef sets `sectionName`
+                  and `port`, all ParentRefs referencing the same object must also
+                  set `sectionName` and `port`. \n It is invalid to reference non-distinct
+                  ParentRefs in the same Route object. In this case, the Route must
+                  have the `Accepted` Condition set to `false`, with a Reason of `ParentsNotDistinct`.
+                  Note that _all_ ParentRefs must be distinct - having one distinct
+                  ParentRef and two indistinct ParentRefs must result in the entire
+                  Route being marked not `Accepted`, for example. \n It is possible
+                  to separately reference multiple distinct objects that may be merged
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route. \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -124,27 +124,43 @@ spec:
                   support: \n * Gateway (Gateway conformance profile) * Service (Mesh
                   conformance profile, experimental, ClusterIP Services only) \n This
                   API may be extended in the future to support additional kinds of
-                  parent resources. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  parent resources. \n ParentRefs must be _distinct_. This means either
+                  that: \n * They select different objects.  If this is the case,
+                  then parentRef entries are distinct. In terms of fields, this means
+                  that the multi-part key defined by `group`, `kind`, `namespace`,
+                  and `name` must be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field
+                  used, each ParentRef that selects the same object must set the same
+                  set of optional fields to different values. If one ParentRef sets
+                  a combination of optional fields, all must set the same combination.
+                  \n Some examples: \n * If one ParentRef sets `sectionName`, all
+                  ParentRefs referencing the same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                  object must also set `port`. * If one ParentRef sets `sectionName`
+                  and `port`, all ParentRefs referencing the same object must also
+                  set `sectionName` and `port`. \n It is invalid to reference non-distinct
+                  ParentRefs in the same Route object. In this case, the Route must
+                  have the `Accepted` Condition set to `false`, with a Reason of `ParentsNotDistinct`.
+                  Note that _all_ ParentRefs must be distinct - having one distinct
+                  ParentRef and two indistinct ParentRefs must result in the entire
+                  Route being marked not `Accepted`, for example. \n It is possible
+                  to separately reference multiple distinct objects that may be merged
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route. \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually
@@ -2456,27 +2472,43 @@ spec:
                   support: \n * Gateway (Gateway conformance profile) * Service (Mesh
                   conformance profile, experimental, ClusterIP Services only) \n This
                   API may be extended in the future to support additional kinds of
-                  parent resources. \n It is invalid to reference an identical parent
-                  more than once. It is valid to reference multiple distinct sections
-                  within the same parent resource, such as two separate Listeners
-                  on the same Gateway or two separate ports on the same Service. \n
-                  It is possible to separately reference multiple distinct objects
-                  that may be collapsed by an implementation. For example, some implementations
-                  may choose to merge compatible Gateway Listeners together. If that
-                  is the case, the list of routes attached to those resources should
-                  also be merged. \n Note that for ParentRefs that cross namespace
-                  boundaries, there are specific rules. Cross-namespace references
-                  are only valid if they are explicitly allowed by something in the
-                  namespace they are referring to. For example, Gateway has the AllowedRoutes
-                  field, and ReferenceGrant provides a generic way to enable other
-                  kinds of cross-namespace reference. \n ParentRefs from a Route to
-                  a Service in the same namespace are \"producer\" routes, which apply
-                  default routing rules to inbound connections from any namespace
-                  to the Service. \n ParentRefs from a Route to a Service in a different
-                  namespace are \"consumer\" routes, and these routing rules are only
-                  applied to outbound connections originating from the same namespace
-                  as the Route, for which the intended destination of the connections
-                  are a Service targeted as a ParentRef of the Route. \n "
+                  parent resources. \n ParentRefs must be _distinct_. This means either
+                  that: \n * They select different objects.  If this is the case,
+                  then parentRef entries are distinct. In terms of fields, this means
+                  that the multi-part key defined by `group`, `kind`, `namespace`,
+                  and `name` must be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field
+                  used, each ParentRef that selects the same object must set the same
+                  set of optional fields to different values. If one ParentRef sets
+                  a combination of optional fields, all must set the same combination.
+                  \n Some examples: \n * If one ParentRef sets `sectionName`, all
+                  ParentRefs referencing the same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                  object must also set `port`. * If one ParentRef sets `sectionName`
+                  and `port`, all ParentRefs referencing the same object must also
+                  set `sectionName` and `port`. \n It is invalid to reference non-distinct
+                  ParentRefs in the same Route object. In this case, the Route must
+                  have the `Accepted` Condition set to `false`, with a Reason of `ParentsNotDistinct`.
+                  Note that _all_ ParentRefs must be distinct - having one distinct
+                  ParentRef and two indistinct ParentRefs must result in the entire
+                  Route being marked not `Accepted`, for example. \n It is possible
+                  to separately reference multiple distinct objects that may be merged
+                  by an implementation. For example, some implementations may choose
+                  to merge compatible Gateway Listeners together. If that is the case,
+                  the list of routes attached to those resources should also be merged.
+                  \n Note that for ParentRefs that cross namespace boundaries, there
+                  are specific rules. Cross-namespace references are only valid if
+                  they are explicitly allowed by something in the namespace they are
+                  referring to. For example, Gateway has the AllowedRoutes field,
+                  and ReferenceGrant provides a generic way to enable other kinds
+                  of cross-namespace reference. \n ParentRefs from a Route to a Service
+                  in the same namespace are \"producer\" routes, which apply default
+                  routing rules to inbound connections from any namespace to the Service.
+                  \n ParentRefs from a Route to a Service in a different namespace
+                  are \"consumer\" routes, and these routing rules are only applied
+                  to outbound connections originating from the same namespace as the
+                  Route, for which the intended destination of the connections are
+                  a Service targeted as a ParentRef of the Route. \n "
                 items:
                   description: "ParentReference identifies an API object (usually
                     a Gateway) that can be considered a parent of this resource (usually

--- a/conformance/tests/httproute-invalid-parentref-not-distinct.go
+++ b/conformance/tests/httproute-invalid-parentref-not-distinct.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteInvalidParentRefNotMatchingSectionName)
+}
+
+var HTTPRouteInvalidParentRefNotDistinct = suite.ConformanceTest{
+	ShortName:   "HTTPRouteInvalidParentRefNotDistinct",
+	Description: "A single HTTPRoute in the gateway-conformance-infra namespace should set the Accepted status to False with reason ParentsNotDistinct.",
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportHTTPRoute,
+	},
+	Manifests: []string{"tests/httproute-invalid-parentref-not-matching-section-name.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
+		routeNames := []string{
+			"httproute-parentrefs-indistinct-matching-sectionname",
+			"httproute-parentrefs-identical",
+			"httproute-parentrefs-one-sectionname",
+			"httproute-parentrefs-one-port",
+			"httproute-parentrefs-one-port-and-sectionname",
+		}
+		for _, routeName := range routeNames {
+
+			routeNN := types.NamespacedName{Name: routeName, Namespace: "gateway-conformance-infra"}
+
+			// The Route must have an Accepted Condition with a ParentsNotDistinct Reason.
+			t.Run("HTTPRoute with no matching sectionName in ParentRef has an Accepted Condition with status False and Reason ParentsNotDistinct", func(t *testing.T) {
+				resolvedRefsCond := metav1.Condition{
+					Type:   string(v1beta1.RouteConditionAccepted),
+					Status: metav1.ConditionFalse,
+					Reason: string(v1beta1.RouteReasonParentsNotDistinct),
+				}
+
+				kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, resolvedRefsCond)
+			})
+
+			t.Run("Route should not have Parents accepted in status", func(t *testing.T) {
+				kubernetes.HTTPRouteMustHaveNoAcceptedParents(t, suite.Client, suite.TimeoutConfig, routeNN)
+			})
+
+			t.Run("Gateway should have 0 Routes attached", func(t *testing.T) {
+				kubernetes.GatewayMustHaveZeroRoutes(t, suite.Client, suite.TimeoutConfig, gwNN)
+			})
+
+		}
+	},
+}

--- a/conformance/tests/httproute-invalid-parentref-not-distinct.yaml
+++ b/conformance/tests/httproute-invalid-parentref-not-distinct.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: httproute-parentrefs-indistinct-matching-sectionname
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+    namespace: gateway-conformance-infra
+    sectionName: http1
+  - name: same-namespace
+    namespace: gateway-conformance-infra
+    sectionName: http1
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      kind: Service
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: httproute-parentrefs-identical
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+    namespace: gateway-conformance-infra
+  - name: same-namespace
+    namespace: gateway-conformance-infra
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      kind: Service
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: httproute-parentrefs-one-sectionname
+  namespace: gateway-conformance-infra
+spec:
+  # This parentRefs section has two entries that are both individually valid
+  # but invalid when combined.
+  parentRefs:
+  - name: same-namespace
+    namespace: gateway-conformance-infra
+  - name: same-namespace
+    namespace: gateway-conformance-infra
+    sectionName: http
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      kind: Service
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: httproute-parentrefs-one-port
+  namespace: gateway-conformance-infra
+spec:
+  # This parentRefs section has two entries that are both individually valid
+  # but invalid when combined.
+  parentRefs:
+  - name: same-namespace
+    namespace: gateway-conformance-infra
+  - name: same-namespace
+    namespace: gateway-conformance-infra
+    port: 80
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      kind: Service
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: httproute-parentrefs-one-port-and-sectionname
+  namespace: gateway-conformance-infra
+spec:
+  # This parentRefs section has two entries that are both individually valid
+  # but invalid when combined.
+  parentRefs:
+  - name: same-namespace
+    namespace: gateway-conformance-infra
+  - name: same-namespace
+    namespace: gateway-conformance-infra
+    port: 80
+    sectionName: http
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      kind: Service
+      port: 8080


### PR DESCRIPTION
/kind cleanup
/kind test

/area conformance
-->

**What this PR does / why we need it**:
This PR adds clarity around how ParentRefs must be distinct, with conformance tests to verify.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2326
Fixes #1925

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Clarified that ParentRefs must be distinct.
```
