### PR TITLE
GAMMA: update language around Service as parentRef

### DIFF
--- a/geps/gep-1426/index.md
+++ b/geps/gep-1426/index.md
@@ -59,7 +59,7 @@ Add to that the ubiquity of Service in the Kubernetes ecosystem as well as the t
 
 Unfortunately, Service is a badly overloaded resource. It orchestrates not only IP address allocation and DNS but also endpoint collection and propagation, load balancing, etc. For this reason, it cannot be the only long-term answer for `parentRef` binding -- however, it is the only feasible option that mesh implementations have today, and as such the graduated GAMMA specification MUST support Service as a `parentRef`.
 
-We expect this situation to change -- and, indeed, we plan to be a part of that change. Luckily, `parentRef` is flexible enough to support additional resources in the future, which allows work on a replacement for Service in GAMMA to begin and continue in parallel with the graduation of this spec. In fact, we believe that GAMMA's use case can serve as an excellent basis for developing and trialing new, more composable mechanisms for managing IP address allocation and DNS.
+We expect this situation to change -- and, indeed, we plan to be a part of that change. Luckily, `parentRef` is flexible enough to support additional resources in the future, which allows work on adding a Service alternative in GAMMA to begin and continue in parallel with the graduation of this spec. In fact, we believe that GAMMA's use case can serve as an excellent basis for developing and trialing new, more composable mechanisms for managing IP address allocation and DNS.
 
 
 ## API

--- a/geps/gep-1426/index.md
+++ b/geps/gep-1426/index.md
@@ -53,7 +53,16 @@ This approach is dependent on both the "frontend" role of the Kubernetes `Servic
 
 ### Why Service?
 
-The GAMMA initiative has been working to bring service mesh use-cases to the Gateway API spec, taking the best practices and learnings from mesh implementations and codifying them in a spec. Most mesh users are familiar with using the Kubernetes `Service` resource as the foundation for traffic routing. Generally, this architecture makes perfect sense; unfortunately, `Service` is far too coupled of a resource. It orchestrates IP address allocation, DNS, endpoint collection and propagation, load balancing, etc. For this reason, it **cannot** be the right long-term answer for `parentRef` binding; however, it is the only feasible option that Kubernetes has for mesh implementations today. We expect this to change (indeed, we hope to be a part of that change), but in the interest of developing a spec now, we must once again lean on the `Service` resource. However, we will provide provisions to support additional resources as a `parentRef`.
+The GAMMA initiative has been working to bring service mesh use-cases to the Gateway API spec, taking the best practices and learnings from mesh implementations and codifying them in a spec. Most mesh users are familiar with using the Kubernetes `Service` resource as the foundation for traffic routing. In particular, service meshes take advantage of the IP address management and corresponding DNS functionality provided by `Service`.
+
+Generally, this architecture makes perfect sense; unfortunately, `Service` is far too coupled of a resource. It orchestrates not only IP address allocation and DNS but also endpoint collection and propagation, load balancing, etc. For this reason, it **cannot** be the right long-term answer for `parentRef` binding; however, it is the only feasible option that mesh implementations have today.
+One of the key value propositions of service meshes is that they can be added "on top" to preexisting deployments. These deployments are very likely to already consist of `Service` resources.
+In particular, the ubiquity of `Service` in the Kubernetes ecosystem and the time and effort needed to get support for a new resource into the ecosystem, for example with managed Kubernetes providers, makes waiting for a replacement infeasible.
+
+We expect this to change and indeed, we plan to be a part of that change. However, in the interest of releasing a spec for service meshes in particular now, the `Service` resource must be supported by the graduated GAMMA spec.
+
+Luckily `parentRef` is flexible enough to support additional resources in the future. Work on a replacement for `Service` in GAMMA can begin and continue in parallel with the graduation of this spec.
+In fact we believe the GAMMA use case for `Service`, i.e. IP management and DNS, serves as a great basis for developing and trialing a replacement resource.
 
 ## API
 

--- a/geps/gep-1426/index.md
+++ b/geps/gep-1426/index.md
@@ -53,16 +53,14 @@ This approach is dependent on both the "frontend" role of the Kubernetes `Servic
 
 ### Why Service?
 
-The GAMMA initiative has been working to bring service mesh use-cases to the Gateway API spec, taking the best practices and learnings from mesh implementations and codifying them in a spec. Most mesh users are familiar with using the Kubernetes `Service` resource as the foundation for traffic routing. In particular, service meshes take advantage of the IP address management and corresponding DNS functionality provided by `Service`.
+The GAMMA initiative has been working to bring service mesh use-cases to the Gateway API spec, taking the best practices and learnings from mesh implementations and codifying them in a spec. Most mesh users are familiar with using the Kubernetes Service resource as the foundation for traffic routing: not only do service meshes take advantage of the IP address management and corresponding DNS functionality provided by Service, but one of the key value propositions of service meshes is that they can be added "on top" of preexisting deployments, which are almost certain to already be using Service resources. This architecture is generally a simple, effective way for service meshes to operate.
 
-Generally, this architecture makes perfect sense; unfortunately, `Service` is far too coupled of a resource. It orchestrates not only IP address allocation and DNS but also endpoint collection and propagation, load balancing, etc. For this reason, it **cannot** be the right long-term answer for `parentRef` binding; however, it is the only feasible option that mesh implementations have today.
-One of the key value propositions of service meshes is that they can be added "on top" to preexisting deployments. These deployments are very likely to already consist of `Service` resources.
-In particular, the ubiquity of `Service` in the Kubernetes ecosystem and the time and effort needed to get support for a new resource into the ecosystem, for example with managed Kubernetes providers, makes waiting for a replacement infeasible.
+Add to that the ubiquity of Service in the Kubernetes ecosystem as well as the time and effort needed to get support for a new resource into the ecosystem (especially true for managed Kubernetes providers), and it's clearly impractical to force GAMMA to wait for a replacement for Service.
 
-We expect this to change and indeed, we plan to be a part of that change. However, in the interest of releasing a spec for service meshes in particular now, the `Service` resource must be supported by the graduated GAMMA spec.
+Unfortunately, Service is a badly overloaded resource. It orchestrates not only IP address allocation and DNS but also endpoint collection and propagation, load balancing, etc. For this reason, it cannot be the only long-term answer for `parentRef` binding -- however, it is the only feasible option that mesh implementations have today, and as such the graduated GAMMA specification MUST support Service as a `parentRef`.
 
-Luckily `parentRef` is flexible enough to support additional resources in the future. Work on a replacement for `Service` in GAMMA can begin and continue in parallel with the graduation of this spec.
-In fact we believe the GAMMA use case for `Service`, i.e. IP management and DNS, serves as a great basis for developing and trialing a replacement resource.
+We expect this situation to change -- and, indeed, we plan to be a part of that change. Luckily, `parentRef` is flexible enough to support additional resources in the future, which allows work on a replacement for Service in GAMMA to begin and continue in parallel with the graduation of this spec. In fact, we believe that GAMMA's use case can serve as an excellent basis for developing and trialing new, more composable mechanisms for managing IP address allocation and DNS.
+
 
 ## API
 

--- a/geps/gep-1426/metadata.yaml
+++ b/geps/gep-1426/metadata.yaml
@@ -12,3 +12,5 @@ relationships:
     - number: 1324
       name: Service Mesh in Gateway API
       description: Adds initial Service binding proposal
+changelog:
+  - "https://github.com/kubernetes-sigs/gateway-api/pull/2688"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind gep
/kind documentation

**What this PR does / why we need it**:

The GEP is already relatively clear on needing `Service` as `parentRef` for graduating the GEP but this tweaks the language to clarify the position.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
