### PR TITLE
[GEP-1911] websocket backend protocol conformance

### DIFF
--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -100,6 +100,11 @@ spec:
     appProtocol: kubernetes.io/h2c
     port: 8081
     targetPort: 3001
+  - name: third-port
+    protocol: TCP
+    appProtocol: kubernetes.io/ws
+    port: 8082
+    targetPort: 3000
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/conformance/echo-basic/echo-basic.go
+++ b/conformance/echo-basic/echo-basic.go
@@ -135,6 +135,8 @@ func main() {
 
 func wsHandler(ws *websocket.Conn) {
 	fmt.Println("established websocket connection", ws.RemoteAddr())
+	// Echo websocket frames from the connection back to the client
+	// until io.EOF
 	io.Copy(ws, ws)
 }
 

--- a/conformance/tests/httproute-backend-protocol-ws.go
+++ b/conformance/tests/httproute-backend-protocol-ws.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"golang.org/x/net/websocket"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests,
+		HTTPRouteBackendProtocolWebSocket,
+	)
+}
+
+var HTTPRouteBackendProtocolWebSocket = suite.ConformanceTest{
+	ShortName:   "HTTPRouteBackendProtocolWebSocket",
+	Description: "A HTTPRoute with a BackendRef that has an appProtocol kubernetes.io/ws should be functional",
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportHTTPRoute,
+		suite.SupportHTTPRouteBackendProtocolWebSocket,
+	},
+	Manifests: []string{
+		"tests/httproute-backend-protocol-ws.yaml",
+	},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Name: "backend-protocol-ws", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+
+		threshold := suite.TimeoutConfig.RequiredConsecutiveSuccesses
+		maxTimeToConsistency := suite.TimeoutConfig.MaxTimeToConsistency
+
+		t.Run("websocket connection should reach backend", func(t *testing.T) {
+			http.AwaitConvergence(t, threshold, maxTimeToConsistency, func(elapsed time.Duration) bool {
+				origin := fmt.Sprintf("ws://gateway/%s", t.Name())
+				remote := fmt.Sprintf("ws://%s/ws", gwAddr)
+
+				ws, err := websocket.Dial(remote, "", origin)
+				if err != nil {
+					t.Log("failed to dial", err)
+					return false
+				}
+				defer ws.Close()
+
+				// Send text frame
+				var (
+					textMessage = "Websocket Support!"
+					textReply   string
+				)
+				if err := websocket.Message.Send(ws, textMessage); err != nil {
+					t.Log("failed to send text frame", err)
+					return false
+				}
+				if err := websocket.Message.Receive(ws, &textReply); err != nil {
+					t.Log("failed to receive text frame", err)
+					return false
+				}
+				if textMessage != textReply {
+					t.Logf("unexpected reply - want: %s got: %s", textMessage, textReply)
+					return false
+				}
+
+				// Send byte frame
+				var (
+					binaryMessage = []byte{1, 2, 3, 4, 5, 6, 7}
+					binaryReply   []byte
+				)
+				if err := websocket.Message.Send(ws, binaryMessage); err != nil {
+					t.Log("failed to send binary frame", err)
+					return false
+				}
+				if err := websocket.Message.Receive(ws, &binaryReply); err != nil {
+					t.Log("failed to receive binary frame", err)
+				}
+				if !bytes.Equal(binaryMessage, binaryReply) {
+					t.Logf("unexpected reply - want: %#v got: %#v", binaryMessage, binaryReply)
+					return false
+				}
+				return true
+			})
+		})
+	},
+}

--- a/conformance/tests/httproute-backend-protocol-ws.yaml
+++ b/conformance/tests/httproute-backend-protocol-ws.yaml
@@ -13,6 +13,6 @@ spec:
     #   appProtocol: kubernetes.io/ws
     #   protocol: TCP
     #   port: 8082
-    # targetPort: 3000
+    #   targetPort: 3000
     - name: infra-backend-v1
       port: 8082

--- a/conformance/tests/httproute-backend-protocol-ws.yaml
+++ b/conformance/tests/httproute-backend-protocol-ws.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-protocol-ws
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    # This points to a Service with the following ServicePort
+    # - name: third-port
+    #   appProtocol: kubernetes.io/ws
+    #   protocol: TCP
+    #   port: 8082
+    # targetPort: 3000
+    - name: infra-backend-v1
+      port: 8082

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -136,6 +136,9 @@ const (
 
 	// This option indicates support for HTTPRoute with a backendref with an appProtocol 'kubernetes.io/h2c'
 	SupportHTTPRouteBackendProtocolH2C SupportedFeature = "HTTPRouteBackendProtocolH2C"
+
+	// This option indicates support for HTTPRoute with a backendref with an appProtoocol 'kubernetes.io/ws'
+	SupportHTTPRouteBackendProtocolWebSocket SupportedFeature = "HTTPRouteBackendProtocolWebSocket"
 )
 
 // HTTPRouteExtendedFeatures includes all the supported features for HTTPRoute
@@ -171,6 +174,7 @@ const (
 var HTTPRouteExperimentalFeatures = sets.New(
 	SupportHTTPRouteDestinationPortMatching,
 	SupportHTTPRouteBackendProtocolH2C,
+	SupportHTTPRouteBackendProtocolWebSocket,
 )
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION

/kind test
/area conformance

**What this PR does / why we need it**:

This PR adds a conformance test validating implementations support websocket over cleartext when the target Kubernetes Service Service Port has a `kubernetes.io/ws` `appProtocol`

This PR includes echo-basic changes so it will need to bumped after this PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related https://github.com/kubernetes-sigs/gateway-api/issues/1911 https://github.com/kubernetes-sigs/gateway-api/issues/205

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
