### PR TITLE
rm webhook resources from installation yaml

### DIFF
--- a/hack/build-install-yaml.sh
+++ b/hack/build-install-yaml.sh
@@ -39,7 +39,15 @@ cat << EOF >> release/standard-install.yaml
 #
 EOF
 
-for file in `ls config/webhook/*.yaml config/crd/experimental/gateway*.yaml`
+cat hack/boilerplate/boilerplate.sh.txt > release/webhook-install.yaml
+sed -i "s/YEAR/$thisyear/g" release/webhook-install.yaml
+cat << EOF >> release/webhook-install.yaml
+#
+# Gateway API deprecated webhook install
+#
+EOF
+
+for file in `ls config/crd/experimental/gateway*.yaml`
 do
     echo "---" >> release/experimental-install.yaml
     echo "#" >> release/experimental-install.yaml
@@ -48,13 +56,22 @@ do
     cat $file >> release/experimental-install.yaml
 done
 
-for file in `ls config/webhook/*.yaml config/crd/standard/*.yaml`
+for file in `ls config/crd/standard/*.yaml`
 do
     echo "---" >> release/standard-install.yaml
     echo "#" >> release/standard-install.yaml
     echo "# $file" >> release/standard-install.yaml
     echo "#" >> release/standard-install.yaml
     cat $file >> release/standard-install.yaml
+done
+
+for file in `ls config/webhook/*.yaml`
+do
+    echo "---" >> release/webhook-install.yaml
+    echo "#" >> release/webhook-install.yaml
+    echo "# $file" >> release/webhook-install.yaml
+    echo "#" >> release/webhook-install.yaml
+    cat $file >> release/webhook-install.yaml
 done
 
 echo "Generated:" release/*-install.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/kubernetes-sigs/gateway-api/issues/2400

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Resources related to the validating webhook such as the `gateway-system` namespace and the `gateway-api-admission-server` deployment have been removed from the installation manifests, in favor of CEL based Validations that are built into the CRD definition. These are still available in `webhook-install.yaml` in case you would like to optionally install them.
```
