### PR TITLE
conformance: make GatewayStaticAddresses more leniant

### DIFF
--- a/conformance/tests/gateway-static-addresses.go
+++ b/conformance/tests/gateway-static-addresses.go
@@ -134,10 +134,26 @@ var GatewayStaticAddresses = suite.ConformanceTest{
 		})
 		kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, finalExpectedListenerState)
 		require.Len(t, currentGW.Spec.Addresses, 1, "expected only 1 address left specified on Gateway")
-		require.Len(t, currentGW.Status.Addresses, 1, "one usable address was provided, so it should be the one reflected in status")
-		require.Equal(t, usableAddress.Type, currentGW.Status.Addresses[0].Type, "expected address type to match the usable address")
-		require.Equal(t, usableAddress.Value, currentGW.Status.Addresses[0].Value, "expected usable address to be assigned")
+		statusAddresses := extractStatusAddresses(currentGW.Status.Addresses)
+		require.NotContains(t, statusAddresses, unusableAddress.Value, "should contain the unusable address")
+		require.NotContains(t, statusAddresses, invalidAddress.Value, "should contain the invalid address")
+		require.Contains(t, statusAddresses, usableAddress.Value, "should contain the usable address")
+		for _, addr := range currentGW.Status.Addresses {
+			if usableAddress.Value != addr.Value {
+				continue
+			}
+			require.Equal(t, usableAddress.Type, addr.Type, "expected address type to match the usable address")
+		}
 	},
+}
+
+func extractStatusAddresses(addresses []v1.GatewayStatusAddress) []string {
+	res := []string{}
+	for _, a := range addresses {
+		n := a.Value
+		res = append(res, n)
+	}
+	return res
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION

**What type of PR is this?**

/area conformance

**What this PR does / why we need it**:
Currently, this strictly enforces that spec and status addresses are 1:1. This doesn't allow variance in implementations. For example, assigning an IPv4 and IPv6 address, internal and external address, IP and hostname, etc.


**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
