### PR TITLE
clarify attachment by two policies to the same object when one uses a sectionName

### DIFF
--- a/geps/gep-713/index.md
+++ b/geps/gep-713/index.md
@@ -1465,7 +1465,7 @@ and the policy implementation should record a `resolvedRefs` or similar Conditio
 
 When multiple Policies of the same type target the same object, one with a `sectionName` specified, and one without,
 the one with a `sectionName` is more specific, and so will have all its settings applied to the named target. The less-specific Policy will
-still be applied but MUST not affect the named target.
+still be applied but MUST not affect the named target i.e. it will be applied to all other sections which have not been targeted by another Policy 
 
 Note that the `sectionName` is currently intended to be used only for Direct Policy Attachment when references to
 SectionName are actually needed. Inherited Policies are always applied to the entire object. 

--- a/geps/gep-713/index.md
+++ b/geps/gep-713/index.md
@@ -1463,7 +1463,7 @@ type RouteRule struct {
 If a `sectionName` is specified, but does not exist on the targeted object, the Policy must fail to attach,
 and the policy implementation should record a `resolvedRefs` or similar Condition in the Policy's status.
 
-When multiple Policies of the same type target the same object, one with a `sectionName`, and one without, the policy with a `sectionName` is more specific, and so will have its entire `spec` applied to the named section. The less-specific Policy will still have its `spec` applied to the target but MUST not affect the named section i.e. the non specific policy will have its `spec` applied to all other sections of the target which have not been targeted by another Policy. 
+When multiple Policies of the same type target the same object, one with a `sectionName` and one without, the more specific policy (i.e., the one with a `sectionName`) will have its entire `spec` applied to the named section. The less specific policy will also have its `spec` applied to the target but MUST not affect the named section. The less specific policy will have its `spec` applied to all other sections of the target that are not targeted by any other more specific policies. 
 
 Note that the `sectionName` is currently intended to be used only for Direct Policy Attachment when references to
 SectionName are actually needed. Inherited Policies are always applied to the entire object. 

--- a/geps/gep-713/index.md
+++ b/geps/gep-713/index.md
@@ -1463,9 +1463,7 @@ type RouteRule struct {
 If a `sectionName` is specified, but does not exist on the targeted object, the Policy must fail to attach,
 and the policy implementation should record a `resolvedRefs` or similar Condition in the Policy's status.
 
-When multiple Policies of the same type target the same object, one with a `sectionName` specified, and one without,
-the one with a `sectionName` is more specific, and so will have all its settings applied to the named target. The less-specific Policy will
-still be applied but MUST not affect the named target i.e. it will be applied to all other sections which have not been targeted by another Policy 
+When multiple Policies of the same type target the same object, one with a `sectionName`, and one without, the policy with a `sectionName` is more specific, and so will have its entire `spec` applied to the named section. The less-specific Policy will still have its `spec` applied to the target but MUST not affect the named section i.e. the non specific policy will have its `spec` applied to all other sections of the target which have not been targeted by another Policy. 
 
 Note that the `sectionName` is currently intended to be used only for Direct Policy Attachment when references to
 SectionName are actually needed. Inherited Policies are always applied to the entire object. 

--- a/geps/gep-713/index.md
+++ b/geps/gep-713/index.md
@@ -1464,8 +1464,8 @@ If a `sectionName` is specified, but does not exist on the targeted object, the 
 and the policy implementation should record a `resolvedRefs` or similar Condition in the Policy's status.
 
 When multiple Policies of the same type target the same object, one with a `sectionName` specified, and one without,
-the one with a `sectionName` is more specific, and so will have all its settings apply. The less-specific Policy will
-not attach to the target.
+the one with a `sectionName` is more specific, and so will have all its settings applied to the named target. The less-specific Policy will
+still be applied but MUST not affect the named target.
 
 Note that the `sectionName` is currently intended to be used only for Direct Policy Attachment when references to
 SectionName are actually needed. Inherited Policies are always applied to the entire object. 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation


**What this PR does / why we need it**:

Clarifies how two policies targeting the same resource should work when one uses a `sectionName` and the other does not

**Which issue(s) this PR fixes**:
created based on Slack chat https://kubernetes.slack.com/archives/CR0H13KGA/p1695713117110159

**Does this PR introduce a user-facing change?**:
None

**Release Note**
```release-note
clarify policy attachment by two of the same policy types when using section names.
```