### PR TITLE
chore: conformance report for KIC 3.1.1

### DIFF
--- a/conformance/reports/v1.0.0/kong-kubernetes-ingress-controller/README.md
+++ b/conformance/reports/v1.0.0/kong-kubernetes-ingress-controller/README.md
@@ -5,5 +5,6 @@
 |API channel|Implementation version|Mode|Report|
 |-----------|----------------------|----|------|
 |x|[v3.0.2](https://github.com/Kong/kubernetes-ingress-controller/releases/tag/v3.0.2)|x|[link](./v3.0.2-report.yaml)|
+|x|[v3.1.1](https://github.com/Kong/kubernetes-ingress-controller/releases/tag/v3.1.1)|x|[link](./v3.1.1-report.yaml)|
 
 ## Reproduce

--- a/conformance/reports/v1.0.0/kong-kubernetes-ingress-controller/README.md
+++ b/conformance/reports/v1.0.0/kong-kubernetes-ingress-controller/README.md
@@ -8,3 +8,37 @@
 |x|[v3.1.1](https://github.com/Kong/kubernetes-ingress-controller/releases/tag/v3.1.1)|x|[link](./v3.1.1-report.yaml)|
 
 ## Reproduce
+
+### Prerequisites
+
+In order to properly run the conformance tests, you need to have [KinD](https://github.com/kubernetes-sigs/kind)
+and [Helm](https://github.com/helm/helm) installed on your local machine, as the
+test suite will create a fresh KinD cluster and will use Helm to deploy some additional
+components.
+
+### Steps
+
+1. Clone the Kong Ingress Controller GitHub repository
+
+   ```bash
+   git clone https://github.com/Kong/kubernetes-ingress-controller.git && cd kubernetes-ingress-controller
+   ```
+
+2. Check out the desired version
+
+   ```bash
+   export VERSION=v<x.y.z>
+   git checkout $VERSION
+   ```
+
+3. Run the conformance tests
+
+   ```bash
+   KONG_TEST_EXPRESSION_ROUTES=true make test.conformance
+   ```
+
+4. Check the produced report
+
+   ```bash
+   cat ./kong-kubernetes-ingress-controller.yaml
+   ```

--- a/conformance/reports/v1.0.0/kong-kubernetes-ingress-controller/v3.1.1-report.yaml
+++ b/conformance/reports/v1.0.0/kong-kubernetes-ingress-controller/v3.1.1-report.yaml
@@ -1,0 +1,41 @@
+apiVersion: gateway.networking.k8s.io/v1alpha1
+date: "2024-03-01T15:45:22+01:00"
+gatewayAPIVersion: v1.0.0
+implementation:
+  contact:
+  - github.com/kong/kubernetes-ingress-controller/issues/new/choose
+  organization: Kong
+  project: kubernetes-ingress-controller
+  url: github.com/kong/kubernetes-ingress-controller
+  version: v3.1.1
+kind: ConformanceReport
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 29
+      Skipped: 0
+    summary: ""
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 4
+      Skipped: 0
+    summary: ""
+    supportedFeatures:
+    - HTTPRouteMethodMatching
+    - HTTPRouteBackendTimeout
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteResponseHeaderModification
+    unsupportedFeatures:
+    - HTTPRouteSchemeRedirect
+    - HTTPRoutePathRedirect
+    - HTTPRouteHostRewrite
+    - HTTPRoutePathRewrite
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestTimeout
+    - HTTPRoutePortRedirect
+  name: HTTP


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/area conformance

**What this PR does / why we need it**:

Conformance report for Kong ingress Controller 3.1.1

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
