### PR TITLE
Add route port attachment conformance test

### DIFF
--- a/conformance/tests/httproute-listener-port-matching.go
+++ b/conformance/tests/httproute-listener-port-matching.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteListenerPortMatching)
+}
+
+var HTTPRouteListenerPortMatching = suite.ConformanceTest{
+	ShortName:   "HTTPRouteListenerPortMatching",
+	Description: "Multiple HTTP listeners with different ports, each with a different HTTPRoute",
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportHTTPRoute,
+		suite.SupportHTTPRouteParentRefPort,
+	},
+	Manifests: []string{"tests/httproute-listener-port-matching.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+
+		// This test creates an additional Gateway in the gateway-conformance-infra
+		// namespace so we have to wait for it to be ready.
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+
+		routeNN1 := types.NamespacedName{Name: "backend-v1", Namespace: ns}
+		routeNN2 := types.NamespacedName{Name: "backend-v2", Namespace: ns}
+		routeNN3 := types.NamespacedName{Name: "backend-v3", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "httproute-listener-port-matching", Namespace: ns}
+
+		gwAddr80 := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-1"), routeNN1)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN1, gwNN)
+
+		gwAddr8080 := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-2"), routeNN2)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN2, gwNN)
+
+		gwAddr8090 := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-4"), routeNN3)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN3, gwNN)
+
+		testCases := []http.ExpectedResponse{{
+			Request:   http.Request{Host: "foo.com", Path: "/"},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Host: "foo.com:8080", Path: "/"},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Host: "bar.com:8080", Path: "/"},
+			Backend:   "infra-backend-v2",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Host: "foo.com:8090", Path: "/"},
+			Backend:   "infra-backend-v3",
+			Namespace: ns,
+		}, {
+			Request:  http.Request{Host: "bar.com:8090", Path: "/"},
+			Response: http.Response{StatusCode: 404},
+		}}
+
+		for i := range testCases {
+			// Declare tc here to avoid loop variable
+			// reuse issues across parallel tests.
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				gwAddr := gwAddr80
+				hostport := strings.Split(tc.Request.Host, ":")
+				if len(hostport) == 2 {
+					switch hostport[1] {
+					case "8080":
+						gwAddr = gwAddr8080
+						break
+					case "8090":
+						gwAddr = gwAddr8090
+						break
+					}
+				}
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-listener-port-matching.go
+++ b/conformance/tests/httproute-listener-port-matching.go
@@ -94,10 +94,8 @@ var HTTPRouteListenerPortMatching = suite.ConformanceTest{
 					switch hostport[1] {
 					case "8080":
 						gwAddr = gwAddr8080
-						break
 					case "8090":
 						gwAddr = gwAddr8090
-						break
 					}
 				}
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)

--- a/conformance/tests/httproute-listener-port-matching.yaml
+++ b/conformance/tests/httproute-listener-port-matching.yaml
@@ -1,0 +1,89 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: httproute-listener-port-matching
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: listener-1
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: foo.com
+  - name: listener-2
+    port: 8080
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: foo.com
+  - name: listener-3
+    port: 8080
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: bar.com
+  - name: listener-4
+    port: 8090
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: foo.com
+  - name: listener-5
+    port: 8090
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: bar.com
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-v1
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: httproute-listener-port-matching
+    namespace: gateway-conformance-infra
+    port: 80
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-v2
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: httproute-listener-port-matching
+    namespace: gateway-conformance-infra
+    port: 8080
+  rules:
+  - backendRefs:
+    - name: infra-backend-v2
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-v3
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: httproute-listener-port-matching
+    namespace: gateway-conformance-infra
+    port: 8090
+    sectionName: listener-4
+  rules:
+  - backendRefs:
+    - name: infra-backend-v3
+      port: 8080

--- a/conformance/tests/mesh-ports.go
+++ b/conformance/tests/mesh-ports.go
@@ -34,6 +34,7 @@ var MeshPorts = suite.ConformanceTest{
 	Features: []suite.SupportedFeature{
 		suite.SupportMesh,
 		suite.SupportHTTPRoute,
+		suite.SupportHTTPRouteParentRefPort,
 		suite.SupportHTTPRouteResponseHeaderModification,
 	},
 	Manifests: []string{"tests/mesh-ports.yaml"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind test
/area conformance

**What this PR does / why we need it**:

Conformance test needed to promote GEP-957 to standard.

Tested and passes with Istio implementation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
