### PR TITLE
conformance: fix flakes in mirror tests

### DIFF
--- a/conformance/tests/httproute-request-multiple-mirrors.go
+++ b/conformance/tests/httproute-request-multiple-mirrors.go
@@ -49,11 +49,11 @@ var HTTPRouteRequestMultipleMirrors = suite.ConformanceTest{
 		testCases := []http.ExpectedResponse{
 			{
 				Request: http.Request{
-					Path: "/mirror",
+					Path: "/multi-mirror",
 				},
 				ExpectedRequest: &http.ExpectedRequest{
 					Request: http.Request{
-						Path: "/mirror",
+						Path: "/multi-mirror",
 					},
 				},
 				Backend: "infra-backend-v1",
@@ -70,7 +70,7 @@ var HTTPRouteRequestMultipleMirrors = suite.ConformanceTest{
 				Namespace: ns,
 			}, {
 				Request: http.Request{
-					Path: "/mirror-and-modify-request-headers",
+					Path: "/multi-mirror-and-modify-request-headers",
 					Headers: map[string]string{
 						"X-Header-Remove":     "remove-val",
 						"X-Header-Add-Append": "append-val-1",
@@ -78,7 +78,7 @@ var HTTPRouteRequestMultipleMirrors = suite.ConformanceTest{
 				},
 				ExpectedRequest: &http.ExpectedRequest{
 					Request: http.Request{
-						Path: "/mirror-and-modify-request-headers",
+						Path: "/multi-mirror-and-modify-request-headers",
 						Headers: map[string]string{
 							"X-Header-Add":        "header-val-1",
 							"X-Header-Add-Append": "append-val-1,header-val-2",

--- a/conformance/tests/httproute-request-multiple-mirrors.yaml
+++ b/conformance/tests/httproute-request-multiple-mirrors.yaml
@@ -10,7 +10,7 @@ spec:
   - matches:
     - path:
         type: PathPrefix
-        value: /mirror
+        value: /multi-mirror
     filters:
     - type: RequestMirror
       requestMirror:
@@ -31,7 +31,7 @@ spec:
   - matches:
     - path:
         type: PathPrefix
-        value: /mirror-and-modify-request-headers
+        value: /multi-mirror-and-modify-request-headers
     filters:
     - type: RequestHeaderModifier
       requestHeaderModifier:

--- a/conformance/utils/http/mirror.go
+++ b/conformance/utils/http/mirror.go
@@ -45,7 +45,6 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 			defer wg.Done()
 
 			require.Eventually(t, func() bool {
-				var mirrored bool
 				mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to \\%s to client", path))
 
 				t.Log("Searching for the mirrored request log")
@@ -58,12 +57,11 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 
 				for _, log := range logs {
 					if mirrorLogRegexp.MatchString(string(log)) {
-						mirrored = true
-						break
+						return true
 					}
 				}
-				return mirrored
-			}, 60*time.Second, time.Second, fmt.Sprintf(`Couldn't find mirrored request in "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name))
+				return false
+			}, 60*time.Second, time.Millisecond*100, fmt.Sprintf(`Couldn't find mirrored request in "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name))
 		}(mirrorPod)
 	}
 


### PR DESCRIPTION

**What type of PR is this?**

/kind test
/area conformance

**What this PR does / why we need it**:
The test in isolation is fine, but combined with the other mirror test we have problems.

1. Test 1 sets up /mirror -> v1. Passes, starts cleanup
2. Test 2 sets up /mirror -> v2. Sends request to /mirror, gets a 200. It sent to v1, though, since cleanup wasn't done.
3. We look for logs in v2 forever, never find them. :-(

This fixes things by making the two use isolated paths


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
