### PR TITLE
[GEP-1911] h2c backend protocol conformance

### DIFF
--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -91,9 +91,15 @@ spec:
   selector:
     app: infra-backend-v1
   ports:
-  - protocol: TCP
+  - name: first-port
+    protocol: TCP
     port: 8080
     targetPort: 3000
+  - name: second-port
+    protocol: TCP
+    appProtocol: kubernetes.io/h2c
+    port: 8081
+    targetPort: 3001
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/conformance/tests/httproute-backend-protocol-h2c.go
+++ b/conformance/tests/httproute-backend-protocol-h2c.go
@@ -48,25 +48,8 @@ var HTTPRouteBackendProtocolH2C = suite.ConformanceTest{
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
-		// TODO - client h2c upgrade flow
-		//
-		// Go's HTTP client is unable to handle the protocol change transparently see: https://github.com/golang/go/issues/46249
-		//
-		// t.Run("h2c upgrade request should reach backend", func(t *testing.T) {
-		// 	http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
-		// 		Request: http.Request{
-		// 			Path: "/",
-		// 			Headers: map[string]string{
-		// 				"Connection":     "Upgrade, HTTP2-Settings",
-		// 				"Upgrade":        "h2c",
-		// 				"HTTP2-Settings": "",
-		// 			},
-		// 		},
-		// 		Response:  http.Response{StatusCode: 200},
-		// 		Backend:   "infra-backend-v1",
-		// 		Namespace: "gateway-conformance-infra",
-		// 	})
-		// })
+		// We are not testing the h2c HTTP upgrade mechanism as it is deprecated
+		// See: https://datatracker.ietf.org/doc/html/rfc9113#versioning
 
 		t.Run("http2 prior knowledge request should reach backend", func(t *testing.T) {
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{

--- a/conformance/tests/httproute-backend-protocol-h2c.go
+++ b/conformance/tests/httproute-backend-protocol-h2c.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteBackendProtocolH2C)
+}
+
+var HTTPRouteBackendProtocolH2C = suite.ConformanceTest{
+	ShortName:   "HTTPRouteBackendProtocolH2C",
+	Description: "A HTTPRoute with a BackendRef that has an appProtocol kubernetes.io/h2c should be functional",
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportHTTPRoute,
+		suite.SupportHTTPRouteBackendProtocolH2C,
+	},
+	Manifests: []string{
+		"tests/httproute-backend-protocol-h2c.yaml",
+	},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Name: "backend-protocol-h2c", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+
+		// TODO - client h2c upgrade flow
+		//
+		// Go's HTTP client is unable to handle the protocol change transparently see: https://github.com/golang/go/issues/46249
+		//
+		// t.Run("h2c upgrade request should reach backend", func(t *testing.T) {
+		// 	http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
+		// 		Request: http.Request{
+		// 			Path: "/",
+		// 			Headers: map[string]string{
+		// 				"Connection":     "Upgrade, HTTP2-Settings",
+		// 				"Upgrade":        "h2c",
+		// 				"HTTP2-Settings": "",
+		// 			},
+		// 		},
+		// 		Response:  http.Response{StatusCode: 200},
+		// 		Backend:   "infra-backend-v1",
+		// 		Namespace: "gateway-conformance-infra",
+		// 	})
+		// })
+
+		t.Run("http2 prior knowledge request should reach backend", func(t *testing.T) {
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
+				Request: http.Request{
+					Path:     "/",
+					Protocol: roundtripper.H2CPriorKnowledgeProtocol,
+				},
+				Response:  http.Response{StatusCode: 200},
+				Backend:   "infra-backend-v1",
+				Namespace: "gateway-conformance-infra",
+			})
+		})
+	},
+}

--- a/conformance/tests/httproute-backend-protocol-h2c.yaml
+++ b/conformance/tests/httproute-backend-protocol-h2c.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: backend-protocol-h2c
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+  # This points to a Service with the following ServicePort
+  # - protocol: TCP
+  #   appProtocol: kubernetes.io/h2c
+  #   port: 8081
+  #   targetPort: 3001
+    - name: infra-backend-v1
+      port: 8081

--- a/conformance/tests/httproute-backend-protocol-h2c.yaml
+++ b/conformance/tests/httproute-backend-protocol-h2c.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: backend-protocol-h2c

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -116,6 +116,10 @@ func MakeRequest(t *testing.T, expected *ExpectedResponse, gwAddr, protocol, sch
 		expected.Response.StatusCode = 200
 	}
 
+	if expected.Request.Protocol == "" {
+		expected.Request.Protocol = protocol
+	}
+
 	path, query, _ := strings.Cut(expected.Request.Path, "?")
 	reqURL := url.URL{Scheme: scheme, Host: CalculateHost(t, gwAddr, scheme), Path: path, RawQuery: query}
 
@@ -125,7 +129,7 @@ func MakeRequest(t *testing.T, expected *ExpectedResponse, gwAddr, protocol, sch
 		Method:           expected.Request.Method,
 		Host:             expected.Request.Host,
 		URL:              reqURL,
-		Protocol:         protocol,
+		Protocol:         expected.Request.Protocol,
 		Headers:          map[string][]string{},
 		UnfollowRedirect: expected.Request.UnfollowRedirect,
 	}

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -134,7 +134,7 @@ const (
 	// This option indicates support for HTTPRoute backendRequest timeouts (extended conformance).
 	SupportHTTPRouteBackendTimeout SupportedFeature = "HTTPRouteBackendTimeout"
 
-	// This option indicates support for HTTPRoute with a backendref with an appProtoocol 'kubernetes.io/h2c'
+	// This option indicates support for HTTPRoute with a backendref with an appProtocol 'kubernetes.io/h2c'
 	SupportHTTPRouteBackendProtocolH2C SupportedFeature = "HTTPRouteBackendProtocolH2C"
 )
 

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -133,6 +133,9 @@ const (
 
 	// This option indicates support for HTTPRoute backendRequest timeouts (extended conformance).
 	SupportHTTPRouteBackendTimeout SupportedFeature = "HTTPRouteBackendTimeout"
+
+	// This option indicates support for HTTPRoute with a backendref with an appProtoocol 'kubernetes.io/h2c'
+	SupportHTTPRouteBackendProtocolH2C SupportedFeature = "HTTPRouteBackendProtocolH2C"
 )
 
 // HTTPRouteExtendedFeatures includes all the supported features for HTTPRoute
@@ -167,6 +170,7 @@ const (
 // Implementations have the flexibility to opt-in for either specific features or the entire set.
 var HTTPRouteExperimentalFeatures = sets.New(
 	SupportHTTPRouteDestinationPortMatching,
+	SupportHTTPRouteBackendProtocolH2C,
 )
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
/kind test
/area conformance

**What this PR does / why we need it**:

This PR adds a conformance test validating implementations support h2c when the target Kubernetes Service Service Port has a `kubernetes.io/h2c` `appProtocol`

Depends on echo-basic changes which are being bumped here: https://github.com/kubernetes-sigs/gateway-api/pull/2456

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related https://github.com/kubernetes-sigs/gateway-api/issues/1911

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
