### PR TITLE
Check listeners conditions serially

### DIFF
--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -44,9 +44,9 @@ type TimeoutConfig struct {
 	// Max value for conformant implementation: None
 	GatewayStatusMustHaveListeners time.Duration
 
-	// GatewayListenersMustHaveCondition represents the maximum time for a Gateway to have all listeners with a specific condition.
+	// GatewayListenersMustHaveConditions represents the maximum time for a Gateway to have all listeners with a specific condition.
 	// Max value for conformant implementation: None
-	GatewayListenersMustHaveCondition time.Duration
+	GatewayListenersMustHaveConditions time.Duration
 
 	// GWCMustBeAccepted represents the maximum time for a GatewayClass to have an Accepted condition set to true.
 	// Max value for conformant implementation: None
@@ -100,24 +100,24 @@ type TimeoutConfig struct {
 // DefaultTimeoutConfig populates a TimeoutConfig with the default values.
 func DefaultTimeoutConfig() TimeoutConfig {
 	return TimeoutConfig{
-		CreateTimeout:                     60 * time.Second,
-		DeleteTimeout:                     10 * time.Second,
-		GetTimeout:                        10 * time.Second,
-		GatewayMustHaveAddress:            180 * time.Second,
-		GatewayMustHaveCondition:          180 * time.Second,
-		GatewayStatusMustHaveListeners:    60 * time.Second,
-		GatewayListenersMustHaveCondition: 60 * time.Second,
-		GWCMustBeAccepted:                 180 * time.Second,
-		HTTPRouteMustNotHaveParents:       60 * time.Second,
-		HTTPRouteMustHaveCondition:        60 * time.Second,
-		TLSRouteMustHaveCondition:         60 * time.Second,
-		RouteMustHaveParents:              60 * time.Second,
-		ManifestFetchTimeout:              10 * time.Second,
-		MaxTimeToConsistency:              30 * time.Second,
-		NamespacesMustBeReady:             300 * time.Second,
-		RequestTimeout:                    10 * time.Second,
-		LatestObservedGenerationSet:       60 * time.Second,
-		RequiredConsecutiveSuccesses:      3,
+		CreateTimeout:                      60 * time.Second,
+		DeleteTimeout:                      10 * time.Second,
+		GetTimeout:                         10 * time.Second,
+		GatewayMustHaveAddress:             180 * time.Second,
+		GatewayMustHaveCondition:           180 * time.Second,
+		GatewayStatusMustHaveListeners:     60 * time.Second,
+		GatewayListenersMustHaveConditions: 60 * time.Second,
+		GWCMustBeAccepted:                  180 * time.Second,
+		HTTPRouteMustNotHaveParents:        60 * time.Second,
+		HTTPRouteMustHaveCondition:         60 * time.Second,
+		TLSRouteMustHaveCondition:          60 * time.Second,
+		RouteMustHaveParents:               60 * time.Second,
+		ManifestFetchTimeout:               10 * time.Second,
+		MaxTimeToConsistency:               30 * time.Second,
+		NamespacesMustBeReady:              300 * time.Second,
+		RequestTimeout:                     10 * time.Second,
+		LatestObservedGenerationSet:        60 * time.Second,
+		RequiredConsecutiveSuccesses:       3,
 	}
 }
 
@@ -141,8 +141,8 @@ func SetupTimeoutConfig(timeoutConfig *TimeoutConfig) {
 	if timeoutConfig.GatewayStatusMustHaveListeners == 0 {
 		timeoutConfig.GatewayStatusMustHaveListeners = defaultTimeoutConfig.GatewayStatusMustHaveListeners
 	}
-	if timeoutConfig.GatewayListenersMustHaveCondition == 0 {
-		timeoutConfig.GatewayListenersMustHaveCondition = defaultTimeoutConfig.GatewayListenersMustHaveCondition
+	if timeoutConfig.GatewayListenersMustHaveConditions == 0 {
+		timeoutConfig.GatewayListenersMustHaveConditions = defaultTimeoutConfig.GatewayListenersMustHaveConditions
 	}
 	if timeoutConfig.GWCMustBeAccepted == 0 {
 		timeoutConfig.GWCMustBeAccepted = defaultTimeoutConfig.GWCMustBeAccepted

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -24,7 +24,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -72,12 +71,12 @@ func NewGatewayRef(nn types.NamespacedName, listenerNames ...string) GatewayRef 
 	}
 }
 
-// GWCMustBeAcceptedConditionTrue waits until the specified GatewayClass has an Accepted condition set with a status value equal to True.
+// GWCMustHaveAcceptedConditionTrue waits until the specified GatewayClass has an Accepted condition set with a status value equal to True.
 func GWCMustHaveAcceptedConditionTrue(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, gwcName string) string {
 	return gwcMustBeAccepted(t, c, timeoutConfig, gwcName, string(metav1.ConditionTrue))
 }
 
-// GWCMustBeAcceptedConditionAny waits until the specified GatewayClass has an Accepted condition set with a status set to any value.
+// GWCMustHaveAcceptedConditionAny waits until the specified GatewayClass has an Accepted condition set with a status set to any value.
 func GWCMustHaveAcceptedConditionAny(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, gwcName string) string {
 	return gwcMustBeAccepted(t, c, timeoutConfig, gwcName, "")
 }
@@ -429,34 +428,25 @@ func WaitForGatewayAddress(t *testing.T, client client.Client, timeoutConfig con
 func GatewayListenersMustHaveConditions(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, gwName types.NamespacedName, conditions []metav1.Condition) {
 	t.Helper()
 
-	var wg sync.WaitGroup
-	wg.Add(len(conditions))
+	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.GatewayListenersMustHaveConditions, true, func(ctx context.Context) (bool, error) {
+		var gw gatewayv1.Gateway
+		if err := client.Get(ctx, gwName, &gw); err != nil {
+			return false, fmt.Errorf("error fetching Gateway: %w", err)
+		}
 
-	for _, condition := range conditions {
-		go func(condition metav1.Condition) {
-			defer wg.Done()
-
-			waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.GatewayListenersMustHaveCondition, true, func(ctx context.Context) (bool, error) {
-				var gw gatewayv1.Gateway
-				if err := client.Get(ctx, gwName, &gw); err != nil {
-					return false, fmt.Errorf("error fetching Gateway: %w", err)
+		for _, condition := range conditions {
+			for _, listener := range gw.Status.Listeners {
+				if !findConditionInList(t, listener.Conditions, condition.Type, string(condition.Status), condition.Reason) {
+					t.Logf("gateway %s doesn't have %s condition set to %s on %s listener", gwName, condition.Type, condition.Status, listener.Name)
+					return false, nil
 				}
+			}
+		}
 
-				for _, listener := range gw.Status.Listeners {
-					if !findConditionInList(t, listener.Conditions, condition.Type, string(condition.Status), condition.Reason) {
-						return false, nil
-					}
-				}
+		return true, nil
+	})
 
-				return true, nil
-			})
-
-			require.NoErrorf(t, waitErr, "error waiting for Gateway status to have the %s condition set to %s on all listeners",
-				condition.Type, condition.Status)
-		}(condition)
-	}
-
-	wg.Wait()
+	require.NoErrorf(t, waitErr, "error waiting for Gateway status to have conditions matching expectations on all listeners")
 }
 
 // GatewayMustHaveZeroRoutes validates that the gateway has zero routes attached.  The status


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind test
/area conformance

**What this PR does / why we need it**:

Removing concurrency from `GatewayListenersMustHaveConditions` function, as requested.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2459

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
None
```
