### PR TITLE
Clarify Gateway Listener Status AttachedRoutes field

### DIFF
--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -721,8 +721,23 @@ type ListenerStatus struct {
 	// +kubebuilder:validation:MaxItems=8
 	SupportedKinds []RouteGroupKind `json:"supportedKinds"`
 
-	// AttachedRoutes represents the total number of accepted Routes that have been
+	// AttachedRoutes represents the total number of Routes that have been
 	// successfully attached to this Listener.
+	//
+	// Successful attachment of a Route to a Listener is based solely on the
+	// combination of the AllowedRoutes field on the corresponding Listener
+	// and the Route's ParentRefs field. A Route is successfully attached to
+	// a Listener when it is selected by the Listener's AllowedRoutes field
+	// AND the Route has a valid ParentRef selecting the whole Gateway
+	// resource or a specific Listener as a parent resource (more detail on
+	// attachment semantics can be found in the documentation on the various
+	// Route kinds ParentRefs fields). Listener or Route status does not impact
+	// successful attachment, i.e. the AttachedRoutes field count MUST be set
+	// for Listeners with condition Accepted: false and MUST count successfully
+	// attached Routes that may themselves have Accepted: false conditions.
+	//
+	// Uses for this field include troubleshooting Route attachment and
+	// measuring blast radius/impact of changes to a Listener.
 	AttachedRoutes int32 `json:"attachedRoutes"`
 
 	// Conditions describe the current condition of this listener.

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -661,8 +661,23 @@ spec:
                   description: ListenerStatus is the status associated with a Listener.
                   properties:
                     attachedRoutes:
-                      description: AttachedRoutes represents the total number of accepted
+                      description: "AttachedRoutes represents the total number of
                         Routes that have been successfully attached to this Listener.
+                        \n Successful attachment of a Route to a Listener is based
+                        solely on the combination of the AllowedRoutes field on the
+                        corresponding Listener and the Route's ParentRefs field. A
+                        Route is successfully attached to a Listener when it is selected
+                        by the Listener's AllowedRoutes field AND the Route has a
+                        valid ParentRef selecting the whole Gateway resource or a
+                        specific Listener as a parent resource (more detail on attachment
+                        semantics can be found in the documentation on the various
+                        Route kinds ParentRefs fields). Listener or Route status does
+                        not impact successful attachment, i.e. the AttachedRoutes
+                        field count MUST be set for Listeners with condition Accepted:
+                        false and MUST count successfully attached Routes that may
+                        themselves have Accepted: false conditions. \n Uses for this
+                        field include troubleshooting Route attachment and measuring
+                        blast radius/impact of changes to a Listener."
                       format: int32
                       type: integer
                     conditions:
@@ -1439,8 +1454,23 @@ spec:
                   description: ListenerStatus is the status associated with a Listener.
                   properties:
                     attachedRoutes:
-                      description: AttachedRoutes represents the total number of accepted
+                      description: "AttachedRoutes represents the total number of
                         Routes that have been successfully attached to this Listener.
+                        \n Successful attachment of a Route to a Listener is based
+                        solely on the combination of the AllowedRoutes field on the
+                        corresponding Listener and the Route's ParentRefs field. A
+                        Route is successfully attached to a Listener when it is selected
+                        by the Listener's AllowedRoutes field AND the Route has a
+                        valid ParentRef selecting the whole Gateway resource or a
+                        specific Listener as a parent resource (more detail on attachment
+                        semantics can be found in the documentation on the various
+                        Route kinds ParentRefs fields). Listener or Route status does
+                        not impact successful attachment, i.e. the AttachedRoutes
+                        field count MUST be set for Listeners with condition Accepted:
+                        false and MUST count successfully attached Routes that may
+                        themselves have Accepted: false conditions. \n Uses for this
+                        field include troubleshooting Route attachment and measuring
+                        blast radius/impact of changes to a Listener."
                       format: int32
                       type: integer
                     conditions:

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -661,8 +661,23 @@ spec:
                   description: ListenerStatus is the status associated with a Listener.
                   properties:
                     attachedRoutes:
-                      description: AttachedRoutes represents the total number of accepted
+                      description: "AttachedRoutes represents the total number of
                         Routes that have been successfully attached to this Listener.
+                        \n Successful attachment of a Route to a Listener is based
+                        solely on the combination of the AllowedRoutes field on the
+                        corresponding Listener and the Route's ParentRefs field. A
+                        Route is successfully attached to a Listener when it is selected
+                        by the Listener's AllowedRoutes field AND the Route has a
+                        valid ParentRef selecting the whole Gateway resource or a
+                        specific Listener as a parent resource (more detail on attachment
+                        semantics can be found in the documentation on the various
+                        Route kinds ParentRefs fields). Listener or Route status does
+                        not impact successful attachment, i.e. the AttachedRoutes
+                        field count MUST be set for Listeners with condition Accepted:
+                        false and MUST count successfully attached Routes that may
+                        themselves have Accepted: false conditions. \n Uses for this
+                        field include troubleshooting Route attachment and measuring
+                        blast radius/impact of changes to a Listener."
                       format: int32
                       type: integer
                     conditions:
@@ -1439,8 +1454,23 @@ spec:
                   description: ListenerStatus is the status associated with a Listener.
                   properties:
                     attachedRoutes:
-                      description: AttachedRoutes represents the total number of accepted
+                      description: "AttachedRoutes represents the total number of
                         Routes that have been successfully attached to this Listener.
+                        \n Successful attachment of a Route to a Listener is based
+                        solely on the combination of the AllowedRoutes field on the
+                        corresponding Listener and the Route's ParentRefs field. A
+                        Route is successfully attached to a Listener when it is selected
+                        by the Listener's AllowedRoutes field AND the Route has a
+                        valid ParentRef selecting the whole Gateway resource or a
+                        specific Listener as a parent resource (more detail on attachment
+                        semantics can be found in the documentation on the various
+                        Route kinds ParentRefs fields). Listener or Route status does
+                        not impact successful attachment, i.e. the AttachedRoutes
+                        field count MUST be set for Listeners with condition Accepted:
+                        false and MUST count successfully attached Routes that may
+                        themselves have Accepted: false conditions. \n Uses for this
+                        field include troubleshooting Route attachment and measuring
+                        blast radius/impact of changes to a Listener."
                       format: int32
                       type: integer
                     conditions:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind documentation

**What this PR does / why we need it**:

Document that the field intends to count purely Gateway<->Route relationships regardless of validity of either resource.

**Which issue(s) this PR fixes**:

Fixes #1626

**Does this PR introduce a user-facing change?**:

```release-note
Clarify that the Gateway Listener status AttachedRoutes field is a count of the number of Routes associated with a Listener regardless of Gateway or Route status.
```
