### PR TITLE
Add graduation criteria for Conformance Profiles GEP (1709)

### DIFF
--- a/geps/gep-1709/index.md
+++ b/geps/gep-1709/index.md
@@ -2,7 +2,7 @@
 
 * Issue: [#1709](https://github.com/kubernetes-sigs/gateway-api/issues/1709)
 * Status: Experimental
-* Probationary Period: Re-evaluate in February 2024
+* Probationary Period: Re-evaluate in April 2024
 
 ## TLDR
 

--- a/geps/gep-1709/index.md
+++ b/geps/gep-1709/index.md
@@ -646,7 +646,12 @@ The following are items that **MUST** be resolved to move this GEP to
 
 - [x] some kind of basic level of display for the report data needs to exist.
   It's OK for a more robust display layer to be part of a follow-up effort.
-- [ ] initially we were OK with storing reports in the Git repository as files.
+  - for now we ended up with badges in our implementations page. We have
+    [another effort](https://github.com/kubernetes-sigs/gateway-api/issues/2550)
+    underway to build an even better display layer, but we consider this
+    additive and the current display is sufficient for moving the project to
+    standard.
+- [x] initially we were OK with storing reports in the Git repository as files.
   While this is probably sufficient during the `Experimental` phase, we need to
   re-evaluate this before `Standard` and see if this remains sufficient or if
   we want to store the data elsewhere.

--- a/geps/gep-1709/index.md
+++ b/geps/gep-1709/index.md
@@ -655,7 +655,10 @@ The following are items that **MUST** be resolved to move this GEP to
   While this is probably sufficient during the `Experimental` phase, we need to
   re-evaluate this before `Standard` and see if this remains sufficient or if
   we want to store the data elsewhere.
-- [ ] We have been actively [gathering feedback from SIG
+  - During the experimental phase this has not caused any significant issues,
+    so for the purposes of calling this standard we're going to move forward
+    as-is. It should be straightforward and reasonable to change the storage
+    mechanism later as needs arise.
   Arch][sig-arch-feedback]. Some time during the `experimental` phase needs to
   be allowed to continue to engage with SIG Arch and incorporate their feedback
   into the test suite.

--- a/geps/gep-1709/index.md
+++ b/geps/gep-1709/index.md
@@ -659,9 +659,14 @@ The following are items that **MUST** be resolved to move this GEP to
     so for the purposes of calling this standard we're going to move forward
     as-is. It should be straightforward and reasonable to change the storage
     mechanism later as needs arise.
+- [x] We have been actively [gathering feedback from SIG
   Arch][sig-arch-feedback]. Some time during the `experimental` phase needs to
   be allowed to continue to engage with SIG Arch and incorporate their feedback
   into the test suite.
+  - SIG Arch did not have any significant feedback during the experimental
+    phase. In the same timespan the Network Policy group has started using our
+    test suite and APIs as well, so it seems the overall approach has obvious
+    merit, and doesn't appear to be redundant.
 
 [sig-arch-feedback]:https://groups.google.com/g/kubernetes-sig-architecture/c/YjrVZ4NJQiA/m/7Qg7ScddBwAJ
 

--- a/geps/gep-1709/index.md
+++ b/geps/gep-1709/index.md
@@ -667,6 +667,10 @@ The following are items that **MUST** be resolved to move this GEP to
     phase. In the same timespan the Network Policy group has started using our
     test suite and APIs as well, so it seems the overall approach has obvious
     merit, and doesn't appear to be redundant.
+- [ ] Finalize the report organization structure based on feedback during the
+  experimental phase.
+- [ ] Base documentation must exist for implementations to run the tests via
+  the CLI and via the Golang library.
 
 [sig-arch-feedback]:https://groups.google.com/g/kubernetes-sig-architecture/c/YjrVZ4NJQiA/m/7Qg7ScddBwAJ
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind gep

**What this PR does / why we need it**:

This adds two new pieces of graduation criteria to GEP-1709, and resolves some others.

This also includes an explicit request to extend the probationary period of the GEP a couple more months to achieve these goals, so as per our rules this will need to be approved by both my co-maintainers:

/cc @robscott @youngnick 

At this point what we consider to be blocking standard is a bit of re-organization of how `ConformanceReports` look and are stored based on recent GEP updates, and documentation for using the test suite must be present. We currently expect we should be able to get this done prior to Kubecon Paris, thus the April timeline for extension before we re-evaluate.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
