### PR TITLE
fix(conformance): `parentRef` port is extended

### DIFF
--- a/conformance/tests/httproute-invalid-parentref-section-name-not-matching-port.go
+++ b/conformance/tests/httproute-invalid-parentref-section-name-not-matching-port.go
@@ -37,6 +37,7 @@ var HTTPRouteInvalidParentRefSectionNameNotMatchingPort = suite.ConformanceTest{
 	Features: []suite.SupportedFeature{
 		suite.SupportGateway,
 		suite.SupportHTTPRoute,
+		suite.SupportHTTPRouteParentRefPort,
 	},
 	Manifests: []string{"tests/httproute-invalid-parentref-section-name-not-matching-port.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -133,6 +133,9 @@ const (
 
 	// This option indicates support for HTTPRoute backendRequest timeouts (extended conformance).
 	SupportHTTPRouteBackendTimeout SupportedFeature = "HTTPRouteBackendTimeout"
+
+	// This option indicates support for HTTPRoute parentRef port (extended conformance).
+	SupportHTTPRouteParentRefPort SupportedFeature = "HTTPRouteParentRefPort"
 )
 
 // HTTPRouteExtendedFeatures includes all the supported features for HTTPRoute
@@ -151,6 +154,7 @@ var HTTPRouteExtendedFeatures = sets.New(
 	SupportHTTPRouteRequestMultipleMirrors,
 	SupportHTTPRouteRequestTimeout,
 	SupportHTTPRouteBackendTimeout,
+	SupportHTTPRouteParentRefPort,
 )
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind bug
/area conformance

**What this PR does / why we need it**:

The test HTTPRouteInvalidParentRefSectionNameNotMatchingPort uses a ParentRef port (extended feature). For this purpose, a new extended feature HTTPRouteParentRefPort has been introduced and used in the aforementioned test.

Context: https://github.com/kubernetes-sigs/gateway-api/pull/2582#issuecomment-1832158986

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
