### PR TITLE
GEP-696: Fix broken link in template GEP

### DIFF
--- a/geps/gep-696/index.md
+++ b/geps/gep-696/index.md
@@ -3,7 +3,7 @@
 * Issue: [#696](https://github.com/kubernetes-sigs/gateway-api/issues/696)
 * Status: Provisional|Implementable|Experimental|Standard|Deferred|Rejected|Withdrawn|Replaced
 
-(See status definitions [here](overview.md#status).)
+(See status definitions [here](/geps/overview/#gep-states).)
 
 ## TLDR
 


### PR DESCRIPTION
Fix broken link for status definitions in GEP-696, which is the template GEP.

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixes broken link the template GEP

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
