### PR TITLE
added a new unit test case

### DIFF
--- a/conformance/utils/kubernetes/helpers_test.go
+++ b/conformance/utils/kubernetes/helpers_test.go
@@ -59,6 +59,12 @@ func TestNewGatewayRef(t *testing.T) {
 				"fake-listener-3",
 			},
 		},
+		{
+			name: "verifying the contents of a GatewayRef with nil listener names",
+			nsn:  types.NamespacedName{Namespace: corev1.NamespaceDefault, Name: "fake-gateway"},
+			// nil listenerNames
+			listenerNames: nil,
+		},
 	}
 
 	for i := 0; i < len(tests); i++ {
@@ -66,7 +72,7 @@ func TestNewGatewayRef(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ref := NewGatewayRef(test.nsn, test.listenerNames...)
 			require.IsType(t, GatewayRef{}, ref)
-			if test.listenerNames == nil {
+			if test.listenerNames == nil || len(test.listenerNames) == 0 {
 				require.Len(t, ref.listenerNames, 1)
 				assert.Equal(t, "", string(*ref.listenerNames[0]))
 			} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:
In the context of [NewGatewayRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/utils/kubernetes/helpers.go) function, having a nil test case allows you to verify that the function correctly handles nil values for the listenerNames parameter. If function is designed to handle nil values by providing some default behavior, this test case ensures that the default behavior is working as intended.

**Which issue(s) this PR fixes**:
If [NewGatewayRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/utils/kubernetes/helpers.go) function is expected to provide default values or behavior when the listenerNames parameter is nil, the test case helps ensure that the defaults are correctly applied.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
