### PR TITLE
cleanup-conformance-imgs

### DIFF
--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -115,7 +115,9 @@ spec:
       containers:
       - name: infra-backend-v1
         # From https://github.com/kubernetes-sigs/ingress-controller-conformance/tree/master/images/echoserver
-        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
+        image: gcr.io/k8s-staging-gateway-api/echo-server:v20230505-v0.7.0-rc1-10-g497e67da
+        args:
+        - --port=8080
         env:
         - name: POD_NAME
           valueFrom:
@@ -161,7 +163,9 @@ spec:
     spec:
       containers:
       - name: infra-backend-v2
-        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
+        image: gcr.io/k8s-staging-gateway-api/echo-server:v20230505-v0.7.0-rc1-10-g497e67da
+        args:
+        - --port=8080
         env:
         - name: POD_NAME
           valueFrom:
@@ -207,7 +211,9 @@ spec:
     spec:
       containers:
       - name: infra-backend-v3
-        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
+        image: gcr.io/k8s-staging-gateway-api/echo-server:v20230505-v0.7.0-rc1-10-g497e67da
+        args:
+        - --port=8080
         env:
         - name: POD_NAME
           valueFrom:
@@ -253,7 +259,9 @@ spec:
     spec:
       containers:
       - name: tls-backend
-        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
+        image: gcr.io/k8s-staging-gateway-api/echo-server:v20230505-v0.7.0-rc1-10-g497e67da
+        args:
+        - --port=8080
         volumeMounts:
         - name: secret-volume
           mountPath: /etc/secret-volume
@@ -322,7 +330,9 @@ spec:
     spec:
       containers:
       - name: tls-backend
-        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
+        image: gcr.io/k8s-staging-gateway-api/echo-server:v20230505-v0.7.0-rc1-10-g497e67da
+        args:
+        - --port=8080
         volumeMounts:
         - name: secret-volume
           mountPath: /etc/secret-volume
@@ -384,7 +394,9 @@ spec:
     spec:
       containers:
       - name: app-backend-v1
-        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
+        image: gcr.io/k8s-staging-gateway-api/echo-server:v20230505-v0.7.0-rc1-10-g497e67da
+        args:
+        - --port=8080
         env:
         - name: POD_NAME
           valueFrom:
@@ -430,7 +442,9 @@ spec:
     spec:
       containers:
       - name: app-backend-v2
-        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
+        image: gcr.io/k8s-staging-gateway-api/echo-server:v20230505-v0.7.0-rc1-10-g497e67da
+        args:
+        - --port=8080
         env:
         - name: POD_NAME
           valueFrom:
@@ -483,7 +497,9 @@ spec:
     spec:
       containers:
       - name: web-backend
-        image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
+        image: gcr.io/k8s-staging-gateway-api/echo-server:v20230505-v0.7.0-rc1-10-g497e67da
+        args:
+        - --port=8080
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind test
/area conformance

**What this PR does / why we need it**:
* replace the echo-server image
* use newer echo-server image from Istio supports delay
* use same image for all tests to minimise resources to be instantiated during CI

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
* Relates to comment https://github.com/kubernetes-sigs/gateway-api/pull/2254/files#r1327727364
* Relates to conformance tests for #2013

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
NONE
```release-note

```
