### PR TITLE
 GEP-2627 DNS Configuration - Initial Provisional PR

### DIFF
--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -8,13 +8,16 @@
 For gateway infrastructure to be valuable we need to be able to connect clients to these gateways. A common way to achieve this is to use domain names/hostnames and DNS. Gateways define listeners that can have assigned hostnames or wildcards.  The guidelines for DNS configuration are a critical piece of service networking, but this is currently not expressible as part of Gateway API.   Instead of leaving this as an exercise for the user to figure out, this proposal attempts to provide options to ease Gateway API operations.
 
 ## Goals
-* Allow cluster operators to declaratively express which DNS service they want to use with a particular Gateway or Gateway Listener.
-* Provide a mechanism to allow the DNS configuration to be delegated to a chosen controller.
-* Provide a standard CRD-based API with expressive status reporting and remove the need for "loose" APIs such as annotations.
+* Provide a way for Gateway API resource owners to mark their resources as relevant for external DNS provisioning
+* Ensure that the above method has a way for multiple providers to be present in the cluster and be able to actuate external DNS provisioning requests
+* Ensure that any method is based on structured fields and makes the most of `status` on whatever resources are relevant, whether they are existing Gateway API resources or new resources.
 * Increase portability and supportability between Gateway API implementations and third party controllers offering DNS integration.
+* Clarity on the scope of hostnames under management. (This should _not_ be able to be used to affect the standard in-cluster DNS configuration)
 
 ## Non-Goals
 
+* Anything to do with configuring in-cluster DNS. This support is for configuration outside the cluster only.
+* Ways to define if the Gateway API resources are allowed to request particular hostnames. These choices should be left to the implementations that actually actuate the requests for hostnames. However, `status` flows should be specified so as to make clear if a hostname provisioning request cannot be performed.
 * Cover more complex DNS routing strategies that come into play for multi-cluster topologies such as round robin, failover, health checks, weighted and geo location with this first pass. Supporting these types of use cases for distributed gateways (e.g., in different regions or multiple gateways for resilience within a region) and offering a form of global load balancing leveraging DNS is a potential future goal.
 
 ## Use Cases

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -25,7 +25,7 @@ As a cluster administrator, I would like to have the DNS names automatically pop
 
 As a cluster administrator I would have the status of the DNS records reported back to me, so that I can leverage existing kube based monitoring tools to know the status of the integration.
 
-As a cluster administrator, I would like the DNS records to be setup automatically based on the assigned gateways address and if the IP or hostname changes, I would like for the DNS to update automatically to ensure traffic continues to reach my gateway. 
+As a cluster administrator, I would like the DNS records to be updated automatically if the `spec` of assigned gateways changes, whether those changes are for IP address or hostname. 
 
 ## API
 

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -10,7 +10,7 @@ For gateway infrastructure to be valuable we need to be able to connect clients 
 ## Goals
 * Allow cluster operators to declaratively express which DNS service they want to use with a particular Gateway or Gateway Listener.
 * Provide a mechanism to allow the DNS configuration to be delegated to a chosen controller.
-* Provide a standard CRD-based API as an alternative to the need for "loose" APIs such as annotations.   Support an easily extended, standardized, versioned, and status-reporting API.
+* Provide a standard CRD-based API with expressive status reporting and remove the need for "loose" APIs such as annotations.
 * Increase portability and supportability between Gateway API implementations and third party controllers offering DNS integration.
 
 ## Non-Goals
@@ -19,7 +19,7 @@ For gateway infrastructure to be valuable we need to be able to connect clients 
 
 ## Use Cases
 
-As a cluster administrator, I manage a set of domains and a set of gateways. I would like to declaratively define which DNS provider to use to configure connectivity for clients accessing these domains and my gateway so that I can see and configure which DNS provider is being used and limit which domains can be used.
+As a cluster administrator, I manage a set of domains and a set of gateways. I would like to declaratively define which DNS provider to use to configure connectivity for clients accessing these domains and my gateway so that I can see and configure which DNS provider is being used.
 
 As a cluster administrator, I would like to have the DNS names automatically populated into my specified DNS zones as a set of records based on the assigned addresses of my gateways so that I do not have to undertake external automation or management of this essential task.
 
@@ -32,7 +32,7 @@ As a cluster administrator, I would like the DNS records to be setup automatical
 Initial draft will not offer an API yet until the use cases are agreed. Some thoughts worth thinking about: 
 - I think it is important that we try to move away from APIs based on annotations which, while convenient, are not a full API and suffer from several limitations. An example: I want to configure a listener with a domain I own that is in a different provider than the domains of the other listeners. I want to add a new option to configure a particular weighting and so on. Soon you end up with a large set of connected annotations that often grow in complexity that really should be expressed as an API.
 
-- It is also important that this API can be delegated to controllers other than the Gateway provider. This is because there are existing solutions that may want to support whatever API decided upon. It should not **have** to be a gateway provider that has to integrate with many DNS providers. 
+- It is also important that this API can be delegated to controllers other than the Gateway API provider/implementor. This is because there are existing solutions that may want to support whatever API decided upon. It should not **have** to be a gateway provider that has to integrate with many DNS providers. 
 
 ## Conformance Details
 

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -1,0 +1,50 @@
+# GEP-2627: DNS configuration within Gateway API
+
+* Issue: [#2627](https://github.com/kubernetes-sigs/gateway-api/issues/2627)
+* Status: Provisional
+
+## TLDR
+
+For gateway infrastructure to be valuable we need to be able to connect clients to these gateways. A common way to achieve this is to use domain names/hostnames and DNS. Gateways define listeners that can have assigned hostnames or wildcards.  The guidelines for DNS configuration are a critical piece of service networking, but this is currently not expressible as part of Gateway API.   Instead of leaving this as an exercise for the user to figure out, this proposal attempts to provide options to ease Gateway API operations.
+
+## Goals
+* Allow cluster operators or infrastructure providers to declaratively express which DNS service they want to use with a particular Gateway or Gateway Listener and have that DNS service interacted with via a controller to provision and configure the defined listener hostnames as DNS names and records based on the addresses assigned to the gateway instances.
+* Provide a standard CRD-based API as an alternative to the need for "loose" APIs such as annotations.   Support an easily extended, standardized, versioned, and status-reporting API. 
+* Increase portability and supportability across gateway providers and third party implementors, for this type of key configuration
+
+## Non-Goals
+
+* Cover more complex DNS routing strategies that come into play for multi-cluster topologies such as round robin, failover, health checks, weighted and geo location with this first pass. Supporting these types of use cases for distributed gateways (e.g., in different regions or multiple gateways for resilience within a region) and offering a form of global load balancing leveraging DNS is a potential future goal.
+
+## Use Cases
+
+As a cluster administrator, I manage a set of domains and a set of gateways. I would like to declaratively define which DNS provider to use to configure connectivity for clients accessing these domains and my gateway so that I can see and configure which DNS provider is being used and limit which domains can be used.
+
+A a cluster administrator, I would like to have the dns names automatically populated into my specified dns zones as a set of records based on the assigned addresses of my gateways and have the status of the DNS records reported back to me, so that I do not have to undertake external automation or management of this essential task and can leverage existing kube based monitoring tools to know the status of the integration.
+
+As a cluster administrator, I would like the DNS records to be setup automatically based on the assigned gateways address and if the IP or hostname changes, I would like for the DNS to update automatically to ensure traffic continues to reach my gateway. 
+
+## API
+
+Initial draft will not offer an API yet until the use cases are agreed. Some thoughts worth thinking about: 
+- I think it is important that we try to move away from APIs based on annotations which, while convenient, are not a full API and suffer from several limitations. An example: I want to configure a listener with a domain I own that is in a different provider than the domains of the other listeners. I want to add a new option to configure a particular weighting and so on. Soon you end up with a large set of connected annotations that often grow in complexity that really should be expressed as an API.
+
+- It is also important that this API can be delegated to controllers other than the Gateway provider. This is because there are existing solutions that may want to support whatever API decided upon. It should not **have** to be a gateway provider that has to integrate with many DNS providers. 
+
+## Conformance Details
+
+(This section describes the names to be used for the feature or
+features in conformance tests and profiles.
+
+These should be `CamelCase` names that specify the feature as
+precisely as possible, and are particularly important for
+Extended features, since they may be surfaced to users.)
+
+## Alternatives
+
+it is possible to use `external-dns` to manage dns based on HTTPRoutes and Gateways https://github.com/kubernetes-sigs/external-dns/blob/7f3c10d65297ec1c4bcc8dd6f88c189b7f3e80d0/docs/tutorials/gateway-api.md. The aim of this GEP is not remove this as an option, but instead provide a common API that could then be leveraged by something like external-dns. 
+
+## References
+
+(Add any additional document links. Again, we should try to avoid
+too much content not in version control to avoid broken links)

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -29,7 +29,7 @@ As a cluster administrator, I would like to have the DNS names automatically pop
 As a cluster administrator I would have the status of the DNS records reported back to me, so that I can leverage existing kube based monitoring tools to know the status of the integration.
 
 As a cluster administrator, I would like the DNS records to be updated automatically if the `spec` of assigned gateways changes, whether those changes are for IP address or hostname. 
-
+As a DNS administrator, I should be able to ensure that only approved External DNS controllers can make changes to DNS zone configuration. (This should in general be taken care of by DNS system <-> External DNS controller interactions like user credentials and operation status responses, but it is important to remember that it needs to happen).
 ## API
 
 Initial draft will not offer an API yet until the use cases are agreed. Some thoughts worth thinking about: 

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -22,7 +22,7 @@ For gateway infrastructure to be valuable we need to be able to connect clients 
 
 ## Use Cases
 
-As a cluster administrator, I manage a set of domains and a set of gateways. I would like to declaratively define which DNS provider to use to configure connectivity for clients accessing these domains and my gateway so that I can see and configure which DNS provider is being used.
+As a cluster administrator, I manage a set of domains and a set of gateways. I would like to declaratively define which gateways should be used for provisioning DNS records, and, if necessary, which DNS provider to use to configure connectivity for clients accessing these domains and my gateway so that I can see and configure which DNS provider is being used.
 
 As a cluster administrator, I would like to have the DNS names automatically populated into my specified DNS zones as a set of records based on the assigned addresses of my gateways so that I do not have to undertake external automation or management of this essential task.
 

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -8,9 +8,10 @@
 For gateway infrastructure to be valuable we need to be able to connect clients to these gateways. A common way to achieve this is to use domain names/hostnames and DNS. Gateways define listeners that can have assigned hostnames or wildcards.  The guidelines for DNS configuration are a critical piece of service networking, but this is currently not expressible as part of Gateway API.   Instead of leaving this as an exercise for the user to figure out, this proposal attempts to provide options to ease Gateway API operations.
 
 ## Goals
-* Allow cluster operators or infrastructure providers to declaratively express which DNS service they want to use with a particular Gateway or Gateway Listener and have that DNS service interacted with via a controller to provision and configure the defined listener hostnames as DNS names and records based on the addresses assigned to the gateway instances.
-* Provide a standard CRD-based API as an alternative to the need for "loose" APIs such as annotations.   Support an easily extended, standardized, versioned, and status-reporting API. 
-* Increase portability and supportability across gateway providers and third party implementors, for this type of key configuration
+* Allow cluster operators to declaratively express which DNS service they want to use with a particular Gateway or Gateway Listener.
+* Provide a mechanism to allow the DNS configuration to be delegated to a chosen controller.
+* Provide a standard CRD-based API as an alternative to the need for "loose" APIs such as annotations.   Support an easily extended, standardized, versioned, and status-reporting API.
+* Increase portability and supportability between Gateway API implementations and third party controllers offering DNS integration.
 
 ## Non-Goals
 
@@ -20,7 +21,9 @@ For gateway infrastructure to be valuable we need to be able to connect clients 
 
 As a cluster administrator, I manage a set of domains and a set of gateways. I would like to declaratively define which DNS provider to use to configure connectivity for clients accessing these domains and my gateway so that I can see and configure which DNS provider is being used and limit which domains can be used.
 
-A a cluster administrator, I would like to have the dns names automatically populated into my specified dns zones as a set of records based on the assigned addresses of my gateways and have the status of the DNS records reported back to me, so that I do not have to undertake external automation or management of this essential task and can leverage existing kube based monitoring tools to know the status of the integration.
+As a cluster administrator, I would like to have the DNS names automatically populated into my specified DNS zones as a set of records based on the assigned addresses of my gateways so that I do not have to undertake external automation or management of this essential task.
+
+As a cluster administrator I would have the status of the DNS records reported back to me, so that I can leverage existing kube based monitoring tools to know the status of the integration.
 
 As a cluster administrator, I would like the DNS records to be setup automatically based on the assigned gateways address and if the IP or hostname changes, I would like for the DNS to update automatically to ensure traffic continues to reach my gateway. 
 
@@ -33,12 +36,7 @@ Initial draft will not offer an API yet until the use cases are agreed. Some tho
 
 ## Conformance Details
 
-(This section describes the names to be used for the feature or
-features in conformance tests and profiles.
-
-These should be `CamelCase` names that specify the feature as
-precisely as possible, and are particularly important for
-Extended features, since they may be surfaced to users.)
+TBD
 
 ## Alternatives
 
@@ -46,5 +44,4 @@ it is possible to use `external-dns` to manage dns based on HTTPRoutes and Gatew
 
 ## References
 
-(Add any additional document links. Again, we should try to avoid
-too much content not in version control to avoid broken links)
+TBD

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -15,7 +15,6 @@ For gateway infrastructure to be valuable we need to be able to connect clients 
 
 ## Non-Goals
 
-* Anything to do with configuring in-cluster DNS. This support is for configuration outside the cluster only.
 * Providing any upstream hostname validation mechanisms. We can provide status for validation failure, but implementations are responsible for validation.
 * Multi-cluster DNS for multi-cluster ingress solutions
 

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -5,7 +5,7 @@
 
 ## TLDR
 
-For gateway infrastructure to be valuable we need to be able to connect clients to these gateways. A common way to achieve this is to use domain names/hostnames and DNS. Gateways define listeners that can have assigned hostnames or wildcards. The guidelines for DNS configuration are a critical piece of service networking, but this is currently not expressible as part of Gateway API. Instead of leaving this unspecified and having implementations do this in potentially wildly different ways, the purpose of this proposal is to provide a standard way to specify DNS for Gateways.
+For gateway infrastructure to be valuable we need to be able to connect clients to these gateways. A common way to achieve this is to use domain names/hostnames and DNS. The guidelines for DNS configuration are a critical piece of service networking, but this is currently not expressible as part of Gateway API. Instead of leaving this unspecified and having implementations likely to do this in different ways, the purpose of this proposal is to provide a standard way to specify DNS for Gateways.
 
 ## Goals
 * Provide DNS specification for Gateway resources
@@ -16,7 +16,7 @@ For gateway infrastructure to be valuable we need to be able to connect clients 
 ## Non-Goals
 
 * Providing any upstream hostname validation mechanisms. We can provide status for validation failure, but implementations are responsible for validation.
-* Multi-cluster DNS for multi-cluster ingress solutions
+* Multi-cluster DNS for multi-cluster ingress solutions (at least not as part of the initial API)
 
 ## Use Cases
 
@@ -27,7 +27,9 @@ As a cluster administrator, I would like to have the DNS names automatically pop
 As a cluster administrator I would have the status of the DNS records reported back to me, so that I can leverage existing kube based monitoring tools to know the status of the integration.
 
 As a cluster administrator, I would like the DNS records to be updated automatically if the `spec` of assigned gateways changes, whether those changes are for IP address or hostname. 
+
 As a DNS administrator, I should be able to ensure that only approved External DNS controllers can make changes to DNS zone configuration. (This should in general be taken care of by DNS system <-> External DNS controller interactions like user credentials and operation status responses, but it is important to remember that it needs to happen).
+
 ## API
 
 Initial draft will not offer an API yet until the use cases are agreed. Some thoughts worth thinking about: 
@@ -42,6 +44,8 @@ TBD
 ## Alternatives
 
 it is possible to use `external-dns` to manage dns based on HTTPRoutes and Gateways https://github.com/kubernetes-sigs/external-dns/blob/7f3c10d65297ec1c4bcc8dd6f88c189b7f3e80d0/docs/tutorials/gateway-api.md. The aim of this GEP is not remove this as an option, but instead provide a common API that could then be leveraged by something like external-dns. 
+
+The Kuadrant project (full disclosure I work on this project), offers a [DNSPolicy API](https://docs.kuadrant.io/1.2.x/kuadrant-operator/doc/reference/dnspolicy/#dnspolicy) which in part was the basis and inspiration for opening this GEP. The DNSPolicy offered by Kuadrant goes beyond what is outlined here as it also handles multi-cluster ingress and offers common routing options such as GEO and Weighted responses. 
 
 ## References
 

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -17,7 +17,7 @@ For gateway infrastructure to be valuable we need to be able to connect clients 
 
 * Anything to do with configuring in-cluster DNS. This support is for configuration outside the cluster only.
 * Providing any upstream hostname validation mechanisms. We can provide status for validation failure, but implementations are responsible for validation.
-* Cover more complex DNS routing strategies that come into play for multi-cluster topologies such as round robin, failover, health checks, weighted and geo location with this first pass. Supporting these types of use cases for distributed gateways (e.g., in different regions or multiple gateways for resilience within a region) and offering a form of global load balancing leveraging DNS is a potential future goal.
+* Multi-cluster DNS for multi-cluster ingress solutions
 
 ## Use Cases
 

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -5,7 +5,7 @@
 
 ## TLDR
 
-For gateway infrastructure to be valuable we need to be able to connect clients to these gateways. A common way to achieve this is to use domain names/hostnames and DNS. Gateways define listeners that can have assigned hostnames or wildcards.  The guidelines for DNS configuration are a critical piece of service networking, but this is currently not expressible as part of Gateway API.   Instead of leaving this as an exercise for the user to figure out, this proposal attempts to provide options to ease Gateway API operations.
+For gateway infrastructure to be valuable we need to be able to connect clients to these gateways. A common way to achieve this is to use domain names/hostnames and DNS. Gateways define listeners that can have assigned hostnames or wildcards. The guidelines for DNS configuration are a critical piece of service networking, but this is currently not expressible as part of Gateway API. Instead of leaving this unspecified and having implementations do this in potentially wildly different ways, the purpose of this proposal is to provide a standard way to specify DNS for Gateways.
 
 ## Goals
 * Provide a way for Gateway API resource owners to mark their resources as relevant for external DNS provisioning

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -10,7 +10,7 @@ For gateway infrastructure to be valuable we need to be able to connect clients 
 ## Goals
 * Provide DNS specification for Gateway resources
 * Support multiple DNS providers and a selection mechanism for Gateways
-* Ensure that any method is based on structured fields and makes the most of `status` on whatever resources are relevant, whether they are existing Gateway API resources or new resources.
+* Provide Gateway status to communicate the state of provisioned DNS
 * Increase portability and supportability between Gateway API implementations and third party controllers offering DNS integration.
 * Clarity on the scope of hostnames under management. (This should _not_ be able to be used to affect the standard in-cluster DNS configuration)
 

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -45,8 +45,7 @@ TBD
 
 it is possible to use `external-dns` to manage dns based on HTTPRoutes and Gateways https://github.com/kubernetes-sigs/external-dns/blob/7f3c10d65297ec1c4bcc8dd6f88c189b7f3e80d0/docs/tutorials/gateway-api.md. The aim of this GEP is not remove this as an option, but instead provide a common API that could then be leveraged by something like external-dns. 
 
-The Kuadrant project (full disclosure I work on this project), offers a [DNSPolicy API](https://docs.kuadrant.io/1.2.x/kuadrant-operator/doc/reference/dnspolicy/#dnspolicy) which in part was the basis and inspiration for opening this GEP. The DNSPolicy offered by Kuadrant goes beyond what is outlined here as it also handles multi-cluster ingress and offers common routing options such as GEO and Weighted responses. 
 
 ## References
 
-TBD
+The Kuadrant project, offers a [DNSPolicy API](https://docs.kuadrant.io/1.2.x/kuadrant-operator/doc/reference/dnspolicy/#dnspolicy) which in part was the basis and inspiration for opening this GEP. The DNSPolicy offered by Kuadrant goes beyond what is outlined here as it also handles multi-cluster ingress and offers common routing options such as GEO and Weighted responses. 

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -9,7 +9,7 @@ For gateway infrastructure to be valuable we need to be able to connect clients 
 
 ## Goals
 * Provide DNS specification for Gateway resources
-* Ensure that the above method has a way for multiple providers to be present in the cluster and be able to actuate external DNS provisioning requests
+* Support multiple DNS providers and a selection mechanism for Gateways
 * Ensure that any method is based on structured fields and makes the most of `status` on whatever resources are relevant, whether they are existing Gateway API resources or new resources.
 * Increase portability and supportability between Gateway API implementations and third party controllers offering DNS integration.
 * Clarity on the scope of hostnames under management. (This should _not_ be able to be used to affect the standard in-cluster DNS configuration)

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -8,7 +8,7 @@
 For gateway infrastructure to be valuable we need to be able to connect clients to these gateways. A common way to achieve this is to use domain names/hostnames and DNS. Gateways define listeners that can have assigned hostnames or wildcards. The guidelines for DNS configuration are a critical piece of service networking, but this is currently not expressible as part of Gateway API. Instead of leaving this unspecified and having implementations do this in potentially wildly different ways, the purpose of this proposal is to provide a standard way to specify DNS for Gateways.
 
 ## Goals
-* Provide a way for Gateway API resource owners to mark their resources as relevant for external DNS provisioning
+* Provide DNS specification for Gateway resources
 * Ensure that the above method has a way for multiple providers to be present in the cluster and be able to actuate external DNS provisioning requests
 * Ensure that any method is based on structured fields and makes the most of `status` on whatever resources are relevant, whether they are existing Gateway API resources or new resources.
 * Increase portability and supportability between Gateway API implementations and third party controllers offering DNS integration.

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -12,7 +12,6 @@ For gateway infrastructure to be valuable we need to be able to connect clients 
 * Support multiple DNS providers and a selection mechanism for Gateways
 * Provide Gateway status to communicate the state of provisioned DNS
 * Increase portability and supportability between Gateway API implementations and third party controllers offering DNS integration.
-* Clarity on the scope of hostnames under management. (This should _not_ be able to be used to affect the standard in-cluster DNS configuration)
 
 ## Non-Goals
 

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -16,7 +16,7 @@ For gateway infrastructure to be valuable we need to be able to connect clients 
 ## Non-Goals
 
 * Anything to do with configuring in-cluster DNS. This support is for configuration outside the cluster only.
-* Ways to define if the Gateway API resources are allowed to request particular hostnames. These choices should be left to the implementations that actually actuate the requests for hostnames. However, `status` flows should be specified so as to make clear if a hostname provisioning request cannot be performed.
+* Providing any upstream hostname validation mechanisms. We can provide status for validation failure, but implementations are responsible for validation.
 * Cover more complex DNS routing strategies that come into play for multi-cluster topologies such as round robin, failover, health checks, weighted and geo location with this first pass. Supporting these types of use cases for distributed gateways (e.g., in different regions or multiple gateways for resilience within a region) and offering a form of global load balancing leveraging DNS is a potential future goal.
 
 ## Use Cases

--- a/geps/gep-2627/metadata.yaml
+++ b/geps/gep-2627/metadata.yaml
@@ -2,7 +2,7 @@ apiVersion: internal.gateway.networking.k8s.io/v1alpha1
 kind: GEPDetails
 number: 2627
 name: DNS configuration for Gateway API
-status: Experimental
+status: Provisional
 authors:
   - maleck13
   

--- a/geps/gep-2627/metadata.yaml
+++ b/geps/gep-2627/metadata.yaml
@@ -1,0 +1,8 @@
+apiVersion: internal.gateway.networking.k8s.io/v1alpha1
+kind: GEPDetails
+number: 2627
+name: DNS configuration for Gateway API
+status: Experimental
+authors:
+  - maleck13
+  

--- a/geps/gep-2627/metadata.yaml
+++ b/geps/gep-2627/metadata.yaml
@@ -5,4 +5,3 @@ name: DNS configuration for Gateway API
 status: Provisional
 authors:
   - maleck13
-  


### PR DESCRIPTION


/kind gep

**What this PR does / why we need it**:
Adds a draft GEP outlining more on the what and why for supporting DNS configuration as part of Gateway API


Fixes #2627 