### PR TITLE
Update broken link of implementation in faq.md

### DIFF
--- a/site-src/faq.md
+++ b/site-src/faq.md
@@ -18,7 +18,7 @@ For more information, see the [Migrating from
 Ingress](/guides/migrating-from-ingress/) guide.
 
 #### Will there be a default controller implementation?
-No. There are already many great [implementations](/implementations) to choose
+No. There are already many great [implementations](/implementations.md) to choose
 from. The scope of this project is to define the API, conformance tests, and
 overall documentation.
 

--- a/site-src/faq.md
+++ b/site-src/faq.md
@@ -18,7 +18,7 @@ For more information, see the [Migrating from
 Ingress](/guides/migrating-from-ingress/) guide.
 
 #### Will there be a default controller implementation?
-No. There are already many great [implementations](/implementations.md) to choose
+No. There are already many great [implementations](/site-src/implementations.md) to choose
 from. The scope of this project is to define the API, conformance tests, and
 overall documentation.
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
Fixed a broken link in `site-src/faq.md` for `implementations.md`

PS: This is my first contribution to gateway-api project.