### PR TITLE
Move BackendTLSPolicy WellKnownCACerts field to implementation-specific

### DIFF
--- a/apis/v1alpha2/backendtlspolicy_types.go
+++ b/apis/v1alpha2/backendtlspolicy_types.go
@@ -85,7 +85,8 @@ type BackendTLSPolicyConfig struct {
 	// If CACertRefs is empty or unspecified, then WellKnownCACerts must be
 	// specified. Only one of CACertRefs or WellKnownCACerts may be specified,
 	// not both. If CACertRefs is empty or unspecified, the configuration for
-	// WellKnownCACerts MUST be honored instead.
+	// WellKnownCACerts MUST be honored instead if supported by the
+	// implementation.
 	//
 	// References to a resource in a different namespace are invalid for the
 	// moment, although we will revisit this in the future.
@@ -109,9 +110,12 @@ type BackendTLSPolicyConfig struct {
 	//
 	// If WellKnownCACerts is unspecified or empty (""), then CACertRefs must be
 	// specified with at least one entry for a valid configuration. Only one of
-	// CACertRefs or WellKnownCACerts may be specified, not both.
+	// CACertRefs or WellKnownCACerts may be specified, not both. If an
+	// implementation does not support the WellKnownCACerts field or the value
+	// supplied is not supported, the Status Conditions on the Policy MUST be
+	// updated to include an Accepted: False Condition with Reason: Invalid.
 	//
-	// Support: Core for "System"
+	// Support: Implementation-specific
 	//
 	// +optional
 	WellKnownCACerts *WellKnownCACertType `json:"wellKnownCACerts,omitempty"`

--- a/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -130,7 +130,8 @@ spec:
                       If CACertRefs is empty or unspecified, then WellKnownCACerts must be
                       specified. Only one of CACertRefs or WellKnownCACerts may be specified,
                       not both. If CACertRefs is empty or unspecified, the configuration for
-                      WellKnownCACerts MUST be honored instead.
+                      WellKnownCACerts MUST be honored instead if supported by the
+                      implementation.
 
 
                       References to a resource in a different namespace are invalid for the
@@ -210,10 +211,13 @@ spec:
 
                       If WellKnownCACerts is unspecified or empty (""), then CACertRefs must be
                       specified with at least one entry for a valid configuration. Only one of
-                      CACertRefs or WellKnownCACerts may be specified, not both.
+                      CACertRefs or WellKnownCACerts may be specified, not both. If an
+                      implementation does not support the WellKnownCACerts field or the value
+                      supplied is not supported, the Status Conditions on the Policy MUST be
+                      updated to include an Accepted: False Condition with Reason: Invalid.
 
 
-                      Support: Core for "System"
+                      Support: Implementation-specific
                     enum:
                     - System
                     type: string


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind documentation

**What this PR does / why we need it**:

Changes WellKnownCACerts field of BackendTLSPolicy to Implementation-specific support

Also updates language around what to do if WellKnownCACerts is not supported

**Which issue(s) this PR fixes**:

Fixes #2726

**Does this PR introduce a user-facing change?**:

```release-note
BackendTLSPolicy WellKnownCACerts field has been updated to implementation-specific support
```
