### PR TITLE
Conformance tests for static Gateway addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,24 @@
 - [v0.1.0-rc2](#v010-rc2)
 - [v0.1.0-rc1](#v010-rc1)
 
+# Unreleased
+
+## Other Changes
+
+- The condition reason `GatewayReasonUnsupportedAddress` for `Accepted` now ONLY
+  applies when an address type is provided for a `Gateway` which it does not
+  support.
+  (#2412 @shaneutt)
+- The condition reason `GatewayReasonAddressNotAssigned` for `Programmed` now
+  ONLY applies to problems with dynamic address allocation.
+  (#2412 @shaneutt)
+- The condition reason `GatewayReasonAddressNotUsable` for `Programmed` has been
+  added to deal with situations where a static address has been provided for a
+  Gateway which is of a supported type, and is syntatically valid, but for some
+  reason it can not be used for this Gateway (e.g. the address is already in use
+  on the network).
+  (#2412 @shaneutt)
+
 # v0.8.1
 
 This is a patch release that includes small bug fixes and a new conformance test

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -532,10 +532,15 @@ type GatewayStatusAddress struct {
 
 // GatewayStatus defines the observed state of Gateway.
 type GatewayStatus struct {
-	// Addresses lists the IP addresses that have actually been
-	// bound to the Gateway. These addresses may differ from the
-	// addresses in the Spec, e.g. if the Gateway automatically
-	// assigns an address from a reserved pool.
+	// Addresses lists the network addresses that have been bound to the
+	// Gateway.
+	//
+	// This list may differ from the addresses provided in the spec under some
+	// conditions:
+	//
+	//   * no addresses are specified, all addresses are dynamically assigned
+	//   * a combination of specified and dynamic addresses are assigned
+	//   * a specified address was unusable (e.g. already in use)
 	//
 	// +optional
 	// <gateway:validateIPAddress>

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -630,10 +630,18 @@ const (
 	// resources are available.
 	GatewayReasonNoResources GatewayConditionReason = "NoResources"
 
-	// This reason is used with the "Programmed" condition when none of the requested
-	// addresses have been assigned to the Gateway. This reason can be used to
-	// express a range of circumstances, including (but not limited to) IPAM
-	// address exhaustion, address not yet allocated, or a named address not being found.
+	// This reason is used with the "Programmed" condition when the underlying
+	// implementation and network have yet to dynamically assign addresses for a
+	// Gateway.
+	//
+	// Some example situations where this reason can be used:
+	//
+	//   * IPAM address exhaustion
+	//   * Address not yet allocated
+	//
+	// When this reason is used the implementation SHOULD provide a clear
+	// message explaining the underlying problem, ideally with some hints as to
+	// what actions can be taken that might resolve the problem.
 	GatewayReasonAddressNotAssigned GatewayConditionReason = "AddressNotAssigned"
 )
 

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -510,7 +510,7 @@ type GatewayAddress struct {
 	Value string `json:"value"`
 }
 
-// GatewayStatusAddress describes an address that is bound to a Gateway.
+// GatewayStatusAddress describes a network address that is bound to a Gateway.
 //
 // +kubebuilder:validation:XValidation:message="Hostname value must only contain valid characters (matching ^(\\*\\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)",rule="self.type == 'Hostname' ? self.value.matches(r\"\"\"^(\\*\\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\"\"\"): true"
 type GatewayStatusAddress struct {

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -643,6 +643,21 @@ const (
 	// message explaining the underlying problem, ideally with some hints as to
 	// what actions can be taken that might resolve the problem.
 	GatewayReasonAddressNotAssigned GatewayConditionReason = "AddressNotAssigned"
+
+	// This reason is used with the "Programmed" condition when the underlying
+	// implementation (and possibly, network) are unable to use an address that
+	// was provided in the Gateway specification.
+	//
+	// Some example situations where this reason can be used:
+	//
+	//   * a named address not being found
+	//   * a provided static address can't be used
+	//   * the address is already in use
+	//
+	// When this reason is used the implementation SHOULD provide prescriptive
+	// information on which address is causing the problem and how to resolve it
+	// in the condition message.
+	GatewayReasonAddressNotUsable GatewayConditionReason = "AddressNotUsable"
 )
 
 const (

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -688,12 +688,9 @@ const (
 	// the Gateway.
 	GatewayReasonPending GatewayConditionReason = "Pending"
 
-	// This reason is used with the "Accepted" condition when the Gateway could not be configured
-	// because the requested address is not supported. This reason could be used in a number of
-	// instances, including:
-	//
-	// * The address is already in use.
-	// * The type of address is not supported by the implementation.
+	// This reason is used with the "Accepted" condition to indicate that the
+	// Gateway could not be accepted because an address that was provided is a
+	// type which is not supported by the implementation.
 	GatewayReasonUnsupportedAddress GatewayConditionReason = "UnsupportedAddress"
 )
 

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -534,13 +534,15 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: "Addresses lists the IP addresses that have actually
-                  been bound to the Gateway. These addresses may differ from the addresses
-                  in the Spec, e.g. if the Gateway automatically assigns an address
-                  from a reserved pool. \n "
+                description: "Addresses lists the network addresses that have been
+                  bound to the Gateway. \n This list may differ from the addresses
+                  provided in the spec under some conditions: \n * no addresses are
+                  specified, all addresses are dynamically assigned * a combination
+                  of specified and dynamic addresses are assigned * a specified address
+                  was unusable (e.g. already in use) \n "
                 items:
-                  description: GatewayStatusAddress describes an address that is bound
-                    to a Gateway.
+                  description: GatewayStatusAddress describes a network address that
+                    is bound to a Gateway.
                   oneOf:
                   - properties:
                       type:
@@ -1342,13 +1344,15 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: "Addresses lists the IP addresses that have actually
-                  been bound to the Gateway. These addresses may differ from the addresses
-                  in the Spec, e.g. if the Gateway automatically assigns an address
-                  from a reserved pool. \n "
+                description: "Addresses lists the network addresses that have been
+                  bound to the Gateway. \n This list may differ from the addresses
+                  provided in the spec under some conditions: \n * no addresses are
+                  specified, all addresses are dynamically assigned * a combination
+                  of specified and dynamic addresses are assigned * a specified address
+                  was unusable (e.g. already in use) \n "
                 items:
-                  description: GatewayStatusAddress describes an address that is bound
-                    to a Gateway.
+                  description: GatewayStatusAddress describes a network address that
+                    is bound to a Gateway.
                   oneOf:
                   - properties:
                       type:

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -534,13 +534,15 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: "Addresses lists the IP addresses that have actually
-                  been bound to the Gateway. These addresses may differ from the addresses
-                  in the Spec, e.g. if the Gateway automatically assigns an address
-                  from a reserved pool. \n "
+                description: "Addresses lists the network addresses that have been
+                  bound to the Gateway. \n This list may differ from the addresses
+                  provided in the spec under some conditions: \n * no addresses are
+                  specified, all addresses are dynamically assigned * a combination
+                  of specified and dynamic addresses are assigned * a specified address
+                  was unusable (e.g. already in use) \n "
                 items:
-                  description: GatewayStatusAddress describes an address that is bound
-                    to a Gateway.
+                  description: GatewayStatusAddress describes a network address that
+                    is bound to a Gateway.
                   oneOf:
                   - properties:
                       type:
@@ -1342,13 +1344,15 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: "Addresses lists the IP addresses that have actually
-                  been bound to the Gateway. These addresses may differ from the addresses
-                  in the Spec, e.g. if the Gateway automatically assigns an address
-                  from a reserved pool. \n "
+                description: "Addresses lists the network addresses that have been
+                  bound to the Gateway. \n This list may differ from the addresses
+                  provided in the spec under some conditions: \n * no addresses are
+                  specified, all addresses are dynamically assigned * a combination
+                  of specified and dynamic addresses are assigned * a specified address
+                  was unusable (e.g. already in use) \n "
                 items:
-                  description: GatewayStatusAddress describes an address that is bound
-                    to a Gateway.
+                  description: GatewayStatusAddress describes a network address that
+                    is bound to a Gateway.
                   oneOf:
                   - properties:
                       type:

--- a/conformance/tests/gateway-static-addresses.go
+++ b/conformance/tests/gateway-static-addresses.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayStaticAddresses)
+}
+
+// GatewayStaticAddresses tests the implementation's support of deploying
+// Gateway resources with static addresses, or in other words addresses
+// provided via the specification rather than relying on the underlying
+// implementation/network to dynamically assign the Gateway an address.
+//
+// Running this test against your own implementation is currently a little bit
+// messy, as at the time of writing we didn't have great ways to provide the
+// test suite with things like known good, or known bad addresses to run the
+// test with (as we obviously can't determine that for the implementation).
+//
+// As such, if you're trying to enable this test for yourself and you're getting
+// confused about how to provide addresses, you'll actually do that in the
+// conformance test suite BEFORE you even set up and run your tests. Make sure
+// you populate the following test suite fields:
+//
+//   - suite.UsableNetworkAddresses
+//   - suite.UnusableNetworkAddresses
+//
+// With appropriate network addresses for your network environment.
+var GatewayStaticAddresses = suite.ConformanceTest{
+	ShortName:   "GatewayStaticAddresses",
+	Description: "A Gateway in the gateway-conformance-infra namespace should be able to use previously determined addresses.",
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportGatewayStaticAddresses,
+	},
+	Manifests: []string{
+		"tests/gateway-static-addresses.yaml",
+	},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		gwNN := types.NamespacedName{
+			Name:      "gateway-static-addresses",
+			Namespace: "gateway-conformance-infra",
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+
+		t.Logf("waiting for namespace %s and Gateway %s to be ready for testing", gwNN.Namespace, gwNN.Name)
+		kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
+
+		t.Logf("retrieving Gateway %s/%s and noting the provided addresses", gwNN.Namespace, gwNN.Name)
+		currentGW := &v1beta1.Gateway{}
+		err := s.Client.Get(ctx, gwNN, currentGW)
+		require.NoError(t, err, "error getting Gateway: %v", err)
+		require.Len(t, currentGW.Spec.Addresses, 3, "expected 3 addresses on the Gateway, one invalid, one usable and one unusable. somehow got %d", len(currentGW.Spec.Addresses))
+		invalidAddress := currentGW.Spec.Addresses[0]
+		unusableAddress := currentGW.Spec.Addresses[1]
+		usableAddress := currentGW.Spec.Addresses[2]
+
+		t.Logf("verifying that the Gateway %s/%s is NOT accepted due to an address type that the implementation doesn't support", gwNN.Namespace, gwNN.Name)
+		kubernetes.GatewayMustHaveCondition(t, s.Client, s.TimeoutConfig, gwNN, metav1.Condition{
+			Type:   string(v1beta1.GatewayConditionAccepted),
+			Status: metav1.ConditionFalse,
+			Reason: string(v1beta1.GatewayReasonUnsupportedAddress),
+		})
+
+		t.Logf("patching Gateway %s/%s to remove the invalid address %s", gwNN.Namespace, gwNN.Name, invalidAddress.Value)
+		updatedGW := currentGW.DeepCopy()
+		updatedGW.Spec.Addresses = filterAddr(currentGW.Spec.Addresses, invalidAddress)
+		err = s.Client.Patch(ctx, updatedGW, client.MergeFrom(currentGW))
+		require.NoError(t, err, "failed to patch Gateway: %v", err)
+		kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
+
+		t.Logf("verifying that the Gateway %s/%s is now accepted, but is not programmed due to an address that can't be used", gwNN.Namespace, gwNN.Name)
+		err = s.Client.Get(ctx, gwNN, currentGW)
+		require.NoError(t, err, "error getting Gateway: %v", err)
+		kubernetes.GatewayMustHaveCondition(t, s.Client, s.TimeoutConfig, gwNN, metav1.Condition{
+			Type:   string(v1beta1.GatewayConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(v1beta1.GatewayReasonAccepted),
+		})
+		kubernetes.GatewayMustHaveCondition(t, s.Client, s.TimeoutConfig, gwNN, metav1.Condition{
+			Type:   string(v1beta1.GatewayConditionProgrammed),
+			Status: metav1.ConditionFalse,
+			Reason: string(v1beta1.GatewayReasonAddressNotUsable),
+		})
+
+		t.Logf("patching Gateway %s/%s to remove the unusable address %s", gwNN.Namespace, gwNN.Name, unusableAddress.Value)
+		updatedGW = currentGW.DeepCopy()
+		updatedGW.Spec.Addresses = filterAddr(currentGW.Spec.Addresses, unusableAddress)
+		err = s.Client.Patch(ctx, updatedGW, client.MergeFrom(currentGW))
+		require.NoError(t, err, "failed to patch Gateway: %v", err)
+		kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
+
+		t.Logf("verifying that the Gateway %s/%s is accepted and programmed with the usable static address %s assigned", gwNN.Namespace, gwNN.Name, usableAddress.Value)
+		err = s.Client.Get(ctx, gwNN, currentGW)
+		require.NoError(t, err, "error getting Gateway: %v", err)
+		kubernetes.GatewayMustHaveCondition(t, s.Client, s.TimeoutConfig, gwNN, metav1.Condition{
+			Type:   string(v1beta1.GatewayConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(v1beta1.GatewayReasonAccepted),
+		})
+		kubernetes.GatewayMustHaveCondition(t, s.Client, s.TimeoutConfig, gwNN, metav1.Condition{
+			Type:   string(v1beta1.GatewayConditionProgrammed),
+			Status: metav1.ConditionTrue,
+			Reason: string(v1beta1.GatewayReasonProgrammed),
+		})
+		kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, finalExpectedListenerState)
+		require.Len(t, currentGW.Spec.Addresses, 1, "expected only 1 address left specified on Gateway")
+		require.Len(t, currentGW.Status.Addresses, 1, "one usable address was provided, so it should be the one reflected in status")
+		require.Equal(t, usableAddress.Type, currentGW.Status.Addresses[0].Type, "expected address type to match the usable address")
+		require.Equal(t, usableAddress.Value, currentGW.Status.Addresses[0].Value, "expected usable address to be assigned")
+	},
+}
+
+// -----------------------------------------------------------------------------
+// Private Helper Functions
+// -----------------------------------------------------------------------------
+
+func filterAddr(addrs []v1beta1.GatewayAddress, filter v1beta1.GatewayAddress) (newAddrs []v1beta1.GatewayAddress) {
+	for _, addr := range addrs {
+		if addr.Value != filter.Value {
+			newAddrs = append(newAddrs, addr)
+		}
+	}
+	return
+}
+
+var finalExpectedListenerState = []v1beta1.ListenerStatus{
+	{
+		Name: v1beta1.SectionName("http"),
+		SupportedKinds: []v1beta1.RouteGroupKind{{
+			Group: (*v1beta1.Group)(&v1beta1.GroupVersion.Group),
+			Kind:  v1beta1.Kind("HTTPRoute"),
+		}},
+		Conditions: []metav1.Condition{
+			{
+				Type:   string(v1beta1.ListenerConditionAccepted),
+				Status: metav1.ConditionTrue,
+				Reason: "", // any reason
+			},
+			{
+				Type:   string(v1beta1.ListenerConditionResolvedRefs),
+				Status: metav1.ConditionTrue,
+				Reason: "", // any reason
+			},
+		},
+		AttachedRoutes: 0,
+	},
+}

--- a/conformance/tests/gateway-static-addresses.yaml
+++ b/conformance/tests/gateway-static-addresses.yaml
@@ -4,6 +4,8 @@ kind: Gateway
 metadata:
   name: gateway-static-addresses
   namespace: gateway-conformance-infra
+  annotations:
+    gateway-api/skip-this-for-readiness: "true"
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
   addresses:

--- a/conformance/tests/gateway-static-addresses.yaml
+++ b/conformance/tests/gateway-static-addresses.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: gateway-static-addresses
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  addresses:
+  # this address type is intentionally unsupported to test that implementations
+  # are indicating Gateways with unsupported addresses are not accepted.
+  # the test will remove this address once it confirms it triggers a status of
+  # Accepted==False.
+  - type: "test/fake-invalid-type"
+    value: "fake address teehee!"
+  # This indicates an address that is known to not be usable by the
+  # implementation and will be substituted with user provided types and values.
+  - value: "PLACEHOLDER_UNUSABLE_ADDRS"
+  # This indicates an address that is known to be usable by the implementation
+  # and will be substituted with user provided types and values.
+  - value: "PLACEHOLDER_USABLE_ADDRS"
+  listeners:
+  - name: http
+    port: 8080
+    protocol: HTTP

--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -35,6 +35,11 @@ type TimeoutConfig struct {
 	// Max value for conformant implementation: None
 	GatewayMustHaveAddress time.Duration
 
+	// GatewayMustHaveCondition represents the maximum amount of time for a
+	// Gateway to have the supplied Condition.
+	// Max value for conformant implementation: None
+	GatewayMustHaveCondition time.Duration
+
 	// GatewayStatusMustHaveListeners represents the maximum time for a Gateway to have listeners in status that match the expected listeners.
 	// Max value for conformant implementation: None
 	GatewayStatusMustHaveListeners time.Duration
@@ -99,6 +104,7 @@ func DefaultTimeoutConfig() TimeoutConfig {
 		DeleteTimeout:                     10 * time.Second,
 		GetTimeout:                        10 * time.Second,
 		GatewayMustHaveAddress:            180 * time.Second,
+		GatewayMustHaveCondition:          180 * time.Second,
 		GatewayStatusMustHaveListeners:    60 * time.Second,
 		GatewayListenersMustHaveCondition: 60 * time.Second,
 		GWCMustBeAccepted:                 180 * time.Second,
@@ -128,6 +134,9 @@ func SetupTimeoutConfig(timeoutConfig *TimeoutConfig) {
 	}
 	if timeoutConfig.GatewayMustHaveAddress == 0 {
 		timeoutConfig.GatewayMustHaveAddress = defaultTimeoutConfig.GatewayMustHaveAddress
+	}
+	if timeoutConfig.GatewayMustHaveCondition == 0 {
+		timeoutConfig.GatewayMustHaveCondition = defaultTimeoutConfig.GatewayMustHaveCondition
 	}
 	if timeoutConfig.GatewayStatusMustHaveListeners == 0 {
 		timeoutConfig.GatewayStatusMustHaveListeners = defaultTimeoutConfig.GatewayStatusMustHaveListeners

--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -30,10 +30,12 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance/utils/config"
 )
 
@@ -51,12 +53,87 @@ type Applier struct {
 
 	// FS is the filesystem to use when reading manifests.
 	FS embed.FS
+
+	// UsableNetworkAddresses is a list of addresses that are expected to be
+	// supported AND usable for Gateways in the underlying implementation.
+	UsableNetworkAddresses []v1beta1.GatewayAddress
+
+	// UnusableNetworkAddresses is a list of addresses that are expected to be
+	// supported, but not usable for Gateways in the underlying implementation.
+	UnusableNetworkAddresses []v1beta1.GatewayAddress
 }
 
 // prepareGateway adjusts the gatewayClassName.
 func (a Applier) prepareGateway(t *testing.T, uObj *unstructured.Unstructured) {
+	ns := uObj.GetNamespace()
+	name := uObj.GetName()
+
 	err := unstructured.SetNestedField(uObj.Object, a.GatewayClass, "spec", "gatewayClassName")
-	require.NoErrorf(t, err, "error setting `spec.gatewayClassName` on %s Gateway resource", uObj.GetName())
+	require.NoErrorf(t, err, "error setting `spec.gatewayClassName` on Gateway %s/%s", ns, name)
+
+	rawSpec, hasSpec, err := unstructured.NestedFieldCopy(uObj.Object, "spec")
+	require.NoError(t, err, "error retrieving spec.addresses to verify if any static addresses were present on Gateway resource %s/%s", ns, name)
+	require.True(t, hasSpec)
+
+	rawSpecMap, ok := rawSpec.(map[string]interface{})
+	require.True(t, ok, "expected gw spec received %T", rawSpec)
+
+	gwspec := &v1beta1.GatewaySpec{}
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(rawSpecMap, gwspec))
+
+	// for tests which have placeholders for static gateway addresses we will
+	// inject real addresses from the address pools the caller provided.
+	if len(gwspec.Addresses) > 0 {
+		// this is a hack because we don't have any other great way to inject custom
+		// values into the test YAML at the time of writing: Gateways that include
+		// addresses with the following values:
+		//
+		//   * PLACEHOLDER_USABLE_ADDRS
+		//   * PLACEHOLDER_UNUSABLE_ADDRS
+		//
+		// indicate that they expect the caller of the test suite to have provided
+		// relevant addresses (usable, or unusable ones) in the test suite, and those
+		// addresses will be injected into the Gateway and the placeholders removed.
+		//
+		// A special "test/fake-invalid-type" can be provided as well in the test to
+		// explicitly trigger a failure to support a type. If an implementation ever
+		// comes along actually trying to support that type, I'm going to be very
+		// cranky.
+		//
+		// Note: I would really love to find a better way to do this kind of
+		// thing in the future.
+		var overlayUsable, overlayUnusuable bool
+		var specialAddrs []v1beta1.GatewayAddress
+		for _, addr := range gwspec.Addresses {
+			switch addr.Value {
+			case "PLACEHOLDER_USABLE_ADDRS":
+				overlayUsable = true
+			case "PLACEHOLDER_UNUSABLE_ADDRS":
+				overlayUnusuable = true
+			}
+
+			if addr.Type != nil && *addr.Type == "test/fake-invalid-type" {
+				specialAddrs = append(specialAddrs, addr)
+			}
+		}
+
+		var primOverlayAddrs []interface{}
+		if overlayUsable {
+			t.Logf("address pool of %d usable addresses will be overlayed", len(a.UsableNetworkAddresses))
+			primOverlayAddrs = append(primOverlayAddrs, convertGatewayAddrsToPrimitives(a.UsableNetworkAddresses)...)
+		}
+		if overlayUnusuable {
+			t.Logf("address pool of %d unusable addresses will be overlayed", len(a.UnusableNetworkAddresses))
+			primOverlayAddrs = append(primOverlayAddrs, convertGatewayAddrsToPrimitives(a.UnusableNetworkAddresses)...)
+		}
+		if len(specialAddrs) > 0 {
+			t.Logf("the test provides %d special addresses that will be kept", len(specialAddrs))
+			primOverlayAddrs = append(primOverlayAddrs, convertGatewayAddrsToPrimitives(specialAddrs)...)
+		}
+
+		err = unstructured.SetNestedSlice(uObj.Object, primOverlayAddrs, "spec", "addresses")
+		require.NoError(t, err, "could not overlay static addresses on Gateway %s/%s", ns, name)
+	}
 }
 
 // prepareGatewayClass adjust the spec.controllerName on the resource
@@ -265,4 +342,21 @@ func getContentsFromPathOrURL(fs embed.FS, location string, timeoutConfig config
 		return nil, err
 	}
 	return bytes.NewBuffer(b), nil
+}
+
+// convertGatewayAddrsToPrimitives converts a slice of Gateway addresses and
+// to a slice of primite types and then returns them as a []interface{} so that
+// they can be applied back to an unstructured Gateway.
+func convertGatewayAddrsToPrimitives(gwaddrs []v1beta1.GatewayAddress) (raw []interface{}) {
+	for _, addr := range gwaddrs {
+		addrType := string(v1beta1.IPAddressType)
+		if addr.Type != nil {
+			addrType = string(*addr.Type)
+		}
+		raw = append(raw, map[string]interface{}{
+			"type":  addrType,
+			"value": addr.Value,
+		})
+	}
+	return
 }

--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -344,8 +344,8 @@ func getContentsFromPathOrURL(fs embed.FS, location string, timeoutConfig config
 	return bytes.NewBuffer(b), nil
 }
 
-// convertGatewayAddrsToPrimitives converts a slice of Gateway addresses and
-// to a slice of primite types and then returns them as a []interface{} so that
+// convertGatewayAddrsToPrimitives converts a slice of Gateway addresses
+// to a slice of primitive types and then returns them as a []interface{} so that
 // they can be applied back to an unstructured Gateway.
 func convertGatewayAddrsToPrimitives(gwaddrs []v1beta1.GatewayAddress) (raw []interface{}) {
 	for _, addr := range gwaddrs {

--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -118,17 +118,17 @@ func (a Applier) prepareGateway(t *testing.T, uObj *unstructured.Unstructured) {
 		}
 
 		var primOverlayAddrs []interface{}
-		if overlayUsable {
-			t.Logf("address pool of %d usable addresses will be overlayed", len(a.UsableNetworkAddresses))
-			primOverlayAddrs = append(primOverlayAddrs, convertGatewayAddrsToPrimitives(a.UsableNetworkAddresses)...)
+		if len(specialAddrs) > 0 {
+			t.Logf("the test provides %d special addresses that will be kept", len(specialAddrs))
+			primOverlayAddrs = append(primOverlayAddrs, convertGatewayAddrsToPrimitives(specialAddrs)...)
 		}
 		if overlayUnusuable {
 			t.Logf("address pool of %d unusable addresses will be overlayed", len(a.UnusableNetworkAddresses))
 			primOverlayAddrs = append(primOverlayAddrs, convertGatewayAddrsToPrimitives(a.UnusableNetworkAddresses)...)
 		}
-		if len(specialAddrs) > 0 {
-			t.Logf("the test provides %d special addresses that will be kept", len(specialAddrs))
-			primOverlayAddrs = append(primOverlayAddrs, convertGatewayAddrsToPrimitives(specialAddrs)...)
+		if overlayUsable {
+			t.Logf("address pool of %d usable addresses will be overlayed", len(a.UsableNetworkAddresses))
+			primOverlayAddrs = append(primOverlayAddrs, convertGatewayAddrsToPrimitives(a.UsableNetworkAddresses)...)
 		}
 
 		err = unstructured.SetNestedSlice(uObj.Object, primOverlayAddrs, "spec", "addresses")

--- a/conformance/utils/suite/experimental_suite.go
+++ b/conformance/utils/suite/experimental_suite.go
@@ -160,10 +160,12 @@ func NewExperimentalConformanceTestSuite(s ExperimentalConformanceOptions) (*Exp
 			NamespaceLabels:      s.NamespaceLabels,
 			NamespaceAnnotations: s.NamespaceAnnotations,
 		},
-		SupportedFeatures: s.SupportedFeatures,
-		TimeoutConfig:     s.TimeoutConfig,
-		SkipTests:         sets.New(s.SkipTests...),
-		FS:                *s.FS,
+		SupportedFeatures:        s.SupportedFeatures,
+		TimeoutConfig:            s.TimeoutConfig,
+		SkipTests:                sets.New(s.SkipTests...),
+		FS:                       *s.FS,
+		UsableNetworkAddresses:   s.UsableNetworkAddresses,
+		UnusableNetworkAddresses: s.UnusableNetworkAddresses,
 	}
 
 	// apply defaults

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -49,12 +49,18 @@ var GatewayCoreFeatures = sets.New(
 const (
 	// This option indicates that the Gateway can also use port 8080
 	SupportGatewayPort8080 SupportedFeature = "GatewayPort8080"
+
+	// SupportGatewayStaticAddresses option indicates that the Gateway is capable
+	// of allocating pre-determined addresses, rather than dynamically having
+	// addresses allocated for it.
+	SupportGatewayStaticAddresses SupportedFeature = "GatewayStaticAddresses"
 )
 
 // StandardExtendedFeatures are extra generic features that implementations may
 // choose to support as an opt-in.
 var GatewayExtendedFeatures = sets.New(
 	SupportGatewayPort8080,
+	SupportGatewayStaticAddresses,
 ).Insert(GatewayCoreFeatures.UnsortedList()...)
 
 // -----------------------------------------------------------------------------

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance"
 	"sigs.k8s.io/gateway-api/conformance/utils/config"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
@@ -35,22 +36,24 @@ import (
 // ConformanceTestSuite defines the test suite used to run Gateway API
 // conformance tests.
 type ConformanceTestSuite struct {
-	Client            client.Client
-	Clientset         clientset.Interface
-	RESTClient        *rest.RESTClient
-	RestConfig        *rest.Config
-	RoundTripper      roundtripper.RoundTripper
-	GatewayClassName  string
-	ControllerName    string
-	Debug             bool
-	Cleanup           bool
-	BaseManifests     string
-	MeshManifests     string
-	Applier           kubernetes.Applier
-	SupportedFeatures sets.Set[SupportedFeature]
-	TimeoutConfig     config.TimeoutConfig
-	SkipTests         sets.Set[string]
-	FS                embed.FS
+	Client                   client.Client
+	Clientset                clientset.Interface
+	RESTClient               *rest.RESTClient
+	RestConfig               *rest.Config
+	RoundTripper             roundtripper.RoundTripper
+	GatewayClassName         string
+	ControllerName           string
+	Debug                    bool
+	Cleanup                  bool
+	BaseManifests            string
+	MeshManifests            string
+	Applier                  kubernetes.Applier
+	SupportedFeatures        sets.Set[SupportedFeature]
+	TimeoutConfig            config.TimeoutConfig
+	SkipTests                sets.Set[string]
+	FS                       embed.FS
+	UsableNetworkAddresses   []v1beta1.GatewayAddress
+	UnusableNetworkAddresses []v1beta1.GatewayAddress
 }
 
 // Options can be used to initialize a ConformanceTestSuite.
@@ -78,6 +81,15 @@ type Options struct {
 	SkipTests []string
 
 	FS *embed.FS
+
+	// UsableNetworkAddresses is an optional pool of usable addresses for
+	// Gateways for tests which need to test manual address assignments.
+	UsableNetworkAddresses []v1beta1.GatewayAddress
+
+	// UnusableNetworkAddresses is an optional pool of unusable addresses for
+	// Gateways for tests which need to test failures with manual Gateway
+	// address assignment.
+	UnusableNetworkAddresses []v1beta1.GatewayAddress
 }
 
 // New returns a new ConformanceTestSuite.
@@ -122,10 +134,12 @@ func New(s Options) *ConformanceTestSuite {
 			NamespaceLabels:      s.NamespaceLabels,
 			NamespaceAnnotations: s.NamespaceAnnotations,
 		},
-		SupportedFeatures: s.SupportedFeatures,
-		TimeoutConfig:     s.TimeoutConfig,
-		SkipTests:         sets.New(s.SkipTests...),
-		FS:                *s.FS,
+		SupportedFeatures:        s.SupportedFeatures,
+		TimeoutConfig:            s.TimeoutConfig,
+		SkipTests:                sets.New(s.SkipTests...),
+		FS:                       *s.FS,
+		UsableNetworkAddresses:   s.UsableNetworkAddresses,
+		UnusableNetworkAddresses: s.UnusableNetworkAddresses,
 	}
 
 	// apply defaults
@@ -143,6 +157,8 @@ func New(s Options) *ConformanceTestSuite {
 // in the cluster. It also ensures that all relevant resources are ready.
 func (suite *ConformanceTestSuite) Setup(t *testing.T) {
 	suite.Applier.FS = suite.FS
+	suite.Applier.UsableNetworkAddresses = suite.UsableNetworkAddresses
+	suite.Applier.UnusableNetworkAddresses = suite.UnusableNetworkAddresses
 
 	if suite.SupportedFeatures.Has(SupportGateway) {
 		t.Logf("Test Setup: Ensuring GatewayClass has been accepted")


### PR DESCRIPTION
**What type of PR is this?**

/area conformance
/kind test

**What this PR does / why we need it**:

Going into GA we have an extended field for supplying static addresses for Gateways, but no conformance tests for that feature. This patch adds the test, while also tweaking some of the related condition reasons (see the explanation in the `CHANGELOG.md`).

**Which issue(s) this PR fixes**:

Resolves #2035

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

> **Warning**: The way we're injecting the address pools into the test is bad. I don't like it. However, I think at this point with GA in the next few weeks, trying to make this better would require some kind of fundamental change to the test suite which we don't have time for. If you have any great ideas for alternatives that are simple, that would be lovely. If your PR comments are going to be something like "man we really need proper templating in the test suite" please note that this will probably have to wait for later.