### PR TITLE
Add distinct concept to Listener definition

### DIFF
--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -69,68 +69,93 @@ type GatewaySpec struct {
 	// logical endpoints that are bound on this Gateway's addresses.
 	// At least one Listener MUST be specified.
 	//
-	// Each listener in a Gateway must have a unique combination of Hostname,
-	// Port, and Protocol.
+	// Each Listener in a set of Listeners (for example, in a single Gateway)
+	// must be _distinct_, in that a traffic flow must be able to be assigned to
+	// exactly one listener. (This section uses "set of Listeners" rather than
+	// "Listeners in a single Gateway" because implementations MAY merge configuration
+	// from multiple Gateways onto a single data plane, and these rules _also_
+	// apply in that case).
 	//
-	// Within the HTTP Conformance Profile, the below combinations of port and
-	// protocol are considered Core and MUST be supported:
+	// Practically, this means that each listener in a set MUST have a unique
+	// combination of Port, Protocol, TLS Settings, and, if supported by the
+	// protocol, Hostname.
+	//
+	// Some combinations of port, protoocl, and TLS settings are are considered
+	// Core support and MUST be supported by implementations:
 	//
 	// 1. Port: 80, Protocol: HTTP
-	// 2. Port: 443, Protocol: HTTPS
+	// 2. Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
+	// 3. Port: 443, Protocol: TLS, TLS Mode: Passthrough
 	//
-	// Within the TLS Conformance Profile, the below combinations of port and
-	// protocol are considered Core and MUST be supported:
+	// "Distinct" Listeners have the following property:
 	//
-	// 1. Port: 443, Protocol: TLS
+	// The implementation can match inbound requests to a single distinct
+	// Listener. When multiple Listeners share values for fields (for
+	// example, two Listeners with the same Port value), the implementation
+	// can can match requests to only one of the Listeners using other
+	// Listener fields.
+    // 
+ 	// For example, the following Listener scenarios are distinct:
+    //
+    // 1. Multiple Listeners with the same Port that all use the "HTTP"
+	//    Protocol that all have unique Hostname values.
+	// 2. Multiple Listeners with the same Port that use either the "HTTPS" or
+	//    "TLS" Protocol that all have unique Hostname values.
+	// 3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
+	//    with the same Protocol has the same Port value.   
+    //
+    // Some fields in the Listener struct have possible values that affect
+    // whether the Listener is distinct. Hostname is particularly relevant
+    // for HTTP or HTTPS protocols.
+    //
+	// When using the Hostname value to select between same-Port, same-Protocol
+    // Listeners, the Hostname value must be different on each Listener for the
+    // Listener to be distinct.
+    // 
+    // When the Listeners are distinct based on Hostname, inbound request
+    // hostnames MUST match from the most specific to least specific Hostname
+    // values to choose the correct Listener and its associated set of Routes.
+    //
+	// Exact matches must be processed before wildcard matches, and wildcard
+	// matches must be processed before fallback (empty Hostname value)
+	// matches. For example, `"foo.example.com"` takes precedence over
+	// `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
+    //
+    // Additionally, if there are multiple wildcard entries, more specific
+    // wildcard entries must be processed before less specific wildcard entries.
+    // For example, `"*.foo.example.com"` takes precedence over `"*.example.com"`.
+    // The precise definition here is that the higher the number of dots in the
+    // hostname to the right of the wildcard character, the higher the precedence.
+    //
+    // The wildcard character will match any number of characters _and dots_ to
+    // the left, however, so `"*.example.com"` will match both
+    // `"foo.bar.example.com"` _and_ `"bar.example.com"`.
+    //
+    // If a set of Listeners contains Listeners that are not distinct, then those
+    // Listeners are Conflicted, and the implementation MUST set the "Conflicted"
+    // condition in the Listener Status to "True".
+    //
+   	// Implementations MAY choose to still accept a Gateway with Conflicted
+	// Listeners if they accept a partial Listener set that contains no
+	// Conflicted Listeners. They MUST set a "ListenersNotValid" condition
+	// the Gateway Status when the Gateway contains Conflicted Listeners
+	// whether or not they accept the Gateway. That Condition SHOULD clearly
+    // indicate in the Message which Listeners are conflicted.
+    //
+    // A Gateway's Listeners are considered "compatible" if:
 	//
-	// Port and protocol combinations not listed above are considered Extended.
-	//
-	// A Gateway's Listeners are considered "compatible" if:
-	//
-	// 1. The implementation can serve them in compliance with the Addresses
+    // 1. They are distinct.
+	// 2. The implementation can serve them in compliance with the Addresses
 	//    requirement that all Listeners are available on all assigned
 	//    addresses.
-	// 2. The implementation can match inbound requests to a single distinct
-	//    Listener. When multiple Listeners share values for fields (for
-	//    example, two Listeners with the same Port value), the implementation
-	//    can can match requests to only one of the Listeners using other
-	//    Listener fields.
 	//
 	// Compatible combinations in Extended support are expected to vary across
 	// implementations. A combination that is compatible for one implementation
 	// may not be compatible for another.
 	//
-	// If this field specifies multiple Listeners that are not compatible, the
-	// implementation MUST set the "Conflicted" condition in the Listener
-	// Status to "True".
-	//
-	// Implementations MAY choose to still accept a Gateway with conflicted
-	// Listeners if they accept a partial Listener set that contains no
-	// incompatible Listeners. They MUST set a "ListenersNotValid" condition
-	// the Gateway Status when the Gateway contains incompatible Listeners
-	// whether or not they accept the Gateway.
-	//
-	// For example, the following Listener scenarios may be compatible
-	// depending on implementation capabilities:
-	//
-	// 1. Multiple Listeners with the same Port that all use the "HTTP"
-	//    Protocol that all have unique Hostname values.
-	// 2. Multiple Listeners with the same Port that use either the "HTTPS" or
-	//    "TLS" Protocol that all have unique Hostname values.
-	// 3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
-	//    with the same Protocol has the same Port value.
-	//
-	// An implementation that cannot serve both TCP and UDP listeners on the same
-	// address, or cannot mix HTTPS and generic TLS listens on the same port
-	// would not consider those cases compatible.
-	//
-	// Implementations using the Hostname value to select between same-Port
-	// Listeners MUST match inbound request hostnames from the most specific
-	// to least specific Hostname values to find the correct set of Routes.
-	// Exact matches must be processed before wildcard matches, and wildcard
-	// matches must be processed before fallback (empty Hostname value)
-	// matches. For example, `"foo.example.com"` takes precedence over
-	// `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
+	// For example, an implementation that cannot serve both TCP and UDP listeners
+    // on the same address, or cannot mix HTTPS and generic TLS listens on the same port
+	// would not consider those cases compatible, even though they are distinct.
 	//
 	// Note that requests SHOULD match at most one Listener. For example, if
 	// Listeners are defined for "foo.example.com" and "*.example.com", a
@@ -165,9 +190,6 @@ type GatewaySpec struct {
 	// This could be the IP address or hostname of an external load balancer or
 	// other networking infrastructure, or some other address that traffic will
 	// be sent to.
-	//
-	// The .listener.hostname field is used to route traffic that has already
-	// arrived at the Gateway to the correct in-cluster destination.
 	//
 	// If no Addresses are specified, the implementation MAY schedule the
 	// Gateway in an implementation-specific manner, assigning an appropriate

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -79,13 +79,18 @@ type GatewaySpec struct {
 	// Practically, this means that each listener in a set MUST have a unique
 	// combination of Port, Protocol, and, if supported by the protocol, Hostname.
 	//
-	// Some combinations of port, protocol, and TLS settings are are considered
-	// Core support and MUST be supported by implementations if they support the
-	// associated Route type:
+	// Some combinations of port, protocol, and TLS settings are considered
+	// Core support and MUST be supported by implementations based on their
+	// targeted conformance profile:
+	//
+	// HTTP Profile
 	//
 	// 1. HTTPRoute, Port: 80, Protocol: HTTP
 	// 2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
-	// 3. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough
+	//
+	// TLS Profile
+	//
+	// 1. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough
 	//
 	// "Distinct" Listeners have the following property:
 	//
@@ -135,12 +140,21 @@ type GatewaySpec struct {
 	// Listeners are Conflicted, and the implementation MUST set the "Conflicted"
 	// condition in the Listener Status to "True".
 	//
-	// Implementations MAY choose to accept a Gateway with Conflicted
-	// Listeners if they accept a partial Listener set that contains no
-	// Conflicted Listeners. They MUST set a "ListenersNotValid" condition
-	// the Gateway Status when the Gateway contains Conflicted Listeners
-	// whether or not they accept the Gateway. That Condition SHOULD clearly
-	// indicate in the Message which Listeners are conflicted.
+	// Implementations MAY choose to accept a Gateway with some Conflicted
+	// Listeners only if they only accept the partial Listener set that contains
+	// no Conflicted Listeners. To put this another way, implementations may
+	// accept a partial Listener set only if they throw out *all* the conflicting
+	// Listeners. No picking one of the conflicting listeners as the winner.
+	// This also means that the Gateway must have at least one non-conflicting
+	// Listener in this case, otherwise it violates the requirement that at
+	// least one Listener must be present.
+	//
+	// The implementation MUST set a "ListenersNotValid" condition on the
+	// Gateway Status when the Gateway contains Conflicted Listeners whether or
+	// not they accept the Gateway. That Condition SHOULD clearly
+	// indicate in the Message which Listeners are conflicted, and which are
+	// Accepted. Additionally, the Listener status for those listeners SHOULD
+	// indicate which Listeners are conflicted and not Accepted.
 	//
 	// A Gateway's Listeners are considered "compatible" if:
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -174,32 +174,33 @@ spec:
                 description: "Listeners associated with this Gateway. Listeners define
                   logical endpoints that are bound on this Gateway's addresses. At
                   least one Listener MUST be specified. \n Each Listener in a set
-                  of Listeners (for example, in a single Gateway) must be _distinct_,
-                  in that a traffic flow must be able to be assigned to exactly one
+                  of Listeners (for example, in a single Gateway) MUST be _distinct_,
+                  in that a traffic flow MUST be able to be assigned to exactly one
                   listener. (This section uses \"set of Listeners\" rather than \"Listeners
                   in a single Gateway\" because implementations MAY merge configuration
                   from multiple Gateways onto a single data plane, and these rules
                   _also_ apply in that case). \n Practically, this means that each
                   listener in a set MUST have a unique combination of Port, Protocol,
-                  TLS Settings, and, if supported by the protocol, Hostname. \n Some
-                  combinations of port, protoocl, and TLS settings are are considered
-                  Core support and MUST be supported by implementations: \n 1. Port:
-                  80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS, TLS Mode: Terminate,
-                  TLS keypair provided 3. Port: 443, Protocol: TLS, TLS Mode: Passthrough
-                  \n \"Distinct\" Listeners have the following property: \n The implementation
+                  and, if supported by the protocol, Hostname. \n Some combinations
+                  of port, protocol, and TLS settings are are considered Core support
+                  and MUST be supported by implementations if they support the associated
+                  Route type: \n 1. HTTPRoute, Port: 80, Protocol: HTTP 2. HTTPRoute,
+                  Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
+                  3. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough \n
+                  \"Distinct\" Listeners have the following property: \n The implementation
                   can match inbound requests to a single distinct Listener. When multiple
                   Listeners share values for fields (for example, two Listeners with
-                  the same Port value), the implementation can can match requests
-                  to only one of the Listeners using other Listener fields. \n For
-                  example, the following Listener scenarios are distinct: \n 1. Multiple
-                  Listeners with the same Port that all use the \"HTTP\" Protocol
-                  that all have unique Hostname values. 2. Multiple Listeners with
-                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
-                  that all have unique Hostname values. 3. A mixture of \"TCP\" and
-                  \"UDP\" Protocol Listeners, where no Listener with the same Protocol
-                  has the same Port value. \n Some fields in the Listener struct have
-                  possible values that affect whether the Listener is distinct. Hostname
-                  is particularly relevant for HTTP or HTTPS protocols. \n When using
+                  the same Port value), the implementation can match requests to only
+                  one of the Listeners using other Listener fields. \n For example,
+                  the following Listener scenarios are distinct: \n 1. Multiple Listeners
+                  with the same Port that all use the \"HTTP\" Protocol that all have
+                  unique Hostname values. 2. Multiple Listeners with the same Port
+                  that use either the \"HTTPS\" or \"TLS\" Protocol that all have
+                  unique Hostname values. 3. A mixture of \"TCP\" and \"UDP\" Protocol
+                  Listeners, where no Listener with the same Protocol has the same
+                  Port value. \n Some fields in the Listener struct have possible
+                  values that affect whether the Listener is distinct. Hostname is
+                  particularly relevant for HTTP or HTTPS protocols. \n When using
                   the Hostname value to select between same-Port, same-Protocol Listeners,
                   the Hostname value must be different on each Listener for the Listener
                   to be distinct. \n When the Listeners are distinct based on Hostname,
@@ -220,26 +221,26 @@ spec:
                   _and_ `\"bar.example.com\"`. \n If a set of Listeners contains Listeners
                   that are not distinct, then those Listeners are Conflicted, and
                   the implementation MUST set the \"Conflicted\" condition in the
-                  Listener Status to \"True\". \n Implementations MAY choose to still
-                  accept a Gateway with Conflicted Listeners if they accept a partial
-                  Listener set that contains no Conflicted Listeners. They MUST set
-                  a \"ListenersNotValid\" condition the Gateway Status when the Gateway
-                  contains Conflicted Listeners whether or not they accept the Gateway.
-                  That Condition SHOULD clearly indicate in the Message which Listeners
-                  are conflicted. \n A Gateway's Listeners are considered \"compatible\"
-                  if: \n 1. They are distinct. 2. The implementation can serve them
-                  in compliance with the Addresses requirement that all Listeners
-                  are available on all assigned addresses. \n Compatible combinations
-                  in Extended support are expected to vary across implementations.
-                  A combination that is compatible for one implementation may not
-                  be compatible for another. \n For example, an implementation that
-                  cannot serve both TCP and UDP listeners on the same address, or
-                  cannot mix HTTPS and generic TLS listens on the same port would
-                  not consider those cases compatible, even though they are distinct.
-                  \n Note that requests SHOULD match at most one Listener. For example,
-                  if Listeners are defined for \"foo.example.com\" and \"*.example.com\",
-                  a request to \"foo.example.com\" SHOULD only be routed using routes
-                  attached to the \"foo.example.com\" Listener (and not the \"*.example.com\"
+                  Listener Status to \"True\". \n Implementations MAY choose to accept
+                  a Gateway with Conflicted Listeners if they accept a partial Listener
+                  set that contains no Conflicted Listeners. They MUST set a \"ListenersNotValid\"
+                  condition the Gateway Status when the Gateway contains Conflicted
+                  Listeners whether or not they accept the Gateway. That Condition
+                  SHOULD clearly indicate in the Message which Listeners are conflicted.
+                  \n A Gateway's Listeners are considered \"compatible\" if: \n 1.
+                  They are distinct. 2. The implementation can serve them in compliance
+                  with the Addresses requirement that all Listeners are available
+                  on all assigned addresses. \n Compatible combinations in Extended
+                  support are expected to vary across implementations. A combination
+                  that is compatible for one implementation may not be compatible
+                  for another. \n For example, an implementation that cannot serve
+                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
+                  and generic TLS listens on the same port would not consider those
+                  cases compatible, even though they are distinct. \n Note that requests
+                  SHOULD match at most one Listener. For example, if Listeners are
+                  defined for \"foo.example.com\" and \"*.example.com\", a request
+                  to \"foo.example.com\" SHOULD only be routed using routes attached
+                  to the \"foo.example.com\" Listener (and not the \"*.example.com\"
                   Listener). This concept is known as \"Listener Isolation\". Implementations
                   that do not support Listener Isolation MUST clearly document this.
                   \n Implementations MAY merge separate Gateways onto a single set
@@ -1052,32 +1053,33 @@ spec:
                 description: "Listeners associated with this Gateway. Listeners define
                   logical endpoints that are bound on this Gateway's addresses. At
                   least one Listener MUST be specified. \n Each Listener in a set
-                  of Listeners (for example, in a single Gateway) must be _distinct_,
-                  in that a traffic flow must be able to be assigned to exactly one
+                  of Listeners (for example, in a single Gateway) MUST be _distinct_,
+                  in that a traffic flow MUST be able to be assigned to exactly one
                   listener. (This section uses \"set of Listeners\" rather than \"Listeners
                   in a single Gateway\" because implementations MAY merge configuration
                   from multiple Gateways onto a single data plane, and these rules
                   _also_ apply in that case). \n Practically, this means that each
                   listener in a set MUST have a unique combination of Port, Protocol,
-                  TLS Settings, and, if supported by the protocol, Hostname. \n Some
-                  combinations of port, protoocl, and TLS settings are are considered
-                  Core support and MUST be supported by implementations: \n 1. Port:
-                  80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS, TLS Mode: Terminate,
-                  TLS keypair provided 3. Port: 443, Protocol: TLS, TLS Mode: Passthrough
-                  \n \"Distinct\" Listeners have the following property: \n The implementation
+                  and, if supported by the protocol, Hostname. \n Some combinations
+                  of port, protocol, and TLS settings are are considered Core support
+                  and MUST be supported by implementations if they support the associated
+                  Route type: \n 1. HTTPRoute, Port: 80, Protocol: HTTP 2. HTTPRoute,
+                  Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
+                  3. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough \n
+                  \"Distinct\" Listeners have the following property: \n The implementation
                   can match inbound requests to a single distinct Listener. When multiple
                   Listeners share values for fields (for example, two Listeners with
-                  the same Port value), the implementation can can match requests
-                  to only one of the Listeners using other Listener fields. \n For
-                  example, the following Listener scenarios are distinct: \n 1. Multiple
-                  Listeners with the same Port that all use the \"HTTP\" Protocol
-                  that all have unique Hostname values. 2. Multiple Listeners with
-                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
-                  that all have unique Hostname values. 3. A mixture of \"TCP\" and
-                  \"UDP\" Protocol Listeners, where no Listener with the same Protocol
-                  has the same Port value. \n Some fields in the Listener struct have
-                  possible values that affect whether the Listener is distinct. Hostname
-                  is particularly relevant for HTTP or HTTPS protocols. \n When using
+                  the same Port value), the implementation can match requests to only
+                  one of the Listeners using other Listener fields. \n For example,
+                  the following Listener scenarios are distinct: \n 1. Multiple Listeners
+                  with the same Port that all use the \"HTTP\" Protocol that all have
+                  unique Hostname values. 2. Multiple Listeners with the same Port
+                  that use either the \"HTTPS\" or \"TLS\" Protocol that all have
+                  unique Hostname values. 3. A mixture of \"TCP\" and \"UDP\" Protocol
+                  Listeners, where no Listener with the same Protocol has the same
+                  Port value. \n Some fields in the Listener struct have possible
+                  values that affect whether the Listener is distinct. Hostname is
+                  particularly relevant for HTTP or HTTPS protocols. \n When using
                   the Hostname value to select between same-Port, same-Protocol Listeners,
                   the Hostname value must be different on each Listener for the Listener
                   to be distinct. \n When the Listeners are distinct based on Hostname,
@@ -1098,26 +1100,26 @@ spec:
                   _and_ `\"bar.example.com\"`. \n If a set of Listeners contains Listeners
                   that are not distinct, then those Listeners are Conflicted, and
                   the implementation MUST set the \"Conflicted\" condition in the
-                  Listener Status to \"True\". \n Implementations MAY choose to still
-                  accept a Gateway with Conflicted Listeners if they accept a partial
-                  Listener set that contains no Conflicted Listeners. They MUST set
-                  a \"ListenersNotValid\" condition the Gateway Status when the Gateway
-                  contains Conflicted Listeners whether or not they accept the Gateway.
-                  That Condition SHOULD clearly indicate in the Message which Listeners
-                  are conflicted. \n A Gateway's Listeners are considered \"compatible\"
-                  if: \n 1. They are distinct. 2. The implementation can serve them
-                  in compliance with the Addresses requirement that all Listeners
-                  are available on all assigned addresses. \n Compatible combinations
-                  in Extended support are expected to vary across implementations.
-                  A combination that is compatible for one implementation may not
-                  be compatible for another. \n For example, an implementation that
-                  cannot serve both TCP and UDP listeners on the same address, or
-                  cannot mix HTTPS and generic TLS listens on the same port would
-                  not consider those cases compatible, even though they are distinct.
-                  \n Note that requests SHOULD match at most one Listener. For example,
-                  if Listeners are defined for \"foo.example.com\" and \"*.example.com\",
-                  a request to \"foo.example.com\" SHOULD only be routed using routes
-                  attached to the \"foo.example.com\" Listener (and not the \"*.example.com\"
+                  Listener Status to \"True\". \n Implementations MAY choose to accept
+                  a Gateway with Conflicted Listeners if they accept a partial Listener
+                  set that contains no Conflicted Listeners. They MUST set a \"ListenersNotValid\"
+                  condition the Gateway Status when the Gateway contains Conflicted
+                  Listeners whether or not they accept the Gateway. That Condition
+                  SHOULD clearly indicate in the Message which Listeners are conflicted.
+                  \n A Gateway's Listeners are considered \"compatible\" if: \n 1.
+                  They are distinct. 2. The implementation can serve them in compliance
+                  with the Addresses requirement that all Listeners are available
+                  on all assigned addresses. \n Compatible combinations in Extended
+                  support are expected to vary across implementations. A combination
+                  that is compatible for one implementation may not be compatible
+                  for another. \n For example, an implementation that cannot serve
+                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
+                  and generic TLS listens on the same port would not consider those
+                  cases compatible, even though they are distinct. \n Note that requests
+                  SHOULD match at most one Listener. For example, if Listeners are
+                  defined for \"foo.example.com\" and \"*.example.com\", a request
+                  to \"foo.example.com\" SHOULD only be routed using routes attached
+                  to the \"foo.example.com\" Listener (and not the \"*.example.com\"
                   Listener). This concept is known as \"Listener Isolation\". Implementations
                   that do not support Listener Isolation MUST clearly document this.
                   \n Implementations MAY merge separate Gateways onto a single set

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -66,14 +66,12 @@ spec:
                   for the address(es) on the \"outside of the Gateway\", that traffic
                   bound for this Gateway will use. This could be the IP address or
                   hostname of an external load balancer or other networking infrastructure,
-                  or some other address that traffic will be sent to. \n The .listener.hostname
-                  field is used to route traffic that has already arrived at the Gateway
-                  to the correct in-cluster destination. \n If no Addresses are specified,
-                  the implementation MAY schedule the Gateway in an implementation-specific
-                  manner, assigning an appropriate set of Addresses. \n The implementation
-                  MUST bind all Listeners to every GatewayAddress that it assigns
-                  to the Gateway and add a corresponding entry in GatewayStatus.Addresses.
-                  \n Support: Extended \n "
+                  or some other address that traffic will be sent to. \n If no Addresses
+                  are specified, the implementation MAY schedule the Gateway in an
+                  implementation-specific manner, assigning an appropriate set of
+                  Addresses. \n The implementation MUST bind all Listeners to every
+                  GatewayAddress that it assigns to the Gateway and add a corresponding
+                  entry in GatewayStatus.Addresses. \n Support: Extended \n "
                 items:
                   description: GatewayAddress describes an address that can be bound
                     to a Gateway.
@@ -175,57 +173,78 @@ spec:
               listeners:
                 description: "Listeners associated with this Gateway. Listeners define
                   logical endpoints that are bound on this Gateway's addresses. At
-                  least one Listener MUST be specified. \n Each listener in a Gateway
-                  must have a unique combination of Hostname, Port, and Protocol.
-                  \n Within the HTTP Conformance Profile, the below combinations of
-                  port and protocol are considered Core and MUST be supported: \n
-                  1. Port: 80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS \n Within
-                  the TLS Conformance Profile, the below combinations of port and
-                  protocol are considered Core and MUST be supported: \n 1. Port:
-                  443, Protocol: TLS \n Port and protocol combinations not listed
-                  above are considered Extended. \n A Gateway's Listeners are considered
-                  \"compatible\" if: \n 1. The implementation can serve them in compliance
-                  with the Addresses requirement that all Listeners are available
-                  on all assigned addresses. 2. The implementation can match inbound
-                  requests to a single distinct Listener. When multiple Listeners
-                  share values for fields (for example, two Listeners with the same
-                  Port value), the implementation can can match requests to only one
-                  of the Listeners using other Listener fields. \n Compatible combinations
-                  in Extended support are expected to vary across implementations.
-                  A combination that is compatible for one implementation may not
-                  be compatible for another. \n If this field specifies multiple Listeners
-                  that are not compatible, the implementation MUST set the \"Conflicted\"
-                  condition in the Listener Status to \"True\". \n Implementations
-                  MAY choose to still accept a Gateway with conflicted Listeners if
-                  they accept a partial Listener set that contains no incompatible
-                  Listeners. They MUST set a \"ListenersNotValid\" condition the Gateway
-                  Status when the Gateway contains incompatible Listeners whether
-                  or not they accept the Gateway. \n For example, the following Listener
-                  scenarios may be compatible depending on implementation capabilities:
-                  \n 1. Multiple Listeners with the same Port that all use the \"HTTP\"
-                  Protocol that all have unique Hostname values. 2. Multiple Listeners
-                  with the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
+                  least one Listener MUST be specified. \n Each Listener in a set
+                  of Listeners (for example, in a single Gateway) must be _distinct_,
+                  in that a traffic flow must be able to be assigned to exactly one
+                  listener. (This section uses \"set of Listeners\" rather than \"Listeners
+                  in a single Gateway\" because implementations MAY merge configuration
+                  from multiple Gateways onto a single data plane, and these rules
+                  _also_ apply in that case). \n Practically, this means that each
+                  listener in a set MUST have a unique combination of Port, Protocol,
+                  TLS Settings, and, if supported by the protocol, Hostname. \n Some
+                  combinations of port, protoocl, and TLS settings are are considered
+                  Core support and MUST be supported by implementations: \n 1. Port:
+                  80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS, TLS Mode: Terminate,
+                  TLS keypair provided 3. Port: 443, Protocol: TLS, TLS Mode: Passthrough
+                  \n \"Distinct\" Listeners have the following property: \n The implementation
+                  can match inbound requests to a single distinct Listener. When multiple
+                  Listeners share values for fields (for example, two Listeners with
+                  the same Port value), the implementation can can match requests
+                  to only one of the Listeners using other Listener fields. \n For
+                  example, the following Listener scenarios are distinct: \n 1. Multiple
+                  Listeners with the same Port that all use the \"HTTP\" Protocol
+                  that all have unique Hostname values. 2. Multiple Listeners with
+                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
                   that all have unique Hostname values. 3. A mixture of \"TCP\" and
                   \"UDP\" Protocol Listeners, where no Listener with the same Protocol
-                  has the same Port value. \n An implementation that cannot serve
-                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
-                  and generic TLS listens on the same port would not consider those
-                  cases compatible. \n Implementations using the Hostname value to
-                  select between same-Port Listeners MUST match inbound request hostnames
-                  from the most specific to least specific Hostname values to find
-                  the correct set of Routes. Exact matches must be processed before
+                  has the same Port value. \n Some fields in the Listener struct have
+                  possible values that affect whether the Listener is distinct. Hostname
+                  is particularly relevant for HTTP or HTTPS protocols. \n When using
+                  the Hostname value to select between same-Port, same-Protocol Listeners,
+                  the Hostname value must be different on each Listener for the Listener
+                  to be distinct. \n When the Listeners are distinct based on Hostname,
+                  inbound request hostnames MUST match from the most specific to least
+                  specific Hostname values to choose the correct Listener and its
+                  associated set of Routes. \n Exact matches must be processed before
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Note that requests SHOULD match
-                  at most one Listener. For example, if Listeners are defined for
-                  \"foo.example.com\" and \"*.example.com\", a request to \"foo.example.com\"
-                  SHOULD only be routed using routes attached to the \"foo.example.com\"
-                  Listener (and not the \"*.example.com\" Listener). This concept
-                  is known as \"Listener Isolation\". Implementations that do not
-                  support Listener Isolation MUST clearly document this. \n Implementations
-                  MAY merge separate Gateways onto a single set of Addresses if all
-                  Listeners across all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Additionally, if there are multiple
+                  wildcard entries, more specific wildcard entries must be processed
+                  before less specific wildcard entries. For example, `\"*.foo.example.com\"`
+                  takes precedence over `\"*.example.com\"`. The precise definition
+                  here is that the higher the number of dots in the hostname to the
+                  right of the wildcard character, the higher the precedence. \n The
+                  wildcard character will match any number of characters _and dots_
+                  to the left, however, so `\"*.example.com\"` will match both `\"foo.bar.example.com\"`
+                  _and_ `\"bar.example.com\"`. \n If a set of Listeners contains Listeners
+                  that are not distinct, then those Listeners are Conflicted, and
+                  the implementation MUST set the \"Conflicted\" condition in the
+                  Listener Status to \"True\". \n Implementations MAY choose to still
+                  accept a Gateway with Conflicted Listeners if they accept a partial
+                  Listener set that contains no Conflicted Listeners. They MUST set
+                  a \"ListenersNotValid\" condition the Gateway Status when the Gateway
+                  contains Conflicted Listeners whether or not they accept the Gateway.
+                  That Condition SHOULD clearly indicate in the Message which Listeners
+                  are conflicted. \n A Gateway's Listeners are considered \"compatible\"
+                  if: \n 1. They are distinct. 2. The implementation can serve them
+                  in compliance with the Addresses requirement that all Listeners
+                  are available on all assigned addresses. \n Compatible combinations
+                  in Extended support are expected to vary across implementations.
+                  A combination that is compatible for one implementation may not
+                  be compatible for another. \n For example, an implementation that
+                  cannot serve both TCP and UDP listeners on the same address, or
+                  cannot mix HTTPS and generic TLS listens on the same port would
+                  not consider those cases compatible, even though they are distinct.
+                  \n Note that requests SHOULD match at most one Listener. For example,
+                  if Listeners are defined for \"foo.example.com\" and \"*.example.com\",
+                  a request to \"foo.example.com\" SHOULD only be routed using routes
+                  attached to the \"foo.example.com\" Listener (and not the \"*.example.com\"
+                  Listener). This concept is known as \"Listener Isolation\". Implementations
+                  that do not support Listener Isolation MUST clearly document this.
+                  \n Implementations MAY merge separate Gateways onto a single set
+                  of Addresses if all Listeners across all Gateways are compatible.
+                  \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -925,14 +944,12 @@ spec:
                   for the address(es) on the \"outside of the Gateway\", that traffic
                   bound for this Gateway will use. This could be the IP address or
                   hostname of an external load balancer or other networking infrastructure,
-                  or some other address that traffic will be sent to. \n The .listener.hostname
-                  field is used to route traffic that has already arrived at the Gateway
-                  to the correct in-cluster destination. \n If no Addresses are specified,
-                  the implementation MAY schedule the Gateway in an implementation-specific
-                  manner, assigning an appropriate set of Addresses. \n The implementation
-                  MUST bind all Listeners to every GatewayAddress that it assigns
-                  to the Gateway and add a corresponding entry in GatewayStatus.Addresses.
-                  \n Support: Extended \n "
+                  or some other address that traffic will be sent to. \n If no Addresses
+                  are specified, the implementation MAY schedule the Gateway in an
+                  implementation-specific manner, assigning an appropriate set of
+                  Addresses. \n The implementation MUST bind all Listeners to every
+                  GatewayAddress that it assigns to the Gateway and add a corresponding
+                  entry in GatewayStatus.Addresses. \n Support: Extended \n "
                 items:
                   description: GatewayAddress describes an address that can be bound
                     to a Gateway.
@@ -1034,57 +1051,78 @@ spec:
               listeners:
                 description: "Listeners associated with this Gateway. Listeners define
                   logical endpoints that are bound on this Gateway's addresses. At
-                  least one Listener MUST be specified. \n Each listener in a Gateway
-                  must have a unique combination of Hostname, Port, and Protocol.
-                  \n Within the HTTP Conformance Profile, the below combinations of
-                  port and protocol are considered Core and MUST be supported: \n
-                  1. Port: 80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS \n Within
-                  the TLS Conformance Profile, the below combinations of port and
-                  protocol are considered Core and MUST be supported: \n 1. Port:
-                  443, Protocol: TLS \n Port and protocol combinations not listed
-                  above are considered Extended. \n A Gateway's Listeners are considered
-                  \"compatible\" if: \n 1. The implementation can serve them in compliance
-                  with the Addresses requirement that all Listeners are available
-                  on all assigned addresses. 2. The implementation can match inbound
-                  requests to a single distinct Listener. When multiple Listeners
-                  share values for fields (for example, two Listeners with the same
-                  Port value), the implementation can can match requests to only one
-                  of the Listeners using other Listener fields. \n Compatible combinations
-                  in Extended support are expected to vary across implementations.
-                  A combination that is compatible for one implementation may not
-                  be compatible for another. \n If this field specifies multiple Listeners
-                  that are not compatible, the implementation MUST set the \"Conflicted\"
-                  condition in the Listener Status to \"True\". \n Implementations
-                  MAY choose to still accept a Gateway with conflicted Listeners if
-                  they accept a partial Listener set that contains no incompatible
-                  Listeners. They MUST set a \"ListenersNotValid\" condition the Gateway
-                  Status when the Gateway contains incompatible Listeners whether
-                  or not they accept the Gateway. \n For example, the following Listener
-                  scenarios may be compatible depending on implementation capabilities:
-                  \n 1. Multiple Listeners with the same Port that all use the \"HTTP\"
-                  Protocol that all have unique Hostname values. 2. Multiple Listeners
-                  with the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
+                  least one Listener MUST be specified. \n Each Listener in a set
+                  of Listeners (for example, in a single Gateway) must be _distinct_,
+                  in that a traffic flow must be able to be assigned to exactly one
+                  listener. (This section uses \"set of Listeners\" rather than \"Listeners
+                  in a single Gateway\" because implementations MAY merge configuration
+                  from multiple Gateways onto a single data plane, and these rules
+                  _also_ apply in that case). \n Practically, this means that each
+                  listener in a set MUST have a unique combination of Port, Protocol,
+                  TLS Settings, and, if supported by the protocol, Hostname. \n Some
+                  combinations of port, protoocl, and TLS settings are are considered
+                  Core support and MUST be supported by implementations: \n 1. Port:
+                  80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS, TLS Mode: Terminate,
+                  TLS keypair provided 3. Port: 443, Protocol: TLS, TLS Mode: Passthrough
+                  \n \"Distinct\" Listeners have the following property: \n The implementation
+                  can match inbound requests to a single distinct Listener. When multiple
+                  Listeners share values for fields (for example, two Listeners with
+                  the same Port value), the implementation can can match requests
+                  to only one of the Listeners using other Listener fields. \n For
+                  example, the following Listener scenarios are distinct: \n 1. Multiple
+                  Listeners with the same Port that all use the \"HTTP\" Protocol
+                  that all have unique Hostname values. 2. Multiple Listeners with
+                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
                   that all have unique Hostname values. 3. A mixture of \"TCP\" and
                   \"UDP\" Protocol Listeners, where no Listener with the same Protocol
-                  has the same Port value. \n An implementation that cannot serve
-                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
-                  and generic TLS listens on the same port would not consider those
-                  cases compatible. \n Implementations using the Hostname value to
-                  select between same-Port Listeners MUST match inbound request hostnames
-                  from the most specific to least specific Hostname values to find
-                  the correct set of Routes. Exact matches must be processed before
+                  has the same Port value. \n Some fields in the Listener struct have
+                  possible values that affect whether the Listener is distinct. Hostname
+                  is particularly relevant for HTTP or HTTPS protocols. \n When using
+                  the Hostname value to select between same-Port, same-Protocol Listeners,
+                  the Hostname value must be different on each Listener for the Listener
+                  to be distinct. \n When the Listeners are distinct based on Hostname,
+                  inbound request hostnames MUST match from the most specific to least
+                  specific Hostname values to choose the correct Listener and its
+                  associated set of Routes. \n Exact matches must be processed before
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Note that requests SHOULD match
-                  at most one Listener. For example, if Listeners are defined for
-                  \"foo.example.com\" and \"*.example.com\", a request to \"foo.example.com\"
-                  SHOULD only be routed using routes attached to the \"foo.example.com\"
-                  Listener (and not the \"*.example.com\" Listener). This concept
-                  is known as \"Listener Isolation\". Implementations that do not
-                  support Listener Isolation MUST clearly document this. \n Implementations
-                  MAY merge separate Gateways onto a single set of Addresses if all
-                  Listeners across all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Additionally, if there are multiple
+                  wildcard entries, more specific wildcard entries must be processed
+                  before less specific wildcard entries. For example, `\"*.foo.example.com\"`
+                  takes precedence over `\"*.example.com\"`. The precise definition
+                  here is that the higher the number of dots in the hostname to the
+                  right of the wildcard character, the higher the precedence. \n The
+                  wildcard character will match any number of characters _and dots_
+                  to the left, however, so `\"*.example.com\"` will match both `\"foo.bar.example.com\"`
+                  _and_ `\"bar.example.com\"`. \n If a set of Listeners contains Listeners
+                  that are not distinct, then those Listeners are Conflicted, and
+                  the implementation MUST set the \"Conflicted\" condition in the
+                  Listener Status to \"True\". \n Implementations MAY choose to still
+                  accept a Gateway with Conflicted Listeners if they accept a partial
+                  Listener set that contains no Conflicted Listeners. They MUST set
+                  a \"ListenersNotValid\" condition the Gateway Status when the Gateway
+                  contains Conflicted Listeners whether or not they accept the Gateway.
+                  That Condition SHOULD clearly indicate in the Message which Listeners
+                  are conflicted. \n A Gateway's Listeners are considered \"compatible\"
+                  if: \n 1. They are distinct. 2. The implementation can serve them
+                  in compliance with the Addresses requirement that all Listeners
+                  are available on all assigned addresses. \n Compatible combinations
+                  in Extended support are expected to vary across implementations.
+                  A combination that is compatible for one implementation may not
+                  be compatible for another. \n For example, an implementation that
+                  cannot serve both TCP and UDP listeners on the same address, or
+                  cannot mix HTTPS and generic TLS listens on the same port would
+                  not consider those cases compatible, even though they are distinct.
+                  \n Note that requests SHOULD match at most one Listener. For example,
+                  if Listeners are defined for \"foo.example.com\" and \"*.example.com\",
+                  a request to \"foo.example.com\" SHOULD only be routed using routes
+                  attached to the \"foo.example.com\" Listener (and not the \"*.example.com\"
+                  Listener). This concept is known as \"Listener Isolation\". Implementations
+                  that do not support Listener Isolation MUST clearly document this.
+                  \n Implementations MAY merge separate Gateways onto a single set
+                  of Addresses if all Listeners across all Gateways are compatible.
+                  \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -182,27 +182,28 @@ spec:
                   _also_ apply in that case). \n Practically, this means that each
                   listener in a set MUST have a unique combination of Port, Protocol,
                   and, if supported by the protocol, Hostname. \n Some combinations
-                  of port, protocol, and TLS settings are are considered Core support
-                  and MUST be supported by implementations if they support the associated
-                  Route type: \n 1. HTTPRoute, Port: 80, Protocol: HTTP 2. HTTPRoute,
-                  Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
-                  3. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough \n
-                  \"Distinct\" Listeners have the following property: \n The implementation
-                  can match inbound requests to a single distinct Listener. When multiple
-                  Listeners share values for fields (for example, two Listeners with
-                  the same Port value), the implementation can match requests to only
-                  one of the Listeners using other Listener fields. \n For example,
-                  the following Listener scenarios are distinct: \n 1. Multiple Listeners
-                  with the same Port that all use the \"HTTP\" Protocol that all have
-                  unique Hostname values. 2. Multiple Listeners with the same Port
-                  that use either the \"HTTPS\" or \"TLS\" Protocol that all have
-                  unique Hostname values. 3. A mixture of \"TCP\" and \"UDP\" Protocol
-                  Listeners, where no Listener with the same Protocol has the same
-                  Port value. \n Some fields in the Listener struct have possible
-                  values that affect whether the Listener is distinct. Hostname is
-                  particularly relevant for HTTP or HTTPS protocols. \n When using
-                  the Hostname value to select between same-Port, same-Protocol Listeners,
-                  the Hostname value must be different on each Listener for the Listener
+                  of port, protocol, and TLS settings are considered Core support
+                  and MUST be supported by implementations based on their targeted
+                  conformance profile: \n HTTP Profile \n 1. HTTPRoute, Port: 80,
+                  Protocol: HTTP 2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode:
+                  Terminate, TLS keypair provided \n TLS Profile \n 1. TLSRoute, Port:
+                  443, Protocol: TLS, TLS Mode: Passthrough \n \"Distinct\" Listeners
+                  have the following property: \n The implementation can match inbound
+                  requests to a single distinct Listener. When multiple Listeners
+                  share values for fields (for example, two Listeners with the same
+                  Port value), the implementation can match requests to only one of
+                  the Listeners using other Listener fields. \n For example, the following
+                  Listener scenarios are distinct: \n 1. Multiple Listeners with the
+                  same Port that all use the \"HTTP\" Protocol that all have unique
+                  Hostname values. 2. Multiple Listeners with the same Port that use
+                  either the \"HTTPS\" or \"TLS\" Protocol that all have unique Hostname
+                  values. 3. A mixture of \"TCP\" and \"UDP\" Protocol Listeners,
+                  where no Listener with the same Protocol has the same Port value.
+                  \n Some fields in the Listener struct have possible values that
+                  affect whether the Listener is distinct. Hostname is particularly
+                  relevant for HTTP or HTTPS protocols. \n When using the Hostname
+                  value to select between same-Port, same-Protocol Listeners, the
+                  Hostname value must be different on each Listener for the Listener
                   to be distinct. \n When the Listeners are distinct based on Hostname,
                   inbound request hostnames MUST match from the most specific to least
                   specific Hostname values to choose the correct Listener and its
@@ -222,25 +223,33 @@ spec:
                   that are not distinct, then those Listeners are Conflicted, and
                   the implementation MUST set the \"Conflicted\" condition in the
                   Listener Status to \"True\". \n Implementations MAY choose to accept
-                  a Gateway with Conflicted Listeners if they accept a partial Listener
-                  set that contains no Conflicted Listeners. They MUST set a \"ListenersNotValid\"
-                  condition the Gateway Status when the Gateway contains Conflicted
+                  a Gateway with some Conflicted Listeners only if they only accept
+                  the partial Listener set that contains no Conflicted Listeners.
+                  To put this another way, implementations may accept a partial Listener
+                  set only if they throw out *all* the conflicting Listeners. No picking
+                  one of the conflicting listeners as the winner. This also means
+                  that the Gateway must have at least one non-conflicting Listener
+                  in this case, otherwise it violates the requirement that at least
+                  one Listener must be present. \n The implementation MUST set a \"ListenersNotValid\"
+                  condition on the Gateway Status when the Gateway contains Conflicted
                   Listeners whether or not they accept the Gateway. That Condition
-                  SHOULD clearly indicate in the Message which Listeners are conflicted.
-                  \n A Gateway's Listeners are considered \"compatible\" if: \n 1.
-                  They are distinct. 2. The implementation can serve them in compliance
-                  with the Addresses requirement that all Listeners are available
-                  on all assigned addresses. \n Compatible combinations in Extended
-                  support are expected to vary across implementations. A combination
-                  that is compatible for one implementation may not be compatible
-                  for another. \n For example, an implementation that cannot serve
-                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
-                  and generic TLS listens on the same port would not consider those
-                  cases compatible, even though they are distinct. \n Note that requests
-                  SHOULD match at most one Listener. For example, if Listeners are
-                  defined for \"foo.example.com\" and \"*.example.com\", a request
-                  to \"foo.example.com\" SHOULD only be routed using routes attached
-                  to the \"foo.example.com\" Listener (and not the \"*.example.com\"
+                  SHOULD clearly indicate in the Message which Listeners are conflicted,
+                  and which are Accepted. Additionally, the Listener status for those
+                  listeners SHOULD indicate which Listeners are conflicted and not
+                  Accepted. \n A Gateway's Listeners are considered \"compatible\"
+                  if: \n 1. They are distinct. 2. The implementation can serve them
+                  in compliance with the Addresses requirement that all Listeners
+                  are available on all assigned addresses. \n Compatible combinations
+                  in Extended support are expected to vary across implementations.
+                  A combination that is compatible for one implementation may not
+                  be compatible for another. \n For example, an implementation that
+                  cannot serve both TCP and UDP listeners on the same address, or
+                  cannot mix HTTPS and generic TLS listens on the same port would
+                  not consider those cases compatible, even though they are distinct.
+                  \n Note that requests SHOULD match at most one Listener. For example,
+                  if Listeners are defined for \"foo.example.com\" and \"*.example.com\",
+                  a request to \"foo.example.com\" SHOULD only be routed using routes
+                  attached to the \"foo.example.com\" Listener (and not the \"*.example.com\"
                   Listener). This concept is known as \"Listener Isolation\". Implementations
                   that do not support Listener Isolation MUST clearly document this.
                   \n Implementations MAY merge separate Gateways onto a single set
@@ -1061,27 +1070,28 @@ spec:
                   _also_ apply in that case). \n Practically, this means that each
                   listener in a set MUST have a unique combination of Port, Protocol,
                   and, if supported by the protocol, Hostname. \n Some combinations
-                  of port, protocol, and TLS settings are are considered Core support
-                  and MUST be supported by implementations if they support the associated
-                  Route type: \n 1. HTTPRoute, Port: 80, Protocol: HTTP 2. HTTPRoute,
-                  Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
-                  3. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough \n
-                  \"Distinct\" Listeners have the following property: \n The implementation
-                  can match inbound requests to a single distinct Listener. When multiple
-                  Listeners share values for fields (for example, two Listeners with
-                  the same Port value), the implementation can match requests to only
-                  one of the Listeners using other Listener fields. \n For example,
-                  the following Listener scenarios are distinct: \n 1. Multiple Listeners
-                  with the same Port that all use the \"HTTP\" Protocol that all have
-                  unique Hostname values. 2. Multiple Listeners with the same Port
-                  that use either the \"HTTPS\" or \"TLS\" Protocol that all have
-                  unique Hostname values. 3. A mixture of \"TCP\" and \"UDP\" Protocol
-                  Listeners, where no Listener with the same Protocol has the same
-                  Port value. \n Some fields in the Listener struct have possible
-                  values that affect whether the Listener is distinct. Hostname is
-                  particularly relevant for HTTP or HTTPS protocols. \n When using
-                  the Hostname value to select between same-Port, same-Protocol Listeners,
-                  the Hostname value must be different on each Listener for the Listener
+                  of port, protocol, and TLS settings are considered Core support
+                  and MUST be supported by implementations based on their targeted
+                  conformance profile: \n HTTP Profile \n 1. HTTPRoute, Port: 80,
+                  Protocol: HTTP 2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode:
+                  Terminate, TLS keypair provided \n TLS Profile \n 1. TLSRoute, Port:
+                  443, Protocol: TLS, TLS Mode: Passthrough \n \"Distinct\" Listeners
+                  have the following property: \n The implementation can match inbound
+                  requests to a single distinct Listener. When multiple Listeners
+                  share values for fields (for example, two Listeners with the same
+                  Port value), the implementation can match requests to only one of
+                  the Listeners using other Listener fields. \n For example, the following
+                  Listener scenarios are distinct: \n 1. Multiple Listeners with the
+                  same Port that all use the \"HTTP\" Protocol that all have unique
+                  Hostname values. 2. Multiple Listeners with the same Port that use
+                  either the \"HTTPS\" or \"TLS\" Protocol that all have unique Hostname
+                  values. 3. A mixture of \"TCP\" and \"UDP\" Protocol Listeners,
+                  where no Listener with the same Protocol has the same Port value.
+                  \n Some fields in the Listener struct have possible values that
+                  affect whether the Listener is distinct. Hostname is particularly
+                  relevant for HTTP or HTTPS protocols. \n When using the Hostname
+                  value to select between same-Port, same-Protocol Listeners, the
+                  Hostname value must be different on each Listener for the Listener
                   to be distinct. \n When the Listeners are distinct based on Hostname,
                   inbound request hostnames MUST match from the most specific to least
                   specific Hostname values to choose the correct Listener and its
@@ -1101,25 +1111,33 @@ spec:
                   that are not distinct, then those Listeners are Conflicted, and
                   the implementation MUST set the \"Conflicted\" condition in the
                   Listener Status to \"True\". \n Implementations MAY choose to accept
-                  a Gateway with Conflicted Listeners if they accept a partial Listener
-                  set that contains no Conflicted Listeners. They MUST set a \"ListenersNotValid\"
-                  condition the Gateway Status when the Gateway contains Conflicted
+                  a Gateway with some Conflicted Listeners only if they only accept
+                  the partial Listener set that contains no Conflicted Listeners.
+                  To put this another way, implementations may accept a partial Listener
+                  set only if they throw out *all* the conflicting Listeners. No picking
+                  one of the conflicting listeners as the winner. This also means
+                  that the Gateway must have at least one non-conflicting Listener
+                  in this case, otherwise it violates the requirement that at least
+                  one Listener must be present. \n The implementation MUST set a \"ListenersNotValid\"
+                  condition on the Gateway Status when the Gateway contains Conflicted
                   Listeners whether or not they accept the Gateway. That Condition
-                  SHOULD clearly indicate in the Message which Listeners are conflicted.
-                  \n A Gateway's Listeners are considered \"compatible\" if: \n 1.
-                  They are distinct. 2. The implementation can serve them in compliance
-                  with the Addresses requirement that all Listeners are available
-                  on all assigned addresses. \n Compatible combinations in Extended
-                  support are expected to vary across implementations. A combination
-                  that is compatible for one implementation may not be compatible
-                  for another. \n For example, an implementation that cannot serve
-                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
-                  and generic TLS listens on the same port would not consider those
-                  cases compatible, even though they are distinct. \n Note that requests
-                  SHOULD match at most one Listener. For example, if Listeners are
-                  defined for \"foo.example.com\" and \"*.example.com\", a request
-                  to \"foo.example.com\" SHOULD only be routed using routes attached
-                  to the \"foo.example.com\" Listener (and not the \"*.example.com\"
+                  SHOULD clearly indicate in the Message which Listeners are conflicted,
+                  and which are Accepted. Additionally, the Listener status for those
+                  listeners SHOULD indicate which Listeners are conflicted and not
+                  Accepted. \n A Gateway's Listeners are considered \"compatible\"
+                  if: \n 1. They are distinct. 2. The implementation can serve them
+                  in compliance with the Addresses requirement that all Listeners
+                  are available on all assigned addresses. \n Compatible combinations
+                  in Extended support are expected to vary across implementations.
+                  A combination that is compatible for one implementation may not
+                  be compatible for another. \n For example, an implementation that
+                  cannot serve both TCP and UDP listeners on the same address, or
+                  cannot mix HTTPS and generic TLS listens on the same port would
+                  not consider those cases compatible, even though they are distinct.
+                  \n Note that requests SHOULD match at most one Listener. For example,
+                  if Listeners are defined for \"foo.example.com\" and \"*.example.com\",
+                  a request to \"foo.example.com\" SHOULD only be routed using routes
+                  attached to the \"foo.example.com\" Listener (and not the \"*.example.com\"
                   Listener). This concept is known as \"Listener Isolation\". Implementations
                   that do not support Listener Isolation MUST clearly document this.
                   \n Implementations MAY merge separate Gateways onto a single set

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -139,27 +139,28 @@ spec:
                   _also_ apply in that case). \n Practically, this means that each
                   listener in a set MUST have a unique combination of Port, Protocol,
                   and, if supported by the protocol, Hostname. \n Some combinations
-                  of port, protocol, and TLS settings are are considered Core support
-                  and MUST be supported by implementations if they support the associated
-                  Route type: \n 1. HTTPRoute, Port: 80, Protocol: HTTP 2. HTTPRoute,
-                  Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
-                  3. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough \n
-                  \"Distinct\" Listeners have the following property: \n The implementation
-                  can match inbound requests to a single distinct Listener. When multiple
-                  Listeners share values for fields (for example, two Listeners with
-                  the same Port value), the implementation can match requests to only
-                  one of the Listeners using other Listener fields. \n For example,
-                  the following Listener scenarios are distinct: \n 1. Multiple Listeners
-                  with the same Port that all use the \"HTTP\" Protocol that all have
-                  unique Hostname values. 2. Multiple Listeners with the same Port
-                  that use either the \"HTTPS\" or \"TLS\" Protocol that all have
-                  unique Hostname values. 3. A mixture of \"TCP\" and \"UDP\" Protocol
-                  Listeners, where no Listener with the same Protocol has the same
-                  Port value. \n Some fields in the Listener struct have possible
-                  values that affect whether the Listener is distinct. Hostname is
-                  particularly relevant for HTTP or HTTPS protocols. \n When using
-                  the Hostname value to select between same-Port, same-Protocol Listeners,
-                  the Hostname value must be different on each Listener for the Listener
+                  of port, protocol, and TLS settings are considered Core support
+                  and MUST be supported by implementations based on their targeted
+                  conformance profile: \n HTTP Profile \n 1. HTTPRoute, Port: 80,
+                  Protocol: HTTP 2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode:
+                  Terminate, TLS keypair provided \n TLS Profile \n 1. TLSRoute, Port:
+                  443, Protocol: TLS, TLS Mode: Passthrough \n \"Distinct\" Listeners
+                  have the following property: \n The implementation can match inbound
+                  requests to a single distinct Listener. When multiple Listeners
+                  share values for fields (for example, two Listeners with the same
+                  Port value), the implementation can match requests to only one of
+                  the Listeners using other Listener fields. \n For example, the following
+                  Listener scenarios are distinct: \n 1. Multiple Listeners with the
+                  same Port that all use the \"HTTP\" Protocol that all have unique
+                  Hostname values. 2. Multiple Listeners with the same Port that use
+                  either the \"HTTPS\" or \"TLS\" Protocol that all have unique Hostname
+                  values. 3. A mixture of \"TCP\" and \"UDP\" Protocol Listeners,
+                  where no Listener with the same Protocol has the same Port value.
+                  \n Some fields in the Listener struct have possible values that
+                  affect whether the Listener is distinct. Hostname is particularly
+                  relevant for HTTP or HTTPS protocols. \n When using the Hostname
+                  value to select between same-Port, same-Protocol Listeners, the
+                  Hostname value must be different on each Listener for the Listener
                   to be distinct. \n When the Listeners are distinct based on Hostname,
                   inbound request hostnames MUST match from the most specific to least
                   specific Hostname values to choose the correct Listener and its
@@ -179,25 +180,33 @@ spec:
                   that are not distinct, then those Listeners are Conflicted, and
                   the implementation MUST set the \"Conflicted\" condition in the
                   Listener Status to \"True\". \n Implementations MAY choose to accept
-                  a Gateway with Conflicted Listeners if they accept a partial Listener
-                  set that contains no Conflicted Listeners. They MUST set a \"ListenersNotValid\"
-                  condition the Gateway Status when the Gateway contains Conflicted
+                  a Gateway with some Conflicted Listeners only if they only accept
+                  the partial Listener set that contains no Conflicted Listeners.
+                  To put this another way, implementations may accept a partial Listener
+                  set only if they throw out *all* the conflicting Listeners. No picking
+                  one of the conflicting listeners as the winner. This also means
+                  that the Gateway must have at least one non-conflicting Listener
+                  in this case, otherwise it violates the requirement that at least
+                  one Listener must be present. \n The implementation MUST set a \"ListenersNotValid\"
+                  condition on the Gateway Status when the Gateway contains Conflicted
                   Listeners whether or not they accept the Gateway. That Condition
-                  SHOULD clearly indicate in the Message which Listeners are conflicted.
-                  \n A Gateway's Listeners are considered \"compatible\" if: \n 1.
-                  They are distinct. 2. The implementation can serve them in compliance
-                  with the Addresses requirement that all Listeners are available
-                  on all assigned addresses. \n Compatible combinations in Extended
-                  support are expected to vary across implementations. A combination
-                  that is compatible for one implementation may not be compatible
-                  for another. \n For example, an implementation that cannot serve
-                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
-                  and generic TLS listens on the same port would not consider those
-                  cases compatible, even though they are distinct. \n Note that requests
-                  SHOULD match at most one Listener. For example, if Listeners are
-                  defined for \"foo.example.com\" and \"*.example.com\", a request
-                  to \"foo.example.com\" SHOULD only be routed using routes attached
-                  to the \"foo.example.com\" Listener (and not the \"*.example.com\"
+                  SHOULD clearly indicate in the Message which Listeners are conflicted,
+                  and which are Accepted. Additionally, the Listener status for those
+                  listeners SHOULD indicate which Listeners are conflicted and not
+                  Accepted. \n A Gateway's Listeners are considered \"compatible\"
+                  if: \n 1. They are distinct. 2. The implementation can serve them
+                  in compliance with the Addresses requirement that all Listeners
+                  are available on all assigned addresses. \n Compatible combinations
+                  in Extended support are expected to vary across implementations.
+                  A combination that is compatible for one implementation may not
+                  be compatible for another. \n For example, an implementation that
+                  cannot serve both TCP and UDP listeners on the same address, or
+                  cannot mix HTTPS and generic TLS listens on the same port would
+                  not consider those cases compatible, even though they are distinct.
+                  \n Note that requests SHOULD match at most one Listener. For example,
+                  if Listeners are defined for \"foo.example.com\" and \"*.example.com\",
+                  a request to \"foo.example.com\" SHOULD only be routed using routes
+                  attached to the \"foo.example.com\" Listener (and not the \"*.example.com\"
                   Listener). This concept is known as \"Listener Isolation\". Implementations
                   that do not support Listener Isolation MUST clearly document this.
                   \n Implementations MAY merge separate Gateways onto a single set
@@ -975,27 +984,28 @@ spec:
                   _also_ apply in that case). \n Practically, this means that each
                   listener in a set MUST have a unique combination of Port, Protocol,
                   and, if supported by the protocol, Hostname. \n Some combinations
-                  of port, protocol, and TLS settings are are considered Core support
-                  and MUST be supported by implementations if they support the associated
-                  Route type: \n 1. HTTPRoute, Port: 80, Protocol: HTTP 2. HTTPRoute,
-                  Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
-                  3. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough \n
-                  \"Distinct\" Listeners have the following property: \n The implementation
-                  can match inbound requests to a single distinct Listener. When multiple
-                  Listeners share values for fields (for example, two Listeners with
-                  the same Port value), the implementation can match requests to only
-                  one of the Listeners using other Listener fields. \n For example,
-                  the following Listener scenarios are distinct: \n 1. Multiple Listeners
-                  with the same Port that all use the \"HTTP\" Protocol that all have
-                  unique Hostname values. 2. Multiple Listeners with the same Port
-                  that use either the \"HTTPS\" or \"TLS\" Protocol that all have
-                  unique Hostname values. 3. A mixture of \"TCP\" and \"UDP\" Protocol
-                  Listeners, where no Listener with the same Protocol has the same
-                  Port value. \n Some fields in the Listener struct have possible
-                  values that affect whether the Listener is distinct. Hostname is
-                  particularly relevant for HTTP or HTTPS protocols. \n When using
-                  the Hostname value to select between same-Port, same-Protocol Listeners,
-                  the Hostname value must be different on each Listener for the Listener
+                  of port, protocol, and TLS settings are considered Core support
+                  and MUST be supported by implementations based on their targeted
+                  conformance profile: \n HTTP Profile \n 1. HTTPRoute, Port: 80,
+                  Protocol: HTTP 2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode:
+                  Terminate, TLS keypair provided \n TLS Profile \n 1. TLSRoute, Port:
+                  443, Protocol: TLS, TLS Mode: Passthrough \n \"Distinct\" Listeners
+                  have the following property: \n The implementation can match inbound
+                  requests to a single distinct Listener. When multiple Listeners
+                  share values for fields (for example, two Listeners with the same
+                  Port value), the implementation can match requests to only one of
+                  the Listeners using other Listener fields. \n For example, the following
+                  Listener scenarios are distinct: \n 1. Multiple Listeners with the
+                  same Port that all use the \"HTTP\" Protocol that all have unique
+                  Hostname values. 2. Multiple Listeners with the same Port that use
+                  either the \"HTTPS\" or \"TLS\" Protocol that all have unique Hostname
+                  values. 3. A mixture of \"TCP\" and \"UDP\" Protocol Listeners,
+                  where no Listener with the same Protocol has the same Port value.
+                  \n Some fields in the Listener struct have possible values that
+                  affect whether the Listener is distinct. Hostname is particularly
+                  relevant for HTTP or HTTPS protocols. \n When using the Hostname
+                  value to select between same-Port, same-Protocol Listeners, the
+                  Hostname value must be different on each Listener for the Listener
                   to be distinct. \n When the Listeners are distinct based on Hostname,
                   inbound request hostnames MUST match from the most specific to least
                   specific Hostname values to choose the correct Listener and its
@@ -1015,25 +1025,33 @@ spec:
                   that are not distinct, then those Listeners are Conflicted, and
                   the implementation MUST set the \"Conflicted\" condition in the
                   Listener Status to \"True\". \n Implementations MAY choose to accept
-                  a Gateway with Conflicted Listeners if they accept a partial Listener
-                  set that contains no Conflicted Listeners. They MUST set a \"ListenersNotValid\"
-                  condition the Gateway Status when the Gateway contains Conflicted
+                  a Gateway with some Conflicted Listeners only if they only accept
+                  the partial Listener set that contains no Conflicted Listeners.
+                  To put this another way, implementations may accept a partial Listener
+                  set only if they throw out *all* the conflicting Listeners. No picking
+                  one of the conflicting listeners as the winner. This also means
+                  that the Gateway must have at least one non-conflicting Listener
+                  in this case, otherwise it violates the requirement that at least
+                  one Listener must be present. \n The implementation MUST set a \"ListenersNotValid\"
+                  condition on the Gateway Status when the Gateway contains Conflicted
                   Listeners whether or not they accept the Gateway. That Condition
-                  SHOULD clearly indicate in the Message which Listeners are conflicted.
-                  \n A Gateway's Listeners are considered \"compatible\" if: \n 1.
-                  They are distinct. 2. The implementation can serve them in compliance
-                  with the Addresses requirement that all Listeners are available
-                  on all assigned addresses. \n Compatible combinations in Extended
-                  support are expected to vary across implementations. A combination
-                  that is compatible for one implementation may not be compatible
-                  for another. \n For example, an implementation that cannot serve
-                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
-                  and generic TLS listens on the same port would not consider those
-                  cases compatible, even though they are distinct. \n Note that requests
-                  SHOULD match at most one Listener. For example, if Listeners are
-                  defined for \"foo.example.com\" and \"*.example.com\", a request
-                  to \"foo.example.com\" SHOULD only be routed using routes attached
-                  to the \"foo.example.com\" Listener (and not the \"*.example.com\"
+                  SHOULD clearly indicate in the Message which Listeners are conflicted,
+                  and which are Accepted. Additionally, the Listener status for those
+                  listeners SHOULD indicate which Listeners are conflicted and not
+                  Accepted. \n A Gateway's Listeners are considered \"compatible\"
+                  if: \n 1. They are distinct. 2. The implementation can serve them
+                  in compliance with the Addresses requirement that all Listeners
+                  are available on all assigned addresses. \n Compatible combinations
+                  in Extended support are expected to vary across implementations.
+                  A combination that is compatible for one implementation may not
+                  be compatible for another. \n For example, an implementation that
+                  cannot serve both TCP and UDP listeners on the same address, or
+                  cannot mix HTTPS and generic TLS listens on the same port would
+                  not consider those cases compatible, even though they are distinct.
+                  \n Note that requests SHOULD match at most one Listener. For example,
+                  if Listeners are defined for \"foo.example.com\" and \"*.example.com\",
+                  a request to \"foo.example.com\" SHOULD only be routed using routes
+                  attached to the \"foo.example.com\" Listener (and not the \"*.example.com\"
                   Listener). This concept is known as \"Listener Isolation\". Implementations
                   that do not support Listener Isolation MUST clearly document this.
                   \n Implementations MAY merge separate Gateways onto a single set

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -131,32 +131,33 @@ spec:
                 description: "Listeners associated with this Gateway. Listeners define
                   logical endpoints that are bound on this Gateway's addresses. At
                   least one Listener MUST be specified. \n Each Listener in a set
-                  of Listeners (for example, in a single Gateway) must be _distinct_,
-                  in that a traffic flow must be able to be assigned to exactly one
+                  of Listeners (for example, in a single Gateway) MUST be _distinct_,
+                  in that a traffic flow MUST be able to be assigned to exactly one
                   listener. (This section uses \"set of Listeners\" rather than \"Listeners
                   in a single Gateway\" because implementations MAY merge configuration
                   from multiple Gateways onto a single data plane, and these rules
                   _also_ apply in that case). \n Practically, this means that each
                   listener in a set MUST have a unique combination of Port, Protocol,
-                  TLS Settings, and, if supported by the protocol, Hostname. \n Some
-                  combinations of port, protoocl, and TLS settings are are considered
-                  Core support and MUST be supported by implementations: \n 1. Port:
-                  80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS, TLS Mode: Terminate,
-                  TLS keypair provided 3. Port: 443, Protocol: TLS, TLS Mode: Passthrough
-                  \n \"Distinct\" Listeners have the following property: \n The implementation
+                  and, if supported by the protocol, Hostname. \n Some combinations
+                  of port, protocol, and TLS settings are are considered Core support
+                  and MUST be supported by implementations if they support the associated
+                  Route type: \n 1. HTTPRoute, Port: 80, Protocol: HTTP 2. HTTPRoute,
+                  Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
+                  3. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough \n
+                  \"Distinct\" Listeners have the following property: \n The implementation
                   can match inbound requests to a single distinct Listener. When multiple
                   Listeners share values for fields (for example, two Listeners with
-                  the same Port value), the implementation can can match requests
-                  to only one of the Listeners using other Listener fields. \n For
-                  example, the following Listener scenarios are distinct: \n 1. Multiple
-                  Listeners with the same Port that all use the \"HTTP\" Protocol
-                  that all have unique Hostname values. 2. Multiple Listeners with
-                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
-                  that all have unique Hostname values. 3. A mixture of \"TCP\" and
-                  \"UDP\" Protocol Listeners, where no Listener with the same Protocol
-                  has the same Port value. \n Some fields in the Listener struct have
-                  possible values that affect whether the Listener is distinct. Hostname
-                  is particularly relevant for HTTP or HTTPS protocols. \n When using
+                  the same Port value), the implementation can match requests to only
+                  one of the Listeners using other Listener fields. \n For example,
+                  the following Listener scenarios are distinct: \n 1. Multiple Listeners
+                  with the same Port that all use the \"HTTP\" Protocol that all have
+                  unique Hostname values. 2. Multiple Listeners with the same Port
+                  that use either the \"HTTPS\" or \"TLS\" Protocol that all have
+                  unique Hostname values. 3. A mixture of \"TCP\" and \"UDP\" Protocol
+                  Listeners, where no Listener with the same Protocol has the same
+                  Port value. \n Some fields in the Listener struct have possible
+                  values that affect whether the Listener is distinct. Hostname is
+                  particularly relevant for HTTP or HTTPS protocols. \n When using
                   the Hostname value to select between same-Port, same-Protocol Listeners,
                   the Hostname value must be different on each Listener for the Listener
                   to be distinct. \n When the Listeners are distinct based on Hostname,
@@ -177,26 +178,26 @@ spec:
                   _and_ `\"bar.example.com\"`. \n If a set of Listeners contains Listeners
                   that are not distinct, then those Listeners are Conflicted, and
                   the implementation MUST set the \"Conflicted\" condition in the
-                  Listener Status to \"True\". \n Implementations MAY choose to still
-                  accept a Gateway with Conflicted Listeners if they accept a partial
-                  Listener set that contains no Conflicted Listeners. They MUST set
-                  a \"ListenersNotValid\" condition the Gateway Status when the Gateway
-                  contains Conflicted Listeners whether or not they accept the Gateway.
-                  That Condition SHOULD clearly indicate in the Message which Listeners
-                  are conflicted. \n A Gateway's Listeners are considered \"compatible\"
-                  if: \n 1. They are distinct. 2. The implementation can serve them
-                  in compliance with the Addresses requirement that all Listeners
-                  are available on all assigned addresses. \n Compatible combinations
-                  in Extended support are expected to vary across implementations.
-                  A combination that is compatible for one implementation may not
-                  be compatible for another. \n For example, an implementation that
-                  cannot serve both TCP and UDP listeners on the same address, or
-                  cannot mix HTTPS and generic TLS listens on the same port would
-                  not consider those cases compatible, even though they are distinct.
-                  \n Note that requests SHOULD match at most one Listener. For example,
-                  if Listeners are defined for \"foo.example.com\" and \"*.example.com\",
-                  a request to \"foo.example.com\" SHOULD only be routed using routes
-                  attached to the \"foo.example.com\" Listener (and not the \"*.example.com\"
+                  Listener Status to \"True\". \n Implementations MAY choose to accept
+                  a Gateway with Conflicted Listeners if they accept a partial Listener
+                  set that contains no Conflicted Listeners. They MUST set a \"ListenersNotValid\"
+                  condition the Gateway Status when the Gateway contains Conflicted
+                  Listeners whether or not they accept the Gateway. That Condition
+                  SHOULD clearly indicate in the Message which Listeners are conflicted.
+                  \n A Gateway's Listeners are considered \"compatible\" if: \n 1.
+                  They are distinct. 2. The implementation can serve them in compliance
+                  with the Addresses requirement that all Listeners are available
+                  on all assigned addresses. \n Compatible combinations in Extended
+                  support are expected to vary across implementations. A combination
+                  that is compatible for one implementation may not be compatible
+                  for another. \n For example, an implementation that cannot serve
+                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
+                  and generic TLS listens on the same port would not consider those
+                  cases compatible, even though they are distinct. \n Note that requests
+                  SHOULD match at most one Listener. For example, if Listeners are
+                  defined for \"foo.example.com\" and \"*.example.com\", a request
+                  to \"foo.example.com\" SHOULD only be routed using routes attached
+                  to the \"foo.example.com\" Listener (and not the \"*.example.com\"
                   Listener). This concept is known as \"Listener Isolation\". Implementations
                   that do not support Listener Isolation MUST clearly document this.
                   \n Implementations MAY merge separate Gateways onto a single set
@@ -966,32 +967,33 @@ spec:
                 description: "Listeners associated with this Gateway. Listeners define
                   logical endpoints that are bound on this Gateway's addresses. At
                   least one Listener MUST be specified. \n Each Listener in a set
-                  of Listeners (for example, in a single Gateway) must be _distinct_,
-                  in that a traffic flow must be able to be assigned to exactly one
+                  of Listeners (for example, in a single Gateway) MUST be _distinct_,
+                  in that a traffic flow MUST be able to be assigned to exactly one
                   listener. (This section uses \"set of Listeners\" rather than \"Listeners
                   in a single Gateway\" because implementations MAY merge configuration
                   from multiple Gateways onto a single data plane, and these rules
                   _also_ apply in that case). \n Practically, this means that each
                   listener in a set MUST have a unique combination of Port, Protocol,
-                  TLS Settings, and, if supported by the protocol, Hostname. \n Some
-                  combinations of port, protoocl, and TLS settings are are considered
-                  Core support and MUST be supported by implementations: \n 1. Port:
-                  80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS, TLS Mode: Terminate,
-                  TLS keypair provided 3. Port: 443, Protocol: TLS, TLS Mode: Passthrough
-                  \n \"Distinct\" Listeners have the following property: \n The implementation
+                  and, if supported by the protocol, Hostname. \n Some combinations
+                  of port, protocol, and TLS settings are are considered Core support
+                  and MUST be supported by implementations if they support the associated
+                  Route type: \n 1. HTTPRoute, Port: 80, Protocol: HTTP 2. HTTPRoute,
+                  Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
+                  3. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough \n
+                  \"Distinct\" Listeners have the following property: \n The implementation
                   can match inbound requests to a single distinct Listener. When multiple
                   Listeners share values for fields (for example, two Listeners with
-                  the same Port value), the implementation can can match requests
-                  to only one of the Listeners using other Listener fields. \n For
-                  example, the following Listener scenarios are distinct: \n 1. Multiple
-                  Listeners with the same Port that all use the \"HTTP\" Protocol
-                  that all have unique Hostname values. 2. Multiple Listeners with
-                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
-                  that all have unique Hostname values. 3. A mixture of \"TCP\" and
-                  \"UDP\" Protocol Listeners, where no Listener with the same Protocol
-                  has the same Port value. \n Some fields in the Listener struct have
-                  possible values that affect whether the Listener is distinct. Hostname
-                  is particularly relevant for HTTP or HTTPS protocols. \n When using
+                  the same Port value), the implementation can match requests to only
+                  one of the Listeners using other Listener fields. \n For example,
+                  the following Listener scenarios are distinct: \n 1. Multiple Listeners
+                  with the same Port that all use the \"HTTP\" Protocol that all have
+                  unique Hostname values. 2. Multiple Listeners with the same Port
+                  that use either the \"HTTPS\" or \"TLS\" Protocol that all have
+                  unique Hostname values. 3. A mixture of \"TCP\" and \"UDP\" Protocol
+                  Listeners, where no Listener with the same Protocol has the same
+                  Port value. \n Some fields in the Listener struct have possible
+                  values that affect whether the Listener is distinct. Hostname is
+                  particularly relevant for HTTP or HTTPS protocols. \n When using
                   the Hostname value to select between same-Port, same-Protocol Listeners,
                   the Hostname value must be different on each Listener for the Listener
                   to be distinct. \n When the Listeners are distinct based on Hostname,
@@ -1012,26 +1014,26 @@ spec:
                   _and_ `\"bar.example.com\"`. \n If a set of Listeners contains Listeners
                   that are not distinct, then those Listeners are Conflicted, and
                   the implementation MUST set the \"Conflicted\" condition in the
-                  Listener Status to \"True\". \n Implementations MAY choose to still
-                  accept a Gateway with Conflicted Listeners if they accept a partial
-                  Listener set that contains no Conflicted Listeners. They MUST set
-                  a \"ListenersNotValid\" condition the Gateway Status when the Gateway
-                  contains Conflicted Listeners whether or not they accept the Gateway.
-                  That Condition SHOULD clearly indicate in the Message which Listeners
-                  are conflicted. \n A Gateway's Listeners are considered \"compatible\"
-                  if: \n 1. They are distinct. 2. The implementation can serve them
-                  in compliance with the Addresses requirement that all Listeners
-                  are available on all assigned addresses. \n Compatible combinations
-                  in Extended support are expected to vary across implementations.
-                  A combination that is compatible for one implementation may not
-                  be compatible for another. \n For example, an implementation that
-                  cannot serve both TCP and UDP listeners on the same address, or
-                  cannot mix HTTPS and generic TLS listens on the same port would
-                  not consider those cases compatible, even though they are distinct.
-                  \n Note that requests SHOULD match at most one Listener. For example,
-                  if Listeners are defined for \"foo.example.com\" and \"*.example.com\",
-                  a request to \"foo.example.com\" SHOULD only be routed using routes
-                  attached to the \"foo.example.com\" Listener (and not the \"*.example.com\"
+                  Listener Status to \"True\". \n Implementations MAY choose to accept
+                  a Gateway with Conflicted Listeners if they accept a partial Listener
+                  set that contains no Conflicted Listeners. They MUST set a \"ListenersNotValid\"
+                  condition the Gateway Status when the Gateway contains Conflicted
+                  Listeners whether or not they accept the Gateway. That Condition
+                  SHOULD clearly indicate in the Message which Listeners are conflicted.
+                  \n A Gateway's Listeners are considered \"compatible\" if: \n 1.
+                  They are distinct. 2. The implementation can serve them in compliance
+                  with the Addresses requirement that all Listeners are available
+                  on all assigned addresses. \n Compatible combinations in Extended
+                  support are expected to vary across implementations. A combination
+                  that is compatible for one implementation may not be compatible
+                  for another. \n For example, an implementation that cannot serve
+                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
+                  and generic TLS listens on the same port would not consider those
+                  cases compatible, even though they are distinct. \n Note that requests
+                  SHOULD match at most one Listener. For example, if Listeners are
+                  defined for \"foo.example.com\" and \"*.example.com\", a request
+                  to \"foo.example.com\" SHOULD only be routed using routes attached
+                  to the \"foo.example.com\" Listener (and not the \"*.example.com\"
                   Listener). This concept is known as \"Listener Isolation\". Implementations
                   that do not support Listener Isolation MUST clearly document this.
                   \n Implementations MAY merge separate Gateways onto a single set

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -66,14 +66,12 @@ spec:
                   for the address(es) on the \"outside of the Gateway\", that traffic
                   bound for this Gateway will use. This could be the IP address or
                   hostname of an external load balancer or other networking infrastructure,
-                  or some other address that traffic will be sent to. \n The .listener.hostname
-                  field is used to route traffic that has already arrived at the Gateway
-                  to the correct in-cluster destination. \n If no Addresses are specified,
-                  the implementation MAY schedule the Gateway in an implementation-specific
-                  manner, assigning an appropriate set of Addresses. \n The implementation
-                  MUST bind all Listeners to every GatewayAddress that it assigns
-                  to the Gateway and add a corresponding entry in GatewayStatus.Addresses.
-                  \n Support: Extended \n "
+                  or some other address that traffic will be sent to. \n If no Addresses
+                  are specified, the implementation MAY schedule the Gateway in an
+                  implementation-specific manner, assigning an appropriate set of
+                  Addresses. \n The implementation MUST bind all Listeners to every
+                  GatewayAddress that it assigns to the Gateway and add a corresponding
+                  entry in GatewayStatus.Addresses. \n Support: Extended \n "
                 items:
                   description: GatewayAddress describes an address that can be bound
                     to a Gateway.
@@ -132,57 +130,78 @@ spec:
               listeners:
                 description: "Listeners associated with this Gateway. Listeners define
                   logical endpoints that are bound on this Gateway's addresses. At
-                  least one Listener MUST be specified. \n Each listener in a Gateway
-                  must have a unique combination of Hostname, Port, and Protocol.
-                  \n Within the HTTP Conformance Profile, the below combinations of
-                  port and protocol are considered Core and MUST be supported: \n
-                  1. Port: 80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS \n Within
-                  the TLS Conformance Profile, the below combinations of port and
-                  protocol are considered Core and MUST be supported: \n 1. Port:
-                  443, Protocol: TLS \n Port and protocol combinations not listed
-                  above are considered Extended. \n A Gateway's Listeners are considered
-                  \"compatible\" if: \n 1. The implementation can serve them in compliance
-                  with the Addresses requirement that all Listeners are available
-                  on all assigned addresses. 2. The implementation can match inbound
-                  requests to a single distinct Listener. When multiple Listeners
-                  share values for fields (for example, two Listeners with the same
-                  Port value), the implementation can can match requests to only one
-                  of the Listeners using other Listener fields. \n Compatible combinations
-                  in Extended support are expected to vary across implementations.
-                  A combination that is compatible for one implementation may not
-                  be compatible for another. \n If this field specifies multiple Listeners
-                  that are not compatible, the implementation MUST set the \"Conflicted\"
-                  condition in the Listener Status to \"True\". \n Implementations
-                  MAY choose to still accept a Gateway with conflicted Listeners if
-                  they accept a partial Listener set that contains no incompatible
-                  Listeners. They MUST set a \"ListenersNotValid\" condition the Gateway
-                  Status when the Gateway contains incompatible Listeners whether
-                  or not they accept the Gateway. \n For example, the following Listener
-                  scenarios may be compatible depending on implementation capabilities:
-                  \n 1. Multiple Listeners with the same Port that all use the \"HTTP\"
-                  Protocol that all have unique Hostname values. 2. Multiple Listeners
-                  with the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
+                  least one Listener MUST be specified. \n Each Listener in a set
+                  of Listeners (for example, in a single Gateway) must be _distinct_,
+                  in that a traffic flow must be able to be assigned to exactly one
+                  listener. (This section uses \"set of Listeners\" rather than \"Listeners
+                  in a single Gateway\" because implementations MAY merge configuration
+                  from multiple Gateways onto a single data plane, and these rules
+                  _also_ apply in that case). \n Practically, this means that each
+                  listener in a set MUST have a unique combination of Port, Protocol,
+                  TLS Settings, and, if supported by the protocol, Hostname. \n Some
+                  combinations of port, protoocl, and TLS settings are are considered
+                  Core support and MUST be supported by implementations: \n 1. Port:
+                  80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS, TLS Mode: Terminate,
+                  TLS keypair provided 3. Port: 443, Protocol: TLS, TLS Mode: Passthrough
+                  \n \"Distinct\" Listeners have the following property: \n The implementation
+                  can match inbound requests to a single distinct Listener. When multiple
+                  Listeners share values for fields (for example, two Listeners with
+                  the same Port value), the implementation can can match requests
+                  to only one of the Listeners using other Listener fields. \n For
+                  example, the following Listener scenarios are distinct: \n 1. Multiple
+                  Listeners with the same Port that all use the \"HTTP\" Protocol
+                  that all have unique Hostname values. 2. Multiple Listeners with
+                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
                   that all have unique Hostname values. 3. A mixture of \"TCP\" and
                   \"UDP\" Protocol Listeners, where no Listener with the same Protocol
-                  has the same Port value. \n An implementation that cannot serve
-                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
-                  and generic TLS listens on the same port would not consider those
-                  cases compatible. \n Implementations using the Hostname value to
-                  select between same-Port Listeners MUST match inbound request hostnames
-                  from the most specific to least specific Hostname values to find
-                  the correct set of Routes. Exact matches must be processed before
+                  has the same Port value. \n Some fields in the Listener struct have
+                  possible values that affect whether the Listener is distinct. Hostname
+                  is particularly relevant for HTTP or HTTPS protocols. \n When using
+                  the Hostname value to select between same-Port, same-Protocol Listeners,
+                  the Hostname value must be different on each Listener for the Listener
+                  to be distinct. \n When the Listeners are distinct based on Hostname,
+                  inbound request hostnames MUST match from the most specific to least
+                  specific Hostname values to choose the correct Listener and its
+                  associated set of Routes. \n Exact matches must be processed before
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Note that requests SHOULD match
-                  at most one Listener. For example, if Listeners are defined for
-                  \"foo.example.com\" and \"*.example.com\", a request to \"foo.example.com\"
-                  SHOULD only be routed using routes attached to the \"foo.example.com\"
-                  Listener (and not the \"*.example.com\" Listener). This concept
-                  is known as \"Listener Isolation\". Implementations that do not
-                  support Listener Isolation MUST clearly document this. \n Implementations
-                  MAY merge separate Gateways onto a single set of Addresses if all
-                  Listeners across all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Additionally, if there are multiple
+                  wildcard entries, more specific wildcard entries must be processed
+                  before less specific wildcard entries. For example, `\"*.foo.example.com\"`
+                  takes precedence over `\"*.example.com\"`. The precise definition
+                  here is that the higher the number of dots in the hostname to the
+                  right of the wildcard character, the higher the precedence. \n The
+                  wildcard character will match any number of characters _and dots_
+                  to the left, however, so `\"*.example.com\"` will match both `\"foo.bar.example.com\"`
+                  _and_ `\"bar.example.com\"`. \n If a set of Listeners contains Listeners
+                  that are not distinct, then those Listeners are Conflicted, and
+                  the implementation MUST set the \"Conflicted\" condition in the
+                  Listener Status to \"True\". \n Implementations MAY choose to still
+                  accept a Gateway with Conflicted Listeners if they accept a partial
+                  Listener set that contains no Conflicted Listeners. They MUST set
+                  a \"ListenersNotValid\" condition the Gateway Status when the Gateway
+                  contains Conflicted Listeners whether or not they accept the Gateway.
+                  That Condition SHOULD clearly indicate in the Message which Listeners
+                  are conflicted. \n A Gateway's Listeners are considered \"compatible\"
+                  if: \n 1. They are distinct. 2. The implementation can serve them
+                  in compliance with the Addresses requirement that all Listeners
+                  are available on all assigned addresses. \n Compatible combinations
+                  in Extended support are expected to vary across implementations.
+                  A combination that is compatible for one implementation may not
+                  be compatible for another. \n For example, an implementation that
+                  cannot serve both TCP and UDP listeners on the same address, or
+                  cannot mix HTTPS and generic TLS listens on the same port would
+                  not consider those cases compatible, even though they are distinct.
+                  \n Note that requests SHOULD match at most one Listener. For example,
+                  if Listeners are defined for \"foo.example.com\" and \"*.example.com\",
+                  a request to \"foo.example.com\" SHOULD only be routed using routes
+                  attached to the \"foo.example.com\" Listener (and not the \"*.example.com\"
+                  Listener). This concept is known as \"Listener Isolation\". Implementations
+                  that do not support Listener Isolation MUST clearly document this.
+                  \n Implementations MAY merge separate Gateways onto a single set
+                  of Addresses if all Listeners across all Gateways are compatible.
+                  \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -882,14 +901,12 @@ spec:
                   for the address(es) on the \"outside of the Gateway\", that traffic
                   bound for this Gateway will use. This could be the IP address or
                   hostname of an external load balancer or other networking infrastructure,
-                  or some other address that traffic will be sent to. \n The .listener.hostname
-                  field is used to route traffic that has already arrived at the Gateway
-                  to the correct in-cluster destination. \n If no Addresses are specified,
-                  the implementation MAY schedule the Gateway in an implementation-specific
-                  manner, assigning an appropriate set of Addresses. \n The implementation
-                  MUST bind all Listeners to every GatewayAddress that it assigns
-                  to the Gateway and add a corresponding entry in GatewayStatus.Addresses.
-                  \n Support: Extended \n "
+                  or some other address that traffic will be sent to. \n If no Addresses
+                  are specified, the implementation MAY schedule the Gateway in an
+                  implementation-specific manner, assigning an appropriate set of
+                  Addresses. \n The implementation MUST bind all Listeners to every
+                  GatewayAddress that it assigns to the Gateway and add a corresponding
+                  entry in GatewayStatus.Addresses. \n Support: Extended \n "
                 items:
                   description: GatewayAddress describes an address that can be bound
                     to a Gateway.
@@ -948,57 +965,78 @@ spec:
               listeners:
                 description: "Listeners associated with this Gateway. Listeners define
                   logical endpoints that are bound on this Gateway's addresses. At
-                  least one Listener MUST be specified. \n Each listener in a Gateway
-                  must have a unique combination of Hostname, Port, and Protocol.
-                  \n Within the HTTP Conformance Profile, the below combinations of
-                  port and protocol are considered Core and MUST be supported: \n
-                  1. Port: 80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS \n Within
-                  the TLS Conformance Profile, the below combinations of port and
-                  protocol are considered Core and MUST be supported: \n 1. Port:
-                  443, Protocol: TLS \n Port and protocol combinations not listed
-                  above are considered Extended. \n A Gateway's Listeners are considered
-                  \"compatible\" if: \n 1. The implementation can serve them in compliance
-                  with the Addresses requirement that all Listeners are available
-                  on all assigned addresses. 2. The implementation can match inbound
-                  requests to a single distinct Listener. When multiple Listeners
-                  share values for fields (for example, two Listeners with the same
-                  Port value), the implementation can can match requests to only one
-                  of the Listeners using other Listener fields. \n Compatible combinations
-                  in Extended support are expected to vary across implementations.
-                  A combination that is compatible for one implementation may not
-                  be compatible for another. \n If this field specifies multiple Listeners
-                  that are not compatible, the implementation MUST set the \"Conflicted\"
-                  condition in the Listener Status to \"True\". \n Implementations
-                  MAY choose to still accept a Gateway with conflicted Listeners if
-                  they accept a partial Listener set that contains no incompatible
-                  Listeners. They MUST set a \"ListenersNotValid\" condition the Gateway
-                  Status when the Gateway contains incompatible Listeners whether
-                  or not they accept the Gateway. \n For example, the following Listener
-                  scenarios may be compatible depending on implementation capabilities:
-                  \n 1. Multiple Listeners with the same Port that all use the \"HTTP\"
-                  Protocol that all have unique Hostname values. 2. Multiple Listeners
-                  with the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
+                  least one Listener MUST be specified. \n Each Listener in a set
+                  of Listeners (for example, in a single Gateway) must be _distinct_,
+                  in that a traffic flow must be able to be assigned to exactly one
+                  listener. (This section uses \"set of Listeners\" rather than \"Listeners
+                  in a single Gateway\" because implementations MAY merge configuration
+                  from multiple Gateways onto a single data plane, and these rules
+                  _also_ apply in that case). \n Practically, this means that each
+                  listener in a set MUST have a unique combination of Port, Protocol,
+                  TLS Settings, and, if supported by the protocol, Hostname. \n Some
+                  combinations of port, protoocl, and TLS settings are are considered
+                  Core support and MUST be supported by implementations: \n 1. Port:
+                  80, Protocol: HTTP 2. Port: 443, Protocol: HTTPS, TLS Mode: Terminate,
+                  TLS keypair provided 3. Port: 443, Protocol: TLS, TLS Mode: Passthrough
+                  \n \"Distinct\" Listeners have the following property: \n The implementation
+                  can match inbound requests to a single distinct Listener. When multiple
+                  Listeners share values for fields (for example, two Listeners with
+                  the same Port value), the implementation can can match requests
+                  to only one of the Listeners using other Listener fields. \n For
+                  example, the following Listener scenarios are distinct: \n 1. Multiple
+                  Listeners with the same Port that all use the \"HTTP\" Protocol
+                  that all have unique Hostname values. 2. Multiple Listeners with
+                  the same Port that use either the \"HTTPS\" or \"TLS\" Protocol
                   that all have unique Hostname values. 3. A mixture of \"TCP\" and
                   \"UDP\" Protocol Listeners, where no Listener with the same Protocol
-                  has the same Port value. \n An implementation that cannot serve
-                  both TCP and UDP listeners on the same address, or cannot mix HTTPS
-                  and generic TLS listens on the same port would not consider those
-                  cases compatible. \n Implementations using the Hostname value to
-                  select between same-Port Listeners MUST match inbound request hostnames
-                  from the most specific to least specific Hostname values to find
-                  the correct set of Routes. Exact matches must be processed before
+                  has the same Port value. \n Some fields in the Listener struct have
+                  possible values that affect whether the Listener is distinct. Hostname
+                  is particularly relevant for HTTP or HTTPS protocols. \n When using
+                  the Hostname value to select between same-Port, same-Protocol Listeners,
+                  the Hostname value must be different on each Listener for the Listener
+                  to be distinct. \n When the Listeners are distinct based on Hostname,
+                  inbound request hostnames MUST match from the most specific to least
+                  specific Hostname values to choose the correct Listener and its
+                  associated set of Routes. \n Exact matches must be processed before
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Note that requests SHOULD match
-                  at most one Listener. For example, if Listeners are defined for
-                  \"foo.example.com\" and \"*.example.com\", a request to \"foo.example.com\"
-                  SHOULD only be routed using routes attached to the \"foo.example.com\"
-                  Listener (and not the \"*.example.com\" Listener). This concept
-                  is known as \"Listener Isolation\". Implementations that do not
-                  support Listener Isolation MUST clearly document this. \n Implementations
-                  MAY merge separate Gateways onto a single set of Addresses if all
-                  Listeners across all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Additionally, if there are multiple
+                  wildcard entries, more specific wildcard entries must be processed
+                  before less specific wildcard entries. For example, `\"*.foo.example.com\"`
+                  takes precedence over `\"*.example.com\"`. The precise definition
+                  here is that the higher the number of dots in the hostname to the
+                  right of the wildcard character, the higher the precedence. \n The
+                  wildcard character will match any number of characters _and dots_
+                  to the left, however, so `\"*.example.com\"` will match both `\"foo.bar.example.com\"`
+                  _and_ `\"bar.example.com\"`. \n If a set of Listeners contains Listeners
+                  that are not distinct, then those Listeners are Conflicted, and
+                  the implementation MUST set the \"Conflicted\" condition in the
+                  Listener Status to \"True\". \n Implementations MAY choose to still
+                  accept a Gateway with Conflicted Listeners if they accept a partial
+                  Listener set that contains no Conflicted Listeners. They MUST set
+                  a \"ListenersNotValid\" condition the Gateway Status when the Gateway
+                  contains Conflicted Listeners whether or not they accept the Gateway.
+                  That Condition SHOULD clearly indicate in the Message which Listeners
+                  are conflicted. \n A Gateway's Listeners are considered \"compatible\"
+                  if: \n 1. They are distinct. 2. The implementation can serve them
+                  in compliance with the Addresses requirement that all Listeners
+                  are available on all assigned addresses. \n Compatible combinations
+                  in Extended support are expected to vary across implementations.
+                  A combination that is compatible for one implementation may not
+                  be compatible for another. \n For example, an implementation that
+                  cannot serve both TCP and UDP listeners on the same address, or
+                  cannot mix HTTPS and generic TLS listens on the same port would
+                  not consider those cases compatible, even though they are distinct.
+                  \n Note that requests SHOULD match at most one Listener. For example,
+                  if Listeners are defined for \"foo.example.com\" and \"*.example.com\",
+                  a request to \"foo.example.com\" SHOULD only be routed using routes
+                  attached to the \"foo.example.com\" Listener (and not the \"*.example.com\"
+                  Listener). This concept is known as \"Listener Isolation\". Implementations
+                  that do not support Listener Isolation MUST clearly document this.
+                  \n Implementations MAY merge separate Gateways onto a single set
+                  of Addresses if all Listeners across all Gateways are compatible.
+                  \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

/area conformance

**What this PR does / why we need it**:
This updates the Listener language to add the concept of `distinct`. Why add this when it's not a huge change? Well, we actually need to consider if things are distinct in many places in the API, and I think that standardizing on this term will help.

I've built on @rainest's great work in #2288, and attempted to incorporate some items from the discussions there and on #2416.

There's still an outstanding item here - to introduce the `GatewayListenerIsolation` concept, but I have specifically left that out of this PR, to make it easier to review. @robscott is on the hook for a follow-up to address that one.

**Which issue(s) this PR fixes**:
Updates #2416


**Does this PR introduce a user-facing change?**:
```release-note
Updated rules about Listener uniqueness to use the term `distinct`
```
