### PR TITLE
Add label filtering (-l) for get commands

### DIFF
--- a/gwctl/cmd/get.go
+++ b/gwctl/cmd/get.go
@@ -18,8 +18,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/clock"

--- a/gwctl/cmd/get.go
+++ b/gwctl/cmd/get.go
@@ -18,10 +18,10 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/spf13/cobra"
 	"os"
 
-	"github.com/spf13/cobra"
-
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/clock"
 
 	"sigs.k8s.io/gateway-api/gwctl/pkg/printer"
@@ -33,6 +33,7 @@ func NewGetCommand() *cobra.Command {
 
 	var namespaceFlag string
 	var allNamespacesFlag bool
+	var labelSelector string
 
 	cmd := &cobra.Command{
 		Use:   "get {gateways|gatewayclasses|policies|policycrds|httproutes}",
@@ -45,6 +46,7 @@ func NewGetCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&namespaceFlag, "namespace", "n", "default", "")
 	cmd.Flags().BoolVarP(&allNamespacesFlag, "all-namespaces", "A", false, "If present, list requested resources from all namespaces.")
+	cmd.Flags().StringVarP(&labelSelector, "selector", "l", "", "Label selector.")
 
 	return cmd
 }
@@ -60,6 +62,12 @@ func runGet(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 	allNs, err := cmd.Flags().GetBool("all-namespaces")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to read flag \"all-namespaces\": %v\n", err)
+		os.Exit(1)
+	}
+
+	labelSelector, err := cmd.Flags().GetString("selector")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read flag \"selector\": %v\n", err)
 		os.Exit(1)
 	}
 
@@ -79,7 +87,12 @@ func runGet(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 
 	switch kind {
 	case "gateway", "gateways":
-		filter := resourcediscovery.Filter{Namespace: ns}
+		selector, err := labels.Parse(labelSelector)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+			os.Exit(1)
+		}
+		filter := resourcediscovery.Filter{Namespace: ns, Labels: selector}
 		if len(args) > 1 {
 			filter.Name = args[1]
 		}
@@ -91,7 +104,12 @@ func runGet(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 		gwPrinter.Print(resourceModel)
 
 	case "gatewayclass", "gatewayclasses":
-		filter := resourcediscovery.Filter{Namespace: ns}
+		selector, err := labels.Parse(labelSelector)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+			os.Exit(1)
+		}
+		filter := resourcediscovery.Filter{Namespace: ns, Labels: selector}
 		if len(args) > 1 {
 			filter.Name = args[1]
 		}
@@ -111,7 +129,12 @@ func runGet(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 		policiesPrinter.PrintCRDs(list)
 
 	case "httproute", "httproutes":
-		filter := resourcediscovery.Filter{Namespace: ns}
+		selector, err := labels.Parse(labelSelector)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+			os.Exit(1)
+		}
+		filter := resourcediscovery.Filter{Namespace: ns, Labels: selector}
 		if len(args) > 1 {
 			filter.Name = args[1]
 		}

--- a/gwctl/pkg/printer/gatewayclasses_test.go
+++ b/gwctl/pkg/printer/gatewayclasses_test.go
@@ -26,6 +26,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	testingclock "k8s.io/utils/clock/testing"
 
@@ -197,6 +198,109 @@ DirectlyAttachedPolicies:
 - Group: foo.com
   Kind: HealthCheckPolicy
   Name: policy-name
+`
+	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
+	}
+}
+
+func TestGatewayClassesPrinter_Label(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	objects := []runtime.Object{
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bar-com-internal-gateway-class",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-365 * 24 * time.Hour),
+				},
+				Labels: map[string]string{
+					"app": "bar",
+				},
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "bar.baz/internal-gateway-class",
+			},
+			Status: gatewayv1.GatewayClassStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   "Accepted",
+						Status: "True",
+					},
+				},
+			},
+		},
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo-com-external-gateway-class",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-100 * 24 * time.Hour),
+				},
+				Labels: map[string]string{
+					"app": "foo",
+				},
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "foo.com/external-gateway-class",
+			},
+			Status: gatewayv1.GatewayClassStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   "Accepted",
+						Status: "False",
+					},
+				},
+			},
+		},
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo-com-internal-gateway-class",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-24 * time.Minute),
+				},
+				Labels: map[string]string{
+					"app": "foo",
+				},
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "foo.com/internal-gateway-class",
+			},
+			Status: gatewayv1.GatewayClassStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   "Accepted",
+						Status: "Unknown",
+					},
+				},
+			},
+		},
+	}
+
+	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
+	discoverer := resourcediscovery.Discoverer{
+		K8sClients:    params.K8sClients,
+		PolicyManager: params.PolicyManager,
+	}
+	labelSelector := "app=foo"
+	selector, err := labels.Parse(labelSelector)
+	if err != nil {
+		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+	}
+	resourceModel, err := discoverer.DiscoverResourcesForGatewayClass(resourcediscovery.Filter{Labels: selector})
+	if err != nil {
+		t.Fatalf("Failed to construct resourceModel: %v", resourceModel)
+	}
+
+	gcp := &GatewayClassesPrinter{
+		Out:   params.Out,
+		Clock: fakeClock,
+	}
+	gcp.Print(resourceModel)
+
+	got := params.Out.(*bytes.Buffer).String()
+	want := `
+NAME                            CONTROLLER                      ACCEPTED  AGE
+foo-com-external-gateway-class  foo.com/external-gateway-class  False     100d
+foo-com-internal-gateway-class  foo.com/internal-gateway-class  Unknown   24m
 `
 	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
 		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)

--- a/gwctl/pkg/printer/gatewayclasses_test.go
+++ b/gwctl/pkg/printer/gatewayclasses_test.go
@@ -204,83 +204,41 @@ DirectlyAttachedPolicies:
 	}
 }
 
-func TestGatewayClassesPrinter_Label(t *testing.T) {
+// TestGatewayClassesPrinter_LabelSelector Tests label selector filtering for GatewayClasses in 'get' command.
+func TestGatewayClassesPrinter_LabelSelector(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
-	objects := []runtime.Object{
-		&gatewayv1.GatewayClass{
+
+	gatewayClass := func(name string, labels map[string]string) *gatewayv1.GatewayClass {
+		return &gatewayv1.GatewayClass{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "bar-com-internal-gateway-class",
+				Name:   name,
+				Labels: labels,
 				CreationTimestamp: metav1.Time{
 					Time: fakeClock.Now().Add(-365 * 24 * time.Hour),
-				},
-				Labels: map[string]string{
-					"app": "bar",
-				},
-			},
+				}},
 			Spec: gatewayv1.GatewayClassSpec{
-				ControllerName: "bar.baz/internal-gateway-class",
+				ControllerName: gatewayv1.GatewayController(name + "/controller"),
 			},
 			Status: gatewayv1.GatewayClassStatus{
 				Conditions: []metav1.Condition{
 					{
 						Type:   "Accepted",
-						Status: "True",
+						Status: metav1.ConditionTrue,
 					},
 				},
 			},
-		},
-		&gatewayv1.GatewayClass{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "foo-com-external-gateway-class",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-100 * 24 * time.Hour),
-				},
-				Labels: map[string]string{
-					"app": "foo",
-				},
-			},
-			Spec: gatewayv1.GatewayClassSpec{
-				ControllerName: "foo.com/external-gateway-class",
-			},
-			Status: gatewayv1.GatewayClassStatus{
-				Conditions: []metav1.Condition{
-					{
-						Type:   "Accepted",
-						Status: "False",
-					},
-				},
-			},
-		},
-		&gatewayv1.GatewayClass{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "foo-com-internal-gateway-class",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-24 * time.Minute),
-				},
-				Labels: map[string]string{
-					"app": "foo",
-				},
-			},
-			Spec: gatewayv1.GatewayClassSpec{
-				ControllerName: "foo.com/internal-gateway-class",
-			},
-			Status: gatewayv1.GatewayClassStatus{
-				Conditions: []metav1.Condition{
-					{
-						Type:   "Accepted",
-						Status: "Unknown",
-					},
-				},
-			},
-		},
+		}
 	}
-
+	objects := []runtime.Object{
+		gatewayClass("foo-com-external-gateway-class", map[string]string{"app": "foo"}),
+		gatewayClass("foo-com-internal-gateway-class", map[string]string{"app": "foo", "env": "internal"}),
+	}
 	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
 	discoverer := resourcediscovery.Discoverer{
 		K8sClients:    params.K8sClients,
 		PolicyManager: params.PolicyManager,
 	}
-	labelSelector := "app=foo"
+	labelSelector := "env=internal"
 	selector, err := labels.Parse(labelSelector)
 	if err != nil {
 		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
@@ -298,9 +256,8 @@ func TestGatewayClassesPrinter_Label(t *testing.T) {
 
 	got := params.Out.(*bytes.Buffer).String()
 	want := `
-NAME                            CONTROLLER                      ACCEPTED  AGE
-foo-com-external-gateway-class  foo.com/external-gateway-class  False     100d
-foo-com-internal-gateway-class  foo.com/internal-gateway-class  Unknown   24m
+NAME                            CONTROLLER                                 ACCEPTED  AGE
+foo-com-internal-gateway-class  foo-com-internal-gateway-class/controller  True      365d
 `
 	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
 		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)

--- a/gwctl/pkg/printer/gateways_test.go
+++ b/gwctl/pkg/printer/gateways_test.go
@@ -366,56 +366,23 @@ EffectivePolicies:
 	}
 }
 
+// TestGatewaysPrinter_LabelSelector tests label selector filtering for Gateways in 'get' command.
 func TestGatewaysPrinter_LabelSelector(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
-	objects := []runtime.Object{
-		&gatewayv1.GatewayClass{
+	gateway := func(name string, labels map[string]string) *gatewayv1.Gateway {
+		return &gatewayv1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "internal-class",
-			},
-			Spec: gatewayv1.GatewayClassSpec{
-				ControllerName: "example.net/gateway-controller",
-				Description:    common.PtrTo("random"),
-			},
-		},
-		&gatewayv1.GatewayClass{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "external-class",
-			},
-			Spec: gatewayv1.GatewayClassSpec{
-				ControllerName: "example.net/gateway-controller",
-				Description:    common.PtrTo("random"),
-			},
-		},
-		&gatewayv1.GatewayClass{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "regional-internal-class",
-			},
-			Spec: gatewayv1.GatewayClassSpec{
-				ControllerName: "example.net/gateway-controller",
-				Description:    common.PtrTo("random"),
-			},
-		},
-		&gatewayv1.Gateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "abc-gateway-12345",
+				Name:   name,
+				Labels: labels,
 				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-20 * 24 * time.Hour),
-				},
-				Labels: map[string]string{
-					"app": "bar",
+					Time: fakeClock.Now().Add(-5 * 24 * time.Hour),
 				},
 			},
 			Spec: gatewayv1.GatewaySpec{
-				GatewayClassName: "internal-class",
+				GatewayClassName: "gatewayclass-1",
 				Listeners: []gatewayv1.Listener{
 					{
-						Name:     gatewayv1.SectionName("https-443"),
-						Protocol: gatewayv1.HTTPSProtocolType,
-						Port:     gatewayv1.PortNumber(443),
-					},
-					{
-						Name:     gatewayv1.SectionName("http-8080"),
+						Name:     "http-8080",
 						Protocol: gatewayv1.HTTPProtocolType,
 						Port:     gatewayv1.PortNumber(8080),
 					},
@@ -434,81 +401,21 @@ func TestGatewaysPrinter_LabelSelector(t *testing.T) {
 					},
 				},
 			},
-		},
-		&gatewayv1.Gateway{
+		}
+	}
+
+	objects := []runtime.Object{
+		&gatewayv1.GatewayClass{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "demo-gateway-2",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-5 * 24 * time.Hour),
-				},
-				Labels: map[string]string{
-					"app": "bar",
-				},
+				Name: "gatewayclass-1",
 			},
-			Spec: gatewayv1.GatewaySpec{
-				GatewayClassName: "external-class",
-				Listeners: []gatewayv1.Listener{
-					{
-						Name:     gatewayv1.SectionName("http-80"),
-						Protocol: gatewayv1.HTTPProtocolType,
-						Port:     gatewayv1.PortNumber(80),
-					},
-				},
-			},
-			Status: gatewayv1.GatewayStatus{
-				Addresses: []gatewayv1.GatewayStatusAddress{
-					{
-						Value: "10.0.0.1",
-					},
-					{
-						Value: "10.0.0.2",
-					},
-					{
-						Value: "10.0.0.3",
-					},
-				},
-				Conditions: []metav1.Condition{
-					{
-						Type:   "Programmed",
-						Status: "True",
-					},
-				},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "example.net/gateway-controller",
+				Description:    common.PtrTo("random"),
 			},
 		},
-		&gatewayv1.Gateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "random-gateway",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-3 * time.Second),
-				},
-				Labels: map[string]string{
-					"app": "foo",
-				},
-			},
-			Spec: gatewayv1.GatewaySpec{
-				GatewayClassName: "regional-internal-class",
-				Listeners: []gatewayv1.Listener{
-					{
-						Name:     gatewayv1.SectionName("http-8443"),
-						Protocol: gatewayv1.HTTPProtocolType,
-						Port:     gatewayv1.PortNumber(8443),
-					},
-				},
-			},
-			Status: gatewayv1.GatewayStatus{
-				Addresses: []gatewayv1.GatewayStatusAddress{
-					{
-						Value: "10.11.12.13",
-					},
-				},
-				Conditions: []metav1.Condition{
-					{
-						Type:   "Programmed",
-						Status: "Unknown",
-					},
-				},
-			},
-		},
+		gateway("gateway-1", map[string]string{"app": "foo"}),
+		gateway("gateway-2", map[string]string{"app": "foo", "env": "internal"}),
 	}
 
 	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
@@ -516,7 +423,7 @@ func TestGatewaysPrinter_LabelSelector(t *testing.T) {
 		K8sClients:    params.K8sClients,
 		PolicyManager: params.PolicyManager,
 	}
-	labelSelector := "app=bar"
+	labelSelector := "env=internal"
 	selector, err := labels.Parse(labelSelector)
 	if err != nil {
 		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
@@ -534,9 +441,8 @@ func TestGatewaysPrinter_LabelSelector(t *testing.T) {
 
 	got := params.Out.(*bytes.Buffer).String()
 	want := `
-NAME               CLASS           ADDRESSES                   PORTS     PROGRAMMED  AGE
-abc-gateway-12345  internal-class  192.168.100.5               443,8080  False       20d
-demo-gateway-2     external-class  10.0.0.1,10.0.0.2 + 1 more  80        True        5d
+NAME       CLASS           ADDRESSES      PORTS  PROGRAMMED  AGE
+gateway-2  gatewayclass-1  192.168.100.5  8080   False       5d
 `
 
 	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {

--- a/gwctl/pkg/printer/gateways_test.go
+++ b/gwctl/pkg/printer/gateways_test.go
@@ -25,6 +25,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	testingclock "k8s.io/utils/clock/testing"
 
@@ -360,6 +361,184 @@ EffectivePolicies:
     condition: path=/abc
     seconds: 30
 `
+	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
+	}
+}
+
+func TestGatewaysPrinter_LabelSelector(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	objects := []runtime.Object{
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "internal-class",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "example.net/gateway-controller",
+				Description:    common.PtrTo("random"),
+			},
+		},
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "external-class",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "example.net/gateway-controller",
+				Description:    common.PtrTo("random"),
+			},
+		},
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "regional-internal-class",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "example.net/gateway-controller",
+				Description:    common.PtrTo("random"),
+			},
+		},
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "abc-gateway-12345",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-20 * 24 * time.Hour),
+				},
+				Labels: map[string]string{
+					"app": "bar",
+				},
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "internal-class",
+				Listeners: []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("https-443"),
+						Protocol: gatewayv1.HTTPSProtocolType,
+						Port:     gatewayv1.PortNumber(443),
+					},
+					{
+						Name:     gatewayv1.SectionName("http-8080"),
+						Protocol: gatewayv1.HTTPProtocolType,
+						Port:     gatewayv1.PortNumber(8080),
+					},
+				},
+			},
+			Status: gatewayv1.GatewayStatus{
+				Addresses: []gatewayv1.GatewayStatusAddress{
+					{
+						Value: "192.168.100.5",
+					},
+				},
+				Conditions: []metav1.Condition{
+					{
+						Type:   "Programmed",
+						Status: "False",
+					},
+				},
+			},
+		},
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "demo-gateway-2",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-5 * 24 * time.Hour),
+				},
+				Labels: map[string]string{
+					"app": "bar",
+				},
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "external-class",
+				Listeners: []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("http-80"),
+						Protocol: gatewayv1.HTTPProtocolType,
+						Port:     gatewayv1.PortNumber(80),
+					},
+				},
+			},
+			Status: gatewayv1.GatewayStatus{
+				Addresses: []gatewayv1.GatewayStatusAddress{
+					{
+						Value: "10.0.0.1",
+					},
+					{
+						Value: "10.0.0.2",
+					},
+					{
+						Value: "10.0.0.3",
+					},
+				},
+				Conditions: []metav1.Condition{
+					{
+						Type:   "Programmed",
+						Status: "True",
+					},
+				},
+			},
+		},
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "random-gateway",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-3 * time.Second),
+				},
+				Labels: map[string]string{
+					"app": "foo",
+				},
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "regional-internal-class",
+				Listeners: []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("http-8443"),
+						Protocol: gatewayv1.HTTPProtocolType,
+						Port:     gatewayv1.PortNumber(8443),
+					},
+				},
+			},
+			Status: gatewayv1.GatewayStatus{
+				Addresses: []gatewayv1.GatewayStatusAddress{
+					{
+						Value: "10.11.12.13",
+					},
+				},
+				Conditions: []metav1.Condition{
+					{
+						Type:   "Programmed",
+						Status: "Unknown",
+					},
+				},
+			},
+		},
+	}
+
+	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
+	discoverer := resourcediscovery.Discoverer{
+		K8sClients:    params.K8sClients,
+		PolicyManager: params.PolicyManager,
+	}
+	labelSelector := "app=bar"
+	selector, err := labels.Parse(labelSelector)
+	if err != nil {
+		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+	}
+	resourceModel, err := discoverer.DiscoverResourcesForGateway(resourcediscovery.Filter{Labels: selector})
+	if err != nil {
+		t.Fatalf("Failed to construct resourceModel: %v", resourceModel)
+	}
+
+	gp := &GatewaysPrinter{
+		Out:   params.Out,
+		Clock: fakeClock,
+	}
+	gp.Print(resourceModel)
+
+	got := params.Out.(*bytes.Buffer).String()
+	want := `
+NAME               CLASS           ADDRESSES                   PORTS     PROGRAMMED  AGE
+abc-gateway-12345  internal-class  192.168.100.5               443,8080  False       20d
+demo-gateway-2     external-class  10.0.0.1,10.0.0.2 + 1 more  80        True        5d
+`
+
 	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
 		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
 	}

--- a/gwctl/pkg/printer/httproutes_test.go
+++ b/gwctl/pkg/printer/httproutes_test.go
@@ -25,10 +25,11 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/google/go-cmp/cmp"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	testingclock "k8s.io/utils/clock/testing"
 
@@ -430,6 +431,217 @@ EffectivePolicies:
     TimeoutPolicy.bar.com:
       condition: path=/def
       seconds: 60
+`
+	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
+	}
+}
+
+func TestHTTPRoutesPrinter_Label(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	objects := []runtime.Object{
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "demo-gatewayclass-1",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "example.net/gateway-controller",
+				Description:    common.PtrTo("random"),
+			},
+		},
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "demo-gatewayclass-2",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "example.net/gateway-controller",
+				Description:    common.PtrTo("random"),
+			},
+		},
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns1",
+			},
+			Status: corev1.NamespaceStatus{
+				Phase: corev1.NamespaceActive,
+			},
+		},
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns2",
+			},
+			Status: corev1.NamespaceStatus{
+				Phase: corev1.NamespaceActive,
+			},
+		},
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "demo-gateway-1",
+				Namespace: "default",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "demo-gatewayclass-1",
+			},
+		},
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "demo-gateway-2",
+				Namespace: "ns2",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "demo-gatewayclass-2",
+			},
+		},
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "demo-gateway-200",
+				Namespace: "default",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "demo-gatewayclass-1",
+			},
+		},
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "demo-gateway-345",
+				Namespace: "ns1",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "demo-gatewayclass-2",
+			},
+		},
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo-httproute-1",
+				Namespace: "default",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-24 * time.Hour),
+				},
+				Labels: map[string]string{
+					"app": "foo",
+				},
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com", "example2.com", "example3.com"},
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Kind:      common.PtrTo(gatewayv1.Kind("Gateway")),
+							Group:     common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
+							Namespace: common.PtrTo(gatewayv1.Namespace("ns2")),
+							Name:      "demo-gateway-2",
+						},
+					},
+				},
+			},
+		},
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "qmn-httproute-100",
+				Namespace: "default",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-11 * time.Hour),
+				},
+				Labels: map[string]string{
+					"app": "bar",
+				},
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Kind:  common.PtrTo(gatewayv1.Kind("Gateway")),
+							Group: common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
+							Name:  "demo-gateway-1",
+						},
+						{
+							Kind:  common.PtrTo(gatewayv1.Kind("Gateway")),
+							Group: common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
+							Name:  "demo-gateway-200",
+						},
+					},
+				},
+			},
+		},
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar-route-21",
+				Namespace: "ns1",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-9 * time.Hour),
+				},
+				Labels: map[string]string{
+					"app": "foo",
+				},
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"foo.com", "bar.com", "example.com", "example2.com", "example3.com", "example4.com", "example5.com"},
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Kind:      common.PtrTo(gatewayv1.Kind("Gateway")),
+							Group:     common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
+							Namespace: common.PtrTo(gatewayv1.Namespace("default")),
+							Name:      "demo-gateway-200",
+						},
+					},
+				},
+			},
+		},
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bax-httproute-18777",
+				Namespace: "ns2",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-5 * time.Minute),
+				},
+				Labels: map[string]string{
+					"app": "bar",
+				},
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Kind:      common.PtrTo(gatewayv1.Kind("Gateway")),
+							Group:     common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
+							Namespace: common.PtrTo(gatewayv1.Namespace("ns1")),
+							Name:      "demo-gateway-345",
+						},
+					},
+				},
+			},
+		},
+	}
+	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
+	discoverer := resourcediscovery.Discoverer{
+		K8sClients:    params.K8sClients,
+		PolicyManager: params.PolicyManager,
+	}
+
+	labelSelector := "app=foo"
+	selector, err := labels.Parse(labelSelector)
+	if err != nil {
+		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+	}
+	resourceModel, err := discoverer.DiscoverResourcesForHTTPRoute(resourcediscovery.Filter{Labels: selector})
+	if err != nil {
+		t.Fatalf("Failed to discover resources: %v", err)
+	}
+
+	hp := &HTTPRoutesPrinter{
+		Out:   params.Out,
+		Clock: fakeClock,
+	}
+
+	hp.Print(resourceModel)
+	got := params.Out.(*bytes.Buffer).String()
+	want := `
+NAMESPACE  NAME             HOSTNAMES                          PARENT REFS  AGE
+default    foo-httproute-1  example.com,example2.com + 1 more  1            24h
+ns1        bar-route-21     foo.com,bar.com + 5 more           1            9h
+
 `
 	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
 		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)

--- a/gwctl/pkg/printer/httproutes_test.go
+++ b/gwctl/pkg/printer/httproutes_test.go
@@ -437,190 +437,63 @@ EffectivePolicies:
 	}
 }
 
-func TestHTTPRoutesPrinter_Label(t *testing.T) {
+// TestHTTPRoutesPrinter_LabelSelector tests label selector filtering for HTTPRoute in 'get' command.
+func TestHTTPRoutesPrinter_LabelSelector(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
-	objects := []runtime.Object{
-		&gatewayv1.GatewayClass{
+	httpRoute := func(name string, labels map[string]string) *gatewayv1.HTTPRoute {
+		return &gatewayv1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "demo-gatewayclass-1",
-			},
-			Spec: gatewayv1.GatewayClassSpec{
-				ControllerName: "example.net/gateway-controller",
-				Description:    common.PtrTo("random"),
-			},
-		},
-		&gatewayv1.GatewayClass{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "demo-gatewayclass-2",
-			},
-			Spec: gatewayv1.GatewayClassSpec{
-				ControllerName: "example.net/gateway-controller",
-				Description:    common.PtrTo("random"),
-			},
-		},
-		&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "ns1",
-			},
-			Status: corev1.NamespaceStatus{
-				Phase: corev1.NamespaceActive,
-			},
-		},
-		&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "ns2",
-			},
-			Status: corev1.NamespaceStatus{
-				Phase: corev1.NamespaceActive,
-			},
-		},
-		&gatewayv1.Gateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "demo-gateway-1",
-				Namespace: "default",
-			},
-			Spec: gatewayv1.GatewaySpec{
-				GatewayClassName: "demo-gatewayclass-1",
-			},
-		},
-		&gatewayv1.Gateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "demo-gateway-2",
-				Namespace: "ns2",
-			},
-			Spec: gatewayv1.GatewaySpec{
-				GatewayClassName: "demo-gatewayclass-2",
-			},
-		},
-		&gatewayv1.Gateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "demo-gateway-200",
-				Namespace: "default",
-			},
-			Spec: gatewayv1.GatewaySpec{
-				GatewayClassName: "demo-gatewayclass-1",
-			},
-		},
-		&gatewayv1.Gateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "demo-gateway-345",
-				Namespace: "ns1",
-			},
-			Spec: gatewayv1.GatewaySpec{
-				GatewayClassName: "demo-gatewayclass-2",
-			},
-		},
-		&gatewayv1.HTTPRoute{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo-httproute-1",
+				Name:      name,
 				Namespace: "default",
 				CreationTimestamp: metav1.Time{
 					Time: fakeClock.Now().Add(-24 * time.Hour),
 				},
-				Labels: map[string]string{
-					"app": "foo",
-				},
-			},
-			Spec: gatewayv1.HTTPRouteSpec{
-				Hostnames: []gatewayv1.Hostname{"example.com", "example2.com", "example3.com"},
-				CommonRouteSpec: gatewayv1.CommonRouteSpec{
-					ParentRefs: []gatewayv1.ParentReference{
-						{
-							Kind:      common.PtrTo(gatewayv1.Kind("Gateway")),
-							Group:     common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
-							Namespace: common.PtrTo(gatewayv1.Namespace("ns2")),
-							Name:      "demo-gateway-2",
-						},
-					},
-				},
-			},
-		},
-		&gatewayv1.HTTPRoute{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "qmn-httproute-100",
-				Namespace: "default",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-11 * time.Hour),
-				},
-				Labels: map[string]string{
-					"app": "bar",
-				},
+				Labels: labels,
 			},
 			Spec: gatewayv1.HTTPRouteSpec{
 				Hostnames: []gatewayv1.Hostname{"example.com"},
 				CommonRouteSpec: gatewayv1.CommonRouteSpec{
 					ParentRefs: []gatewayv1.ParentReference{
 						{
-							Kind:  common.PtrTo(gatewayv1.Kind("Gateway")),
-							Group: common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
-							Name:  "demo-gateway-1",
-						},
-						{
-							Kind:  common.PtrTo(gatewayv1.Kind("Gateway")),
-							Group: common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
-							Name:  "demo-gateway-200",
+							Name: "gateway-1",
 						},
 					},
 				},
 			},
-		},
-		&gatewayv1.HTTPRoute{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "bar-route-21",
-				Namespace: "ns1",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-9 * time.Hour),
-				},
-				Labels: map[string]string{
-					"app": "foo",
-				},
-			},
-			Spec: gatewayv1.HTTPRouteSpec{
-				Hostnames: []gatewayv1.Hostname{"foo.com", "bar.com", "example.com", "example2.com", "example3.com", "example4.com", "example5.com"},
-				CommonRouteSpec: gatewayv1.CommonRouteSpec{
-					ParentRefs: []gatewayv1.ParentReference{
-						{
-							Kind:      common.PtrTo(gatewayv1.Kind("Gateway")),
-							Group:     common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
-							Namespace: common.PtrTo(gatewayv1.Namespace("default")),
-							Name:      "demo-gateway-200",
-						},
-					},
-				},
-			},
-		},
-		&gatewayv1.HTTPRoute{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "bax-httproute-18777",
-				Namespace: "ns2",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-5 * time.Minute),
-				},
-				Labels: map[string]string{
-					"app": "bar",
-				},
-			},
-			Spec: gatewayv1.HTTPRouteSpec{
-				CommonRouteSpec: gatewayv1.CommonRouteSpec{
-					ParentRefs: []gatewayv1.ParentReference{
-						{
-							Kind:      common.PtrTo(gatewayv1.Kind("Gateway")),
-							Group:     common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
-							Namespace: common.PtrTo(gatewayv1.Namespace("ns1")),
-							Name:      "demo-gateway-345",
-						},
-					},
-				},
-			},
-		},
+		}
 	}
+
+	objects := []runtime.Object{
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gatewayclass-1",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "example.net/gateway-controller",
+				Description:    common.PtrTo("random"),
+			},
+		},
+
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gateway-1",
+				Namespace: "default",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "gatewayclass-1",
+			},
+		},
+		httpRoute("httproute-1", map[string]string{"app": "foo"}),
+		httpRoute("httproute-2", map[string]string{"app": "foo", "env": "internal"}),
+	}
+
 	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
 	discoverer := resourcediscovery.Discoverer{
 		K8sClients:    params.K8sClients,
 		PolicyManager: params.PolicyManager,
 	}
 
-	labelSelector := "app=foo"
+	labelSelector := "env=internal"
 	selector, err := labels.Parse(labelSelector)
 	if err != nil {
 		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
@@ -634,13 +507,12 @@ func TestHTTPRoutesPrinter_Label(t *testing.T) {
 		Out:   params.Out,
 		Clock: fakeClock,
 	}
-
 	hp.Print(resourceModel)
+
 	got := params.Out.(*bytes.Buffer).String()
 	want := `
-NAMESPACE  NAME             HOSTNAMES                          PARENT REFS  AGE
-default    foo-httproute-1  example.com,example2.com + 1 more  1            24h
-ns1        bar-route-21     foo.com,bar.com + 5 more           1            9h
+NAMESPACE  NAME         HOSTNAMES    PARENT REFS  AGE
+default    httproute-2  example.com  1            24h
 
 `
 	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {

--- a/gwctl/pkg/resourcediscovery/discoverer.go
+++ b/gwctl/pkg/resourcediscovery/discoverer.go
@@ -40,7 +40,7 @@ import (
 type Filter struct {
 	Namespace string
 	Name      string
-	Labels    map[string]string
+	Labels    labels.Selector
 }
 
 // Discoverer orchestrates the discovery of resources and their associated
@@ -292,7 +292,7 @@ func fetchGatewayClasses(ctx context.Context, k8sClients *common.K8sClients, fil
 	// Use List call.
 	options := &client.ListOptions{
 		Namespace:     filter.Namespace,
-		LabelSelector: labels.SelectorFromSet(filter.Labels),
+		LabelSelector: filter.Labels,
 	}
 	gatewayClassList := &gatewayv1.GatewayClassList{}
 	if err := k8sClients.Client.List(ctx, gatewayClassList, options); err != nil {
@@ -318,7 +318,7 @@ func fetchGateways(ctx context.Context, k8sClients *common.K8sClients, filter Fi
 	// Use List call.
 	options := &client.ListOptions{
 		Namespace:     filter.Namespace,
-		LabelSelector: labels.SelectorFromSet(filter.Labels),
+		LabelSelector: filter.Labels,
 	}
 	gatewayList := &gatewayv1.GatewayList{}
 	if err := k8sClients.Client.List(ctx, gatewayList, options); err != nil {
@@ -344,7 +344,7 @@ func fetchHTTPRoutes(ctx context.Context, k8sClients *common.K8sClients, filter 
 	// Use List call.
 	options := &client.ListOptions{
 		Namespace:     filter.Namespace,
-		LabelSelector: labels.SelectorFromSet(filter.Labels),
+		LabelSelector: filter.Labels,
 	}
 	httpRouteList := &gatewayv1.HTTPRouteList{}
 	if err := k8sClients.Client.List(ctx, httpRouteList, options); err != nil {
@@ -377,7 +377,7 @@ func fetchBackends(ctx context.Context, k8sClients *common.K8sClients, filter Fi
 
 	// Use List call.
 	listOptions := metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(filter.Labels).String(),
+		LabelSelector: filter.Labels.String(),
 	}
 	var backendsList *unstructured.UnstructuredList
 	backendsList, err := k8sClients.DC.Resource(gvr).Namespace(filter.Namespace).List(ctx, listOptions)
@@ -405,7 +405,7 @@ func fetchNamespace(ctx context.Context, k8sClients *common.K8sClients, filter F
 	// Use List call.
 	options := &client.ListOptions{
 		Namespace:     filter.Namespace,
-		LabelSelector: labels.SelectorFromSet(filter.Labels),
+		LabelSelector: filter.Labels,
 	}
 	namespacesList := &corev1.NamespaceList{}
 	if err := k8sClients.Client.List(ctx, namespacesList, options); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2890

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add label filtering (-l) for get commands
```

- Correct label format output
```
➜  gwctl get httproutes -l app=backend
NAMESPACE  NAME     HOSTNAMES        PARENT REFS  AGE
default    backend  www.example.com  1            30d
```

- Error label format output
```
➜  gwctl get httproutes -l aps=dsd,adsa,=ds
Unable to find resources that match the label selector "aps=dsd,adsa,=ds": found '=', expected: identifier after ','
```
