### PR TITLE
Add conformance for multiple mirror filters

### DIFF
--- a/conformance/tests/httproute-request-multiple-mirrors.go
+++ b/conformance/tests/httproute-request-multiple-mirrors.go
@@ -70,7 +70,7 @@ var HTTPRouteRequestMirrors = suite.ConformanceTest{
 				Namespace: ns,
 			}, {
 				Request: http.Request{
-					Path: "/mirror-and-modify-headers",
+					Path: "/mirror-and-modify-request-headers",
 					Headers: map[string]string{
 						"X-Header-Remove":     "remove-val",
 						"X-Header-Add-Append": "append-val-1",
@@ -78,7 +78,7 @@ var HTTPRouteRequestMirrors = suite.ConformanceTest{
 				},
 				ExpectedRequest: &http.ExpectedRequest{
 					Request: http.Request{
-						Path: "/mirror-and-modify-headers",
+						Path: "/mirror-and-modify-request-headers",
 						Headers: map[string]string{
 							"X-Header-Add":        "header-val-1",
 							"X-Header-Add-Append": "append-val-1,header-val-2",

--- a/conformance/tests/httproute-request-multiple-mirrors.go
+++ b/conformance/tests/httproute-request-multiple-mirrors.go
@@ -27,18 +27,18 @@ import (
 )
 
 func init() {
-	ConformanceTests = append(ConformanceTests, HTTPRouteRequestMirrors)
+	ConformanceTests = append(ConformanceTests, HTTPRouteRequestMultipleMirrors)
 }
 
-var HTTPRouteRequestMirrors = suite.ConformanceTest{
-	ShortName:   "HTTPRouteRequestMirrors",
+var HTTPRouteRequestMultipleMirrors = suite.ConformanceTest{
+	ShortName:   "HTTPRouteRequestMultipleMirrors",
 	Description: "An HTTPRoute with multiple request mirror filters",
 	Manifests:   []string{"tests/httproute-request-multiple-mirrors.yaml"},
 	Features: []suite.SupportedFeature{
 		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRouteRequestMirror,
-		suite.SupportHTTPRouteRequestMirrors,
+		suite.SupportHTTPRouteRequestMultipleMirrors,
 	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"

--- a/conformance/tests/httproute-request-multiple-mirrors.go
+++ b/conformance/tests/httproute-request-multiple-mirrors.go
@@ -27,21 +27,22 @@ import (
 )
 
 func init() {
-	ConformanceTests = append(ConformanceTests, HTTPRouteRequestMirror)
+	ConformanceTests = append(ConformanceTests, HTTPRouteRequestMirrors)
 }
 
-var HTTPRouteRequestMirror = suite.ConformanceTest{
-	ShortName:   "HTTPRouteRequestMirror",
-	Description: "An HTTPRoute with request mirror filter",
-	Manifests:   []string{"tests/httproute-request-mirror.yaml"},
+var HTTPRouteRequestMirrors = suite.ConformanceTest{
+	ShortName:   "HTTPRouteRequestMirrors",
+	Description: "An HTTPRoute with multiple request mirror filters",
+	Manifests:   []string{"tests/httproute-request-multiple-mirrors.yaml"},
 	Features: []suite.SupportedFeature{
 		suite.SupportGateway,
 		suite.SupportHTTPRoute,
 		suite.SupportHTTPRouteRequestMirror,
+		suite.SupportHTTPRouteRequestMirrors,
 	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
-		routeNN := types.NamespacedName{Name: "request-mirror", Namespace: ns}
+		routeNN := types.NamespacedName{Name: "request-multiple-mirrors", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
@@ -56,13 +57,18 @@ var HTTPRouteRequestMirror = suite.ConformanceTest{
 					},
 				},
 				Backend: "infra-backend-v1",
-				MirroredTo: []http.BackendRef{{
-					Name:      "infra-backend-v2",
-					Namespace: ns,
-				}},
+				MirroredTo: []http.BackendRef{
+					{
+						Name:      "infra-backend-v2",
+						Namespace: ns,
+					},
+					{
+						Name:      "infra-backend-v3",
+						Namespace: "another-namespace",
+					},
+				},
 				Namespace: ns,
-			},
-			{
+			}, {
 				Request: http.Request{
 					Path: "/mirror-and-modify-headers",
 					Headers: map[string]string{
@@ -83,10 +89,16 @@ var HTTPRouteRequestMirror = suite.ConformanceTest{
 				},
 				Namespace: ns,
 				Backend:   "infra-backend-v1",
-				MirroredTo: []http.BackendRef{{
-					Name:      "infra-backend-v2",
-					Namespace: ns,
-				}},
+				MirroredTo: []http.BackendRef{
+					{
+						Name:      "infra-backend-v2",
+						Namespace: ns,
+					},
+					{
+						Name:      "infra-backend-v3",
+						Namespace: "another-namespace",
+					},
+				},
 			},
 		}
 		for i := range testCases {

--- a/conformance/tests/httproute-request-multiple-mirrors.yaml
+++ b/conformance/tests/httproute-request-multiple-mirrors.yaml
@@ -1,0 +1,63 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: request-multiple-mirrors
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /mirror
+    filters:
+    - type: RequestMirror
+      requestMirror:
+        backendRef:
+          name: infra-backend-v2
+          namespace: gateway-conformance-infra
+          port: 8080
+    - type: RequestMirror
+      requestMirror:
+        backendRef:
+          name: infra-backend-v3
+          namespace: another-namespace
+          port: 8080
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      namespace: gateway-conformance-infra
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /mirror-and-modify-headers
+    filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        set:
+        - name: X-Header-Set
+          value: set-overwrites-values
+        add:
+        - name: X-Header-Add
+          value: header-val-1
+        - name: X-Header-Add-Append
+          value: header-val-2
+        remove:
+        - X-Header-Remove
+    - type: RequestMirror
+      requestMirror:
+        backendRef:
+          name: infra-backend-v2
+          namespace: gateway-conformance-infra
+          port: 8080
+    - type: RequestMirror
+      requestMirror:
+        backendRef:
+          name: infra-backend-v3
+          namespace: another-namespace
+          port: 8080
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      namespace: gateway-conformance-infra

--- a/conformance/tests/httproute-request-multiple-mirrors.yaml
+++ b/conformance/tests/httproute-request-multiple-mirrors.yaml
@@ -31,7 +31,7 @@ spec:
   - matches:
     - path:
         type: PathPrefix
-        value: /mirror-and-modify-headers
+        value: /mirror-and-modify-request-headers
     filters:
     - type: RequestHeaderModifier
       requestHeaderModifier:

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -52,8 +52,8 @@ type ExpectedResponse struct {
 	Backend   string
 	Namespace string
 
-	// MirroredTo is the destination pod of the mirrored request.
-	MirroredTo string
+	// MirroredTo is the destination BackendRefs of the mirrored request.
+	MirroredTo []BackendRef
 
 	// User Given TestCase name
 	TestCaseName string
@@ -85,6 +85,11 @@ type Response struct {
 	StatusCode    int
 	Headers       map[string]string
 	AbsentHeaders []string
+}
+
+type BackendRef struct {
+	Name      string
+	Namespace string
 }
 
 // MakeRequestAndExpectEventuallyConsistentResponse makes a request with the given parameters,

--- a/conformance/utils/http/mirror.go
+++ b/conformance/utils/http/mirror.go
@@ -52,7 +52,7 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 				t.Logf(`Reading "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name)
 				logs, err := kubernetes.DumpEchoLogs(mirrorPod.Namespace, mirrorPod.Name, client, clientset)
 				if err != nil {
-					t.Logf(`could not read "%s/%s" logs: %v`, mirrorPod.Namespace, mirrorPod.Name, err)
+					t.Logf(`Couldn't read "%s/%s" logs: %v`, mirrorPod.Namespace, mirrorPod.Name, err)
 					return false
 				}
 

--- a/conformance/utils/http/mirror.go
+++ b/conformance/utils/http/mirror.go
@@ -31,9 +31,9 @@ import (
 )
 
 func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clientset.Interface, mirrorPods []BackendRef, path string) {
-	for _, mirrorPod := range mirrorPods {
+	for i, mirrorPod := range mirrorPods {
 		if mirrorPod.Name == "" {
-			t.Fatalf("MirroredTo wasn't provided in the testcase, this test should only check http request mirror.")
+			t.Fatalf("Mirrored BackendRef[%d].Name wasn't provided in the testcase, this test should only check http request mirror.", i)
 		}
 	}
 
@@ -49,10 +49,10 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 				mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to \\%s to client", path))
 
 				t.Log("Searching for the mirrored request log")
-				t.Logf("Reading \"%s/%s\" logs", mirrorPod.Namespace, mirrorPod.Name)
+				t.Logf(`Reading "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name)
 				logs, err := kubernetes.DumpEchoLogs(mirrorPod.Namespace, mirrorPod.Name, client, clientset)
 				if err != nil {
-					t.Logf("could not read \"%s/%s\" logs: %v", mirrorPod.Namespace, mirrorPod.Name, err)
+					t.Logf(`could not read "%s/%s" logs: %v`, mirrorPod.Namespace, mirrorPod.Name, err)
 					return false
 				}
 
@@ -63,11 +63,11 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 					}
 				}
 				return mirrored
-			}, 60*time.Second, time.Second, fmt.Sprintf("Couldn't find mirrored request in \"%s/%s\" logs", mirrorPod.Namespace, mirrorPod.Name))
+			}, 60*time.Second, time.Second, fmt.Sprintf(`Couldn't find mirrored request in "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name))
 		}(mirrorPod)
 	}
 
 	wg.Wait()
 
-	t.Log("Mirrored request log found")
+	t.Log("Found mirrored request log in all desired backends")
 }

--- a/conformance/utils/http/mirror.go
+++ b/conformance/utils/http/mirror.go
@@ -19,6 +19,7 @@ package http
 import (
 	"fmt"
 	"regexp"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,31 +30,44 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 )
 
-func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clientset.Interface, ns, mirrorPod, path string) {
-	if mirrorPod == "" {
-		t.Fatalf("MirroredTo wasn't provided in the testcase, this test should only check http request mirror.")
+func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clientset.Interface, mirrorPods []BackendRef, path string) {
+	for _, mirrorPod := range mirrorPods {
+		if mirrorPod.Name == "" {
+			t.Fatalf("MirroredTo wasn't provided in the testcase, this test should only check http request mirror.")
+		}
 	}
 
-	require.Eventually(t, func() bool {
-		var mirrored bool
-		mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to \\%s to client", path))
+	var wg sync.WaitGroup
+	wg.Add(len(mirrorPods))
 
-		t.Log("Searching for the mirrored request log")
-		t.Logf("Reading \"%s/%s\" logs", ns, mirrorPod)
-		logs, err := kubernetes.DumpEchoLogs(ns, mirrorPod, client, clientset)
-		if err != nil {
-			t.Logf("could not read \"%s/%s\" logs: %v", ns, mirrorPod, err)
-			return false
-		}
+	for _, mirrorPod := range mirrorPods {
+		go func(mirrorPod BackendRef) {
+			defer wg.Done()
 
-		for _, log := range logs {
-			if mirrorLogRegexp.MatchString(string(log)) {
-				mirrored = true
-				break
-			}
-		}
-		return mirrored
-	}, 60*time.Second, time.Second, "Mirrored request log wasn't found")
+			require.Eventually(t, func() bool {
+				var mirrored bool
+				mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to \\%s to client", path))
+
+				t.Log("Searching for the mirrored request log")
+				t.Logf("Reading \"%s/%s\" logs", mirrorPod.Namespace, mirrorPod.Name)
+				logs, err := kubernetes.DumpEchoLogs(mirrorPod.Namespace, mirrorPod.Name, client, clientset)
+				if err != nil {
+					t.Logf("could not read \"%s/%s\" logs: %v", mirrorPod.Namespace, mirrorPod.Name, err)
+					return false
+				}
+
+				for _, log := range logs {
+					if mirrorLogRegexp.MatchString(string(log)) {
+						mirrored = true
+						break
+					}
+				}
+				return mirrored
+			}, 60*time.Second, time.Second, "Mirrored request log wasn't found")
+		}(mirrorPod)
+	}
+
+	wg.Wait()
 
 	t.Log("Mirrored request log found")
 }

--- a/conformance/utils/http/mirror.go
+++ b/conformance/utils/http/mirror.go
@@ -63,7 +63,7 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 					}
 				}
 				return mirrored
-			}, 60*time.Second, time.Second, "Mirrored request log wasn't found")
+			}, 60*time.Second, time.Second, fmt.Sprintf("Couldn't find mirrored request in \"%s/%s\" logs", mirrorPod.Namespace, mirrorPod.Name))
 		}(mirrorPod)
 	}
 

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -118,6 +118,9 @@ const (
 
 	// This option indicates support for HTTPRoute request mirror (extended conformance).
 	SupportHTTPRouteRequestMirror SupportedFeature = "HTTPRouteRequestMirror"
+
+	// This option indicates support for HTTPRoute request with multiple mirrors (extended conformance).
+	SupportHTTPRouteRequestMirrors SupportedFeature = "HTTPRouteRequestMirrors"
 )
 
 // HTTPRouteExtendedFeatures includes all the supported features for HTTPRoute

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -120,7 +120,7 @@ const (
 	SupportHTTPRouteRequestMirror SupportedFeature = "HTTPRouteRequestMirror"
 
 	// This option indicates support for multiple RequestMirror filters within the same HTTPRoute rule (extended conformance).
-	SupportHTTPRouteRequestMirrors SupportedFeature = "HTTPRouteRequestMirrors"
+	SupportHTTPRouteRequestMultipleMirrors SupportedFeature = "HTTPRouteRequestMultipleMirrors"
 )
 
 // HTTPRouteExtendedFeatures includes all the supported features for HTTPRoute
@@ -136,6 +136,7 @@ var HTTPRouteExtendedFeatures = sets.New(
 	SupportHTTPRouteHostRewrite,
 	SupportHTTPRoutePathRewrite,
 	SupportHTTPRouteRequestMirror,
+	SupportHTTPRouteRequestMultipleMirrors,
 )
 
 // -----------------------------------------------------------------------------

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -119,7 +119,7 @@ const (
 	// This option indicates support for HTTPRoute request mirror (extended conformance).
 	SupportHTTPRouteRequestMirror SupportedFeature = "HTTPRouteRequestMirror"
 
-	// This option indicates support for HTTPRoute request with multiple mirrors (extended conformance).
+	// This option indicates support for multiple RequestMirror filters within the same HTTPRoute rule (extended conformance).
 	SupportHTTPRouteRequestMirrors SupportedFeature = "HTTPRouteRequestMirrors"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind test
/area conformance

**What this PR does / why we need it**:
Adds a conformance test for multiple mirror filters within the same rule, tested using Contour's implementation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2210 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
None
```
