### PR TITLE
fix yaml linter warning in backend-protocol test yaml

### DIFF
--- a/conformance/tests/httproute-backend-protocol-h2c.yaml
+++ b/conformance/tests/httproute-backend-protocol-h2c.yaml
@@ -8,10 +8,10 @@ spec:
   - name: same-namespace
   rules:
   - backendRefs:
-  # This points to a Service with the following ServicePort
-  # - protocol: TCP
-  #   appProtocol: kubernetes.io/h2c
-  #   port: 8081
-  #   targetPort: 3001
+    # This points to a Service with the following ServicePort
+    # - protocol: TCP
+    #   appProtocol: kubernetes.io/h2c
+    #   port: 8081
+    #   targetPort: 3001
     - name: infra-backend-v1
       port: 8081


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**

/kind cleanup
/kind test
/area conformance

**What this PR does / why we need it**:

Fixes the linter warning
>  ./conformance/tests/httproute-backend-protocol-h2c.yaml
>  11:3      warning  comment not indented like content  (comments-indentation) 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
