### PR TITLE
feat: conformance report summary field

### DIFF
--- a/conformance/apis/v1alpha1/profilereport.go
+++ b/conformance/apis/v1alpha1/profilereport.go
@@ -23,6 +23,10 @@ type ProfileReport struct {
 	// "TLS", "Mesh", e.t.c.).
 	Name string `json:"name"`
 
+	// Summary is a human-readable message intended for end-users to understand
+	// the overall status at a glance.
+	Summary string `json:"summary"`
+
 	// Core indicates the core support level which includes the set of tests
 	// which are the minimum the implementation must pass to be considered at
 	// all conformant.
@@ -50,10 +54,6 @@ type ExtendedStatus struct {
 // Status includes details on the results of a test.
 type Status struct {
 	Result `json:"result"`
-
-	// Summary is a human-readable message intended for end-users to understand
-	// the overall status at a glance.
-	Summary string `json:"summary"`
 
 	// Statistics includes numerical statistics on the result of the test run.
 	Statistics `json:"statistics"`

--- a/conformance/experimental_conformance_test.go
+++ b/conformance/experimental_conformance_test.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/yaml"
 
-	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	confv1a1 "sigs.k8s.io/gateway-api/conformance/apis/v1alpha1"
@@ -66,7 +66,7 @@ func TestExperimentalConformance(t *testing.T) {
 
 	v1alpha2.AddToScheme(mgrClient.Scheme())
 	v1beta1.AddToScheme(mgrClient.Scheme())
-	v1.AddToScheme(mgrClient.Scheme())
+	gatewayv1.AddToScheme(mgrClient.Scheme())
 
 	// standard conformance flags
 	supportedFeatures = suite.ParseSupportedFeatures(*flags.SupportedFeatures)

--- a/conformance/utils/suite/experimental_reports.go
+++ b/conformance/utils/suite/experimental_reports.go
@@ -187,21 +187,21 @@ func isTestExtended(profile ConformanceProfile, test ConformanceTest) bool {
 }
 
 // buildSummary creates a human-readable message about each profile's test outcomes.
-func buildSummary(report confv1a1.ProfileReport) string {
-	reportMessage := fmt.Sprintf("Core tests %s", buildReportMessage(report.Core))
+func buildSummary(report confv1a1.ProfileReport) (reportSummary string) {
+	reportSummary = fmt.Sprintf("Core tests %s", buildReportSummary(report.Core))
 	if report.Extended != nil {
-		reportMessage = fmt.Sprintf("%s. Extended tests %s", reportMessage, buildReportMessage(report.Extended.Status))
+		reportSummary = fmt.Sprintf("%s. Extended tests %s", reportSummary, buildReportSummary(report.Extended.Status))
 	}
-	return fmt.Sprintf("%s.", reportMessage)
+	return fmt.Sprintf("%s.", reportSummary)
 }
 
-func buildReportMessage(status confv1a1.Status) string {
+func buildReportSummary(status confv1a1.Status) string {
 	var message string
 	switch status.Result {
 	case confv1a1.Success:
-		message = "succedeed"
+		message = "succeeded"
 	case confv1a1.Partial:
-		message = fmt.Sprintf("partially succedeed with %d test skips", status.Statistics.Skipped)
+		message = fmt.Sprintf("partially succeeded with %d test skips", status.Statistics.Skipped)
 	case confv1a1.Failure:
 		message = fmt.Sprintf("failed with %d test failures", status.Statistics.Failed)
 	}

--- a/conformance/utils/suite/experimental_reports.go
+++ b/conformance/utils/suite/experimental_reports.go
@@ -17,6 +17,7 @@ limitations under the License.
 package suite
 
 import (
+	"fmt"
 	"sort"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -128,6 +129,7 @@ func (p profileReportsMap) compileResults(supportedFeaturesMap map[ConformancePr
 				report.Extended.Result = confv1a1.Success
 			}
 		}
+		report.Summary = buildSummary(report)
 		p[key] = report
 
 		supportedFeatures := supportedFeaturesMap[ConformanceProfileName(report.Name)]
@@ -182,4 +184,26 @@ func isTestExtended(profile ConformanceProfile, test ConformanceTest) bool {
 		}
 	}
 	return false
+}
+
+// buildSummary creates a human-readable message about each profile's test outcomes.
+func buildSummary(report confv1a1.ProfileReport) string {
+	reportMessage := fmt.Sprintf("Core tests %s", buildReportMessage(report.Core))
+	if report.Extended != nil {
+		reportMessage = fmt.Sprintf("%s. Extended tests %s", reportMessage, buildReportMessage(report.Extended.Status))
+	}
+	return fmt.Sprintf("%s.", reportMessage)
+}
+
+func buildReportMessage(status confv1a1.Status) string {
+	var message string
+	switch status.Result {
+	case confv1a1.Success:
+		message = "succedeed"
+	case confv1a1.Partial:
+		message = fmt.Sprintf("partially succedeed with %d test skips", status.Statistics.Skipped)
+	case confv1a1.Failure:
+		message = fmt.Sprintf("failed with %d test failures", status.Statistics.Failed)
+	}
+	return message
 }

--- a/conformance/utils/suite/experimental_reports_test.go
+++ b/conformance/utils/suite/experimental_reports_test.go
@@ -45,7 +45,7 @@ func TestBuildSummary(t *testing.T) {
 			expectedSummary: "Core tests failed with 3 test failures.",
 		},
 		{
-			name: "core tests succedeed, extended tests failed",
+			name: "core tests succeeded, extended tests failed",
 			report: confv1a1.ProfileReport{
 				Name: string(HTTPConformanceProfileName),
 				Core: confv1a1.Status{
@@ -64,10 +64,10 @@ func TestBuildSummary(t *testing.T) {
 					},
 				},
 			},
-			expectedSummary: "Core tests succedeed. Extended tests failed with 1 test failures.",
+			expectedSummary: "Core tests succeeded. Extended tests failed with 1 test failures.",
 		},
 		{
-			name: "core tests partially succedeed, extended tests succedeed",
+			name: "core tests partially succeeded, extended tests succeeded",
 			report: confv1a1.ProfileReport{
 				Name: string(HTTPConformanceProfileName),
 				Core: confv1a1.Status{
@@ -86,10 +86,10 @@ func TestBuildSummary(t *testing.T) {
 					},
 				},
 			},
-			expectedSummary: "Core tests partially succedeed with 2 test skips. Extended tests succedeed.",
+			expectedSummary: "Core tests partially succeeded with 2 test skips. Extended tests succeeded.",
 		},
 		{
-			name: "core tests succedeed, extended tests partially succedeed",
+			name: "core tests succeeded, extended tests partially succeeded",
 			report: confv1a1.ProfileReport{
 				Name: string(HTTPConformanceProfileName),
 				Core: confv1a1.Status{
@@ -108,7 +108,7 @@ func TestBuildSummary(t *testing.T) {
 					},
 				},
 			},
-			expectedSummary: "Core tests succedeed. Extended tests partially succedeed with 1 test skips.",
+			expectedSummary: "Core tests succeeded. Extended tests partially succeeded with 1 test skips.",
 		},
 	}
 

--- a/conformance/utils/suite/experimental_reports_test.go
+++ b/conformance/utils/suite/experimental_reports_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package suite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	confv1a1 "sigs.k8s.io/gateway-api/conformance/apis/v1alpha1"
+)
+
+func TestBuildSummary(t *testing.T) {
+	testCases := []struct {
+		name            string
+		report          confv1a1.ProfileReport
+		expectedSummary string
+	}{
+		{
+			name: "core tests failed, no extended tests",
+			report: confv1a1.ProfileReport{
+				Name: string(HTTPConformanceProfileName),
+				Core: confv1a1.Status{
+					Result: confv1a1.Failure,
+					Statistics: confv1a1.Statistics{
+						Passed: 5,
+						Failed: 3,
+					},
+				},
+			},
+			expectedSummary: "Core tests failed with 3 test failures.",
+		},
+		{
+			name: "core tests succedeed, extended tests failed",
+			report: confv1a1.ProfileReport{
+				Name: string(HTTPConformanceProfileName),
+				Core: confv1a1.Status{
+					Result: confv1a1.Success,
+					Statistics: confv1a1.Statistics{
+						Passed: 8,
+					},
+				},
+				Extended: &confv1a1.ExtendedStatus{
+					Status: confv1a1.Status{
+						Result: confv1a1.Failure,
+						Statistics: confv1a1.Statistics{
+							Passed: 2,
+							Failed: 1,
+						},
+					},
+				},
+			},
+			expectedSummary: "Core tests succedeed. Extended tests failed with 1 test failures.",
+		},
+		{
+			name: "core tests partially succedeed, extended tests succedeed",
+			report: confv1a1.ProfileReport{
+				Name: string(HTTPConformanceProfileName),
+				Core: confv1a1.Status{
+					Result: confv1a1.Partial,
+					Statistics: confv1a1.Statistics{
+						Passed:  6,
+						Skipped: 2,
+					},
+				},
+				Extended: &confv1a1.ExtendedStatus{
+					Status: confv1a1.Status{
+						Result: confv1a1.Success,
+						Statistics: confv1a1.Statistics{
+							Passed: 2,
+						},
+					},
+				},
+			},
+			expectedSummary: "Core tests partially succedeed with 2 test skips. Extended tests succedeed.",
+		},
+		{
+			name: "core tests succedeed, extended tests partially succedeed",
+			report: confv1a1.ProfileReport{
+				Name: string(HTTPConformanceProfileName),
+				Core: confv1a1.Status{
+					Result: confv1a1.Success,
+					Statistics: confv1a1.Statistics{
+						Passed: 8,
+					},
+				},
+				Extended: &confv1a1.ExtendedStatus{
+					Status: confv1a1.Status{
+						Result: confv1a1.Partial,
+						Statistics: confv1a1.Statistics{
+							Passed:  2,
+							Skipped: 1,
+						},
+					},
+				},
+			},
+			expectedSummary: "Core tests succedeed. Extended tests partially succedeed with 1 test skips.",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc := tc
+			summary := buildSummary(tc.report)
+			require.Equal(t, tc.expectedSummary, summary)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind feature
/area conformance

**What this PR does / why we need it**:

The conformance report `.profiles[*].summary` field is now automatically filled by the conformance test suite with a human-readable message about the outcome of the tests run.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2235 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The conformance report `.profiles[*].summary` field is now automatically filled by the conformance test suite with a human-readable message about the outcome of the tests run.
```
