### PR TITLE
IPv6 conformance: Third time's the charm

### DIFF
--- a/conformance/utils/echo/pod.go
+++ b/conformance/utils/echo/pod.go
@@ -118,7 +118,8 @@ func calculateHost(t *testing.T, reqHost, scheme string) string {
 	if strings.Contains(err.Error(), "too many colons in address") {
 		// This is an IPv6 address; assume it's valid ipv6
 		// Assume caller won't add a port without brackets
-		host, port, err = net.SplitHostPort("[" + reqHost + "]")
+		reqHost = "[" + reqHost + "]"
+		host, port, err = net.SplitHostPort(reqHost)
 	}
 	if err != nil {
 		t.Logf("Failed to parse host %q: %v", reqHost, err)

--- a/conformance/utils/echo/pod.go
+++ b/conformance/utils/echo/pod.go
@@ -115,15 +115,11 @@ func compareRequest(exp http.ExpectedResponse, resp Response) error {
 
 func calculateHost(t *testing.T, reqHost, scheme string) string {
 	host, port, err := net.SplitHostPort(reqHost)
-	if strings.Contains(err.Error(), "too many colons in address") {
+	if err != nil && strings.Contains(err.Error(), "too many colons in address") {
 		// This is an IPv6 address; assume it's valid ipv6
 		// Assume caller won't add a port without brackets
 		reqHost = "[" + reqHost + "]"
 		host, port, err = net.SplitHostPort(reqHost)
-	}
-	// If there's no port, we're ok with that
-	if strings.Contains(err.Error(), "missing port in address") {
-		return reqHost
 	}
 	if err != nil {
 		t.Logf("Failed to parse host %q: %v", reqHost, err)

--- a/conformance/utils/echo/pod.go
+++ b/conformance/utils/echo/pod.go
@@ -121,6 +121,10 @@ func calculateHost(t *testing.T, reqHost, scheme string) string {
 		reqHost = "[" + reqHost + "]"
 		host, port, err = net.SplitHostPort(reqHost)
 	}
+	// If there's no port, we're ok with that
+	if strings.Contains(err.Error(), "missing port in address") {
+		return reqHost
+	}
 	if err != nil {
 		t.Logf("Failed to parse host %q: %v", reqHost, err)
 		return reqHost

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -112,7 +112,7 @@ func MakeRequest(t *testing.T, expected *ExpectedResponse, gwAddr, protocol, sch
 	}
 
 	path, query, _ := strings.Cut(expected.Request.Path, "?")
-	reqURL := url.URL{Scheme: scheme, Host: calculateHost(t, gwAddr, scheme), Path: path, RawQuery: query}
+	reqURL := url.URL{Scheme: scheme, Host: CalculateHost(t, gwAddr, scheme), Path: path, RawQuery: query}
 
 	t.Logf("Making %s request to %s", expected.Request.Method, reqURL.String())
 
@@ -140,12 +140,12 @@ func MakeRequest(t *testing.T, expected *ExpectedResponse, gwAddr, protocol, sch
 	return req
 }
 
-// calculateHost will calculate the Host header as per [HTTP spec]. To
+// CalculateHost will calculate the Host header as per [HTTP spec]. To
 // summarize, host will not include any port if it is implied from the scheme. In
 // case of any error, the input gwAddr will be returned as the default.
 //
 // [HTTP spec]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23
-func calculateHost(t *testing.T, gwAddr, scheme string) string {
+func CalculateHost(t *testing.T, gwAddr, scheme string) string {
 	host, port, err := net.SplitHostPort(gwAddr) // note: this will strip brackets of an IPv6 address
 	if err != nil && strings.Contains(err.Error(), "too many colons in address") {
 		// This is an IPv6 address; assume it's valid ipv6

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -153,6 +153,10 @@ func calculateHost(t *testing.T, reqHost, scheme string) string {
 		reqHost = "[" + reqHost + "]"
 		host, port, err = net.SplitHostPort(reqHost)
 	}
+	// If there's no port, we're ok with that
+	if strings.Contains(err.Error(), "missing port in address") {
+		return reqHost
+	}
 	if err != nil {
 		t.Logf("Failed to parse host %q: %v", reqHost, err)
 		return reqHost

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -150,7 +150,8 @@ func calculateHost(t *testing.T, reqHost, scheme string) string {
 	if strings.Contains(err.Error(), "too many colons in address") {
 		// This is an IPv6 address; assume it's valid ipv6
 		// Assume caller won't add a port without brackets
-		host, port, err = net.SplitHostPort("[" + reqHost + "]")
+		reqHost = "[" + reqHost + "]"
+		host, port, err = net.SplitHostPort(reqHost)
 	}
 	if err != nil {
 		t.Logf("Failed to parse host %q: %v", reqHost, err)

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -147,15 +147,11 @@ func MakeRequest(t *testing.T, expected *ExpectedResponse, gwAddr, protocol, sch
 // [HTTP spec]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23
 func calculateHost(t *testing.T, reqHost, scheme string) string {
 	host, port, err := net.SplitHostPort(reqHost)
-	if strings.Contains(err.Error(), "too many colons in address") {
+	if err != nil && strings.Contains(err.Error(), "too many colons in address") {
 		// This is an IPv6 address; assume it's valid ipv6
 		// Assume caller won't add a port without brackets
 		reqHost = "[" + reqHost + "]"
 		host, port, err = net.SplitHostPort(reqHost)
-	}
-	// If there's no port, we're ok with that
-	if strings.Contains(err.Error(), "missing port in address") {
-		return reqHost
 	}
 	if err != nil {
 		t.Logf("Failed to parse host %q: %v", reqHost, err)


### PR DESCRIPTION
`net.SplitHostPort` errors if ipv6 addresses aren't in brackets; previous implementation fixed a different problem (SplitHostPort removes brackets if they are passed in)

```release-note
Fix IPv6 parsing in conformance tests
```