### PR TITLE
Promote GEP-957 to standard channel

### DIFF
--- a/apis/v1/shared_types.go
+++ b/apis/v1/shared_types.go
@@ -150,7 +150,6 @@ type ParentReference struct {
 	// Support: Extended
 	//
 	// +optional
-	// <gateway:experimental>
 	Port *PortNumber `json:"port,omitempty"`
 }
 

--- a/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -387,7 +387,7 @@ spec:
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
-                          description: |+
+                          description: |-
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
@@ -423,8 +423,6 @@ spec:
 
 
                             Support: Extended
-
-
                           format: int32
                           maximum: 65535
                           minimum: 1

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -338,7 +338,7 @@ spec:
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     port:
-                      description: |+
+                      description: |-
                         Port is the network port this Route targets. It can be interpreted
                         differently based on the type of parent resource.
 
@@ -374,8 +374,6 @@ spec:
 
 
                         Support: Extended
-
-
                       format: int32
                       maximum: 65535
                       minimum: 1
@@ -2162,7 +2160,7 @@ spec:
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
-                          description: |+
+                          description: |-
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
@@ -2198,8 +2196,6 @@ spec:
 
 
                             Support: Extended
-
-
                           format: int32
                           maximum: 65535
                           minimum: 1

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -316,7 +316,7 @@ spec:
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     port:
-                      description: |+
+                      description: |-
                         Port is the network port this Route targets. It can be interpreted
                         differently based on the type of parent resource.
 
@@ -352,8 +352,6 @@ spec:
 
 
                         Support: Extended
-
-
                       format: int32
                       maximum: 65535
                       minimum: 1
@@ -3042,7 +3040,7 @@ spec:
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
-                          description: |+
+                          description: |-
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
@@ -3078,8 +3076,6 @@ spec:
 
 
                             Support: Extended
-
-
                           format: int32
                           maximum: 65535
                           minimum: 1
@@ -3437,7 +3433,7 @@ spec:
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     port:
-                      description: |+
+                      description: |-
                         Port is the network port this Route targets. It can be interpreted
                         differently based on the type of parent resource.
 
@@ -3473,8 +3469,6 @@ spec:
 
 
                         Support: Extended
-
-
                       format: int32
                       maximum: 65535
                       minimum: 1
@@ -6163,7 +6157,7 @@ spec:
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
-                          description: |+
+                          description: |-
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
@@ -6199,8 +6193,6 @@ spec:
 
 
                             Support: Extended
-
-
                           format: int32
                           maximum: 65535
                           minimum: 1

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -221,7 +221,7 @@ spec:
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     port:
-                      description: |+
+                      description: |-
                         Port is the network port this Route targets. It can be interpreted
                         differently based on the type of parent resource.
 
@@ -257,8 +257,6 @@ spec:
 
 
                         Support: Extended
-
-
                       format: int32
                       maximum: 65535
                       minimum: 1
@@ -724,7 +722,7 @@ spec:
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
-                          description: |+
+                          description: |-
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
@@ -760,8 +758,6 @@ spec:
 
 
                             Support: Extended
-
-
                           format: int32
                           maximum: 65535
                           minimum: 1

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -291,7 +291,7 @@ spec:
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     port:
-                      description: |+
+                      description: |-
                         Port is the network port this Route targets. It can be interpreted
                         differently based on the type of parent resource.
 
@@ -327,8 +327,6 @@ spec:
 
 
                         Support: Extended
-
-
                       format: int32
                       maximum: 65535
                       minimum: 1
@@ -797,7 +795,7 @@ spec:
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
-                          description: |+
+                          description: |-
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
@@ -833,8 +831,6 @@ spec:
 
 
                             Support: Extended
-
-
                           format: int32
                           maximum: 65535
                           minimum: 1

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -221,7 +221,7 @@ spec:
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     port:
-                      description: |+
+                      description: |-
                         Port is the network port this Route targets. It can be interpreted
                         differently based on the type of parent resource.
 
@@ -257,8 +257,6 @@ spec:
 
 
                         Support: Extended
-
-
                       format: int32
                       maximum: 65535
                       minimum: 1
@@ -724,7 +722,7 @@ spec:
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
-                          description: |+
+                          description: |-
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
@@ -760,8 +758,6 @@ spec:
 
 
                             Support: Extended
-
-
                           format: int32
                           maximum: 65535
                           minimum: 1

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -291,6 +291,43 @@ spec:
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
                     sectionName:
                       description: |-
                         SectionName is the name of a section within the target resource. In the
@@ -2901,6 +2938,43 @@ spec:
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
                         sectionName:
                           description: |-
                             SectionName is the name of a section within the target resource. In the
@@ -3229,6 +3303,43 @@ spec:
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
                     sectionName:
                       description: |-
                         SectionName is the name of a section within the target resource. In the
@@ -5839,6 +5950,43 @@ spec:
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
                         sectionName:
                           description: |-
                             SectionName is the name of a section within the target resource. In the

--- a/geps/gep-957/index.md
+++ b/geps/gep-957/index.md
@@ -1,13 +1,7 @@
 # GEP-957: Destination Port Matching
 
 * Issue: [#957](https://github.com/kubernetes-sigs/gateway-api/issues/957)
-* Status: Experimental
-
-> **Note**: This GEP is exempt from the [Probationary Period][expprob] rules of
-> our GEP overview as it existed before those rules did, and so it has been
-> explicitly grandfathered in.
-
-[expprob]:https://gateway-api.sigs.k8s.io/geps/overview/#probationary-period
+* Status: Standard
 
 ## TLDR
 

--- a/geps/gep-957/metadata.yaml
+++ b/geps/gep-957/metadata.yaml
@@ -2,7 +2,7 @@ apiVersion: internal.gateway.networking.k8s.io/v1alpha1
 kind: GEPDetails
 number: 957
 name: Destination Port Matching
-status: Experimental
+status: Standard
 authors:
   - cxhiano
   - robscott

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,7 +117,6 @@ nav:
     #   -
     - Experimental:
       - geps/gep-713/index.md
-      - geps/gep-957/index.md
       - geps/gep-1016/index.md
       - geps/gep-1426/index.md
       - geps/gep-1686/index.md
@@ -137,6 +136,7 @@ nav:
       - geps/gep-746/index.md
       - geps/gep-820/index.md
       - geps/gep-851/index.md
+      - geps/gep-957/index.md
       - geps/gep-1323/index.md
       - geps/gep-1364/index.md
     - Memorandum:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind gep

**What this PR does / why we need it**:

GEP-957 should be moved from experimental to standard channel.

Depends on: #2775 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #957

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Attaching routes to gateways by port number (GEP-957) feature moved to standard channel.
```
