### PR TITLE
HTTPBackendRef RequestMirror Conformance Test

### DIFF
--- a/conformance/tests/httproute-request-mirror-backend.yaml
+++ b/conformance/tests/httproute-request-mirror-backend.yaml
@@ -7,14 +7,14 @@ spec:
   parentRefs:
   - name: same-namespace
   rules:
-  - filters:
-    - type: RequestMirror
-      requestMirror:
-        backendRef:
-          name: infra-backend-v2
-          namespace: gateway-conformance-infra
-          port: 8080
-    backendRefs:
+  - backendRefs:
     - name: infra-backend-v1
-      port: 8080
       namespace: gateway-conformance-infra
+      port: 8080
+      filters:
+      - type: RequestMirror
+        requestMirror:
+          backendRef:
+            name: infra-backend-v2
+            namespace: gateway-conformance-infra
+            port: 8080

--- a/conformance/tests/httproute-request-mirror.go
+++ b/conformance/tests/httproute-request-mirror.go
@@ -29,6 +29,19 @@ import (
 
 func init() {
 	ConformanceTests = append(ConformanceTests, HTTPRouteRequestMirror)
+	ConformanceTests = append(ConformanceTests, HTTPRouteRequestMirrorBackend)
+}
+
+var HTTPRouteRequestMirrorBackend = suite.ConformanceTest{
+	ShortName:   "HTTPRouteRequestMirrorBackend",
+	Description: "An HTTPRoute with request mirror filter on the backendRef",
+	Manifests:   []string{"tests/httproute-request-mirror-backend.yaml"},
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportHTTPRoute,
+		suite.SupportHTTPRouteRequestMirrorBackend,
+	},
+	Test: HTTPRouteRequestMirror.Test,
 }
 
 var HTTPRouteRequestMirror = suite.ConformanceTest{
@@ -62,32 +75,6 @@ var HTTPRouteRequestMirror = suite.ConformanceTest{
 					Namespace: ns,
 				}},
 				Namespace: ns,
-			},
-			{
-				Request: http.Request{
-					Path: "/mirror-and-modify-headers",
-					Headers: map[string]string{
-						"X-Header-Remove":     "remove-val",
-						"X-Header-Add-Append": "append-val-1",
-					},
-				},
-				ExpectedRequest: &http.ExpectedRequest{
-					Request: http.Request{
-						Path: "/mirror-and-modify-headers",
-						Headers: map[string]string{
-							"X-Header-Add":        "header-val-1",
-							"X-Header-Add-Append": "append-val-1,header-val-2",
-							"X-Header-Set":        "set-overwrites-values",
-						},
-					},
-					AbsentHeaders: []string{"X-Header-Remove"},
-				},
-				Namespace: ns,
-				Backend:   "infra-backend-v1",
-				MirroredTo: []http.BackendRef{{
-					Name:      "infra-backend-v2",
-					Namespace: ns,
-				}},
 			},
 		}
 		for i := range testCases {

--- a/conformance/tests/httproute-request-mirror.go
+++ b/conformance/tests/httproute-request-mirror.go
@@ -28,18 +28,20 @@ import (
 )
 
 func init() {
-	ConformanceTests = append(ConformanceTests, HTTPRouteRequestMirror)
-	ConformanceTests = append(ConformanceTests, HTTPRouteRequestMirrorBackend)
+	ConformanceTests = append(ConformanceTests,
+		HTTPRouteRequestMirror,
+		HTTPRouteBackendRequestMirror,
+	)
 }
 
-var HTTPRouteRequestMirrorBackend = suite.ConformanceTest{
-	ShortName:   "HTTPRouteRequestMirrorBackend",
-	Description: "An HTTPRoute with request mirror filter on the backendRef",
+var HTTPRouteBackendRequestMirror = suite.ConformanceTest{
+	ShortName:   "HTTPRouteBackendRequestMirror",
+	Description: "An HTTPRoute backendRef with request mirror filter",
 	Manifests:   []string{"tests/httproute-request-mirror-backend.yaml"},
 	Features: []suite.SupportedFeature{
 		suite.SupportGateway,
 		suite.SupportHTTPRoute,
-		suite.SupportHTTPRouteRequestMirrorBackend,
+		suite.SupportHTTPRouteBackendRequestMirror,
 	},
 	Test: HTTPRouteRequestMirror.Test,
 }

--- a/conformance/tests/httproute-request-mirror.go
+++ b/conformance/tests/httproute-request-mirror.go
@@ -38,10 +38,10 @@ var HTTPRouteBackendRequestMirror = suite.ConformanceTest{
 	ShortName:   "HTTPRouteBackendRequestMirror",
 	Description: "An HTTPRoute backendRef with request mirror filter",
 	Manifests:   []string{"tests/httproute-request-mirror-backend.yaml"},
-	Features: []suite.SupportedFeature{
-		suite.SupportGateway,
-		suite.SupportHTTPRoute,
-		suite.SupportHTTPRouteBackendRequestMirror,
+	Features: []features.SupportedFeature{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteBackendRequestMirror,
 	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		RunHTTPRouteRequestMirrorTest(t, suite, HTTPRouteRequestMirrorTestCases)
@@ -79,7 +79,6 @@ func RunHTTPRouteRequestMirrorTest(t *testing.T, suite *suite.ConformanceTestSui
 			http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path)
 		})
 	}
-
 }
 
 var HTTPRouteRequestMirrorTestCases = []http.ExpectedResponse{{

--- a/conformance/tests/httproute-request-mirror.yaml
+++ b/conformance/tests/httproute-request-mirror.yaml
@@ -7,7 +7,38 @@ spec:
   parentRefs:
   - name: same-namespace
   rules:
-  - filters:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /mirror
+    filters:
+    - type: RequestMirror
+      requestMirror:
+        backendRef:
+          name: infra-backend-v2
+          namespace: gateway-conformance-infra
+          port: 8080
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      namespace: gateway-conformance-infra
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /mirror-and-modify-headers
+    filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        set:
+        - name: X-Header-Set
+          value: set-overwrites-values
+        add:
+        - name: X-Header-Add
+          value: header-val-1
+        - name: X-Header-Add-Append
+          value: header-val-2
+        remove:
+        - X-Header-Remove
     - type: RequestMirror
       requestMirror:
         backendRef:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -129,7 +129,7 @@ const (
 	SupportHTTPRouteRequestMirror SupportedFeature = "HTTPRouteRequestMirror"
 
 	// This option indicates support for HTTPRoute backend request mirror (extended conformance).
-	SupportHTTPRouteRequestMirrorBackend SupportedFeature = "HTTPRouteRequestMirrorBackend"
+	SupportHTTPRouteBackendRequestMirror SupportedFeature = "HTTPRouteBackendRequestMirror"
 
 	// This option indicates support for multiple RequestMirror filters within the same HTTPRoute rule (extended conformance).
 	SupportHTTPRouteRequestMultipleMirrors SupportedFeature = "HTTPRouteRequestMultipleMirrors"
@@ -157,7 +157,7 @@ var HTTPRouteExtendedFeatures = sets.New(
 	SupportHTTPRouteHostRewrite,
 	SupportHTTPRoutePathRewrite,
 	SupportHTTPRouteRequestMirror,
-	SupportHTTPRouteRequestMirrorBackend,
+	SupportHTTPRouteBackendRequestMirror,
 	SupportHTTPRouteRequestMultipleMirrors,
 	SupportHTTPRouteRequestTimeout,
 	SupportHTTPRouteBackendTimeout,

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -128,6 +128,9 @@ const (
 	// This option indicates support for HTTPRoute request mirror (extended conformance).
 	SupportHTTPRouteRequestMirror SupportedFeature = "HTTPRouteRequestMirror"
 
+	// This option indicates support for HTTPRoute backend request mirror (extended conformance).
+	SupportHTTPRouteRequestMirrorBackend SupportedFeature = "HTTPRouteRequestMirrorBackend"
+
 	// This option indicates support for multiple RequestMirror filters within the same HTTPRoute rule (extended conformance).
 	SupportHTTPRouteRequestMultipleMirrors SupportedFeature = "HTTPRouteRequestMultipleMirrors"
 
@@ -154,6 +157,7 @@ var HTTPRouteExtendedFeatures = sets.New(
 	SupportHTTPRouteHostRewrite,
 	SupportHTTPRoutePathRewrite,
 	SupportHTTPRouteRequestMirror,
+	SupportHTTPRouteRequestMirrorBackend,
 	SupportHTTPRouteRequestMultipleMirrors,
 	SupportHTTPRouteRequestTimeout,
 	SupportHTTPRouteBackendTimeout,


### PR DESCRIPTION
### What type of PR is this?

/kind cleanup
/kind test
/area conformance

### What this PR does / why we need it

There's currently no conformance test for this feature which is 'Extended'

### Additional notes
I dropped path logic in filter so we can re-use the same test for the backend


```release-note
NONE
```