### PR TITLE
Fix conformance report missing tests

### DIFF
--- a/conformance/tests/mesh-split.go
+++ b/conformance/tests/mesh-split.go
@@ -33,6 +33,7 @@ var MeshTrafficSplit = suite.ConformanceTest{
 	Description: "A mesh client can send traffic to a Service which is split between two versions",
 	Features: []suite.SupportedFeature{
 		suite.SupportMesh,
+		suite.SupportHTTPRoute,
 	},
 	Manifests: []string{"tests/mesh-split.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {

--- a/conformance/utils/suite/experimental_profiles.go
+++ b/conformance/utils/suite/experimental_profiles.go
@@ -67,7 +67,9 @@ var (
 			SupportReferenceGrant,
 			SupportHTTPRoute,
 		),
-		ExtendedFeatures: HTTPRouteExtendedFeatures,
+		ExtendedFeatures: sets.New[SupportedFeature]().
+			Insert(HTTPRouteExtendedFeatures.UnsortedList()...).
+			Insert(GatewayExtendedFeatures.UnsortedList()...),
 	}
 
 	// TLSConformanceProfile is a ConformanceProfile that covers testing TLS
@@ -79,6 +81,7 @@ var (
 			SupportReferenceGrant,
 			SupportTLSRoute,
 		),
+		ExtendedFeatures: GatewayExtendedFeatures,
 	}
 
 	// MeshConformanceProfile is a ConformanceProfile that covers testing
@@ -87,7 +90,9 @@ var (
 		Name: MeshConformanceProfileName,
 		CoreFeatures: sets.New(
 			SupportMesh,
+			SupportHTTPRoute,
 		),
+		ExtendedFeatures: HTTPRouteExtendedFeatures,
 	}
 )
 

--- a/conformance/utils/suite/experimental_profiles.go
+++ b/conformance/utils/suite/experimental_profiles.go
@@ -67,9 +67,7 @@ var (
 			SupportReferenceGrant,
 			SupportHTTPRoute,
 		),
-		ExtendedFeatures: sets.New[SupportedFeature]().
-			Insert(HTTPRouteExtendedFeatures.UnsortedList()...).
-			Insert(GatewayExtendedFeatures.UnsortedList()...),
+		ExtendedFeatures: HTTPRouteExtendedFeatures,
 	}
 
 	// TLSConformanceProfile is a ConformanceProfile that covers testing TLS
@@ -81,7 +79,6 @@ var (
 			SupportReferenceGrant,
 			SupportTLSRoute,
 		),
-		ExtendedFeatures: GatewayExtendedFeatures,
 	}
 
 	// MeshConformanceProfile is a ConformanceProfile that covers testing

--- a/conformance/utils/suite/experimental_reports.go
+++ b/conformance/utils/suite/experimental_reports.go
@@ -182,7 +182,7 @@ func isTestExtended(profile ConformanceProfile, test ConformanceTest) bool {
 	for _, supportedFeature := range test.Features {
 		// if ANY of the features needed for the test are extended features,
 		// then we consider the entire test extended level support.
-		if profile.ExtendedFeatures.Has(supportedFeature) {
+		if !profile.CoreFeatures.Has(supportedFeature) {
 			return true
 		}
 	}

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -133,12 +133,6 @@ const (
 
 	// This option indicates support for HTTPRoute backendRequest timeouts (extended conformance).
 	SupportHTTPRouteBackendTimeout SupportedFeature = "HTTPRouteBackendTimeout"
-
-	// This option indicates support for HTTPRoute with a backendref with an appProtocol 'kubernetes.io/h2c'
-	SupportHTTPRouteBackendProtocolH2C SupportedFeature = "HTTPRouteBackendProtocolH2C"
-
-	// This option indicates support for HTTPRoute with a backendref with an appProtoocol 'kubernetes.io/ws'
-	SupportHTTPRouteBackendProtocolWebSocket SupportedFeature = "HTTPRouteBackendProtocolWebSocket"
 )
 
 // HTTPRouteExtendedFeatures includes all the supported features for HTTPRoute
@@ -166,6 +160,12 @@ var HTTPRouteExtendedFeatures = sets.New(
 const (
 	// This option indicates support for Destination Port matching.
 	SupportHTTPRouteDestinationPortMatching SupportedFeature = "HTTPRouteDestinationPortMatching"
+
+	// This option indicates support for HTTPRoute with a backendref with an appProtocol 'kubernetes.io/h2c'
+	SupportHTTPRouteBackendProtocolH2C SupportedFeature = "HTTPRouteBackendProtocolH2C"
+
+	// This option indicates support for HTTPRoute with a backendref with an appProtoocol 'kubernetes.io/ws'
+	SupportHTTPRouteBackendProtocolWebSocket SupportedFeature = "HTTPRouteBackendProtocolWebSocket"
 )
 
 // HTTPRouteExperimentalFeatures includes all the supported experimental features, currently only


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind bug
/kind conformance

**What this PR does / why we need it**:

Reports generated by the conformance framework are missing information about mesh tests that are using features that are not part of the `MESH` core profile. This PR adds `HTTPRouteExtendedFeatures` to the MESH profile so that several of the mesh tests that weren't showing up in the report are now included. Generating the report (for istio) only showed 2 mesh tests, but now includes all 6 in the report.

Before this PR:
```
profiles:
- core:
    result: success
    statistics:
      Failed: 0
      Passed: 2
      Skipped: 0
    summary: ""
  name: MESH
```

After this PR:
```
profiles:
- core:
    result: success
    statistics:
      Failed: 0
      Passed: 2
      Skipped: 0
    summary: ""
  extended:
    result: partial
    skippedTests:
    - MeshFrontendHostname
    statistics:
      Failed: 0
      Passed: 3
      Skipped: 1
    summary: ""
  name: MESH
```

This PR also includes 2 additional minor changes:

1. Moved `SupportHTTPRouteBackendProtocolH2C` and `SupportHTTPRouteBackendProtocolWebSocket` constants to the correct place in the file.
2. Changed  check for external features to use `!profile.CoreFeatures.Has(supportedFeature)` because checking `profile.ExtendedFeatures.Has(supportedFeature)` doesn't work if `ExtendedFeatures` includes core features, which `GatewayExtendedFeatures` does seem to include.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
