### PR TITLE
Add support for hostname address in conformance tests

### DIFF
--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -409,9 +409,8 @@ func WaitForGatewayAddress(t *testing.T, client client.Client, timeoutConfig con
 
 		port = strconv.FormatInt(int64(gw.Spec.Listeners[0].Port), 10)
 
-		// TODO: Support more than IPAddress
 		for _, address := range gw.Status.Addresses {
-			if address.Type != nil && *address.Type == gatewayv1.IPAddressType {
+			if address.Type != nil && (*address.Type == gatewayv1.IPAddressType || *address.Type == v1alpha2.HostnameAddressType) {
 				ipAddr = address.Value
 				return true, nil
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
Add one of the following kinds:
/kind test

Optionally add one or more of the following kinds if applicable:
/area conformance


**What this PR does / why we need it**:
This PR adds support for addresses of type `Hostname` in the Address section for the status of gateway objects. This change is needed so that cloud load balancers can provide a DNS name in as the address assigned to the gateway and pass the conformance tests.

**Which issue(s) this PR fixes**:
There was a TODO section in the `helpers.go` file that that PR addresses, there is no github issue for it.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
