### PR TITLE
add verify script for docker image building + fix image building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,8 @@ image.buildx.verify:
 		docker buildx version; \
 	fi
 
-BUILDX_CONTEXT = gateway-api-builder
-BUILDX_PLATFORMS = linux/amd64,linux/arm64
+export BUILDX_CONTEXT = gateway-api-builder
+export BUILDX_PLATFORMS = linux/amd64,linux/arm64
 
 # Setup multi-arch docker buildx enviroment.
 .PHONY: image.multiarch.setup

--- a/docker/Dockerfile.echo-basic
+++ b/docker/Dockerfile.echo-basic
@@ -17,9 +17,9 @@ FROM golang:1.20.7 as builder
 
 ENV CGO_ENABLED=0
 
-WORKDIR /go/src/sigs.k8s.io/ingress-controller-conformance/
+WORKDIR /go/src/sigs.k8s.io/gateway-api/conformance/echo-basic
 
-COPY ./conformance/echo-basic/echo-basic.go ./conformance/echo-basic/go.mod ./
+COPY ./conformance/echo-basic ./
 
 RUN go build -trimpath -ldflags="-buildid= -s -w" -o echo-basic .
 
@@ -27,7 +27,7 @@ RUN go build -trimpath -ldflags="-buildid= -s -w" -o echo-basic .
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /go/src/sigs.k8s.io/ingress-controller-conformance/echo-basic /
+COPY --from=builder /go/src/sigs.k8s.io/gateway-api/conformance/echo-basic/echo-basic /
 USER nonroot:nonroot
 
 ENTRYPOINT ["/echo-basic"]

--- a/docker/Dockerfile.echo-basic
+++ b/docker/Dockerfile.echo-basic
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build
-FROM golang:1.20.7 as builder
+FROM golang:1.21.3 as builder
 
 ENV CGO_ENABLED=0
 

--- a/docker/Dockerfile.webhook
+++ b/docker/Dockerfile.webhook
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BUILDPLATFORM=linux/amd64
-FROM --platform=$BUILDPLATFORM golang:1.20.7 AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.21.3 AS build-env
 RUN mkdir -p /go/src/sig.k8s.io/gateway-api
 WORKDIR /go/src/sig.k8s.io/gateway-api
 COPY  . .

--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -20,6 +20,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ -z "${VERIFY-}" ]];
+then
+  export DOCKER_PUSH_FLAG="--push"
+else
+  export DOCKER_PUSH_FLAG=""
+fi
+
 if [[ -z "${GIT_TAG-}" ]];
 then
     echo "GIT_TAG env var must be set and nonempty."
@@ -43,6 +50,8 @@ then
     echo "REGISTRY env var must be set and nonempty."
     exit 1
 fi
+
+
 
 # If our base ref == "main" then we will tag :latest.
 VERSION_TAG=latest
@@ -77,7 +86,7 @@ docker buildx build \
     --build-arg "COMMIT=${COMMIT}" \
     --build-arg "TAG=${BINARY_TAG}" \
     --platform ${BUILDX_PLATFORMS} \
-    --push \
+    ${DOCKER_PUSH_FLAG} \
     -f docker/Dockerfile.webhook \
     .
 
@@ -87,7 +96,7 @@ docker buildx build \
     -t ${REGISTRY}/echo-advanced:${GIT_TAG} \
     -t ${REGISTRY}/echo-advanced:${VERSION_TAG} \
     --platform ${BUILDX_PLATFORMS} \
-    --push \
+    ${DOCKER_PUSH_FLAG} \
     -f docker/Dockerfile.echo-advanced \
     .
 
@@ -97,6 +106,6 @@ docker buildx build \
     -t ${REGISTRY}/echo-basic:${GIT_TAG} \
     -t ${REGISTRY}/echo-basic:${VERSION_TAG} \
     --platform ${BUILDX_PLATFORMS} \
-    --push \
+    ${DOCKER_PUSH_FLAG} \
     -f docker/Dockerfile.echo-basic \
     .

--- a/hack/verify-docker-build.sh
+++ b/hack/verify-docker-build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+echo "Verifying docker images"
+
+docker buildx rm ${BUILDX_CONTEXT} || true
+docker buildx create --use --name ${BUILDX_CONTEXT} --platform "${BUILDX_PLATFORMS}"
+
+VERIFY=true ./hack/build-and-push.sh
+


### PR DESCRIPTION
**What type of PR is this?**

testgrid failed building the echo-basic image because of the Dockerfile didn't copy the `go.sum` file into the build container. 

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-gateway-api-push-images/1712549846159724544

Our Verify script should have caught this

/kind test
/kind build
/kind cleanup


**What this PR does / why we need it**:

This PR tweaks the docker build script to allow it to just build and not push. We then added a verify command to test the docker build.

Once we confirm the failure happens in pre-submit - I'll update the PR to include the fixes we need.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
