### PR TITLE
Marking SupportedVersion as experimental

### DIFF
--- a/apis/v1/gatewayclass_types.go
+++ b/apis/v1/gatewayclass_types.go
@@ -216,6 +216,8 @@ const (
 	//
 	// Controllers should prefer to use the values of GatewayClassConditionReason
 	// for the corresponding Reason, where appropriate.
+	//
+	// <gateway:experimental>
 	GatewayClassConditionStatusSupportedVersion GatewayClassConditionType = "SupportedVersion"
 
 	// This reason is used with the "SupportedVersion" condition when the


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Although this was only a new condition, it feels strange to add it immediately to a GA API without any soak period. This is not really going to have any affect on CRD generation or generated clients, this really just is meant to signal that details of the condition could still change and it does not yet have GA stabililty.

**Does this PR introduce a user-facing change?**:
```release-note
GatewayClass "SupportedVersion" condition has been formally marked as experimental.
```
