### PR TITLE
Include make target for bumping echo-basic & advanced in our conformance files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,10 @@ verify:
 docs:
 	hack/make-docs.sh
 
+.PHONY: update-conformance-image-refs
+update-conformance-image-refs:
+	hack/update-conformance-image-refs.sh
+
 # Verify if support Docker Buildx.
 .PHONY: image.buildx.verify
 image.buildx.verify:

--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -115,7 +115,7 @@ spec:
       containers:
       - name: infra-backend-v1
         # From https://github.com/kubernetes-sigs/ingress-controller-conformance/tree/master/images/echoserver
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231005-v0.8.1-68-gd4ff2d4f
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
         env:
         - name: POD_NAME
           valueFrom:
@@ -161,7 +161,7 @@ spec:
     spec:
       containers:
       - name: infra-backend-v2
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231005-v0.8.1-68-gd4ff2d4f
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
         env:
         - name: POD_NAME
           valueFrom:
@@ -207,7 +207,7 @@ spec:
     spec:
       containers:
       - name: infra-backend-v3
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231005-v0.8.1-68-gd4ff2d4f
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
         env:
         - name: POD_NAME
           valueFrom:
@@ -253,7 +253,7 @@ spec:
     spec:
       containers:
       - name: tls-backend
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231005-v0.8.1-68-gd4ff2d4f
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
         volumeMounts:
         - name: secret-volume
           mountPath: /etc/secret-volume
@@ -322,7 +322,7 @@ spec:
     spec:
       containers:
       - name: tls-backend
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231005-v0.8.1-68-gd4ff2d4f
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
         volumeMounts:
         - name: secret-volume
           mountPath: /etc/secret-volume
@@ -384,7 +384,7 @@ spec:
     spec:
       containers:
       - name: app-backend-v1
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231005-v0.8.1-68-gd4ff2d4f
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
         env:
         - name: POD_NAME
           valueFrom:
@@ -430,7 +430,7 @@ spec:
     spec:
       containers:
       - name: app-backend-v2
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231005-v0.8.1-68-gd4ff2d4f
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
         env:
         - name: POD_NAME
           valueFrom:
@@ -483,7 +483,7 @@ spec:
     spec:
       containers:
       - name: web-backend
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231005-v0.8.1-68-gd4ff2d4f
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
         env:
         - name: POD_NAME
           valueFrom:

--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -115,7 +115,7 @@ spec:
       containers:
       - name: infra-backend-v1
         # From https://github.com/kubernetes-sigs/ingress-controller-conformance/tree/master/images/echoserver
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-133-g3959576a
         env:
         - name: POD_NAME
           valueFrom:
@@ -161,7 +161,7 @@ spec:
     spec:
       containers:
       - name: infra-backend-v2
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-133-g3959576a
         env:
         - name: POD_NAME
           valueFrom:
@@ -207,7 +207,7 @@ spec:
     spec:
       containers:
       - name: infra-backend-v3
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-133-g3959576a
         env:
         - name: POD_NAME
           valueFrom:
@@ -253,7 +253,7 @@ spec:
     spec:
       containers:
       - name: tls-backend
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-133-g3959576a
         volumeMounts:
         - name: secret-volume
           mountPath: /etc/secret-volume
@@ -322,7 +322,7 @@ spec:
     spec:
       containers:
       - name: tls-backend
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-133-g3959576a
         volumeMounts:
         - name: secret-volume
           mountPath: /etc/secret-volume
@@ -384,7 +384,7 @@ spec:
     spec:
       containers:
       - name: app-backend-v1
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-133-g3959576a
         env:
         - name: POD_NAME
           valueFrom:
@@ -430,7 +430,7 @@ spec:
     spec:
       containers:
       - name: app-backend-v2
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-133-g3959576a
         env:
         - name: POD_NAME
           valueFrom:
@@ -483,7 +483,7 @@ spec:
     spec:
       containers:
       - name: web-backend
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-125-gd9014aa2
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231013-v0.8.1-133-g3959576a
         env:
         - name: POD_NAME
           valueFrom:

--- a/conformance/mesh/manifests.yaml
+++ b/conformance/mesh/manifests.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: echo
-        image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20231005-v0.8.1-68-gd4ff2d4f
+        image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20231013-v0.8.1-125-gd9014aa2
         imagePullPolicy: IfNotPresent
         args:
         - --tcp=9090
@@ -82,7 +82,7 @@ spec:
     spec:
       containers:
       - name: echo
-        image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20231005-v0.8.1-68-gd4ff2d4f
+        image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20231013-v0.8.1-125-gd9014aa2
         imagePullPolicy: IfNotPresent
         args:
         - --tcp=9090
@@ -168,5 +168,5 @@ spec:
     spec:
       containers:
       - name: echo
-        image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20231005-v0.8.1-68-gd4ff2d4f
+        image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20231013-v0.8.1-125-gd9014aa2
         imagePullPolicy: IfNotPresent

--- a/conformance/mesh/manifests.yaml
+++ b/conformance/mesh/manifests.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: echo
-        image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20231013-v0.8.1-125-gd9014aa2
+        image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20231013-v0.8.1-133-g3959576a
         imagePullPolicy: IfNotPresent
         args:
         - --tcp=9090
@@ -82,7 +82,7 @@ spec:
     spec:
       containers:
       - name: echo
-        image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20231013-v0.8.1-125-gd9014aa2
+        image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20231013-v0.8.1-133-g3959576a
         imagePullPolicy: IfNotPresent
         args:
         - --tcp=9090
@@ -168,5 +168,5 @@ spec:
     spec:
       containers:
       - name: echo
-        image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20231013-v0.8.1-125-gd9014aa2
+        image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20231013-v0.8.1-133-g3959576a
         imagePullPolicy: IfNotPresent

--- a/hack/update-conformance-image-refs.sh
+++ b/hack/update-conformance-image-refs.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Wrap sed to deal with GNU and BSD sed flags.
+run::sed() {
+    local -r vers="$(sed --version < /dev/null 2>&1 | grep -q GNU && echo gnu || echo bsd)"
+    case "$vers" in
+        gnu) sed -i "$@" ;;
+        *) sed -i '' "$@" ;;
+esac
+}
+
+IMAGES=(
+  gcr.io/k8s-staging-gateway-api/echo-basic
+)
+
+# Export so we can use run::sed in subshells
+# https://stackoverflow.com/questions/4321456/find-exec-a-shell-function-in-linux
+export -f run::sed
+
+for IMAGE in ${IMAGES[@]}; do
+  echo "Fetching latest tags for $IMAGE"
+  TAG_FILE=$(mktemp)
+  go run github.com/google/go-containerregistry/cmd/gcrane@latest ls "$IMAGE" --json \
+    | jq -r '.tags[]' \
+    | grep -v latest \
+    | sort -rV \
+    | head -n1 > "$TAG_FILE"
+
+  export IMAGE_TAG=$(cat "$TAG_FILE")
+  export IMAGE
+  echo "Found tag $IMAGE_TAG - updating manifests..."
+  find . -type f -name "*.yaml" -exec bash -c 'run::sed -e "s,image:.*echo-basic.*$,image: ${IMAGE}:${IMAGE_TAG},g" "$0"' {} \;
+done
+
+

--- a/hack/update-conformance-image-refs.sh
+++ b/hack/update-conformance-image-refs.sh
@@ -29,7 +29,8 @@ esac
 }
 
 IMAGES=(
-  gcr.io/k8s-staging-gateway-api/echo-basic
+ gcr.io/k8s-staging-gateway-api/echo-advanced
+ gcr.io/k8s-staging-gateway-api/echo-basic
 )
 
 # Export so we can use run::sed in subshells
@@ -48,7 +49,7 @@ for IMAGE in ${IMAGES[@]}; do
   export IMAGE_TAG=$(cat "$TAG_FILE")
   export IMAGE
   echo "Found tag $IMAGE_TAG - updating manifests..."
-  find . -type f -name "*.yaml" -exec bash -c 'run::sed -e "s,image:.*echo-basic.*$,image: ${IMAGE}:${IMAGE_TAG},g" "$0"' {} \;
+  find . -type f -name "*.yaml" -exec bash -c 'run::sed -e "s,image:.*${IMAGE}.*$,image: ${IMAGE}:${IMAGE_TAG},g" "$0"' {} \;
 done
 
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/area conformance
/kind test

**What this PR does / why we need it**:

This PR introduces a new make target - `update-conformance-image-refs` it will trigger a new bash script that will update the `echo-basic` & `echo-advanced` to the latest tag (sorted by semver)

I'm including the output of running the script - which is bumping both images to the latest semver tag

I also fixed the mesh yamls to use echo-advanced instead of basic - that was introduced in https://github.com/kubernetes-sigs/gateway-api/pull/2468/files

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Update mesh conformance to point to the correct images
```
