### PR TITLE
Fix typos for TimeoutConfig and getConformanceProfileForName

### DIFF
--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -60,7 +60,7 @@ type TimeoutConfig struct {
 	// Max value for conformant implementation: None
 	HTTPRouteMustHaveCondition time.Duration
 
-	// TLSRouteMustHaveCondition represents the maximum time for an TLSRoute to have the supplied Condition.
+	// TLSRouteMustHaveCondition represents the maximum time for a TLSRoute to have the supplied Condition.
 	// Max value for conformant implementation: None
 	TLSRouteMustHaveCondition time.Duration
 

--- a/conformance/utils/suite/experimental_profiles.go
+++ b/conformance/utils/suite/experimental_profiles.go
@@ -105,7 +105,7 @@ var conformanceProfileMap = map[ConformanceProfileName]ConformanceProfile{
 	MeshConformanceProfileName: MeshConformanceProfile,
 }
 
-// getConformanceProfileForName retrieves a known ConformanceProfile by it's simple
+// getConformanceProfileForName retrieves a known ConformanceProfile by its simple
 // human readable ConformanceProfileName.
 func getConformanceProfileForName(name ConformanceProfileName) (ConformanceProfile, error) {
 	profile, ok := conformanceProfileMap[name]


### PR DESCRIPTION
* Fix typo in the comment for variable TimeoutConfig.TLSRouteMustHaveCondition.
* Fix typo in the comment for function getConformanceProfileForName.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:
Fix typo in comments of variables and functions.

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
None
