### PR TITLE
update signal error log

### DIFF
--- a/cmd/admission/main.go
+++ b/cmd/admission/main.go
@@ -86,7 +86,7 @@ func main() {
 		defer wg.Done()
 		err := server.ListenAndServeTLS("", "")
 		if errors.Is(err, http.ErrServerClosed) {
-			klog.Fatalf("admission-webhook-server stopped: %v", err)
+			klog.Errorf("admission-webhook-server stopped: %v", err)
 		}
 	}()
 	klog.Info("admission webhook server started and listening on :8443")
@@ -98,7 +98,7 @@ func main() {
 
 	klog.Info("admission webhook received kill signal")
 	if err := server.Shutdown(context.Background()); err != nil {
-		klog.Fatalf("server shutdown failed:%+v", err)
+		klog.Errorf("server shutdown failed:%+v", err)
 	}
 	wg.Wait()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Related to https://github.com/kubernetes/kubernetes/issues/120168 

**Does this PR introduce a user-facing change?**:

when gateway-api-webhook stop by sigterm signal in container, it always exit with -1 code. it will make error containerStatus

the log is here
```release-note
$ kubectl delete po gateway-api-admission-server-5d555f679-dm27b
pod "gateway-api-admission-server-5d555f679-dm27b" deleted

$ kubectl logs gateway-api-admission-server-6ccfb998f9-r4rfb -f
gateway-api-admission-webhook version: v0.7.1 (ab03a594e7db13b8d2579929b204d8d10990fd2b)
I0828 03:16:37.519872       1 main.go:90] admission webhook server started and listening on :8443
I0828 03:34:08.893252       1 main.go:97] admission webhook received kill signal
F0828 03:34:08.893547       1 main.go:87] admission-webhook-server stopped: http: Server closed
```


IMO, when process exit, and there are some error happened, it should print with error level, not fatal level
