### PR TITLE
Add doc and httproute example for HTTP request mirroring

### DIFF
--- a/examples/standard/http-request-mirroring/httproute-mirroring.yaml
+++ b/examples/standard/http-request-mirroring/httproute-mirroring.yaml
@@ -1,0 +1,23 @@
+#$ Used in:
+#$ - site-src/guides/http-request-mirroring.md
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-filter-mirror
+  labels:
+    gateway: mirror-gateway
+spec:
+  parentRefs:
+  - name: mirror-gateway
+  hostnames:
+  - mirror.example
+  rules:
+  - backendRefs:
+    - name: foo-v1
+      port: 8080
+    filters:
+    - type: RequestMirror
+      requestMirror:
+        backendRef:
+          name: foo-v2
+          port: 8080

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - HTTP redirects and rewrites: guides/http-redirect-rewrite.md
       - HTTP header modifier: guides/http-header-modifier.md
       - HTTP traffic splitting: guides/traffic-splitting.md
+      - HTTP request mirroring: guides/http-request-mirroring.md
       - Cross-Namespace routing: guides/multiple-ns.md
       - TLS: guides/tls.md
       - TCP routing: guides/tcp.md

--- a/site-src/guides/http-request-mirroring.md
+++ b/site-src/guides/http-request-mirroring.md
@@ -1,0 +1,27 @@
+# HTTP request mirroring
+
+??? example "Extended Support Feature"
+
+    As of v1.0.0, the Request Mirroring feature is an Extended feature, and
+    requires implementations to support the `HTTPRouteRequestMirror` feature.
+
+The [HTTPRoute resource](/api-types/httproute) allows you to mirror HTTP
+requests to another backend using
+[filters](/api-types/httproute#filters-optional). This guide shows how to use
+this feature.
+
+Mirrored requests will must only be sent to one single destination endpoint
+within this backendRef, and responses from this backend MUST be ignored by
+the Gateway.
+
+Request mirroring is particularly useful in blue-green deployment. It can be
+used to assess the impact on application performance without impacting
+responses to clients in any way.
+
+```yaml
+{% include 'standard/http-request-mirroring/httproute-mirroring.yaml' %}
+```
+
+In this example, all requests are forwarded to service `foo-v1` on port `8080`,
+and they are also forwarded to service `foo-v2` on port `8080`, but responses
+are only generated from service `foo-v1`.


### PR DESCRIPTION
* Added example HTTPRoute yaml for configuring HTTP request mirroring.

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Added examples for HTTP request mirroring.

**Which issue(s) this PR fixes**:
Fixes #2833

**Does this PR introduce a user-facing change?**:
```release-note
None
```
