### PR TITLE
Sort items in conformance reports to maintain stability

### DIFF
--- a/conformance/utils/suite/experimental_reports.go
+++ b/conformance/utils/suite/experimental_reports.go
@@ -17,6 +17,8 @@ limitations under the License.
 package suite
 
 import (
+	"sort"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	confv1a1 "sigs.k8s.io/gateway-api/conformance/apis/v1alpha1"
@@ -72,9 +74,6 @@ func (p profileReportsMap) addTestResults(conformanceProfile ConformanceProfile,
 			if report.Extended == nil {
 				report.Extended = &confv1a1.ExtendedStatus{}
 			}
-			if report.Extended.FailedTests == nil {
-				report.Extended.FailedTests = []string{}
-			}
 			report.Extended.FailedTests = append(report.Extended.FailedTests, result.test.ShortName)
 			report.Extended.Statistics.Failed++
 		} else {
@@ -90,15 +89,9 @@ func (p profileReportsMap) addTestResults(conformanceProfile ConformanceProfile,
 				report.Extended = &confv1a1.ExtendedStatus{}
 			}
 			report.Extended.Statistics.Skipped++
-			if report.Extended.SkippedTests == nil {
-				report.Extended.SkippedTests = []string{}
-			}
 			report.Extended.SkippedTests = append(report.Extended.SkippedTests, result.test.ShortName)
 		} else {
 			report.Core.Statistics.Skipped++
-			if report.Core.SkippedTests == nil {
-				report.Core.SkippedTests = []string{}
-			}
 			report.Core.SkippedTests = append(report.Core.SkippedTests, result.test.ShortName)
 		}
 	}
@@ -140,10 +133,11 @@ func (p profileReportsMap) compileResults(supportedFeaturesMap map[ConformancePr
 		supportedFeatures := supportedFeaturesMap[ConformanceProfileName(report.Name)]
 		if report.Extended != nil {
 			if supportedFeatures != nil {
-				if report.Extended.SupportedFeatures == nil {
-					report.Extended.SupportedFeatures = make([]string, 0)
-				}
-				for _, f := range supportedFeatures.UnsortedList() {
+				supportedFeatures := supportedFeatures.UnsortedList()
+				sort.Slice(supportedFeatures, func(i, j int) bool {
+					return supportedFeatures[i] < supportedFeatures[j]
+				})
+				for _, f := range supportedFeatures {
 					report.Extended.SupportedFeatures = append(report.Extended.SupportedFeatures, string(f))
 				}
 			}
@@ -152,10 +146,11 @@ func (p profileReportsMap) compileResults(supportedFeaturesMap map[ConformancePr
 		unsupportedFeatures := unsupportedFeaturesMap[ConformanceProfileName(report.Name)]
 		if report.Extended != nil {
 			if unsupportedFeatures != nil {
-				if report.Extended.UnsupportedFeatures == nil {
-					report.Extended.UnsupportedFeatures = make([]string, 0)
-				}
-				for _, f := range unsupportedFeatures.UnsortedList() {
+				unsupportedFeatures := unsupportedFeatures.UnsortedList()
+				sort.Slice(unsupportedFeatures, func(i, j int) bool {
+					return unsupportedFeatures[i] < unsupportedFeatures[j]
+				})
+				for _, f := range unsupportedFeatures {
 					report.Extended.UnsupportedFeatures = append(report.Extended.UnsupportedFeatures, string(f))
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**

/kind feature
/area conformance
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

Using `UnsortedList()` on a set and iterating over a map gives a random order of items, thus reports are not stable (the order of items in those reports changes), for example, an update of one report that only differs in the app version.
- https://github.com/kubernetes-sigs/gateway-api/pull/2611


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The order of items in a conformance report is stable.
```
