### PR TITLE
fix leaking TCP connections which leads to consistent conformance test failures

### DIFF
--- a/conformance/utils/roundtripper/roundtripper.go
+++ b/conformance/utils/roundtripper/roundtripper.go
@@ -119,6 +119,14 @@ func (d *DefaultRoundTripper) CaptureRoundTrip(request Request) (*CapturedReques
 
 	transport := &http.Transport{
 		DialContext: d.CustomDialContext,
+		// We disable keep-alives so that we don't leak established TCP connections.
+		// Leaking TCP connections is bad because we could eventually hit the
+		// threshold of maximum number of open TCP connections to a specific
+		// destination. Keep-alives are not presently utilized so disabling this has
+		// no adverse affect.
+		//
+		// Ref. https://github.com/kubernetes-sigs/gateway-api/issues/2357
+		DisableKeepAlives: true,
 	}
 	if request.Server != "" && len(request.CertPem) != 0 && len(request.KeyPem) != 0 {
 		tlsConfig, err := tlsClientConfig(request.Server, request.CertPem, request.KeyPem)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

## What type of PR is this?
/kind bug
/kind test
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind gep

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

## What this PR does / why we need it:

### The problem:
* At present, each HTTP request creates a new TCP connection within our tests.
* We make `keep-alive` HTTP requests which means that after the HTTP request completes, we don't close the TCP connection.
* While we are waiting for convergence, we continuously make HTTP requests which keep on leaking TCP connections.
```bash
# Example of active TCP connections to a Gateway with IP 42.54.109.216
❯ ss -tan | grep 42.54.109.216 | head -n 3
ESTAB      0      0               192.168.24.68:50606           42.54.109.216:80
ESTAB      0      0               192.168.24.68:51233           42.54.109.216:80
ESTAB      0      0               192.168.24.68:41312           42.54.109.216:80

# Count of active TCP connections keeps on increasing
❯ ss -tan | grep 42.54.109.216 | wc -l
130
```

* If the implementation takes longer to program the Gateway, the leaks end up exhausting the maximum number of active connections to a single host
    * The limit of maximum active connections to a single destination may either come from the client machine, or from any NAT system which sits in front of the client machine where the tests are run.
* On reaching the limit, we fail to make new HTTP requests and end up failing the tests.

### Solution:
Solution is pretty straightforward: we disable HTTP keep-alives. 
* Even right now, although we use HTTP keep-alive, we are actually not making use of this feature since we always create a new TCP connection for each HTTP request. This means the change does not have any adverse effect as we just closes the old TCP connections which we are no longer using.
* Given that we are just working with tests here, we may not want to over-optimize by reusing TCP connections and just use the simplest approach to fix this right now.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/2357

## Does this PR introduce a user-facing change?:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
