### PR TITLE
Docs: clarify SectionName

### DIFF
--- a/site-src/concepts/api-overview.md
+++ b/site-src/concepts/api-overview.md
@@ -209,8 +209,9 @@ The following is required for a Route to be attached to a Gateway:
 
 A Route can reference a Gateway by specifying the namespace (optional if the
 Route and the Gateway are in the same namespace) and name of the Gateway in
-a `parentRef`. A Route can further select a subset of listeners under the
-Gateway using the following fields in `parentRef`:
+a `parentRef`. By default, a Route will attach to all listeners of a Gateway,
+however it can restrict the selection to a subset of listeners using the
+following fields in `parentRef`:
 
 1. **SectionName** When `sectionName` is set, the Route selects the listener
    with the specified name.


### PR DESCRIPTION
Hi,

On this page of documentation, the setting "SectionName" is explained. While it mentions the effect of adding a "SectionName" it may be slightly lacking in clarifying the default which would be the absence of a "SectionName".  What happens without it?

My assumption, and what's added in this pull request, is that it will "attach to all listeners" of that gateway.

As evidence about the importance of addressing the topic, it seems that even Google's documentation has gotten confused? 
 Consider on this page

https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways

"""
When configuring HTTP-to-HTTPS redirects on the Gateway, the sectionName field is optional. If you don't configure this field, the HTTPS listener is automatically selected as the default option.
"""

What they have just said is "If you don't configure this field (sectionName), a particular listener (the HTTPS listener) is selected." I believe that's wrong and the fact is "If you don't configure this field (sectionName), all listeners are selected."    In either case, it can't hurt to be sure this api-overview page has an answer.

/kind documentation