### PR TITLE
HTTPBackendRef requestHeader filter conformance test

### DIFF
--- a/conformance/tests/httproute-request-header-modifier-backend.yaml
+++ b/conformance/tests/httproute-request-header-modifier-backend.yaml
@@ -1,0 +1,90 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: request-header-modifier
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /set
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+          - name: X-Header-Set
+            value: set-overwrites-values
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /add
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          add:
+          - name: X-Header-Add
+            value: add-appends-values
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /remove
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          remove:
+          - X-Header-Remove
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /multiple
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+          - name: X-Header-Set-1
+            value: header-set-1
+          - name: X-Header-Set-2
+            value: header-set-2
+          add:
+          - name: X-Header-Add-1
+            value: header-add-1
+          - name: X-Header-Add-2
+            value: header-add-2
+          - name: X-Header-Add-3
+            value: header-add-3
+          remove:
+          - X-Header-Remove-1
+          - X-Header-Remove-2
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /case-insensitivity
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+          - name: X-Header-Set
+            value: header-set
+          add:
+          - name: X-Header-Add
+            value: header-add
+          remove:
+          - X-Header-Remove

--- a/conformance/tests/httproute-request-header-modifier.go
+++ b/conformance/tests/httproute-request-header-modifier.go
@@ -28,6 +28,19 @@ import (
 
 func init() {
 	ConformanceTests = append(ConformanceTests, HTTPRouteRequestHeaderModifier)
+	ConformanceTests = append(ConformanceTests, HTTPRouteRequestHeaderModifierBackend)
+}
+
+var HTTPRouteRequestHeaderModifierBackend = suite.ConformanceTest{
+	ShortName:   "HTTPRouteRequestHeaderModifierBackend",
+	Description: "An HTTPRoute backend has request header modifier filters applied correctly",
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportHTTPRoute,
+		suite.SupportHTTPRouteRequestHeaderModificationBackend,
+	},
+	Manifests: []string{"tests/httproute-request-header-modifier-backend.yaml"},
+	Test:      HTTPRouteRequestHeaderModifier.Test,
 }
 
 var HTTPRouteRequestHeaderModifier = suite.ConformanceTest{

--- a/conformance/utils/suite/features.go
+++ b/conformance/utils/suite/features.go
@@ -98,6 +98,9 @@ var HTTPRouteCoreFeatures = sets.New(
 // -----------------------------------------------------------------------------
 
 const (
+	// This option indicates support for HTTPRoute backend request header modification
+	SupportHTTPRouteRequestHeaderModificationBackend SupportedFeature = "HTTPRouteRequestHeaderModificationBackend"
+
 	// This option indicates support for HTTPRoute query param matching (extended conformance).
 	SupportHTTPRouteQueryParamMatching SupportedFeature = "HTTPRouteQueryParamMatching"
 
@@ -155,6 +158,7 @@ var HTTPRouteExtendedFeatures = sets.New(
 	SupportHTTPRouteRequestTimeout,
 	SupportHTTPRouteBackendTimeout,
 	SupportHTTPRouteParentRefPort,
+	SupportHTTPRouteRequestHeaderModificationBackend,
 )
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind cleanup
/kind test
/area conformance

**What this PR does / why we need it**:

This adds test coverage for an extended feature - Supporting request header modification on the HTTPBackendRef

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
