### PR TITLE
Updating docs for v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- [v0.8.1](#v081)
 - [v0.8.0](#v080)
 - [v0.8.0-rc2](#v080-rc2)
 - [v0.8.0-rc1](#v080-rc1)
@@ -29,6 +30,23 @@
 - [v0.1.0](#v010)
 - [v0.1.0-rc2](#v010-rc2)
 - [v0.1.0-rc1](#v010-rc1)
+
+# v0.8.1
+
+This is a patch release that includes small bug fixes and a new conformance test
+as a follow up to the v0.8.0 release.
+
+## Changes by Kind
+
+### Bug Fixes
+
+- Fix CEL validation not handling missing listener hostname correctly. (#2370,
+  @frankbu)
+- Fix IPv6 parsing in conformance tests (#2375, @keithmattix)
+
+### Conformance Tests
+
+- Add conformance test for multiple mirror filters. (#2359, @levikobi)
 
 # v0.8.0
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ the specification and Custom Resource Definitions (CRDs).
 
 ## Status
 
-The latest supported version is `v1beta1` as released by the [v0.7.0
-release](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.7.0) of
+The latest supported version is `v1beta1` as released by the [v0.8.1
+release](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.8.1) of
 this project.
 
 This version of the API is has beta level support for the following resources:

--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -40,7 +40,7 @@ including GatewayClass, Gateway, ReferenceGrant, and HTTPRoute. To install this
 channel, run the following kubectl command:
 
 ```
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.8.0/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.8.1/standard-install.yaml
 ```
 
 ### Install Experimental Channel
@@ -58,7 +58,7 @@ documentation](https://gateway-api.sigs.k8s.io/concepts/versioning/).
 To install the experimental channel, run the following kubectl command:
 
 ```
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.8.0/experimental-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.8.1/experimental-install.yaml
 ```
 
 ### Cleanup


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Updates docs to reflect v0.8.1 release.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
