### PR TITLE
Add conformance test for isolation of HTTP listeners

### DIFF
--- a/conformance/tests/gateway-http-listener-isolation-with-hostname-intersection.yaml
+++ b/conformance/tests/gateway-http-listener-isolation-with-hostname-intersection.yaml
@@ -1,0 +1,131 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: http-listener-isolation-with-hostname-intersection
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: empty-hostname
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: wildcard-example-com
+    port: 80
+    protocol: HTTP
+    hostname: "*.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: wildcard-foo-example-com
+    port: 80
+    protocol: HTTP
+    hostname: "*.foo.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: abc-foo-example-com
+    port: 80
+    protocol: HTTP
+    hostname: "abc.foo.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: attaches-to-empty-hostname-with-hostname-intersection
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: http-listener-isolation-with-hostname-intersection
+    namespace: gateway-conformance-infra
+    sectionName: empty-hostname
+  hostnames:
+  - "bar.com"
+  - "*.example.com" # request matching is prevented by the isolation wildcard-example-com listener
+  - "*.foo.example.com" # request matching is prevented by the isolation wildcard-foo-example-com listener
+  - "abc.foo.example.com" # request matching is prevented by the isolation of abc-foo-example-com listener
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /empty-hostname
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: attaches-to-wildcard-example-com-with-hostname-intersection
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: http-listener-isolation-with-hostname-intersection
+    namespace: gateway-conformance-infra
+    sectionName: wildcard-example-com
+  hostnames:
+  - "bar.com" # doesn't match wildcard-example-com listener
+  - "*.example.com"
+  - "*.foo.example.com" # request matching is prevented by the isolation of wildcard-foo-example-com listener
+  - "abc.foo.example.com" # request matching is prevented by the isolation of abc-foo-example-com listener
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /wildcard-example-com
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: attaches-to-wildcard-foo-example-com-with-hostname-intersection
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: http-listener-isolation-with-hostname-intersection
+    namespace: gateway-conformance-infra
+    sectionName: wildcard-foo-example-com
+  hostnames:
+  - "bar.com" # doesn't match wildcard-foo-example-com listener
+  - "*.example.com" # this becomes *.foo.example.com, as the hostname cannot be less specific than *.foo.example.com of the listener
+  - "*.foo.example.com"
+  - "abc.foo.example.com" # request matching is prevented by the isolation abc-foo-example-com listener
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /wildcard-foo-example-com
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: attaches-to-abc-foo-example-com-with-hostname-intersection
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: http-listener-isolation-with-hostname-intersection
+    namespace: gateway-conformance-infra
+    sectionName: abc-foo-example-com
+  hostnames:
+  - "bar.com" # doesn't match abc-foo-example-com listener
+  - "*.example.com" # becomes abc.foo.example.com as it cannot be less specific than abc.foo.example.com of the listener
+  - "*.foo.example.com" # becomes abc.foo.example.com as it cannot be less specific than abc.foo.example.com of the listener
+  - "abc.foo.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /abc-foo-example-com
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/gateway-http-listener-isolation-with-hostname-intersection.yaml
+++ b/conformance/tests/gateway-http-listener-isolation-with-hostname-intersection.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: http-listener-isolation-with-hostname-intersection

--- a/conformance/tests/gateway-http-listener-isolation.go
+++ b/conformance/tests/gateway-http-listener-isolation.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2024 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/conformance/tests/gateway-http-listener-isolation.go
+++ b/conformance/tests/gateway-http-listener-isolation.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayHTTPListenerIsolation)
+}
+
+var GatewayHTTPListenerIsolation = suite.ConformanceTest{
+	ShortName:   "GatewayHTTPListenerIsolation",
+	Description: "Listener isolation for HTTP listeners with multiple listeners and HTTPRoutes",
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportGatewayHTTPListenerIsolation,
+		suite.SupportHTTPRoute,
+	},
+	Manifests: []string{
+		"tests/gateway-http-listener-isolation.yaml",
+		"tests/gateway-http-listener-isolation-with-hostname-intersection.yaml",
+	},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+
+		testCases := []http.ExpectedResponse{
+			// Requests to the empty-hostname listener
+			{
+				Request:   http.Request{Host: "bar.com", Path: "/empty-hostname"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+			{
+				Request:  http.Request{Host: "bar.com", Path: "/wildcard-example-com"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:  http.Request{Host: "bar.com", Path: "/wildcard-foo-example-com"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:  http.Request{Host: "bar.com", Path: "/abc-foo-example-com"},
+				Response: http.Response{StatusCode: 404},
+			},
+			// Requests to the wildcard-example-com listener
+			{
+				Request:  http.Request{Host: "bar.example.com", Path: "/empty-hostname"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:   http.Request{Host: "bar.example.com", Path: "/wildcard-example-com"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+			{
+				Request:  http.Request{Host: "bar.example.com", Path: "/wildcard-foo-example-com"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:  http.Request{Host: "bar.example.com", Path: "/abc-foo-example-com"},
+				Response: http.Response{StatusCode: 404},
+			},
+			// Requests to the foo-wildcard-example-com listener
+			{
+				Request:  http.Request{Host: "bar.foo.example.com", Path: "/empty-hostname"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:  http.Request{Host: "bar.foo.example.com", Path: "/wildcard-example-com"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:   http.Request{Host: "bar.foo.example.com", Path: "/wildcard-foo-example-com"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+			{
+				Request:  http.Request{Host: "bar.foo.example.com", Path: "/abc-foo-example-com"},
+				Response: http.Response{StatusCode: 404},
+			},
+			// Requests to the abc-foo-example-com listener
+			{
+				Request:  http.Request{Host: "abc.foo.example.com", Path: "/empty-hostname"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:  http.Request{Host: "abc.foo.example.com", Path: "/wildcard-example-com"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:   http.Request{Host: "abc.foo.example.com", Path: "/wildcard-foo-example-com"},
+				Response:  http.Response{StatusCode: 404},
+				Namespace: ns,
+			},
+			{
+				Request:   http.Request{Host: "abc.foo.example.com", Path: "/abc-foo-example-com"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+		}
+
+		t.Run("hostnames are configured only in listeners", func(t *testing.T) {
+			gwNN := types.NamespacedName{Name: "http-listener-isolation", Namespace: ns}
+			routes := []types.NamespacedName{
+				{Namespace: ns, Name: "attaches-to-empty-hostname"},
+				{Namespace: ns, Name: "attaches-to-wildcard-example-com"},
+				{Namespace: ns, Name: "attaches-to-wildcard-foo-example-com"},
+				{Namespace: ns, Name: "attaches-to-abc-foo-example-com"},
+			}
+
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routes...)
+			for _, routeNN := range routes {
+				kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+			}
+
+			for i := range testCases {
+				// Declare tc here to avoid loop variable
+				// reuse issues across parallel tests.
+				tc := testCases[i]
+				t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+					t.Parallel()
+					http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+				})
+			}
+		})
+
+		t.Run("intersecting hostnames are configured in listeners and HTTPRoutes", func(t *testing.T) {
+			gwNN := types.NamespacedName{Name: "http-listener-isolation-with-hostname-intersection", Namespace: ns}
+			routes := []types.NamespacedName{
+				{Namespace: ns, Name: "attaches-to-empty-hostname-with-hostname-intersection"},
+				{Namespace: ns, Name: "attaches-to-wildcard-example-com-with-hostname-intersection"},
+				{Namespace: ns, Name: "attaches-to-wildcard-foo-example-com-with-hostname-intersection"},
+				{Namespace: ns, Name: "attaches-to-abc-foo-example-com-with-hostname-intersection"},
+			}
+
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routes...)
+			for _, routeNN := range routes {
+				kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+			}
+
+			for i := range testCases {
+				// Declare tc here to avoid loop variable
+				// reuse issues across parallel tests.
+				tc := testCases[i]
+				t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+					t.Parallel()
+					http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+				})
+			}
+		})
+	},
+}

--- a/conformance/tests/gateway-http-listener-isolation.yaml
+++ b/conformance/tests/gateway-http-listener-isolation.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: http-listener-isolation

--- a/conformance/tests/gateway-http-listener-isolation.yaml
+++ b/conformance/tests/gateway-http-listener-isolation.yaml
@@ -1,0 +1,111 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: http-listener-isolation
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: empty-hostname
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: wildcard-example-com
+    port: 80
+    protocol: HTTP
+    hostname: "*.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: wildcard-foo-example-com
+    port: 80
+    protocol: HTTP
+    hostname: "*.foo.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: abc-foo-example-com
+    port: 80
+    protocol: HTTP
+    hostname: "abc.foo.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: attaches-to-empty-hostname
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: http-listener-isolation
+    namespace: gateway-conformance-infra
+    sectionName: empty-hostname
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /empty-hostname
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: attaches-to-wildcard-example-com
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: http-listener-isolation
+    namespace: gateway-conformance-infra
+    sectionName: wildcard-example-com
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /wildcard-example-com
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: attaches-to-wildcard-foo-example-com
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: http-listener-isolation
+    namespace: gateway-conformance-infra
+    sectionName: wildcard-foo-example-com
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /wildcard-foo-example-com
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: attaches-to-abc-foo-example-com
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: http-listener-isolation
+    namespace: gateway-conformance-infra
+    sectionName: abc-foo-example-com
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /abc-foo-example-com
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -54,6 +54,10 @@ const (
 	// of allocating pre-determined addresses, rather than dynamically having
 	// addresses allocated for it.
 	SupportGatewayStaticAddresses SupportedFeature = "GatewayStaticAddresses"
+
+	// SupportGatewayHTTPListenerIsolation option indicates support for the isolation
+	// of HTTP listeners.
+	SupportGatewayHTTPListenerIsolation SupportedFeature = "GatewayHTTPListenerIsolation"
 )
 
 // GatewayExtendedFeatures are extra generic features that implementations may
@@ -61,6 +65,7 @@ const (
 var GatewayExtendedFeatures = sets.New(
 	SupportGatewayPort8080,
 	SupportGatewayStaticAddresses,
+	SupportGatewayHTTPListenerIsolation,
 )
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
**What type of PR is this?**
/kind test
/area conformance

**What this PR does / why we need it**:

Listener isolation was clarified in https://github.com/kubernetes-sigs/gateway-api/pull/2465
This PR adds the corresponding extended feature and the conformance test.

The test includes two subtests:
- the one where hostnames are only configured in listeners
- the one where hostnames are configured both in listeners and HTTPRoutes, where HTTPRoutes try to "steal" requests bound to different listeners, but fail to do so because of the listener isolation.

Note:
I added only tests for HTTP listeners. I believe the fix for this issue https://github.com/kubernetes-sigs/gateway-api/issues/2417 might define the tests for the isolation for HTTPS listeners  - those will also involve setting SNI.

**Which issue(s) this PR fixes**:

Fixes #2416 

**Does this PR introduce a user-facing change?**:

```release-note
Adds an extended feature GatewayHTTPListenerIsolation with the corresponding conformance test GatewayHTTPListenerIsolation
```
