### PR TITLE
docs: mark reporting structure grad criteria as complete for GEP 1709

### DIFF
--- a/geps/gep-1709/index.md
+++ b/geps/gep-1709/index.md
@@ -667,7 +667,7 @@ The following are items that **MUST** be resolved to move this GEP to
     phase. In the same timespan the Network Policy group has started using our
     test suite and APIs as well, so it seems the overall approach has obvious
     merit, and doesn't appear to be redundant.
-- [ ] Finalize the report organization structure based on feedback during the
+- [x] Finalize the report organization structure based on feedback during the
   experimental phase.
 - [ ] Base documentation must exist for implementations to run the tests via
   the CLI and via the Golang library.


### PR DESCRIPTION
As per the sub-tasks in https://github.com/kubernetes-sigs/gateway-api/issues/1709 all the reporting structure work has been completed (thank you @mlavacca!). This updates the GEP to reflect that, and now all that's left is documentation as per https://github.com/kubernetes-sigs/gateway-api/issues/2322 (though Mattia also added a bit of documentation as a part of the reporting work recently as well).