### PR TITLE
Add Contour conformance report for v0.8.1

### DIFF
--- a/conformance/reports/v0.8.1/projectcontour-contour.yaml
+++ b/conformance/reports/v0.8.1/projectcontour-contour.yaml
@@ -1,0 +1,46 @@
+apiVersion: gateway.networking.k8s.io/v1alpha1
+date: "2023-10-30T18:29:42Z"
+gatewayAPIVersion: v0.8.1
+implementation:
+  contact:
+  - '@projectcontour/maintainers'
+  organization: projectcontour
+  project: contour
+  url: https://projectcontour.io/
+  version: v1.27.0
+kind: ConformanceReport
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 29
+      Skipped: 0
+    summary: ""
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 10
+      Skipped: 0
+    summary: ""
+    supportedFeatures:
+    - HTTPResponseHeaderModification
+    - HTTPRouteRequestMirror
+    - HTTPRouteMethodMatching
+    - HTTPRouteSchemeRedirect
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRoutePortRedirect
+    - HTTPRoutePathRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteHostRewrite
+    - HTTPRoutePathRewrite
+  name: HTTP
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 11
+      Skipped: 0
+    summary: ""
+  name: TLS

--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -156,13 +156,13 @@ effort, check out the #development channel or join our [weekly developer meeting
 
 ### Contour
 
-[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v0.8.0-Contour-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v0.8.0/projectcontour-contour.yaml)
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v0.8.1-Contour-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v0.8.1/projectcontour-contour.yaml)
 
 [Contour][contour] is a CNCF open source Envoy-based ingress controller for Kubernetes.
 
-Contour [v1.26.0][contour-release] implements Gateway API v0.8.0, supporting the v1alpha2 and v1beta1 API versions.
+Contour [v1.27.0][contour-release] implements Gateway API v0.8.1, supporting the v1alpha2 and v1beta1 API versions.
 All [Standard channel][contour-standard] resources (GatewayClass, Gateway, HTTPRoute, ReferenceGrant), plus TLSRoute, TCPRoute, and GRPCRoute, are supported.
-Contour's implementation passes all core and most extended Gateway API conformance tests included in the v0.8.0 release.
+Contour's implementation passes all core and most extended Gateway API conformance tests included in the v0.8.1 release.
 
 See the [Contour Gateway API Guide][contour-guide] for information on how to deploy and use Contour's Gateway API implementation.
 
@@ -171,9 +171,9 @@ For help and support with Contour's implementation, [create an issue][contour-is
 _Some "extended" functionality is not implemented yet, [contributions welcome!][contour-contrib]._
 
 [contour]:https://projectcontour.io
-[contour-release]:https://github.com/projectcontour/contour/releases/tag/v1.26.0
+[contour-release]:https://github.com/projectcontour/contour/releases/tag/v1.27.0
 [contour-standard]:https://gateway-api.sigs.k8s.io/concepts/versioning/#release-channels-eg-experimental-standard
-[contour-guide]:https://projectcontour.io/docs/1.26/guides/gateway-api/
+[contour-guide]:https://projectcontour.io/docs/1.27/guides/gateway-api/
 [contour-issue-new]:https://github.com/projectcontour/contour/issues/new/choose
 [contour-slack]:https://kubernetes.slack.com/archives/C8XRH2R4J
 [contour-contrib]:https://github.com/projectcontour/contour/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
**What type of PR is this?**

/area conformance

**What this PR does / why we need it**:

Adds conformance report for Contour v1.27.0 which supports Gateway API v0.8.1 and updates implementation summary.

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
