### PR TITLE
Adding gwctl OWNERS, making Gaurav first approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -44,3 +44,9 @@ aliases:
   gateway-api-gep-reviewers:
     - candita
     - gcs278
+
+  gwctl-approvers:
+    - gauravkghildiyal
+
+  gwctl-reviewers:
+    - gauravkghildiyal

--- a/gwctl/OWNERS
+++ b/gwctl/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+# See the OWNERS_ALIASES file at https://github.com/kubernetes-sigs/gateway-api/blob/main/OWNERS_ALIASES for a list of members for each alias.
+
+approvers:
+  - gwctl-approvers
+
+reviewers:
+  - gwctl-reviewers
+
+labels:
+  - area/gwctl


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This adds an OWNERS file for gwctl and makes @gauravkghildiyal the first approver. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @shaneutt @youngnick 