### PR TITLE
conformance: initial UDPRoute test

### DIFF
--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -509,6 +509,7 @@ spec:
             cpu: 10m
 ---
 apiVersion: v1
+<<<<<<< HEAD
 kind: Service
 metadata:
   name: grpc-infra-backend-v1
@@ -520,10 +521,34 @@ spec:
   - protocol: TCP
     port: 8080
     targetPort: 3000
+=======
+kind: Namespace
+metadata:
+  name: gateway-conformance-udp
+  labels:
+    gateway-conformance: udp
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns
+  namespace: gateway-conformance-udp
+  labels:
+    app: udp
+spec:
+  ports:
+  - name: udp-dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  selector:
+    app: udp
+>>>>>>> f4857153 (conformance: initial UDPRoute test)
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+<<<<<<< HEAD
   name: grpc-infra-backend-v1
   namespace: gateway-conformance-infra
   labels:
@@ -654,3 +679,64 @@ spec:
         resources:
           requests:
             cpu: 10m
+=======
+  name: coredns
+  namespace: gateway-conformance-udp
+  labels:
+    app: udp
+spec:
+  selector:
+    matchLabels:
+      app: udp
+  template:
+    metadata:
+      labels:
+        app: udp
+    spec:
+      containers:
+      - args:
+        - -conf
+        - /root/Corefile
+        image: coredns/coredns
+        name: coredns
+        volumeMounts:
+        - mountPath: /root
+          name: conf
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: coredns
+        name: conf
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: gateway-conformance-udp
+data:
+  Corefile: |
+    .:53 {
+        forward . 8.8.8.8 9.9.9.9
+        log
+        errors
+    }
+
+    foo.bar.com:53 {
+      whoami
+    }
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: udp-gateway
+  namespace: gateway-conformance-udp
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: coredns
+    protocol: UDP
+    port: 5300
+    allowedRoutes:
+      kinds:
+      - kind: UDPRoute
+>>>>>>> f4857153 (conformance: initial UDPRoute test)

--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -509,7 +509,6 @@ spec:
             cpu: 10m
 ---
 apiVersion: v1
-<<<<<<< HEAD
 kind: Service
 metadata:
   name: grpc-infra-backend-v1
@@ -521,34 +520,10 @@ spec:
   - protocol: TCP
     port: 8080
     targetPort: 3000
-=======
-kind: Namespace
-metadata:
-  name: gateway-conformance-udp
-  labels:
-    gateway-conformance: udp
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: coredns
-  namespace: gateway-conformance-udp
-  labels:
-    app: udp
-spec:
-  ports:
-  - name: udp-dns
-    port: 53
-    protocol: UDP
-    targetPort: 53
-  selector:
-    app: udp
->>>>>>> f4857153 (conformance: initial UDPRoute test)
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-<<<<<<< HEAD
   name: grpc-infra-backend-v1
   namespace: gateway-conformance-infra
   labels:
@@ -679,9 +654,28 @@ spec:
         resources:
           requests:
             cpu: 10m
-=======
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: coredns
-  namespace: gateway-conformance-udp
+  namespace: gateway-conformance-infra
+  labels:
+    app: udp
+spec:
+  ports:
+  - name: udp-dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  selector:
+    app: udp
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: gateway-conformance-infra
   labels:
     app: udp
 spec:
@@ -712,7 +706,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: coredns
-  namespace: gateway-conformance-udp
+  namespace: gateway-conformance-infra
 data:
   Corefile: |
     .:53 {
@@ -720,7 +714,6 @@ data:
         log
         errors
     }
-
     foo.bar.com:53 {
       whoami
     }
@@ -729,7 +722,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   name: udp-gateway
-  namespace: gateway-conformance-udp
+  namespace: gateway-conformance-infra
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
   listeners:
@@ -739,4 +732,3 @@ spec:
     allowedRoutes:
       kinds:
       - kind: UDPRoute
->>>>>>> f4857153 (conformance: initial UDPRoute test)

--- a/conformance/tests/udproute-simple.go
+++ b/conformance/tests/udproute-simple.go
@@ -36,6 +36,10 @@ var UDPRouteTest = suite.ConformanceTest{
 	ShortName:   "UDPRoute",
 	Description: "Make sure UDPRoute is working",
 	Manifests:   []string{"tests/udproute-simple.yaml"},
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportUDPRoute,
+	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		t.Run("Simple UDP request matching UDPRoute should reach coredns backend", func(t *testing.T) {
 			namespace := "gateway-conformance-udp"

--- a/conformance/tests/udproute-simple.go
+++ b/conformance/tests/udproute-simple.go
@@ -43,7 +43,7 @@ var UDPRouteTest = suite.ConformanceTest{
 	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		t.Run("Simple UDP request matching UDPRoute should reach coredns backend", func(t *testing.T) {
-			namespace := "gateway-conformance-udp"
+			namespace := "gateway-conformance-infra"
 			domain := "foo.bar.com."
 			routeNN := types.NamespacedName{Name: "udp-coredns", Namespace: namespace}
 			gwNN := types.NamespacedName{Name: "udp-gateway", Namespace: namespace}

--- a/conformance/tests/udproute-simple.go
+++ b/conformance/tests/udproute-simple.go
@@ -24,6 +24,7 @@ import (
 	"github.com/miekg/dns"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 )

--- a/conformance/tests/udproute-simple.go
+++ b/conformance/tests/udproute-simple.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, UDPRouteTest)
+}
+
+var UDPRouteTest = suite.ConformanceTest{
+	ShortName:   "UDPRoute",
+	Description: "Make sure UDPRoute is working",
+	Manifests:   []string{"testdata/udproute.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		t.Run("Simple UDP request matching UDPRoute should reach coredns backend", func(t *testing.T) {
+			namespace := "gateway-conformance-udp"
+			domain := "foo.bar.com."
+			routeNN := types.NamespacedName{Name: "udp-coredns", Namespace: namespace}
+			gwNN := types.NamespacedName{Name: "udp-gateway", Namespace: namespace}
+			gwAddr := kubernetes.GatewayAndUDPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+
+			msg := new(dns.Msg)
+			msg.SetQuestion(domain, dns.TypeA)
+
+			if err := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
+				func(_ context.Context) (done bool, err error) {
+					t.Logf("performing DNS query %s on %s", domain, gwAddr)
+					_, err = dns.Exchange(msg, gwAddr)
+					if err != nil {
+						t.Logf("failed to perform a UDP query: %v", err)
+						return false, nil
+					}
+					return true, nil
+				}); err != nil {
+				t.Errorf("failed to perform DNS query: %v", err)
+			}
+		})
+	},
+}

--- a/conformance/tests/udproute-simple.go
+++ b/conformance/tests/udproute-simple.go
@@ -35,7 +35,7 @@ func init() {
 var UDPRouteTest = suite.ConformanceTest{
 	ShortName:   "UDPRoute",
 	Description: "Make sure UDPRoute is working",
-	Manifests:   []string{"testdata/udproute.yaml"},
+	Manifests:   []string{"tests/udproute-simple.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		t.Run("Simple UDP request matching UDPRoute should reach coredns backend", func(t *testing.T) {
 			namespace := "gateway-conformance-udp"

--- a/conformance/tests/udproute-simple.yaml
+++ b/conformance/tests/udproute-simple.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: udp-coredns
+  namespace: gateway-conformance-udp
+spec:
+  parentRefs:
+  - name: udp-gateway
+    sectionName: coredns
+  rules:
+  - backendRefs:
+    - name: coredns
+      port: 53

--- a/conformance/tests/udproute-simple.yaml
+++ b/conformance/tests/udproute-simple.yaml
@@ -2,7 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: UDPRoute
 metadata:
   name: udp-coredns
-  namespace: gateway-conformance-udp
+  namespace: gateway-conformance-infra
 spec:
   parentRefs:
   - name: udp-gateway

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -197,6 +197,21 @@ var TLSRouteCoreFeatures = sets.New(
 )
 
 // -----------------------------------------------------------------------------
+// Features - UDPRoute Conformance (Core)
+// -----------------------------------------------------------------------------
+
+const (
+	// This option indicates support for UDPRoute
+	SupportUDPRoute SupportedFeature = "UDPRoute"
+)
+
+// UDPRouteCoreFeatures includes all SupportedFeatures needed to be conformant with
+// the UDPRoute resource.
+var UDPRouteFeatures = sets.New(
+	SupportUDPRoute,
+)
+
+// -----------------------------------------------------------------------------
 // Features - Mesh Conformance (Core)
 // -----------------------------------------------------------------------------
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,16 @@ require (
 	k8s.io/client-go v0.29.2
 	k8s.io/code-generator v0.29.2
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
+	github.com/lithammer/dedent v1.1.0
+	github.com/miekg/dns v1.1.57
+	github.com/stretchr/testify v1.8.4
+	golang.org/x/net v0.18.0
+	k8s.io/api v0.28.4
+	k8s.io/apiextensions-apiserver v0.28.4
+	k8s.io/apimachinery v0.28.4
+	k8s.io/client-go v0.28.4
+	k8s.io/code-generator v0.28.4
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.16.3
 	sigs.k8s.io/controller-tools v0.14.0
 	sigs.k8s.io/yaml v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0
+	github.com/miekg/dns v1.1.57
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/net v0.20.0
 	google.golang.org/grpc v1.61.0
@@ -14,16 +15,6 @@ require (
 	k8s.io/client-go v0.29.2
 	k8s.io/code-generator v0.29.2
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
-	github.com/lithammer/dedent v1.1.0
-	github.com/miekg/dns v1.1.57
-	github.com/stretchr/testify v1.8.4
-	golang.org/x/net v0.18.0
-	k8s.io/api v0.28.4
-	k8s.io/apiextensions-apiserver v0.28.4
-	k8s.io/apimachinery v0.28.4
-	k8s.io/client-go v0.28.4
-	k8s.io/code-generator v0.28.4
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.16.3
 	sigs.k8s.io/controller-tools v0.14.0
 	sigs.k8s.io/yaml v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
+github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
+github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind test
/area conformance

**What this PR does / why we need it**:
- initial conformance tests for UDPRoute
- dedup code for Route Handler

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/1792

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
