### PR TITLE
Fix bugs in GatewayWithAttachedRoutes

### DIFF
--- a/conformance/tests/gateway-with-attached-routes.go
+++ b/conformance/tests/gateway-with-attached-routes.go
@@ -102,11 +102,6 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 				}},
 				Conditions: []metav1.Condition{
 					{
-						Type:   string(v1.ListenerConditionAccepted),
-						Status: metav1.ConditionTrue,
-						Reason: "", // any reason
-					},
-					{
 						Type:   string(v1.ListenerConditionProgrammed),
 						Status: metav1.ConditionFalse,
 						Reason: "", // any reason
@@ -125,7 +120,7 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 			hrouteNN := types.NamespacedName{Name: "http-route-4", Namespace: "gateway-conformance-infra"}
 			notAccepted := metav1.Condition{
 				Type:   string(v1.RouteConditionAccepted),
-				Status: metav1.ConditionTrue,
+				Status: metav1.ConditionFalse,
 				Reason: "", // any reason
 			}
 			unresolved := metav1.Condition{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind test

Optionally add one or more of the following kinds if applicable:
/kind failing-test
/area conformance
-->

**What this PR does / why we need it**:

* Set status to `False` for `notAccepted` Route condition

* Remove `Accepted` condition from `status.listeners[0].conditions` since it is not mandatory for the `Accepted` condition to be set. In this case the `ResolvedRefs=False` due to `InvalidCertificateRef` so an implementation may choose to not generate any listener config

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Also Fixes # https://github.com/kubernetes-sigs/gateway-api/issues/2526

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Fixed the status condition requirements in the `GatewayWithAttachedRoutes` test
```
