### PR TITLE
bump golangci-lint to latest version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,7 +65,7 @@ issues:
         - gocyclo
         - errcheck
         - dupl
-     # To many false positives - for examples see: https://github.com/Antonboom/testifylint/issues/67
+     # Too many false positives - for examples see: https://github.com/Antonboom/testifylint/issues/67
     - linters:
       - testifylint
       text: "require must only be used in the goroutine running the test function"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
   - whitespace
   disable:
   - scopelint
+  - testifylint # To many false positives https://github.com/Antonboom/testifylint/issues/67
   disable-all: false
   presets:
   - bugs

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,6 @@ linters:
   - whitespace
   disable:
   - scopelint
-  - testifylint # To many false positives https://github.com/Antonboom/testifylint/issues/67
   disable-all: false
   presets:
   - bugs
@@ -66,5 +65,9 @@ issues:
         - gocyclo
         - errcheck
         - dupl
+     # To many false positives - for examples see: https://github.com/Antonboom/testifylint/issues/67
+    - linters:
+      - testifylint
+      text: "require must only be used in the goroutine running the test function"
   exclude:
     - Using the variable on range scope `tc` in function literal

--- a/conformance/tests/gateway-modify-listeners.go
+++ b/conformance/tests/gateway-modify-listeners.go
@@ -149,7 +149,7 @@ var GatewayModifyListeners = suite.ConformanceTest{
 			require.NoErrorf(t, err, "error getting Gateway: %v", err)
 
 			mutate := original.DeepCopy()
-			require.Equalf(t, 2, len(mutate.Spec.Listeners), "the gateway must have 2 listeners")
+			require.Lenf(t, mutate.Spec.Listeners, 2, "the gateway must have 2 listeners")
 
 			// remove the "https" Gateway listener, leaving only the "http" listener
 			var newListeners []v1.Listener

--- a/conformance/tests/httproute-backend-protocol-websocket.go
+++ b/conformance/tests/httproute-backend-protocol-websocket.go
@@ -57,7 +57,7 @@ var HTTPRouteBackendProtocolWebSocket = suite.ConformanceTest{
 		maxTimeToConsistency := suite.TimeoutConfig.MaxTimeToConsistency
 
 		t.Run("websocket connection should reach backend", func(t *testing.T) {
-			http.AwaitConvergence(t, threshold, maxTimeToConsistency, func(elapsed time.Duration) bool {
+			http.AwaitConvergence(t, threshold, maxTimeToConsistency, func(_ time.Duration) bool {
 				origin := fmt.Sprintf("ws://gateway/%s", t.Name())
 				remote := fmt.Sprintf("ws://%s/ws", gwAddr)
 

--- a/conformance/utils/kubernetes/certificate.go
+++ b/conformance/utils/kubernetes/certificate.go
@@ -42,7 +42,7 @@ const (
 
 // MustCreateSelfSignedCertSecret creates a self-signed SSL certificate and stores it in a secret
 func MustCreateSelfSignedCertSecret(t *testing.T, namespace, secretName string, hosts []string) *corev1.Secret {
-	require.Greater(t, len(hosts), 0, "require a non-empty hosts for Subject Alternate Name values")
+	require.NotEmpty(t, hosts, "require a non-empty hosts for Subject Alternate Name values")
 
 	var serverKey, serverCert bytes.Buffer
 

--- a/conformance/utils/roundtripper/roundtripper.go
+++ b/conformance/utils/roundtripper/roundtripper.go
@@ -141,7 +141,7 @@ func (d *DefaultRoundTripper) h2cPriorKnowledgeTransport(request Request) (http.
 
 	transport := &http2.Transport{
 		AllowHTTP: true,
-		DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
 			var d net.Dialer
 			return d.DialContext(ctx, network, addr)
 		},
@@ -176,7 +176,7 @@ func (d *DefaultRoundTripper) defaultRoundTrip(request Request, transport http.R
 	client := &http.Client{}
 
 	if request.UnfollowRedirect {
-		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
 		}
 	}

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly VERSION="v1.52.2"
+readonly VERSION="v1.56.2"
 readonly KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 cd "${KUBE_ROOT}"

--- a/pkg/test/cel/httproute_test.go
+++ b/pkg/test/cel/httproute_test.go
@@ -1346,6 +1346,7 @@ func TestHTTPPathModifier(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			pathModifier := tc.pathModifier
 			route := &gatewayv1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fmt.Sprintf("foo-%v", time.Now().UnixNano()),
@@ -1358,7 +1359,7 @@ func TestHTTPPathModifier(t *testing.T) {
 								{
 									Type: gatewayv1.HTTPRouteFilterRequestRedirect,
 									RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
-										Path: &tc.pathModifier,
+										Path: &pathModifier,
 									},
 								},
 							},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Linter is blocking https://github.com/kubernetes-sigs/gateway-api/pull/2828

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
