### PR TITLE
Fix timeouts conformance tests

### DIFF
--- a/conformance/tests/httproute-timeout-backend-request.go
+++ b/conformance/tests/httproute-timeout-backend-request.go
@@ -52,11 +52,13 @@ var HTTPRouteTimeoutBackendRequest = suite.ConformanceTest{
 
 		testCases := []http.ExpectedResponse{
 			{
-				Request:  http.Request{Path: "/backend-timeout"},
-				Response: http.Response{StatusCode: 200},
+				Request:   http.Request{Path: "/backend-timeout"},
+				Response:  http.Response{StatusCode: 200},
+				Namespace: ns,
 			}, {
-				Request:  http.Request{Path: "/backend-timeout?delay=1s"},
-				Response: http.Response{StatusCode: 504},
+				Request:   http.Request{Path: "/backend-timeout?delay=1s"},
+				Response:  http.Response{StatusCode: 504},
+				Namespace: ns,
 			},
 		}
 

--- a/conformance/tests/httproute-timeout-request.go
+++ b/conformance/tests/httproute-timeout-request.go
@@ -52,11 +52,13 @@ var HTTPRouteTimeoutRequest = suite.ConformanceTest{
 
 		testCases := []http.ExpectedResponse{
 			{
-				Request:  http.Request{Path: "/request-timeout"},
-				Response: http.Response{StatusCode: 200},
+				Request:   http.Request{Path: "/request-timeout"},
+				Response:  http.Response{StatusCode: 200},
+				Namespace: ns,
 			}, {
-				Request:  http.Request{Path: "/request-timeout?delay=1s"},
-				Response: http.Response{StatusCode: 504},
+				Request:   http.Request{Path: "/request-timeout?delay=1s"},
+				Response:  http.Response{StatusCode: 504},
+				Namespace: ns,
 			},
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind bug
/kind conformance

**What this PR does / why we need it**:

This is a followup to  #2254 
When I switched to use the backend-v1 for the test service, the tests were no longer passing. Sorry, I forgot to mark 2254 with `do-not-merge` but this followup fixes the problem. Tests pass again (tested with Istio).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
