### PR TITLE
Update GEP-1742 to use GEP-2257 Duration type

### DIFF
--- a/geps/gep-1742.md
+++ b/geps/gep-1742.md
@@ -424,8 +424,8 @@ type HTTPRouteTimeouts struct {
 	// may result in more than one call from the gateway to the destination backend service,
 	// for example, if automatic retries are supported.
 	//
-	// Because the Request timeout encompasses the BackendRequest timeout,
-	// the value of BackendRequest defaults to and must be <= the value of Request timeout.
+	// Because the Request timeout encompasses the BackendRequest timeout, the value of
+	// BackendRequest must be <= the value of Request timeout.
 	//
 	// Support: Extended
 	//

--- a/geps/gep-1742.md
+++ b/geps/gep-1742.md
@@ -206,7 +206,7 @@ sequenceDiagram
     participant C as Client
     participant P as Proxy
     participant U as Upstream
-    
+
     C->>P: Connection Started
     activate U
     activate C
@@ -224,7 +224,7 @@ sequenceDiagram
     activate U
     note left of U: timeout queue<br/>(wait for available server)
     deactivate U
-		
+
     P->>U: Connection Started
     activate U
     P->>U: Starts sending Request
@@ -368,9 +368,11 @@ sequenceDiagram
     U->>C: Connection ended
 ```
 
-Both timeout fields are string duration values as specified by
-[Golang time.ParseDuration](https://pkg.go.dev/time#ParseDuration) and MUST be >= 1ms
-or 0 to disable (no timeout).
+Both timeout fields are [GEP-2257 Duration] values. A zero-valued timeout
+("0s") MUST be interpreted as disabling the timeout; a non-zero-valued timeout
+MUST be >= 1ms.
+
+[GEP-2257 Duration]:/geps/gep-2257/
 
 ### GO
 
@@ -388,8 +390,12 @@ type HTTPRouteRule struct {
 }
 
 // HTTPRouteTimeouts defines timeouts that can be configured for an HTTPRoute.
-// Timeout values are formatted like 1h/1m/1s/1ms as parsed by Golang time.ParseDuration
-// and MUST BE >= 1ms or 0 to disable (no timeout).
+// Timeout values are formatted like 1h/1m/1s/1ms, as specified in GEP-2257,
+// and MUST BE >= 1ms or "0s" to disable (no timeout).
+//
+// +kubebuilder:validation:XValidation:message="request timeout value must be greater than or equal to 1ms",rule="!(has(self.request) && duration(self.request) != duration('0s') && duration(self.request) < duration('1ms'))"
+// +kubebuilder:validation:XValidation:message="backendRequest timeout value must be greater than or equal to 1ms",rule="!(has(self.backendRequest) && duration(self.backendRequest) != duration('0s') && duration(self.backendRequest) < duration('1ms'))"
+// +kubebuilder:validation:XValidation:message="backendRequest timeout cannot be longer than request timeout",rule="!(has(self.request) && has(self.backendRequest) && duration(self.request) != duration('0s') && duration(self.backendRequest) > duration(self.request))"
 type HTTPRouteTimeouts struct {
 	// Request specifies the duration for processing an HTTP client request after which the
 	// gateway will time out if unable to send a response.
@@ -408,8 +414,7 @@ type HTTPRouteTimeouts struct {
 	// Support: Extended
 	//
 	// +optional
-	// +kubebuilder:validation:Format=duration
-	Request *metav1.Duration `json:"request,omitempty"`
+	Request *Duration `json:"request,omitempty"`
 
 	// BackendRequest specifies a timeout for an individual request from the gateway
 	// to a backend service. This covers the time from when the request first starts being
@@ -425,9 +430,14 @@ type HTTPRouteTimeouts struct {
 	// Support: Extended
 	//
 	// +optional
-	// +kubebuilder:validation:Format=duration
-	BackendRequest *metav1.Duration `json:"backendRequest,omitempty"`
+	BackendRequest *Duration `json:"backendRequest,omitempty"`
 }
+
+// Duration is a string value representing a duration in time. The foramat is as specified
+// in GEP-2257, a strict subset of the syntax parsed by Golang time.ParseDuration.
+//
+// +kubebuilder:validation:Pattern=`^([0-9]{1,5}(h|m|s|ms)){1,4}$`
+type Duration string
 ```
 
 ### YAML

--- a/geps/gep-1742.md
+++ b/geps/gep-1742.md
@@ -392,10 +392,6 @@ type HTTPRouteRule struct {
 // HTTPRouteTimeouts defines timeouts that can be configured for an HTTPRoute.
 // Timeout values are formatted like 1h/1m/1s/1ms, as specified in GEP-2257,
 // and MUST BE >= 1ms or "0s" to disable (no timeout).
-//
-// +kubebuilder:validation:XValidation:message="request timeout value must be greater than or equal to 1ms",rule="!(has(self.request) && duration(self.request) != duration('0s') && duration(self.request) < duration('1ms'))"
-// +kubebuilder:validation:XValidation:message="backendRequest timeout value must be greater than or equal to 1ms",rule="!(has(self.backendRequest) && duration(self.backendRequest) != duration('0s') && duration(self.backendRequest) < duration('1ms'))"
-// +kubebuilder:validation:XValidation:message="backendRequest timeout cannot be longer than request timeout",rule="!(has(self.request) && has(self.backendRequest) && duration(self.request) != duration('0s') && duration(self.backendRequest) > duration(self.request))"
 type HTTPRouteTimeouts struct {
 	// Request specifies the duration for processing an HTTP client request after which the
 	// gateway will time out if unable to send a response.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind gep

**What this PR does / why we need it**:
Completing the update that @kflynn started in #2316.
This PR includes Flynn's changes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
