### PR TITLE
Update examples to v1.

### DIFF
--- a/examples/experimental/basic-grpc.yaml
+++ b/examples/experimental/basic-grpc.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/api-types/grpcroute.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: acme-lb
@@ -11,7 +11,7 @@ spec:
     group: acme.io
     kind: Parameters
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: my-gateway

--- a/examples/experimental/basic-tcp.yaml
+++ b/examples/experimental/basic-tcp.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/v1alpha2/guides/tcp.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: my-tcp-gateway

--- a/examples/experimental/http-response-header.yaml
+++ b/examples/experimental/http-response-header.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: response-header-modifier

--- a/examples/experimental/v1alpha2/grpc-routing/gateway.yaml
+++ b/examples/experimental/v1alpha2/grpc-routing/gateway.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/guides/grpc-routing.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: example-gateway

--- a/examples/standard/basic-http.yaml
+++ b/examples/standard/basic-http.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/api-types/httproute.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: acme-lb
@@ -11,7 +11,7 @@ spec:
     group: acme.io
     kind: Parameters
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: my-gateway
@@ -22,7 +22,7 @@ spec:
     protocol: HTTP
     port: 80
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: http-app-1

--- a/examples/standard/cross-namespace-routing/gateway.yaml
+++ b/examples/standard/cross-namespace-routing/gateway.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/guides/multiple-ns.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: shared-gateway

--- a/examples/standard/cross-namespace-routing/site-route.yaml
+++ b/examples/standard/cross-namespace-routing/site-route.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/guides/multiple-ns.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: home
@@ -14,7 +14,7 @@ spec:
     - name: home
       port: 8080
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: login

--- a/examples/standard/cross-namespace-routing/store-route.yaml
+++ b/examples/standard/cross-namespace-routing/store-route.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/guides/multiple-ns.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: store

--- a/examples/standard/default-match-http.yaml
+++ b/examples/standard/default-match-http.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   controllerName: acme.io/gateway-controller
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: default-match-gw
@@ -20,7 +20,7 @@ spec:
 # specified, CRD defaults adds a default PathPrefix match on the path "/". This
 # matches every HTTP request and ensures that route rules always have at
 # least one valid match.
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: default-match-route

--- a/examples/standard/http-filter.yaml
+++ b/examples/standard/http-filter.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/api-types/httproute.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: http-filter-1

--- a/examples/standard/http-redirect-path.yaml
+++ b/examples/standard/http-redirect-path.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: http-filter-1

--- a/examples/standard/http-redirect-rewrite/httproute-redirect-full.yaml
+++ b/examples/standard/http-redirect-rewrite/httproute-redirect-full.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/api-types/httproute.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: http-filter-redirect

--- a/examples/standard/http-redirect-rewrite/httproute-redirect-prefix.yaml
+++ b/examples/standard/http-redirect-rewrite/httproute-redirect-prefix.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/api-types/httproute.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: http-filter-redirect

--- a/examples/standard/http-redirect-rewrite/httproute-rewrite-path.yaml
+++ b/examples/standard/http-redirect-rewrite/httproute-rewrite-path.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/api-types/httproute.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: http-filter-rewrite

--- a/examples/standard/http-redirect-rewrite/httproute-rewrite.yaml
+++ b/examples/standard/http-redirect-rewrite/httproute-rewrite.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/api-types/httproute.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: http-filter-rewrite

--- a/examples/standard/http-redirect-rewrite/httproute-rewritepath.yaml
+++ b/examples/standard/http-redirect-rewrite/httproute-rewritepath.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/api-types/httproute.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: http-filter-rewrite

--- a/examples/standard/http-redirect.yaml
+++ b/examples/standard/http-redirect.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: filter-lb
@@ -14,7 +14,7 @@ kind: Namespace
 metadata:
   name: gateway-api-example-ns1
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: my-filter-gateway
@@ -34,7 +34,7 @@ spec:
             group: ""
             name: example-com-cert
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: http-filter-1
@@ -51,7 +51,7 @@ spec:
           requestRedirect:
             scheme: https
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: http-filter-2

--- a/examples/standard/http-request-header-add.yaml
+++ b/examples/standard/http-request-header-add.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: header-http-echo

--- a/examples/standard/http-request-header-remove.yaml
+++ b/examples/standard/http-request-header-remove.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: header-http-echo

--- a/examples/standard/http-request-header-set.yaml
+++ b/examples/standard/http-request-header-set.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: header-http-echo

--- a/examples/standard/http-rewrite.yaml
+++ b/examples/standard/http-rewrite.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: http-filter-1

--- a/examples/standard/http-route-attachment/gateway-namespaces.yaml
+++ b/examples/standard/http-route-attachment/gateway-namespaces.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/concepts/api-overview.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: prod-gateway

--- a/examples/standard/http-route-attachment/gateway-strict.yaml
+++ b/examples/standard/http-route-attachment/gateway-strict.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/concepts/api-overview.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: foo-gateway

--- a/examples/standard/http-route-attachment/httproute.yaml
+++ b/examples/standard/http-route-attachment/httproute.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/concepts/api-overview.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: my-route

--- a/examples/standard/http-routing/bar-httproute.yaml
+++ b/examples/standard/http-routing/bar-httproute.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/guides/http-routing.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: bar-route

--- a/examples/standard/http-routing/foo-httproute.yaml
+++ b/examples/standard/http-routing/foo-httproute.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/guides/http-routing.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: foo-route

--- a/examples/standard/http-routing/gateway.yaml
+++ b/examples/standard/http-routing/gateway.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/guides/http-routing.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: example-gateway
@@ -11,7 +11,7 @@ spec:
     protocol: HTTP
     port: 80
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: example-route

--- a/examples/standard/httproute.yaml
+++ b/examples/standard/httproute.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: my-app

--- a/examples/standard/simple-gateway/gateway.yaml
+++ b/examples/standard/simple-gateway/gateway.yaml
@@ -1,7 +1,7 @@
 #$ Used in:
 #$ - site-src/guides/traffic-splitting.md
 #$ - site-src/guides/simple-gateway.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: prod-web

--- a/examples/standard/simple-gateway/httproute.yaml
+++ b/examples/standard/simple-gateway/httproute.yaml
@@ -1,7 +1,7 @@
 #$ Used in:
 #$ - site-src/guides/simple-gateway.md
 #$ - site-src/blog/2021/introducing-v1beta1.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: foo

--- a/examples/standard/simple-http-https/bar-route.yaml
+++ b/examples/standard/simple-http-https/bar-route.yaml
@@ -1,7 +1,7 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: bar 
+  name: bar
 spec:
   parentRefs:
   - name: example-gateway
@@ -14,5 +14,5 @@ spec:
         type: PathPrefix
         value: /
     backendRefs:
-    - name: bar-app 
+    - name: bar-app
       port: 80

--- a/examples/standard/simple-http-https/foo-route.yaml
+++ b/examples/standard/simple-http-https/foo-route.yaml
@@ -1,7 +1,7 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: foo 
+  name: foo
 spec:
   parentRefs:
   - name: example-gateway
@@ -14,12 +14,12 @@ spec:
         type: PathPrefix
         value: /
     backendRefs:
-    - name: foo-app 
+    - name: foo-app
       port: 80
   - matches:
     - path:
         type: PathPrefix
         value: /orders
     backendRefs:
-    - name: foo-orders-app 
+    - name: foo-orders-app
       port: 80

--- a/examples/standard/simple-http-https/gateway.yaml
+++ b/examples/standard/simple-http-https/gateway.yaml
@@ -1,9 +1,9 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: example-gateway
 spec:
-  gatewayClassName: prod 
+  gatewayClassName: prod
   listeners:
   - name: http
     port: 80

--- a/examples/standard/simple-http-https/tls-redirect-route.yaml
+++ b/examples/standard/simple-http-https/tls-redirect-route.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: tls-redirect

--- a/examples/standard/tls-basic.yaml
+++ b/examples/standard/tls-basic.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/guides/tls.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: tls-basic

--- a/examples/standard/tls-cert-cross-namespace.yaml
+++ b/examples/standard/tls-cert-cross-namespace.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/v1alpha2/guides/tls.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: cross-namespace-tls-gateway

--- a/examples/standard/traffic-splitting/simple-split.yaml
+++ b/examples/standard/traffic-splitting/simple-split.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/guides/traffic-splitting.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: simple-split

--- a/examples/standard/traffic-splitting/traffic-split-1.yaml
+++ b/examples/standard/traffic-splitting/traffic-split-1.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/guides/traffic-splitting.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: foo-route

--- a/examples/standard/traffic-splitting/traffic-split-2.yaml
+++ b/examples/standard/traffic-splitting/traffic-split-2.yaml
@@ -1,7 +1,7 @@
 #$ Used in:
 #$ - site-src/guides/traffic-splitting.md
 #$ - site-src/api-types/httproute.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: foo-route

--- a/examples/standard/traffic-splitting/traffic-split-3.yaml
+++ b/examples/standard/traffic-splitting/traffic-split-3.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/guides/traffic-splitting.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: foo-route

--- a/examples/standard/wildcard-tls-gateway.yaml
+++ b/examples/standard/wildcard-tls-gateway.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/guides/tls.md
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: wildcard-tls-gateway


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Updates Gateway, GatewayClass and HTTPRouter examples from v1beta1 to v1.

**Which issue(s) this PR fixes**:
Fixes #2718

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

I validated the changes by applying all the example files in dry-run mode in minikube.