### PR TITLE
Move Bowei to emeritus maintainer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,12 +10,12 @@ aliases:
 
   # Reference: https://github.com/kubernetes/org/blob/main/config/kubernetes-sigs/sig-network/teams.yaml
   gateway-api-maintainers:
-    - bowei
     - robscott
     - shaneutt
     - youngnick
 
   emeritus-gateway-api-maintainers:
+    - bowei
     - danehans
     - hbagdi
     - jpeach


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This moves @bowei to emeritus maintainer. He's had an especially foundational role in the success of this project and will continue to be involved, just not as an active maintainer.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @shaneutt @youngnick 
