### PR TITLE
[GEP-1911] Update BackendRef with GEP details

### DIFF
--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -549,6 +549,41 @@ type GRPCRouteFilter struct {
 }
 
 // GRPCBackendRef defines how a GRPCRoute forwards a gRPC request.
+//
+// Note that when a namespace different than the local namespace is specified, a
+// ReferenceGrant object is required in the referent namespace to allow that
+// namespace's owner to accept the reference. See the ReferenceGrant
+// documentation for details.
+//
+// <gateway:experimental:description>
+//
+// When the BackendRef points to a Kubernetes Service, implementations SHOULD honor the
+// appProtocol field if it is set for the target Service Port.
+//
+// Implementations supporting appProtocol MUST recognize the Kubernetes Standard Application Protocols
+// defined in [KEP-3726]. This supports IANA standard service names and extra constants defined
+// in the KEP that have a prefix of "kubernetes.io/". Gateway API MAY define additional
+// constants with the prefix "gateway.networking.k8s.io/"
+//
+// If a Service appProtocol isn't specified an implementation MAY infer the backend
+// protocol through its own means. Implementations MAY infer the protocol from the
+// Route type referring to the backend Service.
+//
+// Implementations MAY support multiplexing TCP and UDP on the same port. Otherwise
+// implementations MUST set ResolvedRefs condition to False with the "UnsupportedProtocol"
+// Reason with a clear message that multiplexing is not supported.
+//
+// If a Route is not able to send traffic to the backend using the specified protocol then
+// the backend is considered invalid. Implementations MUST set ResolvedRefs condition to
+// False with the "UnsupportedProtocol".
+//
+// Implementations MAY support different combinations of protocol/appProtocol/Route Type.
+// See [GEP-1911] for a table.
+//
+// </gateway:experimental:description>
+//
+// [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
+// [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/
 type GRPCBackendRef struct {
 	// BackendRef is a reference to a backend to forward matched requests to.
 	//

--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -567,11 +567,6 @@ type GRPCRouteFilter struct {
 // protocol through its own means. Implementations MAY infer the protocol from the
 // Route type referring to the backend Service.
 //
-// Implementations MAY support Kubernetes Service BackendRefs that are multiplexing TCP
-// and UDP on the same port. Otherwise implementations MUST set the Route ResolvedRefs
-// condition to False with the "UnsupportedProtocol" Reason with a clear message that
-// multiplexing is not supported.
-//
 // If a Route is not able to send traffic to the backend using the specified protocol then
 // the backend is considered invalid. Implementations MUST set ResolvedRefs condition to
 // False with the "UnsupportedProtocol".

--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -569,9 +569,10 @@ type GRPCRouteFilter struct {
 // protocol through its own means. Implementations MAY infer the protocol from the
 // Route type referring to the backend Service.
 //
-// Implementations MAY support multiplexing TCP and UDP on the same port. Otherwise
-// implementations MUST set ResolvedRefs condition to False with the "UnsupportedProtocol"
-// Reason with a clear message that multiplexing is not supported.
+// Implementations MAY support Kubernetes Service BackendRefs that are multiplexing TCP
+// and UDP on the same port. Otherwise implementations MUST set the Route ResolvedRefs
+// condition to False with the "UnsupportedProtocol" Reason with a clear message that
+// multiplexing is not supported.
 //
 // If a Route is not able to send traffic to the backend using the specified protocol then
 // the backend is considered invalid. Implementations MUST set ResolvedRefs condition to

--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -560,10 +560,8 @@ type GRPCRouteFilter struct {
 // When the BackendRef points to a Kubernetes Service, implementations SHOULD honor the
 // appProtocol field if it is set for the target Service Port.
 //
-// Implementations supporting appProtocol MUST recognize the Kubernetes Standard Application Protocols
-// defined in [KEP-3726]. This supports IANA standard service names and extra constants defined
-// in the KEP that have a prefix of "kubernetes.io/". Gateway API MAY define additional
-// constants with the prefix "gateway.networking.k8s.io/"
+// Implementations supporting appProtocol SHOULD recognize the Kubernetes Standard Application Protocols
+// defined in [KEP-3726].
 //
 // If a Service appProtocol isn't specified an implementation MAY infer the backend
 // protocol through its own means. Implementations MAY infer the protocol from the
@@ -578,13 +576,9 @@ type GRPCRouteFilter struct {
 // the backend is considered invalid. Implementations MUST set ResolvedRefs condition to
 // False with the "UnsupportedProtocol".
 //
-// Implementations MAY support different combinations of protocol/appProtocol/Route Type.
-// See [GEP-1911] for a table.
-//
 // </gateway:experimental:description>
 //
 // [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
-// [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/
 type GRPCBackendRef struct {
 	// BackendRef is a reference to a backend to forward matched requests to.
 	//

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -1131,9 +1131,10 @@ type HTTPRequestMirrorFilter struct {
 // protocol through its own means. Implementations MAY infer the protocol from the
 // Route type referring to the backend Service.
 //
-// Implementations MAY support multiplexing TCP and UDP on the same port. Otherwise
-// implementations MUST set ResolvedRefs condition to False with the "UnsupportedProtocol"
-// Reason with a clear message that multiplexing is not supported.
+// Implementations MAY support Kubernetes Service BackendRefs that are multiplexing TCP
+// and UDP on the same port. Otherwise implementations MUST set the Route ResolvedRefs
+// condition to False with the "UnsupportedProtocol" Reason with a clear message that
+// multiplexing is not supported.
 //
 // If a Route is not able to send traffic to the backend using the specified protocol then
 // the backend is considered invalid. Implementations MUST set ResolvedRefs condition to
@@ -1144,8 +1145,8 @@ type HTTPRequestMirrorFilter struct {
 //
 // </gateway:experimental:description>
 //
-// [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
 // [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/
+// [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
 type HTTPBackendRef struct {
 	// BackendRef is a reference to a backend to forward matched requests to.
 	//

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -1129,11 +1129,6 @@ type HTTPRequestMirrorFilter struct {
 // protocol through its own means. Implementations MAY infer the protocol from the
 // Route type referring to the backend Service.
 //
-// Implementations MAY support Kubernetes Service BackendRefs that are multiplexing TCP
-// and UDP on the same port. Otherwise implementations MUST set the Route ResolvedRefs
-// condition to False with the "UnsupportedProtocol" Reason with a clear message that
-// multiplexing is not supported.
-//
 // If a Route is not able to send traffic to the backend using the specified protocol then
 // the backend is considered invalid. Implementations MUST set ResolvedRefs condition to
 // False with the "UnsupportedProtocol".

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -1122,10 +1122,8 @@ type HTTPRequestMirrorFilter struct {
 // When the BackendRef points to a Kubernetes Service, implementations SHOULD honor the
 // appProtocol field if it is set for the target Service Port.
 //
-// Implementations supporting appProtocol MUST recognize the Kubernetes Standard Application Protocols
-// defined in [KEP-3726]. This supports IANA standard service names and extra constants defined
-// in the KEP that have a prefix of "kubernetes.io/". Gateway API MAY define additional
-// constants with the prefix "gateway.networking.k8s.io/"
+// Implementations supporting appProtocol SHOULD recognize the Kubernetes Standard Application Protocols
+// defined in [KEP-3726].
 //
 // If a Service appProtocol isn't specified an implementation MAY infer the backend
 // protocol through its own means. Implementations MAY infer the protocol from the
@@ -1140,12 +1138,8 @@ type HTTPRequestMirrorFilter struct {
 // the backend is considered invalid. Implementations MUST set ResolvedRefs condition to
 // False with the "UnsupportedProtocol".
 //
-// Implementations MAY support different combinations of protocol/appProtocol/Route Type.
-// See [GEP-1911] for a table.
-//
 // </gateway:experimental:description>
 //
-// [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/
 // [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
 type HTTPBackendRef struct {
 	// BackendRef is a reference to a backend to forward matched requests to.

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -1110,7 +1110,42 @@ type HTTPRequestMirrorFilter struct {
 	BackendRef BackendObjectReference `json:"backendRef"`
 }
 
-// HTTPBackendRef defines how a HTTPRoute should forward an HTTP request.
+// HTTPBackendRef defines how a HTTPRoute forwards a HTTP request.
+//
+// Note that when a namespace different than the local namespace is specified, a
+// ReferenceGrant object is required in the referent namespace to allow that
+// namespace's owner to accept the reference. See the ReferenceGrant
+// documentation for details.
+//
+// <gateway:experimental:description>
+//
+// When the BackendRef points to a Kubernetes Service, implementations SHOULD honor the
+// appProtocol field if it is set for the target Service Port.
+//
+// Implementations supporting appProtocol MUST recognize the Kubernetes Standard Application Protocols
+// defined in [KEP-3726]. This supports IANA standard service names and extra constants defined
+// in the KEP that have a prefix of "kubernetes.io/". Gateway API MAY define additional
+// constants with the prefix "gateway.networking.k8s.io/"
+//
+// If a Service appProtocol isn't specified an implementation MAY infer the backend
+// protocol through its own means. Implementations MAY infer the protocol from the
+// Route type referring to the backend Service.
+//
+// Implementations MAY support multiplexing TCP and UDP on the same port. Otherwise
+// implementations MUST set ResolvedRefs condition to False with the "UnsupportedProtocol"
+// Reason with a clear message that multiplexing is not supported.
+//
+// If a Route is not able to send traffic to the backend using the specified protocol then
+// the backend is considered invalid. Implementations MUST set ResolvedRefs condition to
+// False with the "UnsupportedProtocol".
+//
+// Implementations MAY support different combinations of protocol/appProtocol/Route Type.
+// See [GEP-1911] for a table.
+//
+// </gateway:experimental:description>
+//
+// [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
+// [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/
 type HTTPBackendRef struct {
 	// BackendRef is a reference to a backend to forward matched requests to.
 	//

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -258,9 +258,10 @@ type PortNumber int32
 // protocol through its own means. Implementations MAY infer the protocol from the
 // Route type referring to the backend Service.
 //
-// Implementations MAY support multiplexing TCP and UDP on the same port. Otherwise
-// implementations MUST set ResolvedRefs condition to False with the "UnsupportedProtocol"
-// Reason with a clear message that multiplexing is not supported.
+// Implementations MAY support Kubernetes Service BackendRefs that are multiplexing TCP
+// and UDP on the same port. Otherwise implementations MUST set the Route ResolvedRefs
+// condition to False with the "UnsupportedProtocol" Reason with a clear message that
+// multiplexing is not supported.
 //
 // If a Route is not able to send traffic to the backend using the specified protocol then
 // the backend is considered invalid. Implementations MUST set ResolvedRefs condition to

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -244,6 +244,8 @@ type PortNumber int32
 // namespace's owner to accept the reference. See the ReferenceGrant
 // documentation for details.
 //
+// <gateway:experimental:description>
+//
 // When the BackendRef points to a Kubernetes Service implementations MUST allow
 // the backend protocol to be specified by:
 //   - setting the protocol field on the Service's ServicePort
@@ -270,6 +272,8 @@ type PortNumber int32
 //
 // Implementations MAY support different combinations of protocol/appProtocol/Route Type.
 // See [GEP-1911] for a table.
+//
+// </gateway:experimental:description>
 //
 // [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
 // [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -246,14 +246,10 @@ type PortNumber int32
 //
 // <gateway:experimental:description>
 //
-// When the BackendRef points to a Kubernetes Service implementations MUST allow
-// the backend protocol to be specified by:
-//   - setting the protocol field on the Service's ServicePort
-//   - setting the protocol field on the Service's related Endpoint/EndpointSlice's EndpointPort
-//   - setting the appProtocol field on the Service's ServicePort
-//   - setting the appProtocol field on the Service's related Endpoint/EndpointSlice's EndpointPort
+// When the BackendRef points to a Kubernetes Service, implementations SHOULD honor the
+// appProtocol field if it is set for the target Service Port.
 //
-// For appProtocol implementations MUST recognize the Kubernetes Standard Application Protocols
+// Implementations supporting appProtocol MUST recognize the Kubernetes Standard Application Protocols
 // defined in [KEP-3726]. This supports IANA standard service names and extra constants defined
 // in the KEP that have a prefix of "kubernetes.io/". Gateway API MAY define additional
 // constants with the prefix "gateway.networking.k8s.io/"

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -262,9 +262,9 @@ type PortNumber int32
 // implementations MUST set ResolvedRefs condition to False with the "UnsupportedProtocol"
 // Reason with a clear message that multiplexing is not supported.
 //
-// If a Route attached to a Gateway is not able to send traffic to the backend using
-// the specified protocol then the backend is considered invalid. Implementations
-// MUST set ResolvedRefs condition to False with the Reason UnsupportedProtocol.
+// If a Route is not able to send traffic to the backend using the specified protocol then
+// the backend is considered invalid. Implementations MUST set ResolvedRefs condition to
+// False with the "UnsupportedProtocol".
 //
 // Implementations MAY support different combinations of protocol/appProtocol/Route Type.
 // See [GEP-1911] for a table.

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -263,8 +263,8 @@ type PortNumber int32
 // Route type referring to the backend Service.
 //
 // Implementations MAY support multiplexing TCP and UDP on the same port. Otherwise
-// implementations MUST set ResolvedRefs condition to False with the Reason UnsupportedProtocol
-// with a clear message that multiplexing is not supported.
+// implementations MUST set ResolvedRefs condition to False with the "UnsupportedProtocol"
+// Reason with a clear message that multiplexing is not supported.
 //
 // If a Route attached to a Gateway is not able to send traffic to the backend using
 // the specified protocol then the backend is considered invalid. Implementations
@@ -403,7 +403,7 @@ const (
 	RouteReasonBackendNotFound RouteConditionReason = "BackendNotFound"
 
 	// This reason is used with the "ResolvedRefs" condition when one of the
-	// Route's rules has a reference to a resource with a backend protocol that
+	// Route's rules has a reference to a resource with an app protocol that
 	// is not supported by this implementation.
 	RouteReasonUnsupportedProtocol RouteConditionReason = "UnsupportedProtocol"
 )

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -256,11 +256,6 @@ type PortNumber int32
 // protocol through its own means. Implementations MAY infer the protocol from the
 // Route type referring to the backend Service.
 //
-// Implementations MAY support Kubernetes Service BackendRefs that are multiplexing TCP
-// and UDP on the same port. Otherwise implementations MUST set the Route ResolvedRefs
-// condition to False with the "UnsupportedProtocol" Reason with a clear message that
-// multiplexing is not supported.
-//
 // If a Route is not able to send traffic to the backend using the specified protocol then
 // the backend is considered invalid. Implementations MUST set ResolvedRefs condition to
 // False with the "UnsupportedProtocol".

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -249,10 +249,8 @@ type PortNumber int32
 // When the BackendRef points to a Kubernetes Service, implementations SHOULD honor the
 // appProtocol field if it is set for the target Service Port.
 //
-// Implementations supporting appProtocol MUST recognize the Kubernetes Standard Application Protocols
-// defined in [KEP-3726]. This supports IANA standard service names and extra constants defined
-// in the KEP that have a prefix of "kubernetes.io/". Gateway API MAY define additional
-// constants with the prefix "gateway.networking.k8s.io/"
+// Implementations supporting appProtocol SHOULD recognize the Kubernetes Standard Application Protocols
+// defined in [KEP-3726].
 //
 // If a Service appProtocol isn't specified an implementation MAY infer the backend
 // protocol through its own means. Implementations MAY infer the protocol from the
@@ -267,13 +265,9 @@ type PortNumber int32
 // the backend is considered invalid. Implementations MUST set ResolvedRefs condition to
 // False with the "UnsupportedProtocol".
 //
-// Implementations MAY support different combinations of protocol/appProtocol/Route Type.
-// See [GEP-1911] for a table.
-//
 // </gateway:experimental:description>
 //
 // [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
-// [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/
 type BackendRef struct {
 	// BackendObjectReference references a Kubernetes object.
 	BackendObjectReference `json:",inline"`

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -356,12 +356,7 @@ spec:
                           specified an implementation MAY infer the backend protocol
                           through its own means. Implementations MAY infer the protocol
                           from the Route type referring to the backend Service. \n
-                          Implementations MAY support Kubernetes Service BackendRefs
-                          that are multiplexing TCP and UDP on the same port. Otherwise
-                          implementations MUST set the Route ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\" Reason with a
-                          clear message that multiplexing is not supported. \n If
-                          a Route is not able to send traffic to the backend using
+                          If a Route is not able to send traffic to the backend using
                           the specified protocol then the backend is considered invalid.
                           Implementations MUST set ResolvedRefs condition to False
                           with the \"UnsupportedProtocol\". \n </gateway:experimental:description>

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -351,27 +351,21 @@ spec:
                           \n When the BackendRef points to a Kubernetes Service, implementations
                           SHOULD honor the appProtocol field if it is set for the
                           target Service Port. \n Implementations supporting appProtocol
-                          MUST recognize the Kubernetes Standard Application Protocols
-                          defined in [KEP-3726]. This supports IANA standard service
-                          names and extra constants defined in the KEP that have a
-                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
-                          constants with the prefix \"gateway.networking.k8s.io/\"
-                          \n If a Service appProtocol isn't specified an implementation
-                          MAY infer the backend protocol through its own means. Implementations
-                          MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support Kubernetes
-                          Service BackendRefs that are multiplexing TCP and UDP on
-                          the same port. Otherwise implementations MUST set the Route
-                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
-                          Reason with a clear message that multiplexing is not supported.
-                          \n If a Route is not able to send traffic to the backend
-                          using the specified protocol then the backend is considered
-                          invalid. Implementations MUST set ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\". \n Implementations
-                          MAY support different combinations of protocol/appProtocol/Route
-                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
-                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
-                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
+                          SHOULD recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. \n If a Service appProtocol isn't
+                          specified an implementation MAY infer the backend protocol
+                          through its own means. Implementations MAY infer the protocol
+                          from the Route type referring to the backend Service. \n
+                          Implementations MAY support Kubernetes Service BackendRefs
+                          that are multiplexing TCP and UDP on the same port. Otherwise
+                          implementations MUST set the Route ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\" Reason with a
+                          clear message that multiplexing is not supported. \n If
+                          a Route is not able to send traffic to the backend using
+                          the specified protocol then the backend is considered invalid.
+                          Implementations MUST set ResolvedRefs condition to False
+                          with the \"UnsupportedProtocol\". \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
                         properties:
                           filters:
                             description: "Filters defined at this level MUST be executed

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -359,9 +359,10 @@ spec:
                           \n If a Service appProtocol isn't specified an implementation
                           MAY infer the backend protocol through its own means. Implementations
                           MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support multiplexing
-                          TCP and UDP on the same port. Otherwise implementations
-                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          the backend Service. \n Implementations MAY support Kubernetes
+                          Service BackendRefs that are multiplexing TCP and UDP on
+                          the same port. Otherwise implementations MUST set the Route
+                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
                           Reason with a clear message that multiplexing is not supported.
                           \n If a Route is not able to send traffic to the backend
                           using the specified protocol then the backend is considered

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -342,8 +342,35 @@ spec:
                         Service \n Support: Implementation-specific for any other
                         resource \n Support for weight: Core"
                       items:
-                        description: GRPCBackendRef defines how a GRPCRoute forwards
-                          a gRPC request.
+                        description: "GRPCBackendRef defines how a GRPCRoute forwards
+                          a gRPC request. \n Note that when a namespace different
+                          than the local namespace is specified, a ReferenceGrant
+                          object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details. \n <gateway:experimental:description>
+                          \n When the BackendRef points to a Kubernetes Service, implementations
+                          SHOULD honor the appProtocol field if it is set for the
+                          target Service Port. \n Implementations supporting appProtocol
+                          MUST recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. This supports IANA standard service
+                          names and extra constants defined in the KEP that have a
+                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
+                          constants with the prefix \"gateway.networking.k8s.io/\"
+                          \n If a Service appProtocol isn't specified an implementation
+                          MAY infer the backend protocol through its own means. Implementations
+                          MAY infer the protocol from the Route type referring to
+                          the backend Service. \n Implementations MAY support multiplexing
+                          TCP and UDP on the same port. Otherwise implementations
+                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          Reason with a clear message that multiplexing is not supported.
+                          \n If a Route is not able to send traffic to the backend
+                          using the specified protocol then the backend is considered
+                          invalid. Implementations MUST set ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\". \n Implementations
+                          MAY support different combinations of protocol/appProtocol/Route
+                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
+                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
                         properties:
                           filters:
                             description: "Filters defined at this level MUST be executed

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -343,27 +343,21 @@ spec:
                           \n When the BackendRef points to a Kubernetes Service, implementations
                           SHOULD honor the appProtocol field if it is set for the
                           target Service Port. \n Implementations supporting appProtocol
-                          MUST recognize the Kubernetes Standard Application Protocols
-                          defined in [KEP-3726]. This supports IANA standard service
-                          names and extra constants defined in the KEP that have a
-                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
-                          constants with the prefix \"gateway.networking.k8s.io/\"
-                          \n If a Service appProtocol isn't specified an implementation
-                          MAY infer the backend protocol through its own means. Implementations
-                          MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support Kubernetes
-                          Service BackendRefs that are multiplexing TCP and UDP on
-                          the same port. Otherwise implementations MUST set the Route
-                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
-                          Reason with a clear message that multiplexing is not supported.
-                          \n If a Route is not able to send traffic to the backend
-                          using the specified protocol then the backend is considered
-                          invalid. Implementations MUST set ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\". \n Implementations
-                          MAY support different combinations of protocol/appProtocol/Route
-                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
-                          \n [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/
-                          [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
+                          SHOULD recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. \n If a Service appProtocol isn't
+                          specified an implementation MAY infer the backend protocol
+                          through its own means. Implementations MAY infer the protocol
+                          from the Route type referring to the backend Service. \n
+                          Implementations MAY support Kubernetes Service BackendRefs
+                          that are multiplexing TCP and UDP on the same port. Otherwise
+                          implementations MUST set the Route ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\" Reason with a
+                          clear message that multiplexing is not supported. \n If
+                          a Route is not able to send traffic to the backend using
+                          the specified protocol then the backend is considered invalid.
+                          Implementations MUST set ResolvedRefs condition to False
+                          with the \"UnsupportedProtocol\". \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
                         properties:
                           filters:
                             description: "Filters defined at this level should be
@@ -2820,27 +2814,21 @@ spec:
                           \n When the BackendRef points to a Kubernetes Service, implementations
                           SHOULD honor the appProtocol field if it is set for the
                           target Service Port. \n Implementations supporting appProtocol
-                          MUST recognize the Kubernetes Standard Application Protocols
-                          defined in [KEP-3726]. This supports IANA standard service
-                          names and extra constants defined in the KEP that have a
-                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
-                          constants with the prefix \"gateway.networking.k8s.io/\"
-                          \n If a Service appProtocol isn't specified an implementation
-                          MAY infer the backend protocol through its own means. Implementations
-                          MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support Kubernetes
-                          Service BackendRefs that are multiplexing TCP and UDP on
-                          the same port. Otherwise implementations MUST set the Route
-                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
-                          Reason with a clear message that multiplexing is not supported.
-                          \n If a Route is not able to send traffic to the backend
-                          using the specified protocol then the backend is considered
-                          invalid. Implementations MUST set ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\". \n Implementations
-                          MAY support different combinations of protocol/appProtocol/Route
-                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
-                          \n [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/
-                          [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
+                          SHOULD recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. \n If a Service appProtocol isn't
+                          specified an implementation MAY infer the backend protocol
+                          through its own means. Implementations MAY infer the protocol
+                          from the Route type referring to the backend Service. \n
+                          Implementations MAY support Kubernetes Service BackendRefs
+                          that are multiplexing TCP and UDP on the same port. Otherwise
+                          implementations MUST set the Route ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\" Reason with a
+                          clear message that multiplexing is not supported. \n If
+                          a Route is not able to send traffic to the backend using
+                          the specified protocol then the backend is considered invalid.
+                          Implementations MUST set ResolvedRefs condition to False
+                          with the \"UnsupportedProtocol\". \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
                         properties:
                           filters:
                             description: "Filters defined at this level should be

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -348,12 +348,7 @@ spec:
                           specified an implementation MAY infer the backend protocol
                           through its own means. Implementations MAY infer the protocol
                           from the Route type referring to the backend Service. \n
-                          Implementations MAY support Kubernetes Service BackendRefs
-                          that are multiplexing TCP and UDP on the same port. Otherwise
-                          implementations MUST set the Route ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\" Reason with a
-                          clear message that multiplexing is not supported. \n If
-                          a Route is not able to send traffic to the backend using
+                          If a Route is not able to send traffic to the backend using
                           the specified protocol then the backend is considered invalid.
                           Implementations MUST set ResolvedRefs condition to False
                           with the \"UnsupportedProtocol\". \n </gateway:experimental:description>
@@ -2819,12 +2814,7 @@ spec:
                           specified an implementation MAY infer the backend protocol
                           through its own means. Implementations MAY infer the protocol
                           from the Route type referring to the backend Service. \n
-                          Implementations MAY support Kubernetes Service BackendRefs
-                          that are multiplexing TCP and UDP on the same port. Otherwise
-                          implementations MUST set the Route ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\" Reason with a
-                          clear message that multiplexing is not supported. \n If
-                          a Route is not able to send traffic to the backend using
+                          If a Route is not able to send traffic to the backend using
                           the specified protocol then the backend is considered invalid.
                           Implementations MUST set ResolvedRefs condition to False
                           with the \"UnsupportedProtocol\". \n </gateway:experimental:description>

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -334,8 +334,35 @@ spec:
                         for Kubernetes ServiceImport \n Support: Implementation-specific
                         for any other resource \n Support for weight: Core"
                       items:
-                        description: HTTPBackendRef defines how a HTTPRoute should
-                          forward an HTTP request.
+                        description: "HTTPBackendRef defines how a HTTPRoute forwards
+                          a HTTP request. \n Note that when a namespace different
+                          than the local namespace is specified, a ReferenceGrant
+                          object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details. \n <gateway:experimental:description>
+                          \n When the BackendRef points to a Kubernetes Service, implementations
+                          SHOULD honor the appProtocol field if it is set for the
+                          target Service Port. \n Implementations supporting appProtocol
+                          MUST recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. This supports IANA standard service
+                          names and extra constants defined in the KEP that have a
+                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
+                          constants with the prefix \"gateway.networking.k8s.io/\"
+                          \n If a Service appProtocol isn't specified an implementation
+                          MAY infer the backend protocol through its own means. Implementations
+                          MAY infer the protocol from the Route type referring to
+                          the backend Service. \n Implementations MAY support multiplexing
+                          TCP and UDP on the same port. Otherwise implementations
+                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          Reason with a clear message that multiplexing is not supported.
+                          \n If a Route is not able to send traffic to the backend
+                          using the specified protocol then the backend is considered
+                          invalid. Implementations MUST set ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\". \n Implementations
+                          MAY support different combinations of protocol/appProtocol/Route
+                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
+                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
                         properties:
                           filters:
                             description: "Filters defined at this level should be
@@ -2783,8 +2810,35 @@ spec:
                         for Kubernetes ServiceImport \n Support: Implementation-specific
                         for any other resource \n Support for weight: Core"
                       items:
-                        description: HTTPBackendRef defines how a HTTPRoute should
-                          forward an HTTP request.
+                        description: "HTTPBackendRef defines how a HTTPRoute forwards
+                          a HTTP request. \n Note that when a namespace different
+                          than the local namespace is specified, a ReferenceGrant
+                          object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details. \n <gateway:experimental:description>
+                          \n When the BackendRef points to a Kubernetes Service, implementations
+                          SHOULD honor the appProtocol field if it is set for the
+                          target Service Port. \n Implementations supporting appProtocol
+                          MUST recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. This supports IANA standard service
+                          names and extra constants defined in the KEP that have a
+                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
+                          constants with the prefix \"gateway.networking.k8s.io/\"
+                          \n If a Service appProtocol isn't specified an implementation
+                          MAY infer the backend protocol through its own means. Implementations
+                          MAY infer the protocol from the Route type referring to
+                          the backend Service. \n Implementations MAY support multiplexing
+                          TCP and UDP on the same port. Otherwise implementations
+                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          Reason with a clear message that multiplexing is not supported.
+                          \n If a Route is not able to send traffic to the backend
+                          using the specified protocol then the backend is considered
+                          invalid. Implementations MUST set ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\". \n Implementations
+                          MAY support different combinations of protocol/appProtocol/Route
+                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
+                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
                         properties:
                           filters:
                             description: "Filters defined at this level should be

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -351,9 +351,10 @@ spec:
                           \n If a Service appProtocol isn't specified an implementation
                           MAY infer the backend protocol through its own means. Implementations
                           MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support multiplexing
-                          TCP and UDP on the same port. Otherwise implementations
-                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          the backend Service. \n Implementations MAY support Kubernetes
+                          Service BackendRefs that are multiplexing TCP and UDP on
+                          the same port. Otherwise implementations MUST set the Route
+                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
                           Reason with a clear message that multiplexing is not supported.
                           \n If a Route is not able to send traffic to the backend
                           using the specified protocol then the backend is considered
@@ -361,8 +362,8 @@ spec:
                           to False with the \"UnsupportedProtocol\". \n Implementations
                           MAY support different combinations of protocol/appProtocol/Route
                           Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
-                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
-                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
+                          \n [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/
+                          [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
                         properties:
                           filters:
                             description: "Filters defined at this level should be
@@ -2827,9 +2828,10 @@ spec:
                           \n If a Service appProtocol isn't specified an implementation
                           MAY infer the backend protocol through its own means. Implementations
                           MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support multiplexing
-                          TCP and UDP on the same port. Otherwise implementations
-                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          the backend Service. \n Implementations MAY support Kubernetes
+                          Service BackendRefs that are multiplexing TCP and UDP on
+                          the same port. Otherwise implementations MUST set the Route
+                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
                           Reason with a clear message that multiplexing is not supported.
                           \n If a Route is not able to send traffic to the backend
                           using the specified protocol then the backend is considered
@@ -2837,8 +2839,8 @@ spec:
                           to False with the \"UnsupportedProtocol\". \n Implementations
                           MAY support different combinations of protocol/appProtocol/Route
                           Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
-                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
-                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
+                          \n [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/
+                          [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
                         properties:
                           filters:
                             description: "Filters defined at this level should be

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -262,27 +262,21 @@ spec:
                           \n When the BackendRef points to a Kubernetes Service, implementations
                           SHOULD honor the appProtocol field if it is set for the
                           target Service Port. \n Implementations supporting appProtocol
-                          MUST recognize the Kubernetes Standard Application Protocols
-                          defined in [KEP-3726]. This supports IANA standard service
-                          names and extra constants defined in the KEP that have a
-                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
-                          constants with the prefix \"gateway.networking.k8s.io/\"
-                          \n If a Service appProtocol isn't specified an implementation
-                          MAY infer the backend protocol through its own means. Implementations
-                          MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support Kubernetes
-                          Service BackendRefs that are multiplexing TCP and UDP on
-                          the same port. Otherwise implementations MUST set the Route
-                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
-                          Reason with a clear message that multiplexing is not supported.
-                          \n If a Route is not able to send traffic to the backend
-                          using the specified protocol then the backend is considered
-                          invalid. Implementations MUST set ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\". \n Implementations
-                          MAY support different combinations of protocol/appProtocol/Route
-                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
-                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
-                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
+                          SHOULD recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. \n If a Service appProtocol isn't
+                          specified an implementation MAY infer the backend protocol
+                          through its own means. Implementations MAY infer the protocol
+                          from the Route type referring to the backend Service. \n
+                          Implementations MAY support Kubernetes Service BackendRefs
+                          that are multiplexing TCP and UDP on the same port. Otherwise
+                          implementations MUST set the Route ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\" Reason with a
+                          clear message that multiplexing is not supported. \n If
+                          a Route is not able to send traffic to the backend using
+                          the specified protocol then the backend is considered invalid.
+                          Implementations MUST set ResolvedRefs condition to False
+                          with the \"UnsupportedProtocol\". \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
                         properties:
                           group:
                             default: ""

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -258,7 +258,35 @@ spec:
                           namespace different than the local namespace is specified,
                           a ReferenceGrant object is required in the referent namespace
                           to allow that namespace's owner to accept the reference.
-                          See the ReferenceGrant documentation for details."
+                          See the ReferenceGrant documentation for details. \n <gateway:experimental:description>
+                          \n When the BackendRef points to a Kubernetes Service implementations
+                          MUST allow the backend protocol to be specified by: - setting
+                          the protocol field on the Service's ServicePort - setting
+                          the protocol field on the Service's related Endpoint/EndpointSlice's
+                          EndpointPort - setting the appProtocol field on the Service's
+                          ServicePort - setting the appProtocol field on the Service's
+                          related Endpoint/EndpointSlice's EndpointPort \n For appProtocol
+                          implementations MUST recognize the Kubernetes Standard Application
+                          Protocols defined in [KEP-3726]. This supports IANA standard
+                          service names and extra constants defined in the KEP that
+                          have a prefix of \"kubernetes.io/\". Gateway API MAY define
+                          additional constants with the prefix \"gateway.networking.k8s.io/\"
+                          \n If a Service appProtocol isn't specified an implementation
+                          MAY infer the backend protocol through its own means. Implementations
+                          MAY infer the protocol from the Route type referring to
+                          the backend Service. \n Implementations MAY support multiplexing
+                          TCP and UDP on the same port. Otherwise implementations
+                          MUST set ResolvedRefs condition to False with the Reason
+                          UnsupportedProtocol with a clear message that multiplexing
+                          is not supported. \n If a Route attached to a Gateway is
+                          not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations
+                          MUST set ResolvedRefs condition to False with the Reason
+                          UnsupportedProtocol. \n Implementations MAY support different
+                          combinations of protocol/appProtocol/Route Type. See [GEP-1911]
+                          for a table. \n </gateway:experimental:description> \n [KEP-3726]:
+                          https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
+                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
                         properties:
                           group:
                             default: ""

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -270,9 +270,10 @@ spec:
                           \n If a Service appProtocol isn't specified an implementation
                           MAY infer the backend protocol through its own means. Implementations
                           MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support multiplexing
-                          TCP and UDP on the same port. Otherwise implementations
-                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          the backend Service. \n Implementations MAY support Kubernetes
+                          Service BackendRefs that are multiplexing TCP and UDP on
+                          the same port. Otherwise implementations MUST set the Route
+                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
                           Reason with a clear message that multiplexing is not supported.
                           \n If a Route is not able to send traffic to the backend
                           using the specified protocol then the backend is considered

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -267,12 +267,7 @@ spec:
                           specified an implementation MAY infer the backend protocol
                           through its own means. Implementations MAY infer the protocol
                           from the Route type referring to the backend Service. \n
-                          Implementations MAY support Kubernetes Service BackendRefs
-                          that are multiplexing TCP and UDP on the same port. Otherwise
-                          implementations MUST set the Route ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\" Reason with a
-                          clear message that multiplexing is not supported. \n If
-                          a Route is not able to send traffic to the backend using
+                          If a Route is not able to send traffic to the backend using
                           the specified protocol then the backend is considered invalid.
                           Implementations MUST set ResolvedRefs condition to False
                           with the \"UnsupportedProtocol\". \n </gateway:experimental:description>

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -259,33 +259,28 @@ spec:
                           a ReferenceGrant object is required in the referent namespace
                           to allow that namespace's owner to accept the reference.
                           See the ReferenceGrant documentation for details. \n <gateway:experimental:description>
-                          \n When the BackendRef points to a Kubernetes Service implementations
-                          MUST allow the backend protocol to be specified by: - setting
-                          the protocol field on the Service's ServicePort - setting
-                          the protocol field on the Service's related Endpoint/EndpointSlice's
-                          EndpointPort - setting the appProtocol field on the Service's
-                          ServicePort - setting the appProtocol field on the Service's
-                          related Endpoint/EndpointSlice's EndpointPort \n For appProtocol
-                          implementations MUST recognize the Kubernetes Standard Application
-                          Protocols defined in [KEP-3726]. This supports IANA standard
-                          service names and extra constants defined in the KEP that
-                          have a prefix of \"kubernetes.io/\". Gateway API MAY define
-                          additional constants with the prefix \"gateway.networking.k8s.io/\"
+                          \n When the BackendRef points to a Kubernetes Service, implementations
+                          SHOULD honor the appProtocol field if it is set for the
+                          target Service Port. \n Implementations supporting appProtocol
+                          MUST recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. This supports IANA standard service
+                          names and extra constants defined in the KEP that have a
+                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
+                          constants with the prefix \"gateway.networking.k8s.io/\"
                           \n If a Service appProtocol isn't specified an implementation
                           MAY infer the backend protocol through its own means. Implementations
                           MAY infer the protocol from the Route type referring to
                           the backend Service. \n Implementations MAY support multiplexing
                           TCP and UDP on the same port. Otherwise implementations
-                          MUST set ResolvedRefs condition to False with the Reason
-                          UnsupportedProtocol with a clear message that multiplexing
-                          is not supported. \n If a Route attached to a Gateway is
-                          not able to send traffic to the backend using the specified
-                          protocol then the backend is considered invalid. Implementations
-                          MUST set ResolvedRefs condition to False with the Reason
-                          UnsupportedProtocol. \n Implementations MAY support different
-                          combinations of protocol/appProtocol/Route Type. See [GEP-1911]
-                          for a table. \n </gateway:experimental:description> \n [KEP-3726]:
-                          https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
+                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          Reason with a clear message that multiplexing is not supported.
+                          \n If a Route is not able to send traffic to the backend
+                          using the specified protocol then the backend is considered
+                          invalid. Implementations MUST set ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\". \n Implementations
+                          MAY support different combinations of protocol/appProtocol/Route
+                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
                           [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
                         properties:
                           group:

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -319,9 +319,10 @@ spec:
                           \n If a Service appProtocol isn't specified an implementation
                           MAY infer the backend protocol through its own means. Implementations
                           MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support multiplexing
-                          TCP and UDP on the same port. Otherwise implementations
-                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          the backend Service. \n Implementations MAY support Kubernetes
+                          Service BackendRefs that are multiplexing TCP and UDP on
+                          the same port. Otherwise implementations MUST set the Route
+                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
                           Reason with a clear message that multiplexing is not supported.
                           \n If a Route is not able to send traffic to the backend
                           using the specified protocol then the backend is considered

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -308,33 +308,28 @@ spec:
                           a ReferenceGrant object is required in the referent namespace
                           to allow that namespace's owner to accept the reference.
                           See the ReferenceGrant documentation for details. \n <gateway:experimental:description>
-                          \n When the BackendRef points to a Kubernetes Service implementations
-                          MUST allow the backend protocol to be specified by: - setting
-                          the protocol field on the Service's ServicePort - setting
-                          the protocol field on the Service's related Endpoint/EndpointSlice's
-                          EndpointPort - setting the appProtocol field on the Service's
-                          ServicePort - setting the appProtocol field on the Service's
-                          related Endpoint/EndpointSlice's EndpointPort \n For appProtocol
-                          implementations MUST recognize the Kubernetes Standard Application
-                          Protocols defined in [KEP-3726]. This supports IANA standard
-                          service names and extra constants defined in the KEP that
-                          have a prefix of \"kubernetes.io/\". Gateway API MAY define
-                          additional constants with the prefix \"gateway.networking.k8s.io/\"
+                          \n When the BackendRef points to a Kubernetes Service, implementations
+                          SHOULD honor the appProtocol field if it is set for the
+                          target Service Port. \n Implementations supporting appProtocol
+                          MUST recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. This supports IANA standard service
+                          names and extra constants defined in the KEP that have a
+                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
+                          constants with the prefix \"gateway.networking.k8s.io/\"
                           \n If a Service appProtocol isn't specified an implementation
                           MAY infer the backend protocol through its own means. Implementations
                           MAY infer the protocol from the Route type referring to
                           the backend Service. \n Implementations MAY support multiplexing
                           TCP and UDP on the same port. Otherwise implementations
-                          MUST set ResolvedRefs condition to False with the Reason
-                          UnsupportedProtocol with a clear message that multiplexing
-                          is not supported. \n If a Route attached to a Gateway is
-                          not able to send traffic to the backend using the specified
-                          protocol then the backend is considered invalid. Implementations
-                          MUST set ResolvedRefs condition to False with the Reason
-                          UnsupportedProtocol. \n Implementations MAY support different
-                          combinations of protocol/appProtocol/Route Type. See [GEP-1911]
-                          for a table. \n </gateway:experimental:description> \n [KEP-3726]:
-                          https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
+                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          Reason with a clear message that multiplexing is not supported.
+                          \n If a Route is not able to send traffic to the backend
+                          using the specified protocol then the backend is considered
+                          invalid. Implementations MUST set ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\". \n Implementations
+                          MAY support different combinations of protocol/appProtocol/Route
+                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
                           [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
                         properties:
                           group:

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -307,7 +307,35 @@ spec:
                           namespace different than the local namespace is specified,
                           a ReferenceGrant object is required in the referent namespace
                           to allow that namespace's owner to accept the reference.
-                          See the ReferenceGrant documentation for details."
+                          See the ReferenceGrant documentation for details. \n <gateway:experimental:description>
+                          \n When the BackendRef points to a Kubernetes Service implementations
+                          MUST allow the backend protocol to be specified by: - setting
+                          the protocol field on the Service's ServicePort - setting
+                          the protocol field on the Service's related Endpoint/EndpointSlice's
+                          EndpointPort - setting the appProtocol field on the Service's
+                          ServicePort - setting the appProtocol field on the Service's
+                          related Endpoint/EndpointSlice's EndpointPort \n For appProtocol
+                          implementations MUST recognize the Kubernetes Standard Application
+                          Protocols defined in [KEP-3726]. This supports IANA standard
+                          service names and extra constants defined in the KEP that
+                          have a prefix of \"kubernetes.io/\". Gateway API MAY define
+                          additional constants with the prefix \"gateway.networking.k8s.io/\"
+                          \n If a Service appProtocol isn't specified an implementation
+                          MAY infer the backend protocol through its own means. Implementations
+                          MAY infer the protocol from the Route type referring to
+                          the backend Service. \n Implementations MAY support multiplexing
+                          TCP and UDP on the same port. Otherwise implementations
+                          MUST set ResolvedRefs condition to False with the Reason
+                          UnsupportedProtocol with a clear message that multiplexing
+                          is not supported. \n If a Route attached to a Gateway is
+                          not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations
+                          MUST set ResolvedRefs condition to False with the Reason
+                          UnsupportedProtocol. \n Implementations MAY support different
+                          combinations of protocol/appProtocol/Route Type. See [GEP-1911]
+                          for a table. \n </gateway:experimental:description> \n [KEP-3726]:
+                          https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
+                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
                         properties:
                           group:
                             default: ""

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -311,27 +311,21 @@ spec:
                           \n When the BackendRef points to a Kubernetes Service, implementations
                           SHOULD honor the appProtocol field if it is set for the
                           target Service Port. \n Implementations supporting appProtocol
-                          MUST recognize the Kubernetes Standard Application Protocols
-                          defined in [KEP-3726]. This supports IANA standard service
-                          names and extra constants defined in the KEP that have a
-                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
-                          constants with the prefix \"gateway.networking.k8s.io/\"
-                          \n If a Service appProtocol isn't specified an implementation
-                          MAY infer the backend protocol through its own means. Implementations
-                          MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support Kubernetes
-                          Service BackendRefs that are multiplexing TCP and UDP on
-                          the same port. Otherwise implementations MUST set the Route
-                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
-                          Reason with a clear message that multiplexing is not supported.
-                          \n If a Route is not able to send traffic to the backend
-                          using the specified protocol then the backend is considered
-                          invalid. Implementations MUST set ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\". \n Implementations
-                          MAY support different combinations of protocol/appProtocol/Route
-                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
-                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
-                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
+                          SHOULD recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. \n If a Service appProtocol isn't
+                          specified an implementation MAY infer the backend protocol
+                          through its own means. Implementations MAY infer the protocol
+                          from the Route type referring to the backend Service. \n
+                          Implementations MAY support Kubernetes Service BackendRefs
+                          that are multiplexing TCP and UDP on the same port. Otherwise
+                          implementations MUST set the Route ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\" Reason with a
+                          clear message that multiplexing is not supported. \n If
+                          a Route is not able to send traffic to the backend using
+                          the specified protocol then the backend is considered invalid.
+                          Implementations MUST set ResolvedRefs condition to False
+                          with the \"UnsupportedProtocol\". \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
                         properties:
                           group:
                             default: ""

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -316,12 +316,7 @@ spec:
                           specified an implementation MAY infer the backend protocol
                           through its own means. Implementations MAY infer the protocol
                           from the Route type referring to the backend Service. \n
-                          Implementations MAY support Kubernetes Service BackendRefs
-                          that are multiplexing TCP and UDP on the same port. Otherwise
-                          implementations MUST set the Route ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\" Reason with a
-                          clear message that multiplexing is not supported. \n If
-                          a Route is not able to send traffic to the backend using
+                          If a Route is not able to send traffic to the backend using
                           the specified protocol then the backend is considered invalid.
                           Implementations MUST set ResolvedRefs condition to False
                           with the \"UnsupportedProtocol\". \n </gateway:experimental:description>

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -262,27 +262,21 @@ spec:
                           \n When the BackendRef points to a Kubernetes Service, implementations
                           SHOULD honor the appProtocol field if it is set for the
                           target Service Port. \n Implementations supporting appProtocol
-                          MUST recognize the Kubernetes Standard Application Protocols
-                          defined in [KEP-3726]. This supports IANA standard service
-                          names and extra constants defined in the KEP that have a
-                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
-                          constants with the prefix \"gateway.networking.k8s.io/\"
-                          \n If a Service appProtocol isn't specified an implementation
-                          MAY infer the backend protocol through its own means. Implementations
-                          MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support Kubernetes
-                          Service BackendRefs that are multiplexing TCP and UDP on
-                          the same port. Otherwise implementations MUST set the Route
-                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
-                          Reason with a clear message that multiplexing is not supported.
-                          \n If a Route is not able to send traffic to the backend
-                          using the specified protocol then the backend is considered
-                          invalid. Implementations MUST set ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\". \n Implementations
-                          MAY support different combinations of protocol/appProtocol/Route
-                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
-                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
-                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
+                          SHOULD recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. \n If a Service appProtocol isn't
+                          specified an implementation MAY infer the backend protocol
+                          through its own means. Implementations MAY infer the protocol
+                          from the Route type referring to the backend Service. \n
+                          Implementations MAY support Kubernetes Service BackendRefs
+                          that are multiplexing TCP and UDP on the same port. Otherwise
+                          implementations MUST set the Route ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\" Reason with a
+                          clear message that multiplexing is not supported. \n If
+                          a Route is not able to send traffic to the backend using
+                          the specified protocol then the backend is considered invalid.
+                          Implementations MUST set ResolvedRefs condition to False
+                          with the \"UnsupportedProtocol\". \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
                         properties:
                           group:
                             default: ""

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -258,7 +258,35 @@ spec:
                           namespace different than the local namespace is specified,
                           a ReferenceGrant object is required in the referent namespace
                           to allow that namespace's owner to accept the reference.
-                          See the ReferenceGrant documentation for details."
+                          See the ReferenceGrant documentation for details. \n <gateway:experimental:description>
+                          \n When the BackendRef points to a Kubernetes Service implementations
+                          MUST allow the backend protocol to be specified by: - setting
+                          the protocol field on the Service's ServicePort - setting
+                          the protocol field on the Service's related Endpoint/EndpointSlice's
+                          EndpointPort - setting the appProtocol field on the Service's
+                          ServicePort - setting the appProtocol field on the Service's
+                          related Endpoint/EndpointSlice's EndpointPort \n For appProtocol
+                          implementations MUST recognize the Kubernetes Standard Application
+                          Protocols defined in [KEP-3726]. This supports IANA standard
+                          service names and extra constants defined in the KEP that
+                          have a prefix of \"kubernetes.io/\". Gateway API MAY define
+                          additional constants with the prefix \"gateway.networking.k8s.io/\"
+                          \n If a Service appProtocol isn't specified an implementation
+                          MAY infer the backend protocol through its own means. Implementations
+                          MAY infer the protocol from the Route type referring to
+                          the backend Service. \n Implementations MAY support multiplexing
+                          TCP and UDP on the same port. Otherwise implementations
+                          MUST set ResolvedRefs condition to False with the Reason
+                          UnsupportedProtocol with a clear message that multiplexing
+                          is not supported. \n If a Route attached to a Gateway is
+                          not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations
+                          MUST set ResolvedRefs condition to False with the Reason
+                          UnsupportedProtocol. \n Implementations MAY support different
+                          combinations of protocol/appProtocol/Route Type. See [GEP-1911]
+                          for a table. \n </gateway:experimental:description> \n [KEP-3726]:
+                          https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
+                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
                         properties:
                           group:
                             default: ""

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -270,9 +270,10 @@ spec:
                           \n If a Service appProtocol isn't specified an implementation
                           MAY infer the backend protocol through its own means. Implementations
                           MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support multiplexing
-                          TCP and UDP on the same port. Otherwise implementations
-                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          the backend Service. \n Implementations MAY support Kubernetes
+                          Service BackendRefs that are multiplexing TCP and UDP on
+                          the same port. Otherwise implementations MUST set the Route
+                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
                           Reason with a clear message that multiplexing is not supported.
                           \n If a Route is not able to send traffic to the backend
                           using the specified protocol then the backend is considered

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -267,12 +267,7 @@ spec:
                           specified an implementation MAY infer the backend protocol
                           through its own means. Implementations MAY infer the protocol
                           from the Route type referring to the backend Service. \n
-                          Implementations MAY support Kubernetes Service BackendRefs
-                          that are multiplexing TCP and UDP on the same port. Otherwise
-                          implementations MUST set the Route ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\" Reason with a
-                          clear message that multiplexing is not supported. \n If
-                          a Route is not able to send traffic to the backend using
+                          If a Route is not able to send traffic to the backend using
                           the specified protocol then the backend is considered invalid.
                           Implementations MUST set ResolvedRefs condition to False
                           with the \"UnsupportedProtocol\". \n </gateway:experimental:description>

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -259,33 +259,28 @@ spec:
                           a ReferenceGrant object is required in the referent namespace
                           to allow that namespace's owner to accept the reference.
                           See the ReferenceGrant documentation for details. \n <gateway:experimental:description>
-                          \n When the BackendRef points to a Kubernetes Service implementations
-                          MUST allow the backend protocol to be specified by: - setting
-                          the protocol field on the Service's ServicePort - setting
-                          the protocol field on the Service's related Endpoint/EndpointSlice's
-                          EndpointPort - setting the appProtocol field on the Service's
-                          ServicePort - setting the appProtocol field on the Service's
-                          related Endpoint/EndpointSlice's EndpointPort \n For appProtocol
-                          implementations MUST recognize the Kubernetes Standard Application
-                          Protocols defined in [KEP-3726]. This supports IANA standard
-                          service names and extra constants defined in the KEP that
-                          have a prefix of \"kubernetes.io/\". Gateway API MAY define
-                          additional constants with the prefix \"gateway.networking.k8s.io/\"
+                          \n When the BackendRef points to a Kubernetes Service, implementations
+                          SHOULD honor the appProtocol field if it is set for the
+                          target Service Port. \n Implementations supporting appProtocol
+                          MUST recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. This supports IANA standard service
+                          names and extra constants defined in the KEP that have a
+                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
+                          constants with the prefix \"gateway.networking.k8s.io/\"
                           \n If a Service appProtocol isn't specified an implementation
                           MAY infer the backend protocol through its own means. Implementations
                           MAY infer the protocol from the Route type referring to
                           the backend Service. \n Implementations MAY support multiplexing
                           TCP and UDP on the same port. Otherwise implementations
-                          MUST set ResolvedRefs condition to False with the Reason
-                          UnsupportedProtocol with a clear message that multiplexing
-                          is not supported. \n If a Route attached to a Gateway is
-                          not able to send traffic to the backend using the specified
-                          protocol then the backend is considered invalid. Implementations
-                          MUST set ResolvedRefs condition to False with the Reason
-                          UnsupportedProtocol. \n Implementations MAY support different
-                          combinations of protocol/appProtocol/Route Type. See [GEP-1911]
-                          for a table. \n </gateway:experimental:description> \n [KEP-3726]:
-                          https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
+                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          Reason with a clear message that multiplexing is not supported.
+                          \n If a Route is not able to send traffic to the backend
+                          using the specified protocol then the backend is considered
+                          invalid. Implementations MUST set ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\". \n Implementations
+                          MAY support different combinations of protocol/appProtocol/Route
+                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
                           [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
                         properties:
                           group:

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -301,9 +301,10 @@ spec:
                           \n If a Service appProtocol isn't specified an implementation
                           MAY infer the backend protocol through its own means. Implementations
                           MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support multiplexing
-                          TCP and UDP on the same port. Otherwise implementations
-                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          the backend Service. \n Implementations MAY support Kubernetes
+                          Service BackendRefs that are multiplexing TCP and UDP on
+                          the same port. Otherwise implementations MUST set the Route
+                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
                           Reason with a clear message that multiplexing is not supported.
                           \n If a Route is not able to send traffic to the backend
                           using the specified protocol then the backend is considered
@@ -311,8 +312,8 @@ spec:
                           to False with the \"UnsupportedProtocol\". \n Implementations
                           MAY support different combinations of protocol/appProtocol/Route
                           Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
-                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
-                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
+                          \n [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/
+                          [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
                         properties:
                           filters:
                             description: "Filters defined at this level should be
@@ -2644,9 +2645,10 @@ spec:
                           \n If a Service appProtocol isn't specified an implementation
                           MAY infer the backend protocol through its own means. Implementations
                           MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support multiplexing
-                          TCP and UDP on the same port. Otherwise implementations
-                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          the backend Service. \n Implementations MAY support Kubernetes
+                          Service BackendRefs that are multiplexing TCP and UDP on
+                          the same port. Otherwise implementations MUST set the Route
+                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
                           Reason with a clear message that multiplexing is not supported.
                           \n If a Route is not able to send traffic to the backend
                           using the specified protocol then the backend is considered
@@ -2654,8 +2656,8 @@ spec:
                           to False with the \"UnsupportedProtocol\". \n Implementations
                           MAY support different combinations of protocol/appProtocol/Route
                           Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
-                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
-                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
+                          \n [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/
+                          [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
                         properties:
                           filters:
                             description: "Filters defined at this level should be

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -298,12 +298,7 @@ spec:
                           specified an implementation MAY infer the backend protocol
                           through its own means. Implementations MAY infer the protocol
                           from the Route type referring to the backend Service. \n
-                          Implementations MAY support Kubernetes Service BackendRefs
-                          that are multiplexing TCP and UDP on the same port. Otherwise
-                          implementations MUST set the Route ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\" Reason with a
-                          clear message that multiplexing is not supported. \n If
-                          a Route is not able to send traffic to the backend using
+                          If a Route is not able to send traffic to the backend using
                           the specified protocol then the backend is considered invalid.
                           Implementations MUST set ResolvedRefs condition to False
                           with the \"UnsupportedProtocol\". \n </gateway:experimental:description>
@@ -2636,12 +2631,7 @@ spec:
                           specified an implementation MAY infer the backend protocol
                           through its own means. Implementations MAY infer the protocol
                           from the Route type referring to the backend Service. \n
-                          Implementations MAY support Kubernetes Service BackendRefs
-                          that are multiplexing TCP and UDP on the same port. Otherwise
-                          implementations MUST set the Route ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\" Reason with a
-                          clear message that multiplexing is not supported. \n If
-                          a Route is not able to send traffic to the backend using
+                          If a Route is not able to send traffic to the backend using
                           the specified protocol then the backend is considered invalid.
                           Implementations MUST set ResolvedRefs condition to False
                           with the \"UnsupportedProtocol\". \n </gateway:experimental:description>

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -293,27 +293,21 @@ spec:
                           \n When the BackendRef points to a Kubernetes Service, implementations
                           SHOULD honor the appProtocol field if it is set for the
                           target Service Port. \n Implementations supporting appProtocol
-                          MUST recognize the Kubernetes Standard Application Protocols
-                          defined in [KEP-3726]. This supports IANA standard service
-                          names and extra constants defined in the KEP that have a
-                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
-                          constants with the prefix \"gateway.networking.k8s.io/\"
-                          \n If a Service appProtocol isn't specified an implementation
-                          MAY infer the backend protocol through its own means. Implementations
-                          MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support Kubernetes
-                          Service BackendRefs that are multiplexing TCP and UDP on
-                          the same port. Otherwise implementations MUST set the Route
-                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
-                          Reason with a clear message that multiplexing is not supported.
-                          \n If a Route is not able to send traffic to the backend
-                          using the specified protocol then the backend is considered
-                          invalid. Implementations MUST set ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\". \n Implementations
-                          MAY support different combinations of protocol/appProtocol/Route
-                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
-                          \n [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/
-                          [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
+                          SHOULD recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. \n If a Service appProtocol isn't
+                          specified an implementation MAY infer the backend protocol
+                          through its own means. Implementations MAY infer the protocol
+                          from the Route type referring to the backend Service. \n
+                          Implementations MAY support Kubernetes Service BackendRefs
+                          that are multiplexing TCP and UDP on the same port. Otherwise
+                          implementations MUST set the Route ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\" Reason with a
+                          clear message that multiplexing is not supported. \n If
+                          a Route is not able to send traffic to the backend using
+                          the specified protocol then the backend is considered invalid.
+                          Implementations MUST set ResolvedRefs condition to False
+                          with the \"UnsupportedProtocol\". \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
                         properties:
                           filters:
                             description: "Filters defined at this level should be
@@ -2637,27 +2631,21 @@ spec:
                           \n When the BackendRef points to a Kubernetes Service, implementations
                           SHOULD honor the appProtocol field if it is set for the
                           target Service Port. \n Implementations supporting appProtocol
-                          MUST recognize the Kubernetes Standard Application Protocols
-                          defined in [KEP-3726]. This supports IANA standard service
-                          names and extra constants defined in the KEP that have a
-                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
-                          constants with the prefix \"gateway.networking.k8s.io/\"
-                          \n If a Service appProtocol isn't specified an implementation
-                          MAY infer the backend protocol through its own means. Implementations
-                          MAY infer the protocol from the Route type referring to
-                          the backend Service. \n Implementations MAY support Kubernetes
-                          Service BackendRefs that are multiplexing TCP and UDP on
-                          the same port. Otherwise implementations MUST set the Route
-                          ResolvedRefs condition to False with the \"UnsupportedProtocol\"
-                          Reason with a clear message that multiplexing is not supported.
-                          \n If a Route is not able to send traffic to the backend
-                          using the specified protocol then the backend is considered
-                          invalid. Implementations MUST set ResolvedRefs condition
-                          to False with the \"UnsupportedProtocol\". \n Implementations
-                          MAY support different combinations of protocol/appProtocol/Route
-                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
-                          \n [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/
-                          [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
+                          SHOULD recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. \n If a Service appProtocol isn't
+                          specified an implementation MAY infer the backend protocol
+                          through its own means. Implementations MAY infer the protocol
+                          from the Route type referring to the backend Service. \n
+                          Implementations MAY support Kubernetes Service BackendRefs
+                          that are multiplexing TCP and UDP on the same port. Otherwise
+                          implementations MUST set the Route ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\" Reason with a
+                          clear message that multiplexing is not supported. \n If
+                          a Route is not able to send traffic to the backend using
+                          the specified protocol then the backend is considered invalid.
+                          Implementations MUST set ResolvedRefs condition to False
+                          with the \"UnsupportedProtocol\". \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols"
                         properties:
                           filters:
                             description: "Filters defined at this level should be

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -284,8 +284,35 @@ spec:
                         for Kubernetes ServiceImport \n Support: Implementation-specific
                         for any other resource \n Support for weight: Core"
                       items:
-                        description: HTTPBackendRef defines how a HTTPRoute should
-                          forward an HTTP request.
+                        description: "HTTPBackendRef defines how a HTTPRoute forwards
+                          a HTTP request. \n Note that when a namespace different
+                          than the local namespace is specified, a ReferenceGrant
+                          object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details. \n <gateway:experimental:description>
+                          \n When the BackendRef points to a Kubernetes Service, implementations
+                          SHOULD honor the appProtocol field if it is set for the
+                          target Service Port. \n Implementations supporting appProtocol
+                          MUST recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. This supports IANA standard service
+                          names and extra constants defined in the KEP that have a
+                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
+                          constants with the prefix \"gateway.networking.k8s.io/\"
+                          \n If a Service appProtocol isn't specified an implementation
+                          MAY infer the backend protocol through its own means. Implementations
+                          MAY infer the protocol from the Route type referring to
+                          the backend Service. \n Implementations MAY support multiplexing
+                          TCP and UDP on the same port. Otherwise implementations
+                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          Reason with a clear message that multiplexing is not supported.
+                          \n If a Route is not able to send traffic to the backend
+                          using the specified protocol then the backend is considered
+                          invalid. Implementations MUST set ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\". \n Implementations
+                          MAY support different combinations of protocol/appProtocol/Route
+                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
+                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
                         properties:
                           filters:
                             description: "Filters defined at this level should be
@@ -2600,8 +2627,35 @@ spec:
                         for Kubernetes ServiceImport \n Support: Implementation-specific
                         for any other resource \n Support for weight: Core"
                       items:
-                        description: HTTPBackendRef defines how a HTTPRoute should
-                          forward an HTTP request.
+                        description: "HTTPBackendRef defines how a HTTPRoute forwards
+                          a HTTP request. \n Note that when a namespace different
+                          than the local namespace is specified, a ReferenceGrant
+                          object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details. \n <gateway:experimental:description>
+                          \n When the BackendRef points to a Kubernetes Service, implementations
+                          SHOULD honor the appProtocol field if it is set for the
+                          target Service Port. \n Implementations supporting appProtocol
+                          MUST recognize the Kubernetes Standard Application Protocols
+                          defined in [KEP-3726]. This supports IANA standard service
+                          names and extra constants defined in the KEP that have a
+                          prefix of \"kubernetes.io/\". Gateway API MAY define additional
+                          constants with the prefix \"gateway.networking.k8s.io/\"
+                          \n If a Service appProtocol isn't specified an implementation
+                          MAY infer the backend protocol through its own means. Implementations
+                          MAY infer the protocol from the Route type referring to
+                          the backend Service. \n Implementations MAY support multiplexing
+                          TCP and UDP on the same port. Otherwise implementations
+                          MUST set ResolvedRefs condition to False with the \"UnsupportedProtocol\"
+                          Reason with a clear message that multiplexing is not supported.
+                          \n If a Route is not able to send traffic to the backend
+                          using the specified protocol then the backend is considered
+                          invalid. Implementations MUST set ResolvedRefs condition
+                          to False with the \"UnsupportedProtocol\". \n Implementations
+                          MAY support different combinations of protocol/appProtocol/Route
+                          Type. See [GEP-1911] for a table. \n </gateway:experimental:description>
+                          \n [KEP-3726]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3726-standard-application-protocols
+                          [GEP-1911]: https://gateway-api.sigs.k8s.io/geps/gep-1911/"
                         properties:
                           filters:
                             description: "Filters defined at this level should be

--- a/geps/gep-1911.md
+++ b/geps/gep-1911.md
@@ -36,12 +36,9 @@ Note: Kubernetes will automatically create `EndpointSlices` for `Services` that 
 
 A Gateway implementation MUST recognize the Kubernetes Standard Application Protocols ([KEP-3726][kep-3726]) for specifying the protocol for a backend reference in a Gateway API `*Route` resource
 
-Thus when a `*Route` points to a Kubernetes Service resource the backend protocol for each port can be specified by
+Thus when a `*Route` points to a Kubernetes Service, implementions SHOULD honor the appProtocol field if it
+is set for the target Service Port.
 
-- setting the `protocol` field on the Kubernetes `Service`
-- setting the `protocol` field on the `Endpoint`/`EndpointSlice` object associated with a Kubernetes `Service`
-- setting the `appProtocol` field on the Kubernetes `Service`
-- setting the `appProtocol` field on an `Endpoint`/`EndpointSlice` object associated with a Kubernetes `Service`
 
 At the moment there exists three defined constants:
 

--- a/geps/gep-1911.md
+++ b/geps/gep-1911.md
@@ -68,7 +68,7 @@ Currently Kubernetes `Service` API only allows different `appProtocol` values fo
 
 ### Supporting Protocols
 
-If a Route attached to a Gateway is not able to send traffic to the backend using the specified protocol then the backend is considered invalid. Implementations MUST set `ResolvedRefs` condition to `False` with the Reason `UnsupportedProtocol`.
+If a Route is not able to send traffic to the backend using the specified protocol then the backend is considered invalid. Implementations MUST set `ResolvedRefs` condition to `False` with the Reason `UnsupportedProtocol`.
 
 Implementations MAY support the following combinations below:
 

--- a/geps/gep-1911.md
+++ b/geps/gep-1911.md
@@ -62,7 +62,7 @@ Absence of the `appProtocol` field does not imply the implementation should disa
 
 Only the Kubernetes `Service` `protocol` field supports multiple protocols on the same port. See the details in [KEP-1435][kep-1435].
 
-Implementations MAY support multiplexing `TCP` and `UDP` on the same port. Otherwise implementations MUST set `ResolvedRefs` condition to `False` with the Reason `UnsupportedProtocol` with a clear message that multiplexing is not supported.
+Implementations MAY support Kubernetes Service BackendRefs that are multiplexing TCP and UDP on the same port. Otherwise implementations MUST set *Route ResolvedRefs condition to False with the "UnsupportedProtocol" Reason with a clear message that multiplexing is not supported.
 
 Currently Kubernetes `Service` API only allows different `appProtocol` values for the same port when `protocol` fields differs. At this time there seems to be interest in changing `appProtocol` to be a list in order to faciliate this use-case.
 

--- a/geps/gep-1911.md
+++ b/geps/gep-1911.md
@@ -38,6 +38,8 @@ A Gateway implementation MUST recognize the Kubernetes Standard Application Prot
 
 Thus when a `*Route` points to a Kubernetes Service resource the backend protocol for each port can be specified by
 
+- setting the `protocol` field on the Kubernetes `Service`
+- setting the `protocol` field on the `Endpoint`/`EndpointSlice` object associated with a Kubernetes `Service`
 - setting the `appProtocol` field on the Kubernetes `Service`
 - setting the `appProtocol` field on an `Endpoint`/`EndpointSlice` object associated with a Kubernetes `Service`
 

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -209,7 +209,7 @@ func gatewayTweaks(channel string, props map[string]apiext.JSONSchemaProps) map[
 		}
 		startTag := "<gateway:experimental:description>"
 		endTag := "</gateway:experimental:description>"
-		regexPattern := startTag + `(?s:(.*?))` + endTag
+		regexPattern := regexp.QuoteMeta(startTag) + `(?s:(.*?))` + regexp.QuoteMeta(endTag)
 		if channel == "standard" && strings.Contains(jsonProps.Description, "<gateway:experimental:description>") {
 			re := regexp.MustCompile(regexPattern)
 			match := re.FindStringSubmatch(jsonProps.Description)


### PR DESCRIPTION
/kind gep
/kind documentation

**What this PR does / why we need it**:

- This takes [GEP-1911](https://gateway-api.sigs.k8s.io/geps/gep-1911/) and updates the godoc for `BackendRef`
- Mention users can signal backend protocol using `ServicePort.protocol`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
