### PR TITLE
Loosening TLS validation to enable indirect TLS config

### DIFF
--- a/apis/v1/gateway_types.go
+++ b/apis/v1/gateway_types.go
@@ -186,7 +186,6 @@ type GatewaySpec struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64
-	// +kubebuilder:validation:XValidation:message="tls must be specified for protocols ['HTTPS', 'TLS']",rule="self.all(l, l.protocol in ['HTTPS', 'TLS'] ? has(l.tls) : true)"
 	// +kubebuilder:validation:XValidation:message="tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']",rule="self.all(l, l.protocol in ['HTTP', 'TCP', 'UDP'] ? !has(l.tls) : true)"
 	// +kubebuilder:validation:XValidation:message="tls mode must be Terminate for protocol HTTPS",rule="self.all(l, (l.protocol == 'HTTPS' && has(l.tls)) ? (l.tls.mode == '' || l.tls.mode == 'Terminate') : true)"
 	// +kubebuilder:validation:XValidation:message="hostname must not be specified for protocols ['TCP', 'UDP']",rule="self.all(l, l.protocol in ['TCP', 'UDP']  ? (!has(l.hostname) || l.hostname == '') : true)"
@@ -375,19 +374,18 @@ const (
 )
 
 // GatewayTLSConfig describes a TLS configuration.
-//
-// +kubebuilder:validation:XValidation:message="certificateRefs must be specified when TLSModeType is Terminate",rule="self.mode == 'Terminate' ? size(self.certificateRefs) > 0 : true"
 type GatewayTLSConfig struct {
 	// Mode defines the TLS behavior for the TLS session initiated by the client.
 	// There are two possible modes:
 	//
-	// - Terminate: The TLS session between the downstream client
-	//   and the Gateway is terminated at the Gateway. This mode requires
-	//   certificateRefs to be set and contain at least one element.
+	// - Terminate: The TLS session between the downstream client and the
+	//   Gateway is terminated at the Gateway. This mode requires certificates
+	//   to be specified in some way, such as populating the certificateRefs
+	//   field.
 	// - Passthrough: The TLS session is NOT terminated by the Gateway. This
 	//   implies that the Gateway can't decipher the TLS stream except for
-	//   the ClientHello message of the TLS protocol.
-	//   CertificateRefs field is ignored in this mode.
+	//   the ClientHello message of the TLS protocol. The certificateRefs field
+	//   is ignored in this mode.
 	//
 	// Support: Core
 	//
@@ -701,8 +699,10 @@ const (
 	// true.
 	GatewayReasonProgrammed GatewayConditionReason = "Programmed"
 
-	// This reason is used with the "Programmed" and "Accepted" conditions when the Gateway is
-	// syntactically or semantically invalid.
+	// This reason is used with the "Programmed" and "Accepted" conditions when
+	// the Gateway is syntactically or semantically invalid. For example, this
+	// could include unspecified TLS configuration, or some unrecognized or
+	// invalid values in the TLS configuration.
 	GatewayReasonInvalid GatewayConditionReason = "Invalid"
 
 	// This reason is used with the "Programmed" condition when the

--- a/apis/v1/gateway_types.go
+++ b/apis/v1/gateway_types.go
@@ -374,6 +374,8 @@ const (
 )
 
 // GatewayTLSConfig describes a TLS configuration.
+//
+// +kubebuilder:validation:XValidation:message="certificateRefs or options must be specified when mode is Terminate",rule="self.mode == 'Terminate' ? size(self.certificateRefs) > 0 || size(self.options) > 0 : true"
 type GatewayTLSConfig struct {
 	// Mode defines the TLS behavior for the TLS session initiated by the client.
 	// There are two possible modes:

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -730,6 +730,11 @@ spec:
                           maxProperties: 16
                           type: object
                       type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs or options must be specified when
+                          mode is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 || size(self.options) > 0 : true'
                   required:
                   - name
                   - port
@@ -1814,6 +1819,11 @@ spec:
                           maxProperties: 16
                           type: object
                       type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs or options must be specified when
+                          mode is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 || size(self.options) > 0 : true'
                   required:
                   - name
                   - port

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -689,13 +689,14 @@ spec:
                             There are two possible modes:
 
 
-                            - Terminate: The TLS session between the downstream client
-                              and the Gateway is terminated at the Gateway. This mode requires
-                              certificateRefs to be set and contain at least one element.
+                            - Terminate: The TLS session between the downstream client and the
+                              Gateway is terminated at the Gateway. This mode requires certificates
+                              to be specified in some way, such as populating the certificateRefs
+                              field.
                             - Passthrough: The TLS session is NOT terminated by the Gateway. This
                               implies that the Gateway can't decipher the TLS stream except for
-                              the ClientHello message of the TLS protocol.
-                              CertificateRefs field is ignored in this mode.
+                              the ClientHello message of the TLS protocol. The certificateRefs field
+                              is ignored in this mode.
 
 
                             Support: Core
@@ -729,11 +730,6 @@ spec:
                           maxProperties: 16
                           type: object
                       type: object
-                      x-kubernetes-validations:
-                      - message: certificateRefs must be specified when TLSModeType
-                          is Terminate
-                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
-                          > 0 : true'
                   required:
                   - name
                   - port
@@ -746,9 +742,6 @@ spec:
                 - name
                 x-kubernetes-list-type: map
                 x-kubernetes-validations:
-                - message: tls must be specified for protocols ['HTTPS', 'TLS']
-                  rule: 'self.all(l, l.protocol in [''HTTPS'', ''TLS''] ? has(l.tls)
-                    : true)'
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
                   rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
@@ -1780,13 +1773,14 @@ spec:
                             There are two possible modes:
 
 
-                            - Terminate: The TLS session between the downstream client
-                              and the Gateway is terminated at the Gateway. This mode requires
-                              certificateRefs to be set and contain at least one element.
+                            - Terminate: The TLS session between the downstream client and the
+                              Gateway is terminated at the Gateway. This mode requires certificates
+                              to be specified in some way, such as populating the certificateRefs
+                              field.
                             - Passthrough: The TLS session is NOT terminated by the Gateway. This
                               implies that the Gateway can't decipher the TLS stream except for
-                              the ClientHello message of the TLS protocol.
-                              CertificateRefs field is ignored in this mode.
+                              the ClientHello message of the TLS protocol. The certificateRefs field
+                              is ignored in this mode.
 
 
                             Support: Core
@@ -1820,11 +1814,6 @@ spec:
                           maxProperties: 16
                           type: object
                       type: object
-                      x-kubernetes-validations:
-                      - message: certificateRefs must be specified when TLSModeType
-                          is Terminate
-                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
-                          > 0 : true'
                   required:
                   - name
                   - port
@@ -1837,9 +1826,6 @@ spec:
                 - name
                 x-kubernetes-list-type: map
                 x-kubernetes-validations:
-                - message: tls must be specified for protocols ['HTTPS', 'TLS']
-                  rule: 'self.all(l, l.protocol in [''HTTPS'', ''TLS''] ? has(l.tls)
-                    : true)'
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
                   rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -631,13 +631,14 @@ spec:
                             There are two possible modes:
 
 
-                            - Terminate: The TLS session between the downstream client
-                              and the Gateway is terminated at the Gateway. This mode requires
-                              certificateRefs to be set and contain at least one element.
+                            - Terminate: The TLS session between the downstream client and the
+                              Gateway is terminated at the Gateway. This mode requires certificates
+                              to be specified in some way, such as populating the certificateRefs
+                              field.
                             - Passthrough: The TLS session is NOT terminated by the Gateway. This
                               implies that the Gateway can't decipher the TLS stream except for
-                              the ClientHello message of the TLS protocol.
-                              CertificateRefs field is ignored in this mode.
+                              the ClientHello message of the TLS protocol. The certificateRefs field
+                              is ignored in this mode.
 
 
                             Support: Core
@@ -671,11 +672,6 @@ spec:
                           maxProperties: 16
                           type: object
                       type: object
-                      x-kubernetes-validations:
-                      - message: certificateRefs must be specified when TLSModeType
-                          is Terminate
-                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
-                          > 0 : true'
                   required:
                   - name
                   - port
@@ -688,9 +684,6 @@ spec:
                 - name
                 x-kubernetes-list-type: map
                 x-kubernetes-validations:
-                - message: tls must be specified for protocols ['HTTPS', 'TLS']
-                  rule: 'self.all(l, l.protocol in [''HTTPS'', ''TLS''] ? has(l.tls)
-                    : true)'
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
                   rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
@@ -1664,13 +1657,14 @@ spec:
                             There are two possible modes:
 
 
-                            - Terminate: The TLS session between the downstream client
-                              and the Gateway is terminated at the Gateway. This mode requires
-                              certificateRefs to be set and contain at least one element.
+                            - Terminate: The TLS session between the downstream client and the
+                              Gateway is terminated at the Gateway. This mode requires certificates
+                              to be specified in some way, such as populating the certificateRefs
+                              field.
                             - Passthrough: The TLS session is NOT terminated by the Gateway. This
                               implies that the Gateway can't decipher the TLS stream except for
-                              the ClientHello message of the TLS protocol.
-                              CertificateRefs field is ignored in this mode.
+                              the ClientHello message of the TLS protocol. The certificateRefs field
+                              is ignored in this mode.
 
 
                             Support: Core
@@ -1704,11 +1698,6 @@ spec:
                           maxProperties: 16
                           type: object
                       type: object
-                      x-kubernetes-validations:
-                      - message: certificateRefs must be specified when TLSModeType
-                          is Terminate
-                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
-                          > 0 : true'
                   required:
                   - name
                   - port
@@ -1721,9 +1710,6 @@ spec:
                 - name
                 x-kubernetes-list-type: map
                 x-kubernetes-validations:
-                - message: tls must be specified for protocols ['HTTPS', 'TLS']
-                  rule: 'self.all(l, l.protocol in [''HTTPS'', ''TLS''] ? has(l.tls)
-                    : true)'
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
                   rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -672,6 +672,11 @@ spec:
                           maxProperties: 16
                           type: object
                       type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs or options must be specified when
+                          mode is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 || size(self.options) > 0 : true'
                   required:
                   - name
                   - port
@@ -1698,6 +1703,11 @@ spec:
                           maxProperties: 16
                           type: object
                       type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs or options must be specified when
+                          mode is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 || size(self.options) > 0 : true'
                   required:
                   - name
                   - port

--- a/pkg/test/cel/gateway_test.go
+++ b/pkg/test/cel/gateway_test.go
@@ -125,7 +125,6 @@ func TestValidateGateway(t *testing.T) {
 					},
 				}
 			},
-			wantErrors: []string{"tls must be specified for protocols ['HTTPS', 'TLS']"},
 		},
 		{
 			desc: "tls config not set with tls protocol",
@@ -138,7 +137,6 @@ func TestValidateGateway(t *testing.T) {
 					},
 				}
 			},
-			wantErrors: []string{"tls must be specified for protocols ['HTTPS', 'TLS']"},
 		},
 		{
 			desc: "tls config not set with http protocol",
@@ -221,7 +219,6 @@ func TestValidateGateway(t *testing.T) {
 					},
 				}
 			},
-			wantErrors: []string{"certificateRefs must be specified when TLSModeType is Terminate"},
 		},
 		{
 			desc: "certificateRefs not set with tls protocol and TLS terminate mode",
@@ -238,7 +235,6 @@ func TestValidateGateway(t *testing.T) {
 					},
 				}
 			},
-			wantErrors: []string{"certificateRefs must be specified when TLSModeType is Terminate"},
 		},
 		{
 			desc: "certificateRefs set with tls protocol and TLS terminate mode",

--- a/pkg/test/cel/gateway_test.go
+++ b/pkg/test/cel/gateway_test.go
@@ -205,7 +205,7 @@ func TestValidateGateway(t *testing.T) {
 			wantErrors: []string{"hostname must not be specified for protocols ['TCP', 'UDP']"},
 		},
 		{
-			desc: "certificateRefs not set with https protocol and TLS terminate mode",
+			desc: "certificateRefs not set with HTTPS protocol and TLS terminate mode",
 			mutate: func(gw *gatewayv1.Gateway) {
 				tlsMode := gatewayv1.TLSModeType("Terminate")
 				gw.Spec.Listeners = []gatewayv1.Listener{
@@ -219,9 +219,10 @@ func TestValidateGateway(t *testing.T) {
 					},
 				}
 			},
+			wantErrors: []string{"certificateRefs or options must be specified when mode is Terminate"},
 		},
 		{
-			desc: "certificateRefs not set with tls protocol and TLS terminate mode",
+			desc: "certificateRefs not set with TLS protocol and TLS terminate mode",
 			mutate: func(gw *gatewayv1.Gateway) {
 				tlsMode := gatewayv1.TLSModeType("Terminate")
 				gw.Spec.Listeners = []gatewayv1.Listener{
@@ -235,9 +236,29 @@ func TestValidateGateway(t *testing.T) {
 					},
 				}
 			},
+			wantErrors: []string{"certificateRefs or options must be specified when mode is Terminate"},
 		},
 		{
-			desc: "certificateRefs set with tls protocol and TLS terminate mode",
+			desc: "certificateRefs set with HTTPS protocol and TLS terminate mode",
+			mutate: func(gw *gatewayv1.Gateway) {
+				tlsMode := gatewayv1.TLSModeType("Terminate")
+				gw.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("https"),
+						Protocol: gatewayv1.HTTPSProtocolType,
+						Port:     gatewayv1.PortNumber(8443),
+						TLS: &gatewayv1.GatewayTLSConfig{
+							Mode: &tlsMode,
+							CertificateRefs: []gatewayv1.SecretObjectReference{
+								{Name: gatewayv1.ObjectName("foo")},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "certificateRefs set with TLS protocol and TLS terminate mode",
 			mutate: func(gw *gatewayv1.Gateway) {
 				tlsMode := gatewayv1.TLSModeType("Terminate")
 				gw.Spec.Listeners = []gatewayv1.Listener{
@@ -249,6 +270,44 @@ func TestValidateGateway(t *testing.T) {
 							Mode: &tlsMode,
 							CertificateRefs: []gatewayv1.SecretObjectReference{
 								{Name: gatewayv1.ObjectName("foo")},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "options set with HTTPS protocol and TLS terminate mode",
+			mutate: func(gw *gatewayv1.Gateway) {
+				tlsMode := gatewayv1.TLSModeType("Terminate")
+				gw.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("https"),
+						Protocol: gatewayv1.HTTPSProtocolType,
+						Port:     gatewayv1.PortNumber(8443),
+						TLS: &gatewayv1.GatewayTLSConfig{
+							Mode: &tlsMode,
+							Options: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+								"networking.example.com/tls-version": "1.2",
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			desc: "options set with tls protocol and TLS terminate mode",
+			mutate: func(gw *gatewayv1.Gateway) {
+				tlsMode := gatewayv1.TLSModeType("Terminate")
+				gw.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("tls"),
+						Protocol: gatewayv1.TLSProtocolType,
+						Port:     gatewayv1.PortNumber(8443),
+						TLS: &gatewayv1.GatewayTLSConfig{
+							Mode: &tlsMode,
+							Options: map[gatewayv1.AnnotationKey]gatewayv1.AnnotationValue{
+								"networking.example.com/tls-version": "1.2",
 							},
 						},
 					},

--- a/site-src/guides/implementers.md
+++ b/site-src/guides/implementers.md
@@ -211,7 +211,7 @@ certificate stored by the external `vendor.example.com` TLS Certificate
 provider.
 
 #### 2. Automatically generated TLS certs that are populated later
-Many users would prefer that TLS certs were automatically generated on their
+Many users would prefer that TLS certs will be automatically generated on their
 behalf. One potential implementation of that would involve a controller that
 watches Gateways and HTTPRoutes, generates TLS certs, and attaches them to the
 Gateway. Depending on the implementation details, Gateway owners may need to

--- a/site-src/guides/tls.md
+++ b/site-src/guides/tls.md
@@ -4,6 +4,12 @@ Gateway API allows for a variety of ways to configure TLS. This document lays
 out various TLS settings and gives general guidelines on how to use them
 effectively.
 
+Although this doc covers the most common forms of TLS configuration with Gateway
+API, some implementations may also offer implementation-specific extensions that
+allow for different or more advanced forms of TLS configuration. In addition to
+this documentation, it's worth reading the TLS documentation for whichever
+implementation(s) you're using with Gateway API.
+
 !!! info "Experimental Channel"
 
     The `TLSRoute` and `BackendTLSPolicy` resources described below are currently only included in the


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/kind feature

**What this PR does / why we need it**:
This loosens TLS validation as requested by #2668 and #2713 and adds documentation for the self-service approaches and overall indirect TLS config this enables. This also adds a new `InvalidTLSConfig` reason for the `Programmed` condition on Gateways.

**Which issue(s) this PR fixes**:
Fixes #763 
Fixes #2668
Fixes #2713

**Does this PR introduce a user-facing change?**:
```release-note
TLS Configuration is no longer required on Gateway Listeners to enable more flexible TLS configuration.
```

This is a big PR, going to leave it on hold for a bit while we wait for consensus.
