### PR TITLE
Reordering GEPs from most to least stable

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,13 +109,21 @@ nav:
     - Policy Attachment: reference/policy-attachment.md
   - Enhancements:
     - Overview: geps/overview.md
-    - Provisional:
-      - geps/gep-91/index.md
-      - geps/gep-1619/index.md
-      - geps/gep-1651/index.md
-      - geps/gep-1867/index.md
-    # - Implementable:
-    #   -
+    - Memorandum:
+      - geps/gep-917/index.md
+      - geps/gep-922/index.md
+      - geps/gep-1324/index.md
+      - geps/gep-2659/index.md
+    - Standard:
+      - geps/gep-709/index.md
+      - geps/gep-718/index.md
+      - geps/gep-724/index.md
+      - geps/gep-726/index.md
+      - geps/gep-746/index.md
+      - geps/gep-820/index.md
+      - geps/gep-851/index.md
+      - geps/gep-1323/index.md
+      - geps/gep-1364/index.md
     - Experimental:
       - geps/gep-713/index.md
       - geps/gep-957/index.md
@@ -130,21 +138,13 @@ nav:
       - geps/gep-1911/index.md
       - geps/gep-2162/index.md
       - geps/gep-2257/index.md
-    - Standard:
-      - geps/gep-709/index.md
-      - geps/gep-718/index.md
-      - geps/gep-724/index.md
-      - geps/gep-726/index.md
-      - geps/gep-746/index.md
-      - geps/gep-820/index.md
-      - geps/gep-851/index.md
-      - geps/gep-1323/index.md
-      - geps/gep-1364/index.md
-    - Memorandum:
-      - geps/gep-917/index.md
-      - geps/gep-922/index.md
-      - geps/gep-1324/index.md
-      - geps/gep-2659/index.md
+    # - Implementable:
+    #   -
+    - Provisional:
+      - geps/gep-91/index.md
+      - geps/gep-1619/index.md
+      - geps/gep-1651/index.md
+      - geps/gep-1867/index.md
     - Declined:
       - geps/gep-735/index.md
       - geps/gep-1282/index.md


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This is a follow up to @youngnick's feedback in https://github.com/kubernetes-sigs/gateway-api/pull/2691#discussion_r1442498991. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
