### PR TITLE
Adding venv for verify-yamllint

### DIFF
--- a/hack/verify-yamllint.sh
+++ b/hack/verify-yamllint.sh
@@ -23,9 +23,14 @@ readonly KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 cd "${KUBE_ROOT}"
 
+python3 -m venv .venv
+source .venv/bin/activate
+
 # See configuration file in ${KUBE_ROOT}/.yamllint.yaml.
 pip3 install yamllint==$VERSION
 
 yamllint -c .yamllint.yaml .
+
+deactivate
 
 # ex: ts=2 sw=2 et filetype=sh


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind failing-test

**What this PR does / why we need it**:
When https://github.com/kubernetes/test-infra/pull/30973 merged it broken our verify-yamllint script with the following error when the script ran `pip3 install yamllint`:

```
× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
```

This is an attempt to resolve that, alternatives welcome. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
