### PR TITLE
Add examples for HTTP-to-HTTPS redirects.

### DIFF
--- a/examples/standard/http-redirect-rewrite/gateway-redirect-http-https.yaml
+++ b/examples/standard/http-redirect-rewrite/gateway-redirect-http-https.yaml
@@ -1,0 +1,19 @@
+#$ Used in:
+#$ - site-src/guides/http-redirect-rewrite.md
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: redirect-gateway
+spec:
+  gatewayClassName: foo-lb
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+  - name: https
+    protocol: HTTPS
+    port: 443
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: redirect-example

--- a/examples/standard/http-redirect-rewrite/httproute-redirect-http.yaml
+++ b/examples/standard/http-redirect-rewrite/httproute-redirect-http.yaml
@@ -3,16 +3,16 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: https-route
-  labels:
-    gateway: redirect-gateway
+  name: http-filter-redirect
 spec:
   parentRefs:
   - name: redirect-gateway
-    sectionName: https
+    sectionName: http
   hostnames:
   - redirect.example
   rules:
-  - backendRefs:
-    - name: example-svc
-      port: 80
+  - filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        statusCode: 301

--- a/site-src/guides/http-redirect-rewrite.md
+++ b/site-src/guides/http-redirect-rewrite.md
@@ -21,7 +21,7 @@ example, to issue a permanent redirect (301) from HTTP to HTTPS, configure
 `requestRedirect.statusCode=301` and `requestRedirect.scheme="https"`:
 
 ```yaml
-{% include 'standard/http-redirect-rewrite/httproute-redirect-https.yaml' %}
+{% include 'standard/http-redirect-rewrite/httproute-redirect-http.yaml' %}
 ```
 
 Redirects change configured URL components to match the redirect configuration
@@ -30,6 +30,32 @@ example, the request `GET http://redirect.example/cinnamon` will result in a
 301 response with a `location: https://redirect.example/cinnamon` header. The
 hostname (`redirect.example`), path (`/cinnamon`), and port (implicit) remain
 unchanged.
+
+### HTTP-to-HTTPS redirects
+
+To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP
+and HTTPS listeners.
+
+```yaml
+{% include 'standard/http-redirect-rewrite/gateway-redirect-http-https.yaml' %}
+```
+There are multiple ways to secure a Gateway. In this example, it is secured
+using a Kubernetes Secret(`redirect-example` in the `certificateRefs` section).
+
+You need a HTTPRoute that attaches to the HTTP listener and does the redirect
+to HTTPS. Here we set `sectionName` to be `http` so it only selects the
+listener named `http`.
+
+```yaml
+{% include 'standard/http-redirect-rewrite/httproute-redirect-http.yaml' %}
+```
+
+You also need a HTTPRoute that attaches to the HTTPS listener that forwards
+HTTPS traffic to application backends.
+
+```yaml
+{% include 'standard/http-redirect-rewrite/httproute-redirect-https.yaml' %}
+```
 
 ### Path redirects
 


### PR DESCRIPTION
* Add example Gateway and HTTPRoute yamls for configuring HTTP-to-HTTPS redirect for Gateway.
* Rename httproute-redirect-https.yaml to httproute-redirect-http.yaml since the redirect HTTPRoute only applies on HTTP listener. Update all reference to this file.
* Include a HTTPRoute for HTTPS traffic handling in httproute-redirect-https.yaml.

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Add examples for HTTP-to-HTTPS redirects.

**Which issue(s) this PR fixes**:
Fixes #2622 

**Does this PR introduce a user-facing change?**:
None
