### PR TITLE
Remove hidden dependency for client-go/plugin/pkg/client/auth

### DIFF
--- a/conformance/utils/kubernetes/certificate.go
+++ b/conformance/utils/kubernetes/certificate.go
@@ -33,9 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	// ensure auth plugins are loaded
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 const (


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/area conformance

**What this PR does / why we need it**:
There is unnecessary import of `client-go/plugin/pkg/client/auth` in `conformance/utils/kubernetes/certificates.go`.
So, this PR proposes to remove the import.

Since `conformance/conformance.go` already import the auth plugin package, it is not necessary to import. 
In addition, due to this dependency, if we want to make a code based on `conformance/utils/suite` or `conformance/utils/kubernetes` package, the code should unavoidably have the auth plugin dependencies comes from `client-go/plugin/pkg/client/auth`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
