### PR TITLE
Conformance test for HTTPRoute weights

### DIFF
--- a/conformance/tests/httproute-weight.go
+++ b/conformance/tests/httproute-weight.go
@@ -17,13 +17,15 @@ limitations under the License.
 package tests
 
 import (
+	"cmp"
+	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -55,84 +57,101 @@ var HTTPRouteWeight = suite.ConformanceTest{
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		t.Run("Requests should have a distribution that matches the weight", func(t *testing.T) {
-			const (
-				totalRequests       = 1000.0
-				concurrentRequests  = 10
-				tolerancePercentage = 5.0
-			)
-			var (
-				roundTripper = suite.RoundTripper
-				expected     = http.ExpectedResponse{
-					Request:   http.Request{Path: "/"},
-					Response:  http.Response{StatusCode: 200},
-					Namespace: "gateway-conformance-infra",
-				}
-
-				seenMutex       sync.Mutex
-				seen            = make(map[string]float64, 3 /* number of backends */)
-				req             = http.MakeRequest(t, &expected, gwAddr, "HTTP", "http")
-				expectedWeights = map[string]float64{
-					"infra-backend-v1": 0.7,
-					"infra-backend-v2": 0.3,
-					"infra-backend-v3": 0.0,
-				}
-			)
+			expected := http.ExpectedResponse{
+				Request:   http.Request{Path: "/"},
+				Response:  http.Response{StatusCode: 200},
+				Namespace: "gateway-conformance-infra",
+			}
 
 			// Assert request succeeds before doing our distribution check
 			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expected)
 
-			var g errgroup.Group
-			g.SetLimit(concurrentRequests)
-
-			for i := 0.0; i < totalRequests; i++ {
-				g.Go(func() error {
-					cReq, cRes, err := roundTripper.CaptureRoundTrip(req)
-					if err != nil {
-						t.Logf("Failed to roundtrip request: %v", err.Error())
-						return fmt.Errorf("failed to roundtrip request: %w", err)
-					}
-					if err := http.CompareRequest(t, &req, cReq, cRes, expected); err != nil {
-						t.Logf("Response expectation failed for request: %v", err)
-						return fmt.Errorf("response expectation failed for request: %w", err)
-					}
-
-					seenMutex.Lock()
-					defer seenMutex.Unlock()
-
-					for expectedBackend := range expectedWeights {
-						if strings.HasPrefix(cReq.Pod, expectedBackend) {
-							seen[expectedBackend]++
-							return nil
-						}
-					}
-
-					return fmt.Errorf("request was handled by an unexpected pod %q", cReq.Pod)
-				})
-			}
-
-			if err := g.Wait(); err != nil {
-				t.Error("Error while sending requests:", err)
-			}
-
-			require.Len(t, seen, 2, "Expected only two backends to receive traffic")
-
-			for wantBackend, wantPercent := range expectedWeights {
-				gotCount, ok := seen[wantBackend]
-
-				if !ok && wantPercent != 0.0 {
-					t.Errorf("Expect traffic to hit backend %q - but none was received", wantBackend)
-					continue
-				}
-
-				gotPercent := gotCount / totalRequests
-				if math.Abs(gotPercent-wantPercent) > tolerancePercentage {
-					t.Errorf("Backend %q weighted traffic of %v no within tolerance %v +/-5%%",
-						wantBackend,
-						gotPercent,
-						wantPercent,
-					)
+			for i := 0; i < 10; i++ {
+				if err := testDistribution(t, suite, gwAddr, expected); err != nil {
+					t.Logf("Traffic distribution test failed (%d/10): %s", i+1, err)
+				} else {
+					return
 				}
 			}
+			t.Fatal("Weighted distribution tests failed")
 		})
 	},
+}
+
+func testDistribution(t *testing.T, suite *suite.ConformanceTestSuite, gwAddr string, expected http.ExpectedResponse) error {
+	const (
+		concurrentRequests  = 10
+		tolerancePercentage = 0.05
+		totalRequests       = 500.0
+	)
+	var (
+		roundTripper = suite.RoundTripper
+
+		g               errgroup.Group
+		seenMutex       sync.Mutex
+		seen            = make(map[string]float64, 3 /* number of backends */)
+		req             = http.MakeRequest(t, &expected, gwAddr, "HTTP", "http")
+		expectedWeights = map[string]float64{
+			"infra-backend-v1": 0.7,
+			"infra-backend-v2": 0.3,
+			"infra-backend-v3": 0.0,
+		}
+	)
+	g.SetLimit(concurrentRequests)
+	for i := 0.0; i < totalRequests; i++ {
+		g.Go(func() error {
+			cReq, cRes, err := roundTripper.CaptureRoundTrip(req)
+			if err != nil {
+				return fmt.Errorf("failed to roundtrip request: %w", err)
+			}
+			if err := http.CompareRequest(t, &req, cReq, cRes, expected); err != nil {
+				return fmt.Errorf("response expectation failed for request: %w", err)
+			}
+
+			seenMutex.Lock()
+			defer seenMutex.Unlock()
+
+			for expectedBackend := range expectedWeights {
+				if strings.HasPrefix(cReq.Pod, expectedBackend) {
+					seen[expectedBackend]++
+					return nil
+				}
+			}
+
+			return fmt.Errorf("request was handled by an unexpected pod %q", cReq.Pod)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("error while sending requests: %w", err)
+	}
+
+	var errs []error
+	if len(seen) != 2 {
+		errs = append(errs, fmt.Errorf("expected only two backends to receive traffic"))
+	}
+
+	for wantBackend, wantPercent := range expectedWeights {
+		gotCount, ok := seen[wantBackend]
+
+		if !ok && wantPercent != 0.0 {
+			errs = append(errs, fmt.Errorf("expect traffic to hit backend %q - but none was received", wantBackend))
+			continue
+		}
+
+		gotPercent := gotCount / totalRequests
+
+		if math.Abs(gotPercent-wantPercent) > tolerancePercentage {
+			errs = append(errs, fmt.Errorf("backend %q weighted traffic of %v not within tolerance %v (+/-%f)",
+				wantBackend,
+				gotPercent,
+				wantPercent,
+				tolerancePercentage,
+			))
+		}
+	}
+	slices.SortFunc(errs, func(a, b error) int {
+		return cmp.Compare(a.Error(), b.Error())
+	})
+	return errors.Join(errs...)
 }

--- a/conformance/tests/httproute-weight.go
+++ b/conformance/tests/httproute-weight.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteWeight)
+}
+
+var HTTPRouteWeight = suite.ConformanceTest{
+	ShortName:   "HTTPRouteWeight",
+	Description: "An HTTPRoute with weighted backends",
+	Manifests:   []string{"tests/httproute-weight.yaml"},
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportHTTPRoute,
+	},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		var (
+			ns      = "gateway-conformance-infra"
+			routeNN = types.NamespacedName{Name: "weighted-backends", Namespace: ns}
+			gwNN    = types.NamespacedName{Name: "same-namespace", Namespace: ns}
+			gwAddr  = kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		)
+
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		t.Run("Requests should have a distribution that matches the weight", func(t *testing.T) {
+			const (
+				totalRequests       = 1000.0
+				concurrentRequests  = 10
+				tolerancePercentage = 5.0
+			)
+			var (
+				roundTripper = suite.RoundTripper
+				expected     = http.ExpectedResponse{
+					Request:   http.Request{Path: "/"},
+					Response:  http.Response{StatusCode: 200},
+					Namespace: "gateway-conformance-infra",
+				}
+
+				seenMutex       sync.Mutex
+				seen            = make(map[string]float64, 3 /* number of backends */)
+				req             = http.MakeRequest(t, &expected, gwAddr, "HTTP", "http")
+				expectedWeights = map[string]float64{
+					"infra-backend-v1": 0.7,
+					"infra-backend-v2": 0.3,
+					"infra-backend-v3": 0.0,
+				}
+			)
+
+			// Assert request succeeds before doing our distribution check
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expected)
+
+			var g errgroup.Group
+			g.SetLimit(concurrentRequests)
+
+			for i := 0.0; i < totalRequests; i++ {
+				g.Go(func() error {
+					cReq, cRes, err := roundTripper.CaptureRoundTrip(req)
+					if err != nil {
+						t.Logf("Failed to roundtrip request: %v", err.Error())
+						return fmt.Errorf("failed to roundtrip request: %w", err)
+					}
+					if err := http.CompareRequest(t, &req, cReq, cRes, expected); err != nil {
+						t.Logf("Response expectation failed for request: %v", err)
+						return fmt.Errorf("response expectation failed for request: %w", err)
+					}
+
+					seenMutex.Lock()
+					defer seenMutex.Unlock()
+
+					for expectedBackend := range expectedWeights {
+						if strings.HasPrefix(cReq.Pod, expectedBackend) {
+							seen[expectedBackend]++
+							return nil
+						}
+					}
+
+					return fmt.Errorf("request was handled by an unexpected pod %q", cReq.Pod)
+				})
+			}
+
+			if err := g.Wait(); err != nil {
+				t.Error("Error while sending requests:", err)
+			}
+
+			require.Len(t, seen, 2, "Expected only two backends to receive traffic")
+
+			for wantBackend, wantPercent := range expectedWeights {
+				gotCount, ok := seen[wantBackend]
+
+				if !ok && wantPercent != 0.0 {
+					t.Errorf("Expect traffic to hit backend %q - but none was received", wantBackend)
+					continue
+				}
+
+				gotPercent := gotCount / totalRequests
+				if math.Abs(gotPercent-wantPercent) > tolerancePercentage {
+					t.Errorf("Backend %q weighted traffic of %v no within tolerance %v +/-5%%",
+						wantBackend,
+						gotPercent,
+						wantPercent,
+					)
+				}
+			}
+		})
+	},
+}

--- a/conformance/tests/httproute-weight.go
+++ b/conformance/tests/httproute-weight.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/types"
+
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"

--- a/conformance/tests/httproute-weight.yaml
+++ b/conformance/tests/httproute-weight.yaml
@@ -1,0 +1,20 @@
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: weighted-backends
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+    - backendRefs:
+      - name: infra-backend-v1
+        port: 8080
+        weight: 70
+      - name: infra-backend-v2
+        port: 8080
+        weight: 30
+      - name: infra-backend-v3
+        port: 8080
+        weight: 0

--- a/conformance/tests/httproute-weight.yaml
+++ b/conformance/tests/httproute-weight.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -8,13 +7,13 @@ spec:
   parentRefs:
   - name: same-namespace
   rules:
-    - backendRefs:
-      - name: infra-backend-v1
-        port: 8080
-        weight: 70
-      - name: infra-backend-v2
-        port: 8080
-        weight: 30
-      - name: infra-backend-v3
-        port: 8080
-        weight: 0
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      weight: 70
+    - name: infra-backend-v2
+      port: 8080
+      weight: 30
+    - name: infra-backend-v3
+      port: 8080
+      weight: 0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/miekg/dns v1.1.58
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/net v0.20.0
-	golang.org/x/sync v0.5.0
+	golang.org/x/sync v0.6.0
 	google.golang.org/grpc v1.61.0
 	google.golang.org/protobuf v1.33.0
 	k8s.io/api v0.29.3
@@ -15,9 +15,11 @@ require (
 	k8s.io/apimachinery v0.29.3
 	k8s.io/client-go v0.29.3
 	k8s.io/code-generator v0.29.3
+	k8s.io/kube-openapi v0.0.0-20240105020646-a37d4de58910
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	sigs.k8s.io/controller-runtime v0.16.3
 	sigs.k8s.io/controller-tools v0.14.0
+	sigs.k8s.io/structured-merge-diff/v4 v4.4.1
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -77,7 +79,5 @@ require (
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
 	k8s.io/klog v0.2.0 // indirect
 	k8s.io/klog/v2 v2.120.0 // indirect
-	k8s.io/kube-openapi v0.0.0-20240105020646-a37d4de58910 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/miekg/dns v1.1.58
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/net v0.20.0
+	golang.org/x/sync v0.5.0
 	google.golang.org/grpc v1.61.0
 	google.golang.org/protobuf v1.33.0
 	k8s.io/api v0.29.3


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind cleanup
/kind test
/area conformance


**What this PR does / why we need it**:

There currently isn't a conformance test for weighted routing. This is a core feature for HTTPRoute.

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
