### PR TITLE
Bump parent images for echo apps

### DIFF
--- a/docker/Dockerfile.echo-advanced
+++ b/docker/Dockerfile.echo-advanced
@@ -1,2 +1,1 @@
-# TODO(https://github.com/kubernetes-sigs/gateway-api/issues/1895): build it ourselves
-FROM gcr.io/istio-release/app:1.17.1
+FROM gcr.io/istio-release/app:1.20.1

--- a/docker/Dockerfile.echo-basic
+++ b/docker/Dockerfile.echo-basic
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build
-FROM golang:1.21.3 as builder
+FROM golang:1.21.5 as builder
 
 ENV CGO_ENABLED=0
 


### PR DESCRIPTION
In particular, the newer "advanced" echo no longer runs as root (it now has `USER` configured), which makes it possible to run in more strict environments like OpenShift.

```release-note
NONE
```
