### PR TITLE
Implement `gwctl get gateways`

### DIFF
--- a/gwctl/pkg/printer/gateways.go
+++ b/gwctl/pkg/printer/gateways.go
@@ -19,11 +19,17 @@ package printer
 import (
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
 
 	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/gateway-api/gwctl/pkg/policymanager"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery"
+
+	"k8s.io/apimachinery/pkg/util/duration"
 )
 
 type GatewaysPrinter struct {
@@ -38,6 +44,50 @@ type gatewayDescribeView struct {
 	GatewayClass             string                                             `json:",omitempty"`
 	DirectlyAttachedPolicies []policymanager.ObjRef                             `json:",omitempty"`
 	EffectivePolicies        map[policymanager.PolicyCrdID]policymanager.Policy `json:",omitempty"`
+}
+
+func (gp *GatewaysPrinter) Print(resourceModel *resourcediscovery.ResourceModel) {
+	tw := tabwriter.NewWriter(gp.Out, 0, 0, 2, ' ', 0)
+	row := []string{"NAME", "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE"}
+	tw.Write([]byte(strings.Join(row, "\t") + "\n"))
+
+	for _, gatewayNode := range resourceModel.Gateways {
+		var addresses []string
+		for _, address := range gatewayNode.Gateway.Status.Addresses {
+			addresses = append(addresses, address.Value)
+		}
+		addressesOutput := strings.Join(addresses, ",")
+		if cnt := len(addresses); cnt > 2 {
+			addressesOutput = fmt.Sprintf("%v + %v more", strings.Join(addresses[:2], ","), cnt-2)
+		}
+
+		var ports []string
+		for _, listener := range gatewayNode.Gateway.Spec.Listeners {
+			ports = append(ports, strconv.Itoa(int(listener.Port)))
+		}
+		portsOutput := strings.Join(ports, ",")
+
+		programmedStatus := "Unknown"
+		for _, condition := range gatewayNode.Gateway.Status.Conditions {
+			if condition.Type == "Programmed" {
+				programmedStatus = string(condition.Status)
+				break
+			}
+		}
+
+		age := duration.HumanDuration(time.Since(gatewayNode.Gateway.GetCreationTimestamp().Time))
+
+		row := []string{
+			gatewayNode.Gateway.GetName(),
+			string(gatewayNode.Gateway.Spec.GatewayClassName),
+			addressesOutput,
+			portsOutput,
+			programmedStatus,
+			age,
+		}
+		tw.Write([]byte(strings.Join(row, "\t") + "\n"))
+	}
+	tw.Flush()
 }
 
 func (gp *GatewaysPrinter) PrintDescribeView(resourceModel *resourcediscovery.ResourceModel) {


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind feature
/area gwctl
/cc @gauravkghildiyal

**What this PR does / why we need it**:

Implement `gwctl get gateways`.

| Output Columns     | Description                                           | Visibility |
|------------|-------------------------------------------------------|---------|
| `NAME`       | Name of the Gateway                                   |         |
| `CLASS`      | Class of the Gateway                                  |         |
| `ADDRESSES`  | Addresses of the Gateway (displayed using +n more)    |         |
| `PORTS`      | Ports exposed by the Gateway                          |         |
| `PROGRAMMED` | Whether the Gateway is programmed                     |         |
| `AGE`        | Age of the Gateway                                    |         |
| `POLICIES`   | Count of policies affecting this Gateway              | `-o wide` |
| `HTTPROUTES` | Count of HTTPRoutes that are attached to this Gateway | `-o wide` |

The `-o wide` format is not yet implemented, so the columns `POLICIES`, `HTTPROUTES` are excluded.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2778 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Implement `gwctl get gateways`
```
