### PR TITLE
Adding a note to explain the prolonged experimental state of MCS GEP

### DIFF
--- a/geps/gep-1748.md
+++ b/geps/gep-1748.md
@@ -3,9 +3,14 @@
 * Issue: [#1748](https://github.com/kubernetes-sigs/gateway-api/issues/1748)
 * Status: Experimental
 
-> **Note**: This GEP is exempt from the [Probationary Period][expprob] rules of
-> our GEP overview as it existed before those rules did, and so it has been
-> explicitly grandfathered in.
+???+ Prolonged Experimental Phase
+    This GEP will be in the "Experimental" channel for a prolonged period of
+    time. This explores the interaction of Gateway API with the Multi-Cluster
+    Services API. Until the MCS API is also GA, it will be impossible for this
+    GEP to graduate beyond "Experimental".
+
+    This GEP is also exempt from the [Probationary Period][expprob] rules as it
+    predated them.
 
 [expprob]:https://gateway-api.sigs.k8s.io/geps/overview/#probationary-period
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind gep

**What this PR does / why we need it**:
This helps explain that the MCS GEP (#1748) will be stuck in experimental until the MCS API graduates to GA.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
