### PR TITLE
test: when running a specific test don't require the feature to be enabled

### DIFF
--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -233,11 +233,14 @@ func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) {
 		t.Parallel()
 	}
 
-	// Check that all features exercised by the test have been opted into by
-	// the suite.
-	for _, feature := range test.Features {
-		if !suite.SupportedFeatures.Has(feature) {
-			t.Skipf("Skipping %s: suite does not support %s", test.ShortName, feature)
+	// Test against features if the user hasn't focused on a single test
+	if suite.RunTest == "" {
+		// Check that all features exercised by the test have been opted into by
+		// the suite.
+		for _, feature := range test.Features {
+			if !suite.SupportedFeatures.Has(feature) {
+				t.Skipf("Skipping %s: suite does not support %s", test.ShortName, feature)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind test
/kind gep
/area conformance

**What this PR does / why we need it**:
This is a small quality of life improvment. When running a single test you have to make sure the feature is enabled which isn't necessary. With this change you can now just pass the `gateway-class` and `run-test` flag

```
CONFORMANCE_FLAGS="-gateway-class=istio -run-test=GatewayWithAttachedRoutes" make conformance
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
