### PR TITLE
feat: mode introduced to conformance report API

### DIFF
--- a/conformance/apis/v1alpha1/conformancereport.go
+++ b/conformance/apis/v1alpha1/conformancereport.go
@@ -34,6 +34,9 @@ type ConformanceReport struct {
 	// test report was made for.
 	GatewayAPIVersion string `json:"gatewayAPIVersion"`
 
+	// Mode is the operating mode the implementation used to run conformance tests.
+	Mode string `json:"mode"`
+
 	// ProfileReports is a list of the individual reports for each conformance
 	// profile that was enabled for a test run.
 	ProfileReports []ProfileReport `json:"profiles"`

--- a/conformance/experimental_conformance_test.go
+++ b/conformance/experimental_conformance_test.go
@@ -45,6 +45,7 @@ var (
 	namespaceLabels      map[string]string
 	namespaceAnnotations map[string]string
 	implementation       *confv1a1.Implementation
+	mode                 string
 	conformanceProfiles  sets.Set[suite.ConformanceProfileName]
 	skipTests            []string
 )
@@ -77,6 +78,7 @@ func TestExperimentalConformance(t *testing.T) {
 
 	// experimental conformance flags
 	conformanceProfiles = suite.ParseConformanceProfiles(*flags.ConformanceProfiles)
+	mode = *flags.Mode
 
 	if conformanceProfiles.Len() > 0 {
 		// if some conformance profiles have been set, run the experimental conformance suite...
@@ -119,6 +121,7 @@ func testExperimentalConformance(t *testing.T) {
 				NamespaceAnnotations:       namespaceAnnotations,
 				SkipTests:                  skipTests,
 			},
+			Mode:                mode,
 			Implementation:      *implementation,
 			ConformanceProfiles: conformanceProfiles,
 		})

--- a/conformance/utils/flags/experimental_flags.go
+++ b/conformance/utils/flags/experimental_flags.go
@@ -19,7 +19,14 @@ limitations under the License.
 // among the various suites that are all run by the same Makefile invocation.
 package flags
 
-import "flag"
+import (
+	"flag"
+)
+
+const (
+	// DefaultMode is the operating mode to default to in case no mode is specified.
+	DefaultMode = "default"
+)
 
 var (
 	ImplementationOrganization = flag.String("organization", "", "Implementation's Organization to issue conformance to")
@@ -27,6 +34,7 @@ var (
 	ImplementationURL          = flag.String("url", "", "Implementation's url to issue conformance to")
 	ImplementationVersion      = flag.String("version", "", "Implementation's version to issue conformance to")
 	ImplementationContact      = flag.String("contact", "", "Comma-separated list of contact information for the maintainers")
+	Mode                       = flag.String("mode", DefaultMode, "The operating mode of the implementation.")
 	ConformanceProfiles        = flag.String("conformance-profiles", "", "Comma-separated list of the conformance profiles to run")
 	ReportOutput               = flag.String("report-output", "", "The file where to write the conformance report")
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind feature
/area conformance

**What this PR does / why we need it**:

The mode field has been added to the conformance report API. This field makes customization of the implementations' operating mode possible.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2739 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The mode field has been added to the conformance report API. This field makes customization of the implementations' operating mode possible.
```
