### PR TITLE
Update Gateway API URLRewrite tests

### DIFF
--- a/conformance/tests/httproute-rewrite-path.go
+++ b/conformance/tests/httproute-rewrite-path.go
@@ -61,6 +61,30 @@ var HTTPRouteRewritePath = suite.ConformanceTest{
 			},
 			{
 				Request: http.Request{
+					Path: "/strip-prefix/three",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/three",
+					},
+				},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path: "/strip-prefix",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/",
+					},
+				},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
 					Path: "/full/one/two",
 				},
 				ExpectedRequest: &http.ExpectedRequest{

--- a/conformance/tests/httproute-rewrite-path.yaml
+++ b/conformance/tests/httproute-rewrite-path.yaml
@@ -23,6 +23,19 @@ spec:
   - matches:
     - path:
         type: PathPrefix
+        value: /strip-prefix
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: /
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
         value: /full/one
     filters:
     - type: URLRewrite


### PR DESCRIPTION
Signed-off-by: nxyt <lolnoxy@gmail.com>

**What type of PR is this?**
/kind test
/area conformance

**What this PR does / why we need it**:
Sometimes changing path prefix and stripping it are two different things. While using cilium Gateway API implementation I've found out that it cannot strip prefixes correctly and there are no tests for such edgecases. This change adds tests for stripping path prefixes.


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
