### PR TITLE
Allow an implementation to use listed order for HTTPRouteFilter in a route-rule

### DIFF
--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -205,7 +205,7 @@ type HTTPRouteRule struct {
 	// that behavior.
 	//
 	// To reject an invalid combination or order of filters, implementations SHOULD
-	// consider the Route Rule(s) with this configuration invalid. If all Route Rule(s)
+	// consider the Route Rules with this configuration invalid. If all Route Rules
 	// in a Route are invalid, the entire Route would be considered invalid. If only
 	// a portion of Route Rules are invalid, implementations MUST set the
 	// "PartiallyInvalid" condition for the Route.

--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -196,8 +196,11 @@ type HTTPRouteRule struct {
 	// Filters define the filters that are applied to requests that match
 	// this rule.
 	//
-	// The effects of ordering of multiple behaviors are currently unspecified.
-	// This can change in the future based on feedback during the alpha stage.
+	// This spec does not mandate a specific ordering for the execution of filters.
+	// However an implementation may decide to execute the filters in the listed order.
+	// In case the implementation cannot support the listed order (due to its internal
+	// ordering limitation), the implementation will drop the route rule with such a
+	// conflict and set the status RouteConditionPartiallyInvalid for the Route.
 	//
 	// Conformance-levels at this level are defined based on the type of filter:
 	//

--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -196,11 +196,19 @@ type HTTPRouteRule struct {
 	// Filters define the filters that are applied to requests that match
 	// this rule.
 	//
-	// This spec does not mandate a specific ordering for the execution of filters.
-	// However an implementation may decide to execute the filters in the listed order.
-	// In case the implementation cannot support the listed order (due to its internal
-	// ordering limitation), the implementation will drop the route rule with such a
-	// conflict and set the status RouteConditionPartiallyInvalid for the Route.
+	// Wherever possible, implementations SHOULD implement filters in the order
+	// they are specified. 
+	//
+	// Implementations MAY choose to implement this ordering strictly, rejecting
+	// any combination or order of filters that can not be supported. If implementations
+	// choose a strict interpretation of filter ordering, they MUST clearly document
+	// that behavior.
+	//
+	// To reject an invalid combination or order of filters, implementations SHOULD
+	// consider the Route Rule(s) with this configuration invalid. If all Route Rule(s)
+	// in a Route are invalid, the entire Route would be considered invalid. In only
+	// a portion of Route Rules are invalid, implementations should set the 
+	// "PartiallyInvalid" condition for the Route.
 	//
 	// Conformance-levels at this level are defined based on the type of filter:
 	//

--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -206,7 +206,7 @@ type HTTPRouteRule struct {
 	//
 	// To reject an invalid combination or order of filters, implementations SHOULD
 	// consider the Route Rule(s) with this configuration invalid. If all Route Rule(s)
-	// in a Route are invalid, the entire Route would be considered invalid. In only
+	// in a Route are invalid, the entire Route would be considered invalid. If only
 	// a portion of Route Rules are invalid, implementations MUST set the
 	// "PartiallyInvalid" condition for the Route.
 	//

--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -197,7 +197,7 @@ type HTTPRouteRule struct {
 	// this rule.
 	//
 	// Wherever possible, implementations SHOULD implement filters in the order
-	// they are specified. 
+	// they are specified.
 	//
 	// Implementations MAY choose to implement this ordering strictly, rejecting
 	// any combination or order of filters that can not be supported. If implementations
@@ -207,7 +207,7 @@ type HTTPRouteRule struct {
 	// To reject an invalid combination or order of filters, implementations SHOULD
 	// consider the Route Rule(s) with this configuration invalid. If all Route Rule(s)
 	// in a Route are invalid, the entire Route would be considered invalid. In only
-	// a portion of Route Rules are invalid, implementations should set the 
+	// a portion of Route Rules are invalid, implementations MUST set the
 	// "PartiallyInvalid" condition for the Route.
 	//
 	// Conformance-levels at this level are defined based on the type of filter:

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -1178,12 +1178,16 @@ spec:
                       type: array
                     filters:
                       description: "Filters define the filters that are applied to
-                        requests that match this rule. \n The effects of ordering
-                        of multiple behaviors are currently unspecified. This can
-                        change in the future based on feedback during the alpha stage.
-                        \n Conformance-levels at this level are defined based on the
-                        type of filter: \n - ALL core filters MUST be supported by
-                        all implementations. - Implementers are encouraged to support
+                        requests that match this rule. \n This spec does not mandate
+                        a specific ordering for the execution of filters. However
+                        an implementation may decide to execute the filters in the
+                        listed order. In case the implementation cannot support the
+                        listed order (due to its internal ordering limitation), the
+                        implementation will drop the route rule with such a conflict
+                        and set the status RouteConditionPartiallyInvalid for the
+                        Route. \n Conformance-levels at this level are defined based
+                        on the type of filter: \n - ALL core filters MUST be supported
+                        by all implementations. - Implementers are encouraged to support
                         extended filters. - Implementation-specific custom filters
                         have no API guarantees across implementations. \n Specifying
                         the same filter multiple times is not supported unless explicitly
@@ -3644,12 +3648,16 @@ spec:
                       type: array
                     filters:
                       description: "Filters define the filters that are applied to
-                        requests that match this rule. \n The effects of ordering
-                        of multiple behaviors are currently unspecified. This can
-                        change in the future based on feedback during the alpha stage.
-                        \n Conformance-levels at this level are defined based on the
-                        type of filter: \n - ALL core filters MUST be supported by
-                        all implementations. - Implementers are encouraged to support
+                        requests that match this rule. \n This spec does not mandate
+                        a specific ordering for the execution of filters. However
+                        an implementation may decide to execute the filters in the
+                        listed order. In case the implementation cannot support the
+                        listed order (due to its internal ordering limitation), the
+                        implementation will drop the route rule with such a conflict
+                        and set the status RouteConditionPartiallyInvalid for the
+                        Route. \n Conformance-levels at this level are defined based
+                        on the type of filter: \n - ALL core filters MUST be supported
+                        by all implementations. - Implementers are encouraged to support
                         extended filters. - Implementation-specific custom filters
                         have no API guarantees across implementations. \n Specifying
                         the same filter multiple times is not supported unless explicitly

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -1185,10 +1185,10 @@ spec:
                         be supported. If implementations choose a strict interpretation
                         of filter ordering, they MUST clearly document that behavior.
                         \n To reject an invalid combination or order of filters, implementations
-                        SHOULD consider the Route Rule(s) with this configuration
-                        invalid. If all Route Rule(s) in a Route are invalid, the
-                        entire Route would be considered invalid. In only a portion
-                        of Route Rules are invalid, implementations MUST set the \"PartiallyInvalid\"
+                        SHOULD consider the Route Rules with this configuration invalid.
+                        If all Route Rules in a Route are invalid, the entire Route
+                        would be considered invalid. If only a portion of Route Rules
+                        are invalid, implementations MUST set the \"PartiallyInvalid\"
                         condition for the Route. \n Conformance-levels at this level
                         are defined based on the type of filter: \n - ALL core filters
                         MUST be supported by all implementations. - Implementers are
@@ -3660,10 +3660,10 @@ spec:
                         be supported. If implementations choose a strict interpretation
                         of filter ordering, they MUST clearly document that behavior.
                         \n To reject an invalid combination or order of filters, implementations
-                        SHOULD consider the Route Rule(s) with this configuration
-                        invalid. If all Route Rule(s) in a Route are invalid, the
-                        entire Route would be considered invalid. In only a portion
-                        of Route Rules are invalid, implementations MUST set the \"PartiallyInvalid\"
+                        SHOULD consider the Route Rules with this configuration invalid.
+                        If all Route Rules in a Route are invalid, the entire Route
+                        would be considered invalid. If only a portion of Route Rules
+                        are invalid, implementations MUST set the \"PartiallyInvalid\"
                         condition for the Route. \n Conformance-levels at this level
                         are defined based on the type of filter: \n - ALL core filters
                         MUST be supported by all implementations. - Implementers are

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -1178,27 +1178,32 @@ spec:
                       type: array
                     filters:
                       description: "Filters define the filters that are applied to
-                        requests that match this rule. \n This spec does not mandate
-                        a specific ordering for the execution of filters. However
-                        an implementation may decide to execute the filters in the
-                        listed order. In case the implementation cannot support the
-                        listed order (due to its internal ordering limitation), the
-                        implementation will drop the route rule with such a conflict
-                        and set the status RouteConditionPartiallyInvalid for the
-                        Route. \n Conformance-levels at this level are defined based
-                        on the type of filter: \n - ALL core filters MUST be supported
-                        by all implementations. - Implementers are encouraged to support
-                        extended filters. - Implementation-specific custom filters
-                        have no API guarantees across implementations. \n Specifying
-                        the same filter multiple times is not supported unless explicitly
-                        indicated in the filter. \n All filters are expected to be
-                        compatible with each other except for the URLRewrite and RequestRedirect
-                        filters, which may not be combined. If an implementation can
-                        not support other combinations of filters, they must clearly
-                        document that limitation. In cases where incompatible or unsupported
-                        filters are specified and cause the `Accepted` condition to
-                        be set to status `False`, implementations may use the `IncompatibleFilters`
-                        reason to specify this configuration error. \n Support: Core"
+                        requests that match this rule. \n Wherever possible, implementations
+                        SHOULD implement filters in the order they are specified.
+                        \n Implementations MAY choose to implement this ordering strictly,
+                        rejecting any combination or order of filters that can not
+                        be supported. If implementations choose a strict interpretation
+                        of filter ordering, they MUST clearly document that behavior.
+                        \n To reject an invalid combination or order of filters, implementations
+                        SHOULD consider the Route Rule(s) with this configuration
+                        invalid. If all Route Rule(s) in a Route are invalid, the
+                        entire Route would be considered invalid. In only a portion
+                        of Route Rules are invalid, implementations MUST set the \"PartiallyInvalid\"
+                        condition for the Route. \n Conformance-levels at this level
+                        are defined based on the type of filter: \n - ALL core filters
+                        MUST be supported by all implementations. - Implementers are
+                        encouraged to support extended filters. - Implementation-specific
+                        custom filters have no API guarantees across implementations.
+                        \n Specifying the same filter multiple times is not supported
+                        unless explicitly indicated in the filter. \n All filters
+                        are expected to be compatible with each other except for the
+                        URLRewrite and RequestRedirect filters, which may not be combined.
+                        If an implementation can not support other combinations of
+                        filters, they must clearly document that limitation. In cases
+                        where incompatible or unsupported filters are specified and
+                        cause the `Accepted` condition to be set to status `False`,
+                        implementations may use the `IncompatibleFilters` reason to
+                        specify this configuration error. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -3648,27 +3653,32 @@ spec:
                       type: array
                     filters:
                       description: "Filters define the filters that are applied to
-                        requests that match this rule. \n This spec does not mandate
-                        a specific ordering for the execution of filters. However
-                        an implementation may decide to execute the filters in the
-                        listed order. In case the implementation cannot support the
-                        listed order (due to its internal ordering limitation), the
-                        implementation will drop the route rule with such a conflict
-                        and set the status RouteConditionPartiallyInvalid for the
-                        Route. \n Conformance-levels at this level are defined based
-                        on the type of filter: \n - ALL core filters MUST be supported
-                        by all implementations. - Implementers are encouraged to support
-                        extended filters. - Implementation-specific custom filters
-                        have no API guarantees across implementations. \n Specifying
-                        the same filter multiple times is not supported unless explicitly
-                        indicated in the filter. \n All filters are expected to be
-                        compatible with each other except for the URLRewrite and RequestRedirect
-                        filters, which may not be combined. If an implementation can
-                        not support other combinations of filters, they must clearly
-                        document that limitation. In cases where incompatible or unsupported
-                        filters are specified and cause the `Accepted` condition to
-                        be set to status `False`, implementations may use the `IncompatibleFilters`
-                        reason to specify this configuration error. \n Support: Core"
+                        requests that match this rule. \n Wherever possible, implementations
+                        SHOULD implement filters in the order they are specified.
+                        \n Implementations MAY choose to implement this ordering strictly,
+                        rejecting any combination or order of filters that can not
+                        be supported. If implementations choose a strict interpretation
+                        of filter ordering, they MUST clearly document that behavior.
+                        \n To reject an invalid combination or order of filters, implementations
+                        SHOULD consider the Route Rule(s) with this configuration
+                        invalid. If all Route Rule(s) in a Route are invalid, the
+                        entire Route would be considered invalid. In only a portion
+                        of Route Rules are invalid, implementations MUST set the \"PartiallyInvalid\"
+                        condition for the Route. \n Conformance-levels at this level
+                        are defined based on the type of filter: \n - ALL core filters
+                        MUST be supported by all implementations. - Implementers are
+                        encouraged to support extended filters. - Implementation-specific
+                        custom filters have no API guarantees across implementations.
+                        \n Specifying the same filter multiple times is not supported
+                        unless explicitly indicated in the filter. \n All filters
+                        are expected to be compatible with each other except for the
+                        URLRewrite and RequestRedirect filters, which may not be combined.
+                        If an implementation can not support other combinations of
+                        filters, they must clearly document that limitation. In cases
+                        where incompatible or unsupported filters are specified and
+                        cause the `Accepted` condition to be set to status `False`,
+                        implementations may use the `IncompatibleFilters` reason to
+                        specify this configuration error. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -1128,12 +1128,16 @@ spec:
                       type: array
                     filters:
                       description: "Filters define the filters that are applied to
-                        requests that match this rule. \n The effects of ordering
-                        of multiple behaviors are currently unspecified. This can
-                        change in the future based on feedback during the alpha stage.
-                        \n Conformance-levels at this level are defined based on the
-                        type of filter: \n - ALL core filters MUST be supported by
-                        all implementations. - Implementers are encouraged to support
+                        requests that match this rule. \n This spec does not mandate
+                        a specific ordering for the execution of filters. However
+                        an implementation may decide to execute the filters in the
+                        listed order. In case the implementation cannot support the
+                        listed order (due to its internal ordering limitation), the
+                        implementation will drop the route rule with such a conflict
+                        and set the status RouteConditionPartiallyInvalid for the
+                        Route. \n Conformance-levels at this level are defined based
+                        on the type of filter: \n - ALL core filters MUST be supported
+                        by all implementations. - Implementers are encouraged to support
                         extended filters. - Implementation-specific custom filters
                         have no API guarantees across implementations. \n Specifying
                         the same filter multiple times is not supported unless explicitly
@@ -3461,12 +3465,16 @@ spec:
                       type: array
                     filters:
                       description: "Filters define the filters that are applied to
-                        requests that match this rule. \n The effects of ordering
-                        of multiple behaviors are currently unspecified. This can
-                        change in the future based on feedback during the alpha stage.
-                        \n Conformance-levels at this level are defined based on the
-                        type of filter: \n - ALL core filters MUST be supported by
-                        all implementations. - Implementers are encouraged to support
+                        requests that match this rule. \n This spec does not mandate
+                        a specific ordering for the execution of filters. However
+                        an implementation may decide to execute the filters in the
+                        listed order. In case the implementation cannot support the
+                        listed order (due to its internal ordering limitation), the
+                        implementation will drop the route rule with such a conflict
+                        and set the status RouteConditionPartiallyInvalid for the
+                        Route. \n Conformance-levels at this level are defined based
+                        on the type of filter: \n - ALL core filters MUST be supported
+                        by all implementations. - Implementers are encouraged to support
                         extended filters. - Implementation-specific custom filters
                         have no API guarantees across implementations. \n Specifying
                         the same filter multiple times is not supported unless explicitly

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -1135,10 +1135,10 @@ spec:
                         be supported. If implementations choose a strict interpretation
                         of filter ordering, they MUST clearly document that behavior.
                         \n To reject an invalid combination or order of filters, implementations
-                        SHOULD consider the Route Rule(s) with this configuration
-                        invalid. If all Route Rule(s) in a Route are invalid, the
-                        entire Route would be considered invalid. In only a portion
-                        of Route Rules are invalid, implementations MUST set the \"PartiallyInvalid\"
+                        SHOULD consider the Route Rules with this configuration invalid.
+                        If all Route Rules in a Route are invalid, the entire Route
+                        would be considered invalid. If only a portion of Route Rules
+                        are invalid, implementations MUST set the \"PartiallyInvalid\"
                         condition for the Route. \n Conformance-levels at this level
                         are defined based on the type of filter: \n - ALL core filters
                         MUST be supported by all implementations. - Implementers are
@@ -3477,10 +3477,10 @@ spec:
                         be supported. If implementations choose a strict interpretation
                         of filter ordering, they MUST clearly document that behavior.
                         \n To reject an invalid combination or order of filters, implementations
-                        SHOULD consider the Route Rule(s) with this configuration
-                        invalid. If all Route Rule(s) in a Route are invalid, the
-                        entire Route would be considered invalid. In only a portion
-                        of Route Rules are invalid, implementations MUST set the \"PartiallyInvalid\"
+                        SHOULD consider the Route Rules with this configuration invalid.
+                        If all Route Rules in a Route are invalid, the entire Route
+                        would be considered invalid. If only a portion of Route Rules
+                        are invalid, implementations MUST set the \"PartiallyInvalid\"
                         condition for the Route. \n Conformance-levels at this level
                         are defined based on the type of filter: \n - ALL core filters
                         MUST be supported by all implementations. - Implementers are

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -1128,27 +1128,32 @@ spec:
                       type: array
                     filters:
                       description: "Filters define the filters that are applied to
-                        requests that match this rule. \n This spec does not mandate
-                        a specific ordering for the execution of filters. However
-                        an implementation may decide to execute the filters in the
-                        listed order. In case the implementation cannot support the
-                        listed order (due to its internal ordering limitation), the
-                        implementation will drop the route rule with such a conflict
-                        and set the status RouteConditionPartiallyInvalid for the
-                        Route. \n Conformance-levels at this level are defined based
-                        on the type of filter: \n - ALL core filters MUST be supported
-                        by all implementations. - Implementers are encouraged to support
-                        extended filters. - Implementation-specific custom filters
-                        have no API guarantees across implementations. \n Specifying
-                        the same filter multiple times is not supported unless explicitly
-                        indicated in the filter. \n All filters are expected to be
-                        compatible with each other except for the URLRewrite and RequestRedirect
-                        filters, which may not be combined. If an implementation can
-                        not support other combinations of filters, they must clearly
-                        document that limitation. In cases where incompatible or unsupported
-                        filters are specified and cause the `Accepted` condition to
-                        be set to status `False`, implementations may use the `IncompatibleFilters`
-                        reason to specify this configuration error. \n Support: Core"
+                        requests that match this rule. \n Wherever possible, implementations
+                        SHOULD implement filters in the order they are specified.
+                        \n Implementations MAY choose to implement this ordering strictly,
+                        rejecting any combination or order of filters that can not
+                        be supported. If implementations choose a strict interpretation
+                        of filter ordering, they MUST clearly document that behavior.
+                        \n To reject an invalid combination or order of filters, implementations
+                        SHOULD consider the Route Rule(s) with this configuration
+                        invalid. If all Route Rule(s) in a Route are invalid, the
+                        entire Route would be considered invalid. In only a portion
+                        of Route Rules are invalid, implementations MUST set the \"PartiallyInvalid\"
+                        condition for the Route. \n Conformance-levels at this level
+                        are defined based on the type of filter: \n - ALL core filters
+                        MUST be supported by all implementations. - Implementers are
+                        encouraged to support extended filters. - Implementation-specific
+                        custom filters have no API guarantees across implementations.
+                        \n Specifying the same filter multiple times is not supported
+                        unless explicitly indicated in the filter. \n All filters
+                        are expected to be compatible with each other except for the
+                        URLRewrite and RequestRedirect filters, which may not be combined.
+                        If an implementation can not support other combinations of
+                        filters, they must clearly document that limitation. In cases
+                        where incompatible or unsupported filters are specified and
+                        cause the `Accepted` condition to be set to status `False`,
+                        implementations may use the `IncompatibleFilters` reason to
+                        specify this configuration error. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.
@@ -3465,27 +3470,32 @@ spec:
                       type: array
                     filters:
                       description: "Filters define the filters that are applied to
-                        requests that match this rule. \n This spec does not mandate
-                        a specific ordering for the execution of filters. However
-                        an implementation may decide to execute the filters in the
-                        listed order. In case the implementation cannot support the
-                        listed order (due to its internal ordering limitation), the
-                        implementation will drop the route rule with such a conflict
-                        and set the status RouteConditionPartiallyInvalid for the
-                        Route. \n Conformance-levels at this level are defined based
-                        on the type of filter: \n - ALL core filters MUST be supported
-                        by all implementations. - Implementers are encouraged to support
-                        extended filters. - Implementation-specific custom filters
-                        have no API guarantees across implementations. \n Specifying
-                        the same filter multiple times is not supported unless explicitly
-                        indicated in the filter. \n All filters are expected to be
-                        compatible with each other except for the URLRewrite and RequestRedirect
-                        filters, which may not be combined. If an implementation can
-                        not support other combinations of filters, they must clearly
-                        document that limitation. In cases where incompatible or unsupported
-                        filters are specified and cause the `Accepted` condition to
-                        be set to status `False`, implementations may use the `IncompatibleFilters`
-                        reason to specify this configuration error. \n Support: Core"
+                        requests that match this rule. \n Wherever possible, implementations
+                        SHOULD implement filters in the order they are specified.
+                        \n Implementations MAY choose to implement this ordering strictly,
+                        rejecting any combination or order of filters that can not
+                        be supported. If implementations choose a strict interpretation
+                        of filter ordering, they MUST clearly document that behavior.
+                        \n To reject an invalid combination or order of filters, implementations
+                        SHOULD consider the Route Rule(s) with this configuration
+                        invalid. If all Route Rule(s) in a Route are invalid, the
+                        entire Route would be considered invalid. In only a portion
+                        of Route Rules are invalid, implementations MUST set the \"PartiallyInvalid\"
+                        condition for the Route. \n Conformance-levels at this level
+                        are defined based on the type of filter: \n - ALL core filters
+                        MUST be supported by all implementations. - Implementers are
+                        encouraged to support extended filters. - Implementation-specific
+                        custom filters have no API guarantees across implementations.
+                        \n Specifying the same filter multiple times is not supported
+                        unless explicitly indicated in the filter. \n All filters
+                        are expected to be compatible with each other except for the
+                        URLRewrite and RequestRedirect filters, which may not be combined.
+                        If an implementation can not support other combinations of
+                        filters, they must clearly document that limitation. In cases
+                        where incompatible or unsupported filters are specified and
+                        cause the `Accepted` condition to be set to status `False`,
+                        implementations may use the `IncompatibleFilters` reason to
+                        specify this configuration error. \n Support: Core"
                       items:
                         description: HTTPRouteFilter defines processing steps that
                           must be completed during the request or response lifecycle.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--

-->

/kind documentation
/area conformance

**What this PR does / why we need it**:
This PR fixes #1598 by allowing an implementation to optionally implement listed order for HTTPRouteFilters in a route-rule. There are implementations (as described in #1598 and discussion #2628) where the behavior depends on certain order for the filters so we would like to have this specified as an optional behavior in the spec.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1598

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Possibly: users of certain implementations (which will conform to this new optional behavior) may need to reorder the filters they have listed in their routes.
```
