### PR TITLE
HTTPBackendRef ResponseHeaderModifier Conformance Test

### DIFF
--- a/conformance/tests/httproute-response-header-modifier-backend.yaml
+++ b/conformance/tests/httproute-response-header-modifier-backend.yaml
@@ -1,0 +1,98 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: response-header-modifier
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /set
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: ResponseHeaderModifier
+        responseHeaderModifier:
+          set:
+          - name: X-Header-Set
+            value: set-overwrites-values
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /add
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: ResponseHeaderModifier
+        responseHeaderModifier:
+          add:
+          - name: X-Header-Add
+            value: add-appends-values
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /remove
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: ResponseHeaderModifier
+        responseHeaderModifier:
+          remove:
+          - X-Header-Remove
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /multiple
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: ResponseHeaderModifier
+        responseHeaderModifier:
+          set:
+          - name: X-Header-Set-1
+            value: header-set-1
+          - name: X-Header-Set-2
+            value: header-set-2
+          add:
+          - name: X-Header-Add-1
+            value: header-add-1
+          - name: X-Header-Add-2
+            value: header-add-2
+          - name: X-Header-Add-3
+            value: header-add-3
+          remove:
+          - X-Header-Remove-1
+          - X-Header-Remove-2
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /case-insensitivity
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: ResponseHeaderModifier
+        responseHeaderModifier:
+          set:
+          - name: X-Header-Set
+            value: header-set
+          add:
+          - name: X-Header-Add
+            value: header-add
+          - name: x-lowercase-add
+            value: lowercase-add
+          - name: x-Mixedcase-ADD-1
+            value: mixedcase-add-1
+          - name: X-mixeDcase-add-2
+            value: mixedcase-add-2
+          - name: X-UPPERCASE-ADD
+            value: uppercase-add
+          remove:
+          - X-Header-Remove

--- a/conformance/tests/httproute-response-header-modifier.go
+++ b/conformance/tests/httproute-response-header-modifier.go
@@ -28,7 +28,22 @@ import (
 )
 
 func init() {
-	ConformanceTests = append(ConformanceTests, HTTPRouteResponseHeaderModifier)
+	ConformanceTests = append(ConformanceTests,
+		HTTPRouteResponseHeaderModifier,
+		HTTPRouteResponseHeaderModifierBackend,
+	)
+}
+
+var HTTPRouteResponseHeaderModifierBackend = suite.ConformanceTest{
+	ShortName:   "HTTPRouteResponseHeaderModifierBackend",
+	Description: "An HTTPRoute backendRef has response header modifier filters applied correctly",
+	Features: []suite.SupportedFeature{
+		suite.SupportGateway,
+		suite.SupportHTTPRoute,
+		suite.SupportHTTPRouteResponseHeaderModificationBackend,
+	},
+	Manifests: []string{"tests/httproute-response-header-modifier-backend.yaml"},
+	Test:      HTTPRouteResponseHeaderModifier.Test,
 }
 
 var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
@@ -166,48 +181,6 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 					"Another-Header":    "another-header-val",
 				},
 				AbsentHeaders: []string{"x-header-remove", "X-Header-Remove"},
-			},
-			Backend:   "infra-backend-v1",
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path: "/response-and-request-header-modifiers",
-				Headers: map[string]string{
-					"X-Header-Remove":     "remove-val",
-					"X-Header-Add-Append": "append-val-1",
-					"X-Header-Echo":       "echo",
-				},
-			},
-			BackendSetResponseHeaders: map[string]string{
-				"X-Header-Set-2":    "set-val-2",
-				"X-Header-Add-2":    "add-val-2",
-				"X-Header-Remove-2": "remove-val-2",
-				"Another-Header":    "another-header-val",
-				"X-Header-Remove-1": "remove-val-1",
-				"X-Header-Echo":     "echo",
-			},
-			ExpectedRequest: &http.ExpectedRequest{
-				Request: http.Request{
-					Path: "/response-and-request-header-modifiers",
-					Headers: map[string]string{
-						"X-Header-Add":        "header-val-1",
-						"X-Header-Set":        "set-overwrites-values",
-						"X-Header-Add-Append": "append-val-1,header-val-2",
-						"X-Header-Echo":       "echo",
-					},
-				},
-				AbsentHeaders: []string{"X-Header-Remove"},
-			},
-			Response: http.Response{
-				Headers: map[string]string{
-					"X-Header-Set-1": "header-set-1",
-					"X-Header-Set-2": "header-set-2",
-					"X-Header-Add-1": "header-add-1",
-					"X-Header-Add-2": "add-val-2,header-add-2",
-					"Another-Header": "another-header-val",
-					"X-Header-Echo":  "echo",
-				},
-				AbsentHeaders: []string{"X-Header-Remove-1", "X-Header-Remove-2"},
 			},
 			Backend:   "infra-backend-v1",
 			Namespace: ns,

--- a/conformance/tests/httproute-response-header-modifier.go
+++ b/conformance/tests/httproute-response-header-modifier.go
@@ -37,10 +37,10 @@ func init() {
 var HTTPRouteBackendResponseHeaderModifier = suite.ConformanceTest{
 	ShortName:   "HTTPRouteBackendResponseHeaderModifier",
 	Description: "An HTTPRoute backendRef has response header modifier filters applied correctly",
-	Features: []suite.SupportedFeature{
-		suite.SupportGateway,
-		suite.SupportHTTPRoute,
-		suite.SupportHTTPRouteBackendResponseHeaderModification,
+	Features: []features.SupportedFeature{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteBackendResponseHeaderModification,
 	},
 	Manifests: []string{"tests/httproute-response-header-modifier-backend.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {

--- a/conformance/tests/httproute-response-header-modifier.go
+++ b/conformance/tests/httproute-response-header-modifier.go
@@ -30,17 +30,17 @@ import (
 func init() {
 	ConformanceTests = append(ConformanceTests,
 		HTTPRouteResponseHeaderModifier,
-		HTTPRouteResponseHeaderModifierBackend,
+		HTTPRouteBackendResponseHeaderModifier,
 	)
 }
 
-var HTTPRouteResponseHeaderModifierBackend = suite.ConformanceTest{
-	ShortName:   "HTTPRouteResponseHeaderModifierBackend",
+var HTTPRouteBackendResponseHeaderModifier = suite.ConformanceTest{
+	ShortName:   "HTTPRouteBackendResponseHeaderModifier",
 	Description: "An HTTPRoute backendRef has response header modifier filters applied correctly",
 	Features: []suite.SupportedFeature{
 		suite.SupportGateway,
 		suite.SupportHTTPRoute,
-		suite.SupportHTTPRouteResponseHeaderModificationBackend,
+		suite.SupportHTTPRouteBackendResponseHeaderModification,
 	},
 	Manifests: []string{"tests/httproute-response-header-modifier-backend.yaml"},
 	Test:      HTTPRouteResponseHeaderModifier.Test,

--- a/conformance/tests/httproute-response-header-modifier.go
+++ b/conformance/tests/httproute-response-header-modifier.go
@@ -43,7 +43,9 @@ var HTTPRouteBackendResponseHeaderModifier = suite.ConformanceTest{
 		suite.SupportHTTPRouteBackendResponseHeaderModification,
 	},
 	Manifests: []string{"tests/httproute-response-header-modifier-backend.yaml"},
-	Test:      HTTPRouteResponseHeaderModifier.Test,
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		RunHTTPRouteReponseHeaderModifierTest(t, suite, HTTPRouteResponseHeaderModifierTestCases...)
+	},
 }
 
 var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
@@ -56,144 +58,192 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 	},
 	Manifests: []string{"tests/httproute-response-header-modifier.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
-		ns := "gateway-conformance-infra"
-		routeNN := types.NamespacedName{Name: "response-header-modifier", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
-		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
-
-		testCases := []http.ExpectedResponse{{
-			Request: http.Request{
-				Path: "/set",
-			},
-			BackendSetResponseHeaders: map[string]string{
-				"Some-Other-Header": "val",
-			},
-			Response: http.Response{
-				Headers: map[string]string{
-					"Some-Other-Header": "val",
-					"X-Header-Set":      "set-overwrites-values",
-				},
-			},
-			Backend:   "infra-backend-v1",
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path: "/set",
-			},
-			BackendSetResponseHeaders: map[string]string{
-				"Some-Other-Header": "val",
-				"X-Header-Set":      "some-other-value",
-			},
-			Response: http.Response{
-				Headers: map[string]string{
-					"Some-Other-Header": "val",
-					"X-Header-Set":      "set-overwrites-values",
-				},
-			},
-			Backend:   "infra-backend-v1",
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path: "/add",
-			},
-			BackendSetResponseHeaders: map[string]string{
-				"Some-Other-Header": "val",
-			},
-			Response: http.Response{
-				Headers: map[string]string{
-					"Some-Other-Header": "val",
-					"X-Header-Add":      "add-appends-values",
-				},
-			},
-			Backend:   "infra-backend-v1",
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path: "/add",
-			},
-			BackendSetResponseHeaders: map[string]string{
-				"Some-Other-Header": "val",
-				"X-Header-Add":      "some-other-value",
-			},
-			Response: http.Response{
-				Headers: map[string]string{
-					"Some-Other-Header": "val",
-					"X-Header-Add":      "some-other-value,add-appends-values",
-				},
-			},
-			Backend:   "infra-backend-v1",
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path: "/remove",
-			},
-			BackendSetResponseHeaders: map[string]string{
-				"X-Header-Remove": "val",
-			},
-			Response: http.Response{
-				AbsentHeaders: []string{"X-Header-Remove"},
-			},
-			Backend:   "infra-backend-v1",
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path: "/multiple",
-			},
-			BackendSetResponseHeaders: map[string]string{
-				"X-Header-Set-2":    "set-val-2",
-				"X-Header-Add-2":    "add-val-2",
-				"X-Header-Remove-2": "remove-val-2",
-				"Another-Header":    "another-header-val",
-				"X-Header-Remove-1": "val",
-			},
-			Response: http.Response{
-				Headers: map[string]string{
-					"X-Header-Set-1": "header-set-1",
-					"X-Header-Set-2": "header-set-2",
-					"X-Header-Add-1": "header-add-1",
-					"X-Header-Add-2": "add-val-2,header-add-2",
-					"X-Header-Add-3": "header-add-3",
-					"Another-Header": "another-header-val",
-				},
-				AbsentHeaders: []string{"X-Header-Remove-1", "X-Header-Remove-2"},
-			},
-			Backend:   "infra-backend-v1",
-			Namespace: ns,
-		}, {
-			Request: http.Request{
-				Path: "/case-insensitivity",
-			},
-			BackendSetResponseHeaders: map[string]string{
-				"x-header-set":    "original-val-set",
-				"x-header-add":    "original-val-add",
-				"x-header-remove": "original-val-remove",
-				"Another-Header":  "another-header-val",
-			},
-			Response: http.Response{
-				Headers: map[string]string{
-					"X-Header-Set":      "header-set",
-					"X-Header-Add":      "original-val-add,header-add",
-					"X-Lowercase-Add":   "lowercase-add",
-					"X-Mixedcase-Add-1": "mixedcase-add-1",
-					"X-Mixedcase-Add-2": "mixedcase-add-2",
-					"X-Uppercase-Add":   "uppercase-add",
-					"Another-Header":    "another-header-val",
-				},
-				AbsentHeaders: []string{"x-header-remove", "X-Header-Remove"},
-			},
-			Backend:   "infra-backend-v1",
-			Namespace: ns,
-		}}
-
-		for i := range testCases {
-			// Declare tc here to avoid loop variable
-			// reuse issues across parallel tests.
-			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
-				t.Parallel()
-				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
-			})
-		}
+		RunHTTPRouteReponseHeaderModifierTest(t, suite, HTTPRouteResponseHeaderModifierTestCases...)
+		RunHTTPRouteReponseHeaderModifierTest(t, suite, HTTPRouteResponseAndRequestHeaderModifierTestCases...)
 	},
 }
+
+func RunHTTPRouteReponseHeaderModifierTest(t *testing.T, suite *suite.ConformanceTestSuite, testCases ...http.ExpectedResponse) {
+	routeNN := types.NamespacedName{Name: "response-header-modifier", Namespace: "gateway-conformance-infra"}
+	gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
+	gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+	kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+	for i := range testCases {
+		// Declare tc here to avoid loop variable
+		// reuse issues across parallel tests.
+		tc := testCases[i]
+		t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+			t.Parallel()
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+		})
+	}
+}
+
+var HTTPRouteResponseAndRequestHeaderModifierTestCases = []http.ExpectedResponse{{
+	Request: http.Request{
+		Path: "/response-and-request-header-modifiers",
+		Headers: map[string]string{
+			"X-Header-Remove":     "remove-val",
+			"X-Header-Add-Append": "append-val-1",
+			"X-Header-Echo":       "echo",
+		},
+	},
+	BackendSetResponseHeaders: map[string]string{
+		"X-Header-Set-2":    "set-val-2",
+		"X-Header-Add-2":    "add-val-2",
+		"X-Header-Remove-2": "remove-val-2",
+		"Another-Header":    "another-header-val",
+		"X-Header-Remove-1": "remove-val-1",
+		"X-Header-Echo":     "echo",
+	},
+	ExpectedRequest: &http.ExpectedRequest{
+		Request: http.Request{
+			Path: "/response-and-request-header-modifiers",
+			Headers: map[string]string{
+				"X-Header-Add":        "header-val-1",
+				"X-Header-Set":        "set-overwrites-values",
+				"X-Header-Add-Append": "append-val-1,header-val-2",
+				"X-Header-Echo":       "echo",
+			},
+		},
+		AbsentHeaders: []string{"X-Header-Remove"},
+	},
+	Response: http.Response{
+		Headers: map[string]string{
+			"X-Header-Set-1": "header-set-1",
+			"X-Header-Set-2": "header-set-2",
+			"X-Header-Add-1": "header-add-1",
+			"X-Header-Add-2": "add-val-2,header-add-2",
+			"Another-Header": "another-header-val",
+			"X-Header-Echo":  "echo",
+		},
+		AbsentHeaders: []string{"X-Header-Remove-1", "X-Header-Remove-2"},
+	},
+	Backend:   "infra-backend-v1",
+	Namespace: "gateway-conformance-infra",
+}}
+
+var HTTPRouteResponseHeaderModifierTestCases = []http.ExpectedResponse{{
+	Request: http.Request{
+		Path: "/set",
+	},
+	BackendSetResponseHeaders: map[string]string{
+		"Some-Other-Header": "val",
+	},
+	Response: http.Response{
+		Headers: map[string]string{
+			"Some-Other-Header": "val",
+			"X-Header-Set":      "set-overwrites-values",
+		},
+	},
+	Backend:   "infra-backend-v1",
+	Namespace: "gateway-conformance-infra",
+}, {
+	Request: http.Request{
+		Path: "/set",
+	},
+	BackendSetResponseHeaders: map[string]string{
+		"Some-Other-Header": "val",
+		"X-Header-Set":      "some-other-value",
+	},
+	Response: http.Response{
+		Headers: map[string]string{
+			"Some-Other-Header": "val",
+			"X-Header-Set":      "set-overwrites-values",
+		},
+	},
+	Backend:   "infra-backend-v1",
+	Namespace: "gateway-conformance-infra",
+}, {
+	Request: http.Request{
+		Path: "/add",
+	},
+	BackendSetResponseHeaders: map[string]string{
+		"Some-Other-Header": "val",
+	},
+	Response: http.Response{
+		Headers: map[string]string{
+			"Some-Other-Header": "val",
+			"X-Header-Add":      "add-appends-values",
+		},
+	},
+	Backend:   "infra-backend-v1",
+	Namespace: "gateway-conformance-infra",
+}, {
+	Request: http.Request{
+		Path: "/add",
+	},
+	BackendSetResponseHeaders: map[string]string{
+		"Some-Other-Header": "val",
+		"X-Header-Add":      "some-other-value",
+	},
+	Response: http.Response{
+		Headers: map[string]string{
+			"Some-Other-Header": "val",
+			"X-Header-Add":      "some-other-value,add-appends-values",
+		},
+	},
+	Backend:   "infra-backend-v1",
+	Namespace: "gateway-conformance-infra",
+}, {
+	Request: http.Request{
+		Path: "/remove",
+	},
+	BackendSetResponseHeaders: map[string]string{
+		"X-Header-Remove": "val",
+	},
+	Response: http.Response{
+		AbsentHeaders: []string{"X-Header-Remove"},
+	},
+	Backend:   "infra-backend-v1",
+	Namespace: "gateway-conformance-infra",
+}, {
+	Request: http.Request{
+		Path: "/multiple",
+	},
+	BackendSetResponseHeaders: map[string]string{
+		"X-Header-Set-2":    "set-val-2",
+		"X-Header-Add-2":    "add-val-2",
+		"X-Header-Remove-2": "remove-val-2",
+		"Another-Header":    "another-header-val",
+		"X-Header-Remove-1": "val",
+	},
+	Response: http.Response{
+		Headers: map[string]string{
+			"X-Header-Set-1": "header-set-1",
+			"X-Header-Set-2": "header-set-2",
+			"X-Header-Add-1": "header-add-1",
+			"X-Header-Add-2": "add-val-2,header-add-2",
+			"X-Header-Add-3": "header-add-3",
+			"Another-Header": "another-header-val",
+		},
+		AbsentHeaders: []string{"X-Header-Remove-1", "X-Header-Remove-2"},
+	},
+	Backend:   "infra-backend-v1",
+	Namespace: "gateway-conformance-infra",
+}, {
+	Request: http.Request{
+		Path: "/case-insensitivity",
+	},
+	BackendSetResponseHeaders: map[string]string{
+		"x-header-set":    "original-val-set",
+		"x-header-add":    "original-val-add",
+		"x-header-remove": "original-val-remove",
+		"Another-Header":  "another-header-val",
+	},
+	Response: http.Response{
+		Headers: map[string]string{
+			"X-Header-Set":      "header-set",
+			"X-Header-Add":      "original-val-add,header-add",
+			"X-Lowercase-Add":   "lowercase-add",
+			"X-Mixedcase-Add-1": "mixedcase-add-1",
+			"X-Mixedcase-Add-2": "mixedcase-add-2",
+			"X-Uppercase-Add":   "uppercase-add",
+			"Another-Header":    "another-header-val",
+		},
+		AbsentHeaders: []string{"x-header-remove", "X-Header-Remove"},
+	},
+	Backend:   "infra-backend-v1",
+	Namespace: "gateway-conformance-infra",
+}}

--- a/conformance/tests/httproute-response-header-modifier.go
+++ b/conformance/tests/httproute-response-header-modifier.go
@@ -44,7 +44,7 @@ var HTTPRouteBackendResponseHeaderModifier = suite.ConformanceTest{
 	},
 	Manifests: []string{"tests/httproute-response-header-modifier-backend.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
-		RunHTTPRouteReponseHeaderModifierTest(t, suite, HTTPRouteResponseHeaderModifierTestCases...)
+		RunHTTPRouteReponseHeaderModifierTest(t, suite, HTTPRouteResponseHeaderModifierTestCases)
 	},
 }
 
@@ -58,12 +58,12 @@ var HTTPRouteResponseHeaderModifier = suite.ConformanceTest{
 	},
 	Manifests: []string{"tests/httproute-response-header-modifier.yaml"},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
-		RunHTTPRouteReponseHeaderModifierTest(t, suite, HTTPRouteResponseHeaderModifierTestCases...)
-		RunHTTPRouteReponseHeaderModifierTest(t, suite, HTTPRouteResponseAndRequestHeaderModifierTestCases...)
+		RunHTTPRouteReponseHeaderModifierTest(t, suite, HTTPRouteResponseHeaderModifierTestCases)
+		RunHTTPRouteReponseHeaderModifierTest(t, suite, HTTPRouteResponseAndRequestHeaderModifierTestCases)
 	},
 }
 
-func RunHTTPRouteReponseHeaderModifierTest(t *testing.T, suite *suite.ConformanceTestSuite, testCases ...http.ExpectedResponse) {
+func RunHTTPRouteReponseHeaderModifierTest(t *testing.T, suite *suite.ConformanceTestSuite, testCases []http.ExpectedResponse) {
 	routeNN := types.NamespacedName{Name: "response-header-modifier", Namespace: "gateway-conformance-infra"}
 	gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 	gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -110,6 +110,9 @@ const (
 	// This option indicates support for HTTPRoute response header modification (extended conformance).
 	SupportHTTPRouteResponseHeaderModification SupportedFeature = "HTTPRouteResponseHeaderModification"
 
+	// This option indicates support for HTTPRoute backendRef response header modification (extended conformance).
+	SupportHTTPRouteResponseHeaderModificationBackend SupportedFeature = "HTTPRouteResponseHeaderModificationBackend"
+
 	// This option indicates support for HTTPRoute port redirect (extended conformance).
 	SupportHTTPRoutePortRedirect SupportedFeature = "HTTPRoutePortRedirect"
 
@@ -148,6 +151,7 @@ var HTTPRouteExtendedFeatures = sets.New(
 	SupportHTTPRouteQueryParamMatching,
 	SupportHTTPRouteMethodMatching,
 	SupportHTTPRouteResponseHeaderModification,
+	SupportHTTPRouteResponseHeaderModificationBackend,
 	SupportHTTPRoutePortRedirect,
 	SupportHTTPRouteSchemeRedirect,
 	SupportHTTPRoutePathRedirect,

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -111,7 +111,7 @@ const (
 	SupportHTTPRouteResponseHeaderModification SupportedFeature = "HTTPRouteResponseHeaderModification"
 
 	// This option indicates support for HTTPRoute backendRef response header modification (extended conformance).
-	SupportHTTPRouteResponseHeaderModificationBackend SupportedFeature = "HTTPRouteResponseHeaderModificationBackend"
+	SupportHTTPRouteBackendResponseHeaderModification SupportedFeature = "HTTPRouteResponseHeaderModification"
 
 	// This option indicates support for HTTPRoute port redirect (extended conformance).
 	SupportHTTPRoutePortRedirect SupportedFeature = "HTTPRoutePortRedirect"
@@ -151,7 +151,7 @@ var HTTPRouteExtendedFeatures = sets.New(
 	SupportHTTPRouteQueryParamMatching,
 	SupportHTTPRouteMethodMatching,
 	SupportHTTPRouteResponseHeaderModification,
-	SupportHTTPRouteResponseHeaderModificationBackend,
+	SupportHTTPRouteBackendResponseHeaderModification,
 	SupportHTTPRoutePortRedirect,
 	SupportHTTPRouteSchemeRedirect,
 	SupportHTTPRoutePathRedirect,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind cleanup
/kind test
/area conformance

**What this PR does / why we need it**:

This adds test coverage for an extended feature - HTTPBackendRef being able to support the responseHeader filter

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
