### PR TITLE
Adding new PartiallyInvalid condition for Routes

### DIFF
--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -298,7 +298,7 @@ const (
 	// This condition indicates whether the route has been accepted or rejected
 	// by a Gateway, and why.
 	//
-	// Possible reasons for this condition to be true are:
+	// Possible reasons for this condition to be True are:
 	//
 	// * "Accepted"
 	//
@@ -349,15 +349,17 @@ const (
 	// are incompatible filters present on a route rule (for example if
 	// the URLRewrite and RequestRedirect are both present on an HTTPRoute).
 	RouteReasonIncompatibleFilters RouteConditionReason = "IncompatibleFilters"
+)
 
+const (
 	// This condition indicates whether the controller was able to resolve all
 	// the object references for the Route.
 	//
-	// Possible reasons for this condition to be true are:
+	// Possible reasons for this condition to be True are:
 	//
 	// * "ResolvedRefs"
 	//
-	// Possible reasons for this condition to be false are:
+	// Possible reasons for this condition to be False are:
 	//
 	// * "RefNotPermitted"
 	// * "InvalidKind"
@@ -392,6 +394,43 @@ const (
 	// Route's rules has a reference to a resource with an app protocol that
 	// is not supported by this implementation.
 	RouteReasonUnsupportedProtocol RouteConditionReason = "UnsupportedProtocol"
+)
+
+const (
+	// This condition indicates that the Route contains a combination of both
+	// valid and invalid rules.
+	//
+	// When this happens, implementations MUST take one of the following
+	// approaches:
+	//
+	// 1) Drop Rule(s): With this approach, implementations will drop the
+	//    invalid Route Rule(s) until they are fully valid again. The message
+	//    for this condition MUST start with the prefix "Dropped Rule" and
+	//    include information about which Rules have been dropped. In this
+	//    state, the "Accepted" condition MUST be set to "True" with the latest
+	//    generation of the resource.
+	// 2) Fall Back: With this approach, implementations will fall back to the
+	//    last known good state of the entire Route. The message for this
+	//    condition MUST start with the prefix "Fall Back" and include
+	//    information about why the current Rule(s) are invalid. To represent
+	//    this, the "Accepted" condition MUST be set to "True" with the
+	//    generation of the last known good state of the resource.
+	//
+	// Reverting to the last known good state should only be done by
+	// implementations that have a means of restoring that state if/when they
+	// are restarted.
+	//
+	// This condition MUST NOT be set if a Route is fully valid, fully invalid,
+	// or not accepted. By extension, that means that this condition MUST only
+	// be set when it is "True".
+	//
+	// Possible reasons for this condition to be True are:
+	//
+	// * "UnsupportedValue"
+	//
+	// Controllers may raise this condition with other reasons, but should
+	// prefer to use the reasons listed above to improve interoperability.
+	RouteConditionPartiallyInvalid RouteConditionType = "PartiallyInvalid"
 )
 
 // RouteParentStatus describes the status of a route with respect to an


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This adds a new condition along with corresponding guidance for how to handle Routes that are partially invalid.

Note: I can't think of any way to write conformance tests for this condition since the most likely way to get into this state is when an implementation can't support a feature configured in a Route. 

**Which issue(s) this PR fixes**:
Fixes #1696.

**Does this PR introduce a user-facing change?**:
```release-note
New "PartiallyInvalid" condition has been added for all Route types.
```

/hold for consensus