### PR TITLE
Update webhook manifest to match API version in code.

### DIFF
--- a/config/webhook/admission_webhook.yaml
+++ b/config/webhook/admission_webhook.yaml
@@ -8,7 +8,7 @@ webhooks:
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [ "gateway.networking.k8s.io" ]
-    apiVersions: [ "v1alpha2", "v1beta1" ]
+    apiVersions: [ "v1beta1", "v1" ]
     resources: [ "gateways", "gatewayclasses", "httproutes" ]
   failurePolicy: Fail
   sideEffects: None


### PR DESCRIPTION
* The API version and resource of the webhook should match the ones in pkg/admission/server.go

**What type of PR is this?**
/kind bug
/area webhook

**What this PR does / why we need it**:
Update API resources and versions in the webhook manifest. In v1.0.0, gateway-api-addmission-server watches v1beta1 and v1 resources, while the webhook still limits to v1alpha2 and v1beta1.

**Which issue(s) this PR fixes**:
Fixes #2674 

**Does this PR introduce a user-facing change?**:
```release-note
Updated the configuration for webhook manifest. In v1.0.0, the admission webhook server only supports v1beta1 and v1 API versions for Gateway, GatewayClass, and HTTPRoute, but webhook manifest was not updated.
```
