### PR TITLE
conformance: use echo-advanced in Mesh tests, echo-basic no longer has a client

### DIFF
--- a/conformance/mesh/manifests.yaml
+++ b/conformance/mesh/manifests.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: echo
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231005-v0.8.1-68-gd4ff2d4f
+        image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20231005-v0.8.1-68-gd4ff2d4f
         imagePullPolicy: IfNotPresent
         args:
         - --tcp=9090
@@ -82,7 +82,7 @@ spec:
     spec:
       containers:
       - name: echo
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231005-v0.8.1-68-gd4ff2d4f
+        image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20231005-v0.8.1-68-gd4ff2d4f
         imagePullPolicy: IfNotPresent
         args:
         - --tcp=9090
@@ -168,5 +168,5 @@ spec:
     spec:
       containers:
       - name: echo
-        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231005-v0.8.1-68-gd4ff2d4f
+        image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20231005-v0.8.1-68-gd4ff2d4f
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind bug
/area conformance

**What this PR does / why we need it**:

Reverts changes to the Mesh Pod containers in https://github.com/kubernetes-sigs/gateway-api/pull/2468. The new `echo-basic` doesn't have the `client` binary used to send requests from one `Pod` to another:

```
pod.go:65: Request [client http://echo-v1:8080 --method=GET] failed, not ready yet: Internal error occurred: error executing command in container: failed to exec in container: failed to start exec "814909cdd391efe031b521d0ff0285e21590fa08c2a40b7b61d85edc3577f2fe": OCI runtime exec failed: exec failed: unable to start container process: exec: "client": executable file not found in $PATH: unknown (after 27.225µs)
```

**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
None
```
