### PR TITLE
inital implementaion with TODOs to solve

### DIFF
--- a/apis/v1beta1/gatewayclass_types.go
+++ b/apis/v1beta1/gatewayclass_types.go
@@ -57,6 +57,7 @@ type GatewayClass struct {
 
 	// Status defines the current state of GatewayClass.
 	//
+	// TODO(liorlieberman) must populate status but conditions are optional?
 	// Implementations MUST populate status on all GatewayClass resources which
 	// specify their controller name.
 	//
@@ -200,6 +201,16 @@ type GatewayClassStatus struct {
 	// +kubebuilder:validation:MaxItems=8
 	// +kubebuilder:default={{type: "Accepted", status: "Unknown", message: "Waiting for controller", reason: "Pending", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	//TODO(liorlieberman) should we say here as well that this should be sorted asc?
+	// SupportedFeatures is the features the GatewayClass support.
+	//TODO(liorlieberman) validate this values
+	//+optional
+	// +listType=set
+	// <gateway:experimental>
+	// +kubebuilder:validation:MaxItems=64
+	//TODO(liorliberman) should we use kubebuilder default?
+	SupportedFeatures []string `json:"supportedFeatures,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/v1beta1/gatewayclass_types.go
+++ b/apis/v1beta1/gatewayclass_types.go
@@ -201,6 +201,7 @@ type GatewayClassStatus struct {
 	// +kubebuilder:default={{type: "Accepted", status: "Unknown", message: "Waiting for controller", reason: "Pending", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
+	// TODO(LiorLieberman) explore adding CEL validation to ensure the list is sorted.
 	// SupportedFeatures is the set of features the GatewayClass support.
 	// It should be sorted in ascending alphabetical order.
 	//+optional

--- a/apis/v1beta1/gatewayclass_types.go
+++ b/apis/v1beta1/gatewayclass_types.go
@@ -57,7 +57,6 @@ type GatewayClass struct {
 
 	// Status defines the current state of GatewayClass.
 	//
-	// TODO(liorlieberman) must populate status but conditions are optional?
 	// Implementations MUST populate status on all GatewayClass resources which
 	// specify their controller name.
 	//
@@ -202,14 +201,12 @@ type GatewayClassStatus struct {
 	// +kubebuilder:default={{type: "Accepted", status: "Unknown", message: "Waiting for controller", reason: "Pending", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
-	//TODO(liorlieberman) should we say here as well that this should be sorted asc?
-	// SupportedFeatures is the features the GatewayClass support.
-	//TODO(liorlieberman) validate this values
+	// SupportedFeatures is the set of features the GatewayClass support.
+	// It should be sorted in ascending alphabetical order.
 	//+optional
 	// +listType=set
 	// <gateway:experimental>
 	// +kubebuilder:validation:MaxItems=64
-	//TODO(liorliberman) should we use kubebuilder default?
 	SupportedFeatures []string `json:"supportedFeatures,omitempty"`
 }
 

--- a/conformance/tests/httproute-response-header-modifier.go
+++ b/conformance/tests/httproute-response-header-modifier.go
@@ -36,7 +36,7 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 	Features: []suite.SupportedFeature{
 		suite.SupportGateway,
 		suite.SupportHTTPRoute,
-		suite.SupportHTTPResponseHeaderModification,
+		suite.SupportHTTPRouteResponseHeaderModification,
 	},
 	Manifests: []string{"tests/httproute-response-header-modifier.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {

--- a/conformance/tests/mesh-consumer-route.go
+++ b/conformance/tests/mesh-consumer-route.go
@@ -34,7 +34,7 @@ var MeshConsumerRoute = suite.ConformanceTest{
 	Features: []suite.SupportedFeature{
 		suite.SupportMesh,
 		suite.SupportHTTPRoute,
-		suite.SupportHTTPResponseHeaderModification,
+		suite.SupportHTTPRouteResponseHeaderModification,
 	},
 	Manifests: []string{"tests/mesh-consumer-route.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {

--- a/conformance/tests/mesh-frontend-hostname.go
+++ b/conformance/tests/mesh-frontend-hostname.go
@@ -33,7 +33,7 @@ var MeshFrontendHostname = suite.ConformanceTest{
 	Description: "Mesh parentRef matches Service IP (not Host)",
 	Features: []suite.SupportedFeature{
 		suite.SupportMesh,
-		suite.SupportHTTPResponseHeaderModification,
+		suite.SupportHTTPRouteResponseHeaderModification,
 	},
 	Manifests: []string{"tests/mesh-frontend.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {

--- a/conformance/tests/mesh-frontend.go
+++ b/conformance/tests/mesh-frontend.go
@@ -34,7 +34,7 @@ var MeshFrontend = suite.ConformanceTest{
 	Features: []suite.SupportedFeature{
 		suite.SupportMesh,
 		suite.SupportHTTPRoute,
-		suite.SupportHTTPResponseHeaderModification,
+		suite.SupportHTTPRouteResponseHeaderModification,
 	},
 	Manifests: []string{"tests/mesh-frontend.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {

--- a/conformance/tests/mesh-ports.go
+++ b/conformance/tests/mesh-ports.go
@@ -34,7 +34,7 @@ var MeshPorts = suite.ConformanceTest{
 	Features: []suite.SupportedFeature{
 		suite.SupportMesh,
 		suite.SupportHTTPRoute,
-		suite.SupportHTTPResponseHeaderModification,
+		suite.SupportHTTPRouteResponseHeaderModification,
 	},
 	Manifests: []string{"tests/mesh-ports.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -81,7 +81,7 @@ const (
 	SupportHTTPRoute SupportedFeature = "HTTPRoute"
 )
 
-// HTTPCoreFeatures includes all SupportedFeatures needed to be conformant with
+// HTTPRouteCoreFeatures includes all SupportedFeatures needed to be conformant with
 // the HTTPRoute resource.
 var HTTPRouteCoreFeatures = sets.New(
 	SupportHTTPRoute,
@@ -101,23 +101,19 @@ const (
 	// This option indicates support for HTTPRoute response header modification (extended conformance).
 	SupportHTTPRouteResponseHeaderModification SupportedFeature = "HTTPRouteResponseHeaderModification"
 
-	//TODO(liorlieberman) I think it is better not to have it and make everyone aligned before GA.
-	// This option is the same as above option but left just for backward compatibility
-	SupportHTTPResponseHeaderModification SupportedFeature = "HTTPRouteResponseHeaderModification"
-
 	// This option indicates support for HTTPRoute port redirect (extended conformance).
 	SupportHTTPRoutePortRedirect SupportedFeature = "HTTPRoutePortRedirect"
 
 	// This option indicates support for HTTPRoute scheme redirect (extended conformance).
 	SupportHTTPRouteSchemeRedirect SupportedFeature = "HTTPRouteSchemeRedirect"
 
-	// This option indicates support for HTTPRoute path redirect (experimental conformance).
+	// This option indicates support for HTTPRoute path redirect (extended conformance).
 	SupportHTTPRoutePathRedirect SupportedFeature = "HTTPRoutePathRedirect"
 
-	// This option indicates support for HTTPRoute host rewrite (experimental conformance)
+	// This option indicates support for HTTPRoute host rewrite (extended conformance)
 	SupportHTTPRouteHostRewrite SupportedFeature = "HTTPRouteHostRewrite"
 
-	// This option indicates support for HTTPRoute path rewrite (experimental conformance)
+	// This option indicates support for HTTPRoute path rewrite (extended conformance)
 	SupportHTTPRoutePathRewrite SupportedFeature = "HTTPRoutePathRewrite"
 
 	// This option indicates support for HTTPRoute request mirror (extended conformance).
@@ -137,6 +133,22 @@ var HTTPRouteExtendedFeatures = sets.New(
 	SupportHTTPRouteHostRewrite,
 	SupportHTTPRoutePathRewrite,
 	SupportHTTPRouteRequestMirror,
+)
+
+// -----------------------------------------------------------------------------
+// Features - HTTPRoute Conformance (Experimental)
+// -----------------------------------------------------------------------------
+
+const (
+	// This option indicates support for Destination Port matching.
+	SupportHTTPRouteDestinationPortMatching SupportedFeature = "HTTPRouteDestinationPortMatching"
+)
+
+// HTTPRouteExperimentalFeatures includes all the supported experimental features, currently only
+// available in our experimental release channel.
+// Implementations have the flexibility to opt-in for either specific features or the entire set.
+var HTTPRouteExperimentalFeatures = sets.New(
+	SupportHTTPRouteDestinationPortMatching,
 )
 
 // -----------------------------------------------------------------------------
@@ -170,22 +182,6 @@ var MeshCoreFeatures = sets.New(
 )
 
 // -----------------------------------------------------------------------------
-// Features - Experimental
-// -----------------------------------------------------------------------------
-
-// TODO(liorlieberman) get consensus about making experimental features per resource.
-const (
-	// This option indicates support for Destination Port matching.
-	SupportRouteDestinationPortMatching SupportedFeature = "RouteDestinationPortMatching"
-)
-
-// ExperimentalFeatures are extra generic features that are currently only
-// available in our experimental release channel.
-var ExperimentalFeatures = sets.New(
-	SupportRouteDestinationPortMatching,
-)
-
-// -----------------------------------------------------------------------------
 // Features - Compilations
 // -----------------------------------------------------------------------------
 
@@ -198,6 +194,6 @@ var AllFeatures = sets.New[SupportedFeature]().
 	Insert(ReferenceGrantCoreFeatures.UnsortedList()...).
 	Insert(HTTPRouteCoreFeatures.UnsortedList()...).
 	Insert(HTTPRouteExtendedFeatures.UnsortedList()...).
+	Insert(HTTPRouteExperimentalFeatures.UnsortedList()...).
 	Insert(TLSRouteCoreFeatures.UnsortedList()...).
-	Insert(MeshCoreFeatures.UnsortedList()...).
-	Insert(ExperimentalFeatures.UnsortedList()...)
+	Insert(MeshCoreFeatures.UnsortedList()...)

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -99,7 +99,11 @@ const (
 	SupportHTTPRouteMethodMatching SupportedFeature = "HTTPRouteMethodMatching"
 
 	// This option indicates support for HTTPRoute response header modification (extended conformance).
-	SupportHTTPResponseHeaderModification SupportedFeature = "HTTPResponseHeaderModification"
+	SupportHTTPRouteResponseHeaderModification SupportedFeature = "HTTPRouteResponseHeaderModification"
+
+	//TODO(liorlieberman) I think it is better not to have it and make everyone aligned before GA.
+	// This option is the same as above option but left just for backward compatibility
+	SupportHTTPResponseHeaderModification SupportedFeature = "HTTPRouteResponseHeaderModification"
 
 	// This option indicates support for HTTPRoute port redirect (extended conformance).
 	SupportHTTPRoutePortRedirect SupportedFeature = "HTTPRoutePortRedirect"
@@ -126,7 +130,7 @@ const (
 var HTTPRouteExtendedFeatures = sets.New(
 	SupportHTTPRouteQueryParamMatching,
 	SupportHTTPRouteMethodMatching,
-	SupportHTTPResponseHeaderModification,
+	SupportHTTPRouteResponseHeaderModification,
 	SupportHTTPRoutePortRedirect,
 	SupportHTTPRouteSchemeRedirect,
 	SupportHTTPRoutePathRedirect,
@@ -169,6 +173,7 @@ var MeshCoreFeatures = sets.New(
 // Features - Experimental
 // -----------------------------------------------------------------------------
 
+// TODO(liorlieberman) get consensus about making experimental features per resource.
 const (
 	// This option indicates support for Destination Port matching.
 	SupportRouteDestinationPortMatching SupportedFeature = "RouteDestinationPortMatching"


### PR DESCRIPTION
This is just an initial comment of the PR. I did not run `make generate` purposely as I want to get feedback on all the TODOs I listed in the code.

Essentially it comes down to these questions:

1.  Should we mention in the API that `supportedFeatures` should be asc sorted?
2. I want couple of eyes to looks at the annotations I added for the `supportedFeatures` field
3. We are changing `SupportHTTPResponseHeaderModification` feature name to `SupportHTTPRouteResponseHeaderModification` as per the [new standard convention](https://gateway-api.sigs.k8s.io/geps/gep-2162/#standardize-features-and-conformance-tests-names). It will break a few repos who use this constant, I added one for backward compatibility but I am actually against it. I think it is better to make them fix it now before we go to GA.
4. I think experimental features should be also per resource, same as we have for extneded. And not [one for all](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/utils/suite/features.go#L178C1-L179C1). This will be aligned as well with the [standardized naming and formatting conventions](https://gateway-api.sigs.k8s.io/geps/gep-2162/#standardize-features-and-conformance-tests-names) we established.
5. I am a bit confused about the current requirement in GatewayClass status. Essentially we are saying `Implementations MUST populate status on all GatewayClass resources which specify their controller name` but the conditions field is optional. Can you clarify?

/cc @youngnick @robscott @shaneutt 

/kind feature

**What this PR does / why we need it**:
This PR implements #2163. We are adding new experimental `supportedFeatures` field in GatewayClass status.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2163 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add new experimental `supportedFeatures` field in GatewayClass status
```
