### PR TITLE
Added grpc conformance profile

### DIFF
--- a/conformance/utils/suite/experimental_profiles.go
+++ b/conformance/utils/suite/experimental_profiles.go
@@ -48,6 +48,10 @@ const (
 	// which covers TLS stream functionality, such as the TLSRoute API.
 	TLSConformanceProfileName ConformanceProfileName = "TLS"
 
+	// GRPCConformanceProfileName indicates the name of the conformance profile
+	// which covers GRPC functionality, such as the GRPCRoute API.
+	GRPCConformanceProfileName ConformanceProfileName = "GRPC"
+
 	// MeshConformanceProfileName indicates the name of the conformance profile
 	// which covers service mesh functionality.
 	MeshConformanceProfileName ConformanceProfileName = "MESH"
@@ -81,6 +85,17 @@ var (
 		),
 	}
 
+	// GRPCConformanceProfile is a ConformanceProfile that covers testing GRPC
+	// related functionality with Gateways.
+	GRPCConformanceProfile = ConformanceProfile{
+		Name: GRPCConformanceProfileName,
+		CoreFeatures: sets.New(
+			SupportGateway,
+			SupportReferenceGrant,
+			SupportGRPCRoute,
+		),
+	}
+
 	// MeshConformanceProfile is a ConformanceProfile that covers testing
 	// service mesh related functionality.
 	MeshConformanceProfile = ConformanceProfile{
@@ -102,6 +117,7 @@ var (
 var conformanceProfileMap = map[ConformanceProfileName]ConformanceProfile{
 	HTTPConformanceProfileName: HTTPConformanceProfile,
 	TLSConformanceProfileName:  TLSConformanceProfile,
+	GRPCConformanceProfileName: GRPCConformanceProfile,
 	MeshConformanceProfileName: MeshConformanceProfile,
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind feature
/area conformance

**What this PR does / why we need it**:

This PR introduces a GRPC Conformance Profile to enable downstream implementations to run the test suite in an aggregated manner.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2871

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Added the GRPC Conformance Profile. 
```
