### PR TITLE
Rename NGINX Kubernetes Gateway

### DIFF
--- a/conformance/reports/v0.7.1/nginxinc-nginx-gateway-fabric.yaml
+++ b/conformance/reports/v0.7.1/nginxinc-nginx-gateway-fabric.yaml
@@ -1,38 +1,38 @@
 apiVersion: gateway.networking.k8s.io/v1alpha1
-date: "2023-08-31T16:40:14Z"
-gatewayAPIVersion: v0.8.0
+date: "2023-07-25T20:48:53Z"
+gatewayAPIVersion: v0.7.1
 implementation:
   contact:
-  - https://github.com/nginxinc/nginx-kubernetes-gateway/discussions/new/choose
+  - https://github.com/nginxinc/nginx-gateway-fabric/discussions/new/choose
   organization: nginxinc
-  project: nginx-kubernetes-gateway
-  url: https://github.com/nginxinc/nginx-kubernetes-gateway
-  version: v0.6.0
+  project: nginx-gateway-fabric
+  url: github.com/nginxinc/nginx-gateway-fabric
+  version: "v0.5.0"
 kind: ConformanceReport
 profiles:
 - core:
     result: success
     statistics:
       Failed: 0
-      Passed: 29
+      Passed: 28
       Skipped: 0
-    summary: ""
+    summary: All core HTTP features are supported
   extended:
     result: success
     statistics:
       Failed: 0
       Passed: 4
       Skipped: 0
-    summary: ""
+    summary: Some extended HTTP features are supported
     supportedFeatures:
-    - HTTPRouteSchemeRedirect
     - HTTPRouteMethodMatching
+    - HTTPRouteSchemeRedirect
     - HTTPRouteQueryParamMatching
     - HTTPRoutePortRedirect
     unsupportedFeatures:
+    - HTTPResponseHeaderModification
+    - HTTPRouteHostRewrite
     - HTTPRoutePathRedirect
     - HTTPRoutePathRewrite
-    - HTTPRouteHostRewrite
     - HTTPRouteRequestMirror
-    - HTTPResponseHeaderModification
   name: HTTP

--- a/conformance/reports/v0.8.0/nginxinc-nginx-gateway-fabric.yaml
+++ b/conformance/reports/v0.8.0/nginxinc-nginx-gateway-fabric.yaml
@@ -1,38 +1,38 @@
 apiVersion: gateway.networking.k8s.io/v1alpha1
-date: "2023-07-25T20:48:53Z"
-gatewayAPIVersion: v0.7.1
+date: "2023-08-31T16:40:14Z"
+gatewayAPIVersion: v0.8.0
 implementation:
   contact:
-  - https://github.com/nginxinc/nginx-kubernetes-gateway/discussions/new/choose
+  - https://github.com/nginxinc/nginx-gateway-fabric/discussions/new/choose
   organization: nginxinc
-  project: nginx-kubernetes-gateway
-  url: github.com/nginxinc/nginx-kubernetes-gateway
-  version: "v0.5.0"
+  project: nginx-gateway-fabric
+  url: https://github.com/nginxinc/nginx-gateway-fabric
+  version: v0.6.0
 kind: ConformanceReport
 profiles:
 - core:
     result: success
     statistics:
       Failed: 0
-      Passed: 28
+      Passed: 29
       Skipped: 0
-    summary: All core HTTP features are supported
+    summary: ""
   extended:
     result: success
     statistics:
       Failed: 0
       Passed: 4
       Skipped: 0
-    summary: Some extended HTTP features are supported
+    summary: ""
     supportedFeatures:
-    - HTTPRouteMethodMatching
     - HTTPRouteSchemeRedirect
+    - HTTPRouteMethodMatching
     - HTTPRouteQueryParamMatching
     - HTTPRoutePortRedirect
     unsupportedFeatures:
-    - HTTPResponseHeaderModification
-    - HTTPRouteHostRewrite
     - HTTPRoutePathRedirect
     - HTTPRoutePathRewrite
+    - HTTPRouteHostRewrite
     - HTTPRouteRequestMirror
+    - HTTPResponseHeaderModification
   name: HTTP

--- a/geps/gep-1619.md
+++ b/geps/gep-1619.md
@@ -127,7 +127,7 @@ Generally, the implementation API programs the dataplane API; however these two 
 |  	|  	| [Header-Based](https://docs.konghq.com/gateway/latest/how-kong-works/load-balancing/#balancing-algorithms) 	| name 	| [Upstreams](https://docs.konghq.com/gateway/3.2.x/admin-api/#add-upstream) (Backends) 	| N/A 	|
 | Kuma 	| Implementation (Envoy) 	| None 	| None 	| None 	| Kuma has no documentation on how it supports session persistence or cookies. [Kuma Docs](https://kuma.io/docs/2.1.x/) 	|
 | Nginx  	| Dataplane 	| [Cookie-Based (Nginx Plus Only)](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/#enabling-session-persistence) 	| Name=name<br>Expires=time<br>Domain=domain<br>HttpOnly<br>SameSite = [strict \| lax \| none \| $variable]<br>Secure<br>path=path 	| [Upstream](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/#enabling-session-persistence) (Backends) 	| See also [Sticky Cookie](https://nginx.org/en/docs/http/ngx_http_upstream_module.html?&_ga=2.184452070.1306763907.1680031702-1761609832.1671225057#sticky_cookie) 	|
-| NGINX Kubernetes Gateway 	| Implementation (Nginx) 	| N/A 	| Supports Gateway API Only* 	| N/A 	| *NGINX Kubernetes Gateway solely uses Gateway API; therefore, it doesn’t yet have a way to configure session persistence. [Nginx Kubernetes Gateway Docs](https://github.com/nginxinc/nginx-kubernetes-gateway) 	|
+| NGINX Gateway Fabric 	| Implementation (Nginx) 	| N/A 	| Supports Gateway API Only* 	| N/A 	| *NGINX Gateway Fabric solely uses Gateway API; therefore, it doesn’t yet have a way to configure session persistence. [NGINX Gateway Fabric Docs](https://github.com/nginxinc/nginx-gateway-fabric) 	|
 | Traefik 	| Implementation / Dataplane 	| [Cookie-Based](https://doc.traefik.io/traefik/routing/services/#sticky-sessions) 	| name=name<br>secure<br>httpOnly<br>sameSite=[none \| lax \| strict ] 	| [Services](https://doc.traefik.io/traefik/routing/services/#sticky-sessions) (Backends) 	| N/A 	|
 
 **Session Affinity**
@@ -152,7 +152,7 @@ Generally, the implementation API programs the dataplane API; however these two 
 | Kong 	| Implementation / Dataplane 	| [Consistent Hashing](https://docs.konghq.com/gateway/latest/how-kong-works/load-balancing/#balancing-algorithms) via Source IP or Consumer ID 	| N/A 	|
 | Kuma 	| Implementation (Envoy) 	| Consistent Hashing via [Ring Hash](https://kuma.io/docs/2.1.x/policies/traffic-route/#load-balancer-types) 	| N/A 	|
 | Nginx 	| Dataplane 	| [Consistent Hashing](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#hash) via IP or other connection attributes (Nginx Open Source) 	| N/A 	|
-| NGINX Kubernetes Gateway 	| Implementation (Nginx) 	| Supports Gateway API Only* 	| *NGINX Kubernetes Gateway solely uses Gateway API; therefore, it doesn’t yet have a way to configure session affinity. [Nginx Kubernetes Gateway Docs](https://github.com/nginxinc/nginx-kubernetes-gateway) 	|
+| NGINX Gateway Fabric 	| Implementation (Nginx) 	| Supports Gateway API Only* 	| *NGINX Gateway Fabric solely uses Gateway API; therefore, it doesn’t yet have a way to configure session affinity. [NGINX Gateway Fabric Docs](https://github.com/nginxinc/nginx-gateway-fabric) 	|
 | Traefik 	| Implementation / Dataplane 	| None 	| [Traefik Docs](https://doc.traefik.io/traefik/) 	|
 
 ### Sessions in Java

--- a/geps/gep-1742.md
+++ b/geps/gep-1742.md
@@ -61,7 +61,7 @@ support layer 7, please feel free to correct them.
 | Kong           | Nginx      |
 | Kuma           | Envoy      |
 | Litespeed      | Litespeed WebADC |
-| Nginx Kubernetes Gateway | Nginx |
+| NGINX Gateway Fabric | Nginx |
 | Traefik        | Traefik    |
 
 

--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -24,7 +24,7 @@ Implementors and integrators of Gateway API are encouraged to update this docume
 - [Kong][10] (beta)
 - [Kuma][11] (beta)
 - [LiteSpeed Ingress Controller][19]
-- [NGINX Kubernetes Gateway][12]
+- [NGINX Gateway Fabric][12]
 - [STUNner][21] (beta)
 - [Traefik][13] (alpha)
 - [Tyk][29] (work in progress)
@@ -55,7 +55,7 @@ Implementors and integrators of Gateway API are encouraged to update this docume
 [9]:#istio
 [10]:#kong
 [11]:#kuma
-[12]:#nginx-kubernetes-gateway
+[12]:#nginx-gateway-fabric
 [13]:#traefik
 [14]:#flagger
 [15]:#cert-manager
@@ -334,19 +334,19 @@ The [LiteSpeed Ingress Controller](https://litespeedtech.com/products/litespeed-
 - [Gateway specific documentation](https://docs.litespeedtech.com/cloud/kubernetes/gateway).
 - Full support is available on the [LiteSpeed support web site](https://www.litespeedtech.com/support).
 
-### NGINX Kubernetes Gateway
+### NGINX Gateway Fabric
 
-[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v0.8.0-NGINX Kubernetes Gateway-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v0.8.0/nginxinc-nginx-kubernetes-gateway.yaml)
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v0.8.0-NGINX Gateway Fabric-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v0.8.0/nginxinc-nginx-gateway-fabric.yaml)
 
-[NGINX Kubernetes Gateway][nginx-kubernetes-gateway] is an open-source project that provides an implementation of the Gateway API using [NGINX][nginx] as the data plane. The goal of this project is to implement the core Gateway API -- Gateway, GatewayClass, HTTPRoute, TCPRoute, TLSRoute, and UDPRoute -- to configure an HTTP or TCP/UDP load balancer, reverse-proxy, or API gateway for applications running on Kubernetes. NGINX Kubernetes Gateway is currently under development and supports a subset of the Gateway API.
+[NGINX Gateway Fabric][nginx-gateway-fabric] is an open-source project that provides an implementation of the Gateway API using [NGINX][nginx] as the data plane. The goal of this project is to implement the core Gateway API -- Gateway, GatewayClass, HTTPRoute, TCPRoute, TLSRoute, and UDPRoute -- to configure an HTTP or TCP/UDP load balancer, reverse-proxy, or API gateway for applications running on Kubernetes. NGINX Gateway Fabric is currently under development and supports a subset of the Gateway API.
 
-If you have any suggestions or experience issues with NGINX Kubernetes Gateway, please [create an issue][nginx-issue-new] or a [discussion][nginx-disc-new] on GitHub. You can also ask for help in the [#nginx-kubernetes-gateway channel on NGINX slack][nginx-slack].
+If you have any suggestions or experience issues with NGINX Gateway Fabric, please [create an issue][nginx-issue-new] or a [discussion][nginx-disc-new] on GitHub. You can also ask for help in the [#nginx-gateway-fabric channel on NGINX slack][nginx-slack].
 
-[nginx-kubernetes-gateway]:https://github.com/nginxinc/nginx-kubernetes-gateway
+[nginx-gateway-fabric]:https://github.com/nginxinc/nginx-gateway-fabric
 [nginx]:https://nginx.org/
-[nginx-issue-new]:https://github.com/nginxinc/nginx-kubernetes-gateway/issues/new
-[nginx-disc-new]:https://github.com/nginxinc/nginx-kubernetes-gateway/discussions/new
-[nginx-slack]:https://nginxcommunity.slack.com/channels/nginx-kubernetes-gateway
+[nginx-issue-new]:https://github.com/nginxinc/nginx-gateway-fabric/issues/new
+[nginx-disc-new]:https://github.com/nginxinc/nginx-gateway-fabric/discussions/new
+[nginx-slack]:https://nginxcommunity.slack.com/channels/nginx-gateway-fabric
 
 ### STUNner
 


### PR DESCRIPTION
NGINX Kubernetes Gateway has been renamed to NGINX Gateway Fabric.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind cleanup

**What this PR does / why we need it**:
NGINX Kubernetes Gateway has been renamed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NGINX Kubernetes Gateway has been renamed to NGINX Gateway Fabric.
```
