### PR TITLE
Fix CEL tests in fix-verify-crds.sh

### DIFF
--- a/hack/verify-crds-kind.sh
+++ b/hack/verify-crds-kind.sh
@@ -60,7 +60,7 @@ for CHANNEL in experimental standard; do
   kubectl apply -f "config/crd/${CHANNEL}/gateway*.yaml"
 
   # Run tests.
-  go test -v -timeout=120s -count=1 --tags ${CHANNEL} sigs.k8s.io/gateway-api/pkg/test/cel
+  go test -v -timeout=120s -count=1 --tags ${CHANNEL} sigs.k8s.io/gateway-api/pkg/test/cel || res=$?
 
   # Delete CRDs to reset environment.
   kubectl delete -f "config/crd/${CHANNEL}/gateway*.yaml"
@@ -203,5 +203,5 @@ EOF
   kubectl delete -f "config/crd/${CHANNEL}/gateway*.yaml" || res=$?
 done
 
-# We've trapped EXIT with cleanup(), so just exit with what we've got.
+### We've trapped EXIT with cleanup(), so just exit with what we've got.
 exit $res


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind test

/kind failing-test

**What this PR does / why we need it**:

When I refactored the `fix-verify-crds.sh` script, I removed the `set -o errexit` directive, but missed that this meant that the `go test` invocation was now not updating the `$res` variable. This fixes that so that CEL test failures will now cause the tests to fail as expected.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
