### PR TITLE
Adds +optional Marker to GatewayInfrastructure Fields

### DIFF
--- a/apis/v1/gateway_types.go
+++ b/apis/v1/gateway_types.go
@@ -636,6 +636,8 @@ type GatewayInfrastructure struct {
 	// An implementation may chose to add additional implementation-specific labels as they see fit.
 	//
 	// Support: Extended
+	//
+	// +optional
 	// +kubebuilder:validation:MaxProperties=8
 	Labels map[AnnotationKey]AnnotationValue `json:"labels,omitempty"`
 
@@ -647,6 +649,8 @@ type GatewayInfrastructure struct {
 	// An implementation may chose to add additional implementation-specific annotations as they see fit.
 	//
 	// Support: Extended
+	//
+	// +optional
 	// +kubebuilder:validation:MaxProperties=8
 	Annotations map[AnnotationKey]AnnotationValue `json:"annotations,omitempty"`
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds the `+optional` Marker to GatewayInfrastructure fields. These fields are optional and therefore should include this marker.

**Which issue(s) this PR fixes**:
Fixes #2509 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
