### PR TITLE
conformance: revert ver to v1beta1 for RefGrant

### DIFF
--- a/conformance/tests/gateway-secret-invalid-reference-grant.yaml
+++ b/conformance/tests/gateway-secret-invalid-reference-grant.yaml
@@ -19,7 +19,7 @@ spec:
             name: certificate
             namespace: gateway-conformance-web-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-namespace
@@ -34,7 +34,7 @@ spec:
       kind: Secret
       name: certificate
 ---
-apiVersion: gateway.networking.k8s.io/v1
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-from-group
@@ -49,7 +49,7 @@ spec:
       kind: Secret
       name: certificate
 ---
-apiVersion: gateway.networking.k8s.io/v1
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-from-kind
@@ -64,7 +64,7 @@ spec:
       kind: Secret
       name: certificate
 ---
-apiVersion: gateway.networking.k8s.io/v1
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-from-namespace
@@ -79,7 +79,7 @@ spec:
       kind: Secret
       name: certificate
 ---
-apiVersion: gateway.networking.k8s.io/v1
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-to-group
@@ -94,7 +94,7 @@ spec:
       kind: Secret
       name: not-the-certificate-youre-looking-for
 ---
-apiVersion: gateway.networking.k8s.io/v1
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-to-kind
@@ -109,7 +109,7 @@ spec:
       kind: Service
       name: certificate
 ---
-apiVersion: gateway.networking.k8s.io/v1
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-to-name


### PR DESCRIPTION
ReferenceGrant's version was moved to `v1` as a mistake in the conformance test YAML

Relates to https://github.com/kubernetes-sigs/gateway-api/pull/2486

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Fixes the API version for `ReferenceGrant` from `v1` to `v1beta1` in the `GatewaySecretInvalidReferenceGrant` conformance test YAML
```
