### PR TITLE
Documenting Listener Isolation in Gateway Spec

### DIFF
--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -132,6 +132,13 @@ type GatewaySpec struct {
 	// matches. For example, `"foo.example.com"` takes precedence over
 	// `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
 	//
+	// Note that requests SHOULD match at most one Listener. For example, if
+	// Listeners are defined for "foo.example.com" and "*.example.com", a
+	// request to "foo.example.com" SHOULD only be routed using routes attached
+	// to the "foo.example.com" Listener (and not the "*.example.com" Listener).
+	// This concept is known as "Listener Isolation". Implementations that do
+	// not support Listener Isolation MUST clearly document this.
+	//
 	// Implementations MAY merge separate Gateways onto a single set of
 	// Addresses if all Listeners across all Gateways are compatible.
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -217,9 +217,15 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations MAY merge separate
-                  Gateways onto a single set of Addresses if all Listeners across
-                  all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Note that requests SHOULD match
+                  at most one Listener. For example, if Listeners are defined for
+                  \"foo.example.com\" and \"*.example.com\", a request to \"foo.example.com\"
+                  SHOULD only be routed using routes attached to the \"foo.example.com\"
+                  Listener (and not the \"*.example.com\" Listener). This concept
+                  is known as \"Listener Isolation\". Implementations that do not
+                  support Listener Isolation MUST clearly document this. \n Implementations
+                  MAY merge separate Gateways onto a single set of Addresses if all
+                  Listeners across all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -1068,9 +1074,15 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations MAY merge separate
-                  Gateways onto a single set of Addresses if all Listeners across
-                  all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Note that requests SHOULD match
+                  at most one Listener. For example, if Listeners are defined for
+                  \"foo.example.com\" and \"*.example.com\", a request to \"foo.example.com\"
+                  SHOULD only be routed using routes attached to the \"foo.example.com\"
+                  Listener (and not the \"*.example.com\" Listener). This concept
+                  is known as \"Listener Isolation\". Implementations that do not
+                  support Listener Isolation MUST clearly document this. \n Implementations
+                  MAY merge separate Gateways onto a single set of Addresses if all
+                  Listeners across all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -174,9 +174,15 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations MAY merge separate
-                  Gateways onto a single set of Addresses if all Listeners across
-                  all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Note that requests SHOULD match
+                  at most one Listener. For example, if Listeners are defined for
+                  \"foo.example.com\" and \"*.example.com\", a request to \"foo.example.com\"
+                  SHOULD only be routed using routes attached to the \"foo.example.com\"
+                  Listener (and not the \"*.example.com\" Listener). This concept
+                  is known as \"Listener Isolation\". Implementations that do not
+                  support Listener Isolation MUST clearly document this. \n Implementations
+                  MAY merge separate Gateways onto a single set of Addresses if all
+                  Listeners across all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.
@@ -982,9 +988,15 @@ spec:
                   wildcard matches, and wildcard matches must be processed before
                   fallback (empty Hostname value) matches. For example, `\"foo.example.com\"`
                   takes precedence over `\"*.example.com\"`, and `\"*.example.com\"`
-                  takes precedence over `\"\"`. \n Implementations MAY merge separate
-                  Gateways onto a single set of Addresses if all Listeners across
-                  all Gateways are compatible. \n Support: Core"
+                  takes precedence over `\"\"`. \n Note that requests SHOULD match
+                  at most one Listener. For example, if Listeners are defined for
+                  \"foo.example.com\" and \"*.example.com\", a request to \"foo.example.com\"
+                  SHOULD only be routed using routes attached to the \"foo.example.com\"
+                  Listener (and not the \"*.example.com\" Listener). This concept
+                  is known as \"Listener Isolation\". Implementations that do not
+                  support Listener Isolation MUST clearly document this. \n Implementations
+                  MAY merge separate Gateways onto a single set of Addresses if all
+                  Listeners across all Gateways are compatible. \n Support: Core"
                 items:
                   description: Listener embodies the concept of a logical endpoint
                     where a Gateway accepts network connections.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
This PR is a follow up to #2416. It introduces a new concept called "Listener Isolation" to describe the recommendation that at most one Listener matches a request, and only Routes attached to that Listener are used for routing.

Originally I'd planned to consider this an "Extended" feature (see https://github.com/kubernetes-sigs/gateway-api/issues/2416#issuecomment-1731747678) but generally the idea of "Extended" and "Core" is per-field, not really a description of behavior. So instead I'm using "SHOULD" which per [RFC-2119](https://www.ietf.org/rfc/rfc2119.txt) is a recommendation and not a requirement. This does add the requirement that implementations that do not support Listener Isolation must document that.

**Which issue(s) this PR fixes**:
Related to #2416 but leaving open until conformance tests are present.

**Does this PR introduce a user-facing change?**:
```release-note
Gateway: A new concept called "Listener Isolation" has been introduced to describe the recommendation that at most one Listener matches a request, and only Routes attached to that Listener are used for routing.
```
