### PR TITLE
kind/documentation: concept/gamma: reword to clarify the namespace goes with clients and not the service

### DIFF
--- a/site-src/concepts/gamma.md
+++ b/site-src/concepts/gamma.md
@@ -164,8 +164,8 @@ important:
     custom timeouts for that consumer's use of the workload). This Route will
     only affect requests from workloads in the same Namespace as the Route.
 
-    For example, this HTTPRoute would cause all clients of the `smiley`
-    workload in the `fast-clients` Namespace to have a 100ms timeout:
+    For example, this HTTPRoute would cause all clients in the `fast-clients`
+    Namespace of the `smiley` workload to have a 100ms timeout:
 
     ```yaml
     kind: HTTPRoute


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:
This clarifies the wording since I was confused by the original wording about the "in the `fast-clients` Namespace" clause as to what it applies to


**Which issue(s) this PR fixes**:
None
**Does this PR introduce a user-facing change?**:

```release-note
None
```
