### PR TITLE
Inject a fake clock during testing `gwctl get gateways`

### DIFF
--- a/gwctl/pkg/cmd/get/get.go
+++ b/gwctl/pkg/cmd/get/get.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/utils/clock"
+
 	"sigs.k8s.io/gateway-api/gwctl/pkg/cmd/utils"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/printer"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery"
@@ -60,7 +62,8 @@ func runGet(args []string, params *utils.CmdParams, flags *getFlags) {
 		K8sClients:    params.K8sClients,
 		PolicyManager: params.PolicyManager,
 	}
-	gwPrinter := &printer.GatewaysPrinter{Out: params.Out}
+	realClock := clock.RealClock{}
+	gwPrinter := &printer.GatewaysPrinter{Out: params.Out, Clock: realClock}
 	policiesPrinter := &printer.PoliciesPrinter{Out: params.Out}
 	httpRoutesPrinter := &printer.HTTPRoutesPrinter{Out: params.Out}
 

--- a/gwctl/pkg/printer/gateways.go
+++ b/gwctl/pkg/printer/gateways.go
@@ -21,18 +21,18 @@ import (
 	"io"
 	"strings"
 	"text/tabwriter"
-	"time"
-
-	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/gateway-api/gwctl/pkg/policymanager"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery"
-
+	"sigs.k8s.io/yaml"
+	
 	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/utils/clock"
 )
 
 type GatewaysPrinter struct {
-	Out io.Writer
+	Out   io.Writer
+	Clock clock.Clock
 }
 
 type gatewayDescribeView struct {
@@ -74,7 +74,7 @@ func (gp *GatewaysPrinter) Print(resourceModel *resourcediscovery.ResourceModel)
 			}
 		}
 
-		age := duration.HumanDuration(time.Since(gatewayNode.Gateway.GetCreationTimestamp().Time))
+		age := duration.HumanDuration(gp.Clock.Since(gatewayNode.Gateway.GetCreationTimestamp().Time))
 
 		row := []string{
 			gatewayNode.Gateway.GetName(),

--- a/gwctl/pkg/printer/gateways_test.go
+++ b/gwctl/pkg/printer/gateways_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	testingclock "k8s.io/utils/clock/testing"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -35,6 +36,7 @@ import (
 )
 
 func TestGatewaysPrinter_Print(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
 	objects := []runtime.Object{
 		&gatewayv1.GatewayClass{
 			ObjectMeta: metav1.ObjectMeta{
@@ -50,7 +52,7 @@ func TestGatewaysPrinter_Print(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo-gateway",
 				CreationTimestamp: metav1.Time{
-					Time: time.Now().Add(-time.Second),
+					Time: fakeClock.Now().Add(-time.Second),
 				},
 			},
 			Spec: gatewayv1.GatewaySpec{
@@ -90,7 +92,8 @@ func TestGatewaysPrinter_Print(t *testing.T) {
 	}
 
 	gp := &GatewaysPrinter{
-		Out: params.Out,
+		Out:   params.Out,
+		Clock: fakeClock,
 	}
 	gp.Print(resourceModel)
 
@@ -106,6 +109,7 @@ foo-gateway  foo-gatewayclass  10.0.0.1   80     True        1s
 }
 
 func TestGatewaysPrinter_PrintDescribeView(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
 	objects := []runtime.Object{
 		&gatewayv1.GatewayClass{
 			ObjectMeta: metav1.ObjectMeta{
@@ -240,7 +244,8 @@ func TestGatewaysPrinter_PrintDescribeView(t *testing.T) {
 	}
 
 	gp := &GatewaysPrinter{
-		Out: params.Out,
+		Out:   params.Out,
+		Clock: fakeClock,
 	}
 	gp.PrintDescribeView(resourceModel)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

/area gwctl
/kind test
/cc @gauravkghildiyal

Inject a fake clock during testing `gwctl get gateways`.

```diff
type GatewaysPrinter struct {
	Out   io.Writer
+	Clock clock.Clock
}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api/pull/2805#discussion_r1502192342

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
