### PR TITLE
Add route port attachment doc

### DIFF
--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -83,7 +83,7 @@ spec:
     port: 8080
 ```
 
-Binding to a port also llows you to attach to multiple listeners at once.
+Binding to a port also allows you to attach to multiple listeners at once.
 For example, binding to port `8090` of the `acme-lb` Gateway would be more
 convenient than binding to the corresponding listeners by name:
 

--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -43,6 +43,64 @@ spec:
 Note that the target Gateway needs to allow HTTPRoutes from the route's
 namespace to be attached for the attachment to be successful.
 
+You can also attach routes to specific sections of the parent resource.
+For example, let's say that the `acme-lb` Gateway includes the following
+listeners:
+
+```yaml
+  listeners:
+  - name: foo
+    protocol: HTTP
+    port: 8080
+    ...
+  - name: bar
+    protocol: HTTP
+    port: 8090
+    ...
+  - name: baz
+    protocol: HTTP
+    port: 8090
+    ...
+```
+
+You can bind a route to listener `foo` only, using the `sectionName` field
+in `parentRefs`:
+
+```yaml
+spec:
+  parentRefs:
+  - name: acme-lb
+    sectionName: foo
+```
+
+Alternatively, you can achieve the same effect by using the `port` field,
+instead of `sectionName`, in the `parentRefs`:
+
+```yaml
+spec:
+  parentRefs:
+  - name: acme-lb
+    port: 8080
+```
+
+Binding to a port also llows you to attach to multiple listeners at once.
+For example, binding to port `8090` of the `acme-lb` Gateway would be more
+convenient than binding to the corresponding listeners by name:
+
+```yaml
+spec:
+  parentRefs:
+  - name: acme-lb
+    sectionName: bar
+  - name: acme-lb
+    sectionName: baz
+```
+
+However, when binding Routes by port number, Gateway admins will no longer have
+the flexibility to switch ports on the Gateway without also updating the Routes.
+The approach should only be used when a Route should apply to a specific port
+number as opposed to listeners whose ports may be changed.
+
 ### Hostnames
 
 Hostnames define a list of hostnames to match against the Host header of the

--- a/site-src/guides/tcp.md
+++ b/site-src/guides/tcp.md
@@ -49,8 +49,24 @@ In this way each `TCPRoute` "attaches" itself to a different port on the
 `Gateway` so that the service `my-foo-service` is taking traffic for port `8080`
 from outside the cluster and `my-bar-service` takes the port `8090` traffic.
 
+Note that you can achieve this same result by binding the Routes to the Gateway
+listeners using the `port` field in the `parentRefs`:
+
+```yaml
+spec:
+  parentRefs:
+  - name: my-tcp-gateway
+    port: 8080
+```
+
+Using the `port` field instead of `sectionName` for the attachment has the
+downside of more tightly coupling the relationship between the Gateway and
+its associated Routes. Refer to [Attaching to Gateways][attaching] for more
+details.
+
 [tcproute]:/reference/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute
 [tcp]:https://datatracker.ietf.org/doc/html/rfc793
 [httproute]:/reference/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRoute
 [gateway]:/reference/spec/#gateway.networking.k8s.io/v1alpha2.Gateway
 [svc]:https://kubernetes.io/docs/concepts/services-networking/service/
+[attaching]:/api-types/httproute/#attaching-to-gateways


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind documentation

**What this PR does / why we need it**:

Add documentation for route port attachment needed to promote GEP-957 to standard.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
