### PR TITLE
Update the contributing page about the GEP process

### DIFF
--- a/site-src/contributing/enhancement-requests.md
+++ b/site-src/contributing/enhancement-requests.md
@@ -29,28 +29,19 @@ It is unlikely to require an enhancement if it:
 If you're unsure the proposed work requires an enhancement, file an issue
 and ask.
 
-## When to Create a New Enhancement
+## New Enhancement process
 
-Create an enhancement once you have:
+The new enhancement process is documented on the [GEP Overview][gep] page. Please
+see that page for all the details about how to log a new GEP, and the process
+it will follow on its journey towards Completed status.
 
-- Circulated your idea to see if there is interest.
-- Identified community members who agree to work on and maintain the enhancement.
-- Enhancements may take several releases to complete.
-- A prototype in your own fork (optional)
+In particular, please note that having a discussion of some form, usually both
+a [Github Discussion][discussion] and some discussion in our [community meetings][meetings]
+is the best way to ensure that your new GEP process will go as smoothly as possible.
 
-## How to Create a New Enhancement
-
-Once you've circulated your idea and received feedback from the maintainers
-that creating a [Gateway Enhancement Proposal (GEP)][gep] is a good next step:
-
-- create an [Issue][issue] and select "Enhancement Request"
-- follow the instructions in the enhancement request template and submit the
-  Issue.
-- create an initial pull request to add your GEP. Follow the directions in the
-  [GEP documentation][gep].
-
-[issue]: https://github.com/kubernetes-sigs/gateway-api/issues/new/choose
 [gep]: /geps/overview
+[discussion]: https://github.com/kubernetes-sigs/gateway-api/discussions/new/choose
+[meetings]: https://gateway-api.sigs.k8s.io/contributing/#meetings
 
 ## Why are Enhancements Tracked
 

--- a/site-src/contributing/enhancement-requests.md
+++ b/site-src/contributing/enhancement-requests.md
@@ -35,9 +35,11 @@ The new enhancement process is documented on the [GEP Overview][gep] page. Pleas
 see that page for all the details about how to log a new GEP, and the process
 it will follow on its journey towards Completed status.
 
-In particular, please note that having a discussion of some form, usually both
-a [Github Discussion][discussion] and some discussion in our [community meetings][meetings]
-is the best way to ensure that your new GEP process will go as smoothly as possible.
+A **documented** discussion of some form **must** exist prior to submitting a request for enhancement
+if that enhancement is non-trivial (which we will define as either: _implicates changes to the API specification_ OR _has some kind of end-user impact_). Please use our [Github Discussions][discussion]
+forum as the initial place to start, and feel free to bring that discussion up for synchronous conversation in
+one of our [community meetings][meetings]. If the created request doesn't include reference to a discussion and/or recordings of discussion in our community meetings, please note that it _may_ get closed
+with a request to create an initial discussion first.
 
 [gep]: /geps/overview
 [discussion]: https://github.com/kubernetes-sigs/gateway-api/discussions/new/choose

--- a/site-src/contributing/enhancement-requests.md
+++ b/site-src/contributing/enhancement-requests.md
@@ -29,17 +29,24 @@ It is unlikely to require an enhancement if it:
 If you're unsure the proposed work requires an enhancement, file an issue
 and ask.
 
-## New Enhancement process
+## New Enhancement Process
 
-The new enhancement process is documented on the [GEP Overview][gep] page. Please
-see that page for all the details about how to log a new GEP, and the process
-it will follow on its journey towards Completed status.
+The process for creating new enhancement proposals is documented on the
+[GEP Overview][gep] page. Please see that page for all the details about how
+to log a new GEP, and the process it will follow on its journey towards
+Completed status.
 
-A **documented** discussion of some form **must** exist prior to submitting a request for enhancement
-if that enhancement is non-trivial (which we will define as either: _implicates changes to the API specification_ OR _has some kind of end-user impact_). Please use our [Github Discussions][discussion]
-forum as the initial place to start, and feel free to bring that discussion up for synchronous conversation in
-one of our [community meetings][meetings]. If the created request doesn't include reference to a discussion and/or recordings of discussion in our community meetings, please note that it _may_ get closed
-with a request to create an initial discussion first.
+A **documented** discussion of some form **must** exist prior to submitting a
+request for enhancement if that enhancement is non-trivial (which we will define
+as either: _implicates changes to the API specification_
+OR _has some kind of end-user impact_).
+
+Please use our [Github Discussions][discussion] forum as the initial place to
+start, and feel free to bring that discussion up for synchronous conversation in
+one of our [community meetings][meetings]. If the created request doesn't
+include reference to a discussion and/or recordings of discussion in our
+community meetings, please note that it _may_ get closed with a request to
+create an initial discussion first.
 
 [gep]: /geps/overview
 [discussion]: https://github.com/kubernetes-sigs/gateway-api/discussions/new/choose


### PR DESCRIPTION
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
While updating GEP-1742 to experimental (#2392), I noticed that we have some redundant info about the new GEP process in the contributing section of the site. This PR updates that page to refer to the correct place (`/geps/overview`), so we only have one place to update.


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
