### PR TITLE
chore(conformance): shorten the resource name

### DIFF
--- a/conformance/tests/httproute-invalid-parentref-section-name-not-matching-port.go
+++ b/conformance/tests/httproute-invalid-parentref-section-name-not-matching-port.go
@@ -41,7 +41,7 @@ var HTTPRouteInvalidParentRefSectionNameNotMatchingPort = suite.ConformanceTest{
 	Manifests: []string{"tests/httproute-invalid-parentref-section-name-not-matching-port.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "httproute-listener-section-name-not-matching-port", Namespace: "gateway-conformance-infra"}
-		gwNN := types.NamespacedName{Name: "gateway-with-one-not-matching-port-and-section-name-route", Namespace: "gateway-conformance-infra"}
+		gwNN := types.NamespacedName{Name: "gw-with-one-section-name-not-matching-port-route", Namespace: "gateway-conformance-infra"}
 
 		// The Route must have an Accepted Condition with a NoMatchingParent Reason.
 		t.Run("HTTPRoute with sectionName does not match Port in ParentRef has an Accepted Condition with status False and Reason NoMatchingParent", func(t *testing.T) {

--- a/conformance/tests/httproute-invalid-parentref-section-name-not-matching-port.yaml
+++ b/conformance/tests/httproute-invalid-parentref-section-name-not-matching-port.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: gateway-with-one-not-matching-port-and-section-name-route
+  name: gw-with-one-section-name-not-matching-port-route
   namespace: gateway-conformance-infra
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
@@ -22,7 +22,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-  - name: gateway-with-one-not-matching-port-and-section-name-route
+  - name: gw-with-one-section-name-not-matching-port-route
     namespace: gateway-conformance-infra
     sectionName: http
     # mismatched port value here (81 does not match gateway http listener's port) triggers NoMatchingParent reason


### PR DESCRIPTION
 prevent it  from destroying other projects
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/area conformance
/kind test
**What this PR does / why we need it**:

> fails with contour since the gateway name has a really long name and that causes a label we add to some resources to be > 63 chars
> 
> selfishly it would be great to have a shorter gateway name here but otherwise the logic of the test looks good
>
> test passes with contour when i shorten the gateway name
> _Originally posted by @sunjayBhatia  https://github.com/kubernetes-sigs/gateway-api/pull/2582#pullrequestreview-1735319447


In Kubernetes, 63 is a very important length.
Although for Gateway resources, its name can exceed 63, different implementations may use it in different positions.

I think conformance tests should be as universal as possible to avoid encountering problems like this.
I also checked other test cases and currently, all lengths are below 50.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
None
```
