### PR TITLE
[GEP-1651] Update website sidebar index to categorize as Provisional

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
       - Provisional:
         - geps/gep-91/index.md
         - geps/gep-1619/index.md
+        - geps/gep-1651/index.md
         - geps/gep-1867/index.md
       # - Implementable:
       #   -
@@ -117,7 +118,6 @@ nav:
         - geps/gep-957/index.md
         - geps/gep-1016/index.md
         - geps/gep-1426/index.md
-        - geps/gep-1651/index.md
         - geps/gep-1686/index.md
         - geps/gep-1709/index.md
         - geps/gep-1742/index.md


### PR DESCRIPTION
**What type of PR is this?**
/kind gep
/kind cleanup
/kind documentation

**What this PR does / why we need it**:

Missed in #2255, refs https://github.com/kubernetes-sigs/gateway-api/issues/1651#issuecomment-1658976444, aligns website sidebar categorization with actual current status for [GEP-1651](https://gateway-api.sigs.k8s.io/geps/gep-1651/)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
