### PR TITLE
Bumping webhook install version

### DIFF
--- a/config/webhook/admission_webhook.yaml
+++ b/config/webhook/admission_webhook.yaml
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
       - name: webhook
-        image: registry.k8s.io/gateway-api/admission-server:v1.0.0-rc1
+        image: registry.k8s.io/gateway-api/admission-server:v1.0.0
         imagePullPolicy: IfNotPresent
         args:
         - -logtostderr


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Small bit of cleanup post-v1.0.0 release - this was already accounted for in the release manifest.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
