### PR TITLE
dependabot: provide ok-to-test with default labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,21 +9,37 @@ updates:
       k8s.io: # Group k8s.io golang dependencies updates
           patterns:
             - "k8s.io/*"
+    labels:
+      - go
+      - dependencies
+      - ok-to-test
 
   # Dependencies listed in .github/workflows/*.yml
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - github_actions
+      - dependencies
+      - ok-to-test
 
   # Dependencies listed in Dockerfile
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - docker
+      - dependencies
+      - ok-to-test
 
   # Dependencies listed in requirements.txt
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - python
+      - dependencies
+      - ok-to-test


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:

This provides the actual dependabot updates with their actual labels and add ok-to-test which help reviewers save some time.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
