### PR TITLE
conformance: Kong Kubernetes Ingress Controller v3.0.1 report for v1.0.0

### DIFF
--- a/conformance/reports/v1.0.0/kong-kubernetes-ingress-controller.yaml
+++ b/conformance/reports/v1.0.0/kong-kubernetes-ingress-controller.yaml
@@ -1,5 +1,5 @@
 apiVersion: gateway.networking.k8s.io/v1alpha1
-date: "2023-11-06T09:41:05Z"
+date: "2023-11-23T09:42:40Z"
 gatewayAPIVersion: v1.0.0
 implementation:
   contact:
@@ -7,7 +7,7 @@ implementation:
   organization: Kong
   project: kubernetes-ingress-controller
   url: github.com/kong/kubernetes-ingress-controller
-  version: v3.0.0
+  version: v3.0.1
 kind: ConformanceReport
 profiles:
   - core:
@@ -25,17 +25,17 @@ profiles:
         Skipped: 0
       summary: ""
       supportedFeatures:
-        - HTTPRouteQueryParamMatching
-        - HTTPRouteResponseHeaderModification
         - HTTPRouteMethodMatching
+        - HTTPRouteResponseHeaderModification
+        - HTTPRouteQueryParamMatching
       unsupportedFeatures:
-        - HTTPRouteBackendTimeout
-        - HTTPRoutePathRewrite
-        - HTTPRouteRequestMirror
-        - HTTPRouteRequestMultipleMirrors
-        - HTTPRouteRequestTimeout
         - HTTPRoutePortRedirect
+        - HTTPRouteHostRewrite
+        - HTTPRouteRequestTimeout
         - HTTPRouteSchemeRedirect
         - HTTPRoutePathRedirect
-        - HTTPRouteHostRewrite
+        - HTTPRoutePathRewrite
+        - HTTPRouteRequestMultipleMirrors
+        - HTTPRouteBackendTimeout
+        - HTTPRouteRequestMirror
     name: HTTP


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**

/kind documentation

/area conformance
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

Adds Kong Kubernetes Ingress Controller v3.0.1 conformance report for v1.0.0.





**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
