### PR TITLE
Conformance: Adds Test to Exercise Gateway AttachedRoutes

### DIFF
--- a/conformance/tests/gateway-with-attached-routes.go
+++ b/conformance/tests/gateway-with-attached-routes.go
@@ -36,6 +36,7 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 	Description: "A Gateway in the gateway-conformance-infra namespace should be attached to routes.",
 	Features: []suite.SupportedFeature{
 		suite.SupportGateway,
+		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/gateway-with-attached-routes.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
@@ -90,6 +91,52 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 
 			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
 		})
+
+		t.Run("Gateway listener should have AttachedRoutes set even when Gateway has unresolved refs", func(t *testing.T) {
+			gwNN := types.NamespacedName{Name: "unresolved-gateway-with-one-attached-unresolved-route", Namespace: "gateway-conformance-infra"}
+			listeners := []v1.ListenerStatus{{
+				Name: v1.SectionName("tls"),
+				SupportedKinds: []v1.RouteGroupKind{{
+					Group: (*v1.Group)(&v1.GroupVersion.Group),
+					Kind:  v1.Kind("HTTPRoute"),
+				}},
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(v1.ListenerConditionAccepted),
+						Status: metav1.ConditionTrue,
+						Reason: "", // any reason
+					},
+					{
+						Type:   string(v1.ListenerConditionProgrammed),
+						Status: metav1.ConditionFalse,
+						Reason: "", // any reason
+					},
+					{
+						Type:   string(v1.ListenerConditionResolvedRefs),
+						Status: metav1.ConditionFalse,
+						Reason: "", // any reason
+					},
+				},
+				AttachedRoutes: 1,
+			}}
+
+			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
+
+			hrouteNN := types.NamespacedName{Name: "http-route-4", Namespace: "gateway-conformance-infra"}
+			notAccepted := metav1.Condition{
+				Type:   string(v1.RouteConditionAccepted),
+				Status: metav1.ConditionTrue,
+				Reason: "", // any reason
+			}
+			unresolved := metav1.Condition{
+				Type:   string(v1.RouteConditionResolvedRefs),
+				Status: metav1.ConditionFalse,
+				Reason: "", // any reason
+			}
+
+			kubernetes.HTTPRouteMustHaveCondition(t, s.Client, s.TimeoutConfig, hrouteNN, gwNN, notAccepted)
+			kubernetes.HTTPRouteMustHaveCondition(t, s.Client, s.TimeoutConfig, hrouteNN, gwNN, unresolved)
+		})
 	},
 }
 
@@ -99,6 +146,7 @@ var GatewayWithAttachedRoutesWithPort8080 = suite.ConformanceTest{
 	Features: []suite.SupportedFeature{
 		suite.SupportGateway,
 		suite.SupportGatewayPort8080,
+		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/gateway-with-attached-routes-with-port-8080.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {

--- a/conformance/tests/gateway-with-attached-routes.yaml
+++ b/conformance/tests/gateway-with-attached-routes.yaml
@@ -86,3 +86,47 @@ spec:
   - backendRefs:
     - name: infra-backend-v1
       port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: unresolved-gateway-with-one-attached-unresolved-route
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: tls
+    port: 443
+    protocol: HTTPS
+    allowedRoutes:
+      kinds:
+      - kind: HTTPRoute
+      namespaces:
+        from: Selector
+        selector:
+          matchLabels:
+            # This label is added automatically as of K8s 1.22
+            # to all namespaces
+            kubernetes.io/metadata.name: gateway-conformance-infra
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: does-not-exist
+      mode: Terminate
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: http-route-4
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - kind: Gateway
+    name: unresolved-gateway-with-one-attached-unresolved-route
+    namespace: gateway-conformance-infra
+    sectionName: tls
+  rules:
+  - backendRefs:
+    - name: does-not-exist
+      port: 8080


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind test

Optionally add one or more of the following kinds if applicable:
/area conformance

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #2402

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
