### PR TITLE
gofumpt the repo

### DIFF
--- a/gwctl/pkg/policymanager/merger_test.go
+++ b/gwctl/pkg/policymanager/merger_test.go
@@ -434,7 +434,6 @@ func TestMergePoliciesOfDifferentHierarchy(t *testing.T) {
 			if diff := cmp.Diff(policySliceToMap(tc.wantMergedPolicies), gotMergedPolicies, cmpopts); diff != "" {
 				t.Errorf("MergePoliciesOfDifferentHierarchy returned unexpected diff (-want, +got):\n%v", diff)
 			}
-
 		})
 	}
 }

--- a/gwctl/pkg/resourcediscovery/nodes.go
+++ b/gwctl/pkg/resourcediscovery/nodes.go
@@ -36,12 +36,14 @@ type resourceID struct {
 	Name      string
 }
 
-type gatewayClassID resourceID
-type namespaceID resourceID
-type gatewayID resourceID
-type httpRouteID resourceID
-type backendID resourceID
-type policyID resourceID
+type (
+	gatewayClassID resourceID
+	namespaceID    resourceID
+	gatewayID      resourceID
+	httpRouteID    resourceID
+	backendID      resourceID
+	policyID       resourceID
+)
 
 // GatewayClassID returns an ID for a GatewayClass.
 func GatewayClassID(gatewayClassName string) gatewayClassID {

--- a/gwctl/pkg/resourcediscovery/resourcemodel.go
+++ b/gwctl/pkg/resourcediscovery/resourcemodel.go
@@ -160,7 +160,6 @@ func (rm *ResourceModel) addPolicyIfTargetExists(policies ...policymanager.Polic
 				policyNode.HTTPRoute = httpRouteNode
 				httpRouteNode.Policies[policyNode.ID()] = policyNode
 			}
-
 		} else if policy.TargetRef().Group == corev1.GroupName && policy.TargetRef().Kind == "Namespace" {
 			namespaceID := NamespaceID(policy.TargetRef().Name)
 			namespaceNode, ok := rm.Namespaces[namespaceID]

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 /*


### PR DESCRIPTION
When linting some code in a PR I realized there were some other files that weren't `gofumpt`-ed

```release-note
NONE
```