### PR TITLE
Check gateway positive-polarity conditions

### DIFF
--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -268,12 +269,14 @@ func MeshNamespacesMustBeReady(t *testing.T, c client.Client, timeoutConfig conf
 }
 
 // GatewayAndHTTPRoutesMustBeAccepted waits until:
-// 1. The specified Gateway has an IP address assigned to it.
-// 2. The route has a ParentRef referring to the Gateway.
-// 3. All the gateway's listeners have the ListenerConditionResolvedRefs set to true.
+//  1. The specified Gateway has an IP address assigned to it.
+//  2. The route has a ParentRef referring to the Gateway.
+//  3. All the gateway's listeners have the following conditions set to true:
+//     - ListenerConditionResolvedRefs
+//     - ListenerConditionAccepted
+//     - ListenerConditionProgrammed
 //
-// The test will fail if these conditions are not met before the
-// timeouts.
+// The test will fail if these conditions are not met before the timeouts.
 func GatewayAndHTTPRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, controllerName string, gw GatewayRef, routeNNs ...types.NamespacedName) string {
 	t.Helper()
 
@@ -310,13 +313,24 @@ func GatewayAndHTTPRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutCo
 		HTTPRouteMustHaveParents(t, c, timeoutConfig, routeNN, parents, namespaceRequired)
 	}
 
-	resolvedRefsCondition := metav1.Condition{
-		Type:   string(v1beta1.ListenerConditionResolvedRefs),
-		Status: metav1.ConditionTrue,
-		Reason: "", // any reason
+	requiredListenerConditions := []metav1.Condition{
+		{
+			Type:   string(v1beta1.ListenerConditionResolvedRefs),
+			Status: metav1.ConditionTrue,
+			Reason: "", // any reason
+		},
+		{
+			Type:   string(v1beta1.ListenerConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: "", // any reason
+		},
+		{
+			Type:   string(v1beta1.ListenerConditionProgrammed),
+			Status: metav1.ConditionTrue,
+			Reason: "", // any reason
+		},
 	}
-
-	GatewayListenersMustHaveCondition(t, c, timeoutConfig, gw.NamespacedName, resolvedRefsCondition)
+	GatewayListenersMustHaveConditions(t, c, timeoutConfig, gw.NamespacedName, requiredListenerConditions)
 
 	return gwAddr
 }
@@ -356,27 +370,38 @@ func WaitForGatewayAddress(t *testing.T, client client.Client, timeoutConfig con
 	return net.JoinHostPort(ipAddr, port), waitErr
 }
 
-// GatewayListenersMustHaveCondition checks if every listener of the specified gateway has a
-// certain condition.
-func GatewayListenersMustHaveCondition(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, gwName types.NamespacedName, condition metav1.Condition) {
+// GatewayListenersMustHaveConditions checks if every listener of the specified gateway has all
+// the specified conditions.
+func GatewayListenersMustHaveConditions(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, gwName types.NamespacedName, conditions []metav1.Condition) {
 	t.Helper()
 
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.GatewayListenersMustHaveCondition, true, func(ctx context.Context) (bool, error) {
-		var gw v1beta1.Gateway
-		if err := client.Get(ctx, gwName, &gw); err != nil {
-			return false, fmt.Errorf("error fetching Gateway: %w", err)
-		}
+	var wg sync.WaitGroup
+	wg.Add(len(conditions))
 
-		for _, listener := range gw.Status.Listeners {
-			if !findConditionInList(t, listener.Conditions, condition.Type, string(condition.Status), condition.Reason) {
-				return false, nil
-			}
-		}
+	for _, condition := range conditions {
+		go func(condition metav1.Condition) {
+			defer wg.Done()
 
-		return true, nil
-	})
+			waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.GatewayListenersMustHaveCondition, true, func(ctx context.Context) (bool, error) {
+				var gw v1beta1.Gateway
+				if err := client.Get(ctx, gwName, &gw); err != nil {
+					return false, fmt.Errorf("error fetching Gateway: %w", err)
+				}
 
-	require.NoErrorf(t, waitErr, "error waiting for Gateway status to have a Condition matching expectations on all listeners")
+				for _, listener := range gw.Status.Listeners {
+					if !findConditionInList(t, listener.Conditions, condition.Type, string(condition.Status), condition.Reason) {
+						return false, nil
+					}
+				}
+
+				return true, nil
+			})
+
+			require.NoErrorf(t, waitErr, "error waiting for Gateway status to have a Condition matching expectations on all listeners")
+		}(condition)
+	}
+
+	wg.Wait()
 }
 
 // GatewayMustHaveZeroRoutes validates that the gateway has zero routes attached.  The status

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -397,7 +397,8 @@ func GatewayListenersMustHaveConditions(t *testing.T, client client.Client, time
 				return true, nil
 			})
 
-			require.NoErrorf(t, waitErr, "error waiting for Gateway status to have a Condition matching expectations on all listeners")
+			require.NoErrorf(t, waitErr, "error waiting for Gateway status to have the %s condition set to %s on all listeners",
+				condition.Type, condition.Status)
 		}(condition)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind test
/area conformance

**What this PR does / why we need it**:
Add a consistent check that all the valid gateways have all three positive-polarity conditions always set to true.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2415 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
None
```
