### PR TITLE
Add label filtering (-l) for `get namespaces`

### DIFF
--- a/gwctl/cmd/describe.go
+++ b/gwctl/cmd/describe.go
@@ -147,12 +147,12 @@ func runDescribe(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 		}
 		backendsPrinter.PrintDescribeView(resourceModel)
 
-	case "namespace", "namespaces":
+	case "namespace", "namespaces", "ns":
 		filter := resourcediscovery.Filter{}
 		if len(args) > 1 {
 			filter.Name = args[1]
 		}
-		
+
 		resourceModel, err := discoverer.DiscoverResourcesForNamespace(filter)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to discover Namespace resources: %v\n", err)

--- a/gwctl/cmd/get.go
+++ b/gwctl/cmd/get.go
@@ -89,7 +89,12 @@ func runGet(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 
 	switch kind {
 	case "namespace", "namespaces":
-		resourceModel, err := discoverer.DiscoverResourcesForNamespace(resourcediscovery.Filter{})
+		selector, err := labels.Parse(labelSelector)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+			os.Exit(1)
+		}
+		resourceModel, err := discoverer.DiscoverResourcesForNamespace(resourcediscovery.Filter{Labels: selector})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to discover Namespace resources: %v\n", err)
 			os.Exit(1)

--- a/gwctl/cmd/get.go
+++ b/gwctl/cmd/get.go
@@ -88,7 +88,7 @@ func runGet(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 	httpRoutesPrinter := &printer.HTTPRoutesPrinter{Out: params.Out, Clock: realClock}
 
 	switch kind {
-	case "namespace", "namespaces":
+	case "namespace", "namespaces", "ns":
 		selector, err := labels.Parse(labelSelector)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)

--- a/gwctl/pkg/printer/namespace_test.go
+++ b/gwctl/pkg/printer/namespace_test.go
@@ -27,6 +27,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	testingclock "k8s.io/utils/clock/testing"
 
@@ -256,5 +257,59 @@ DirectlyAttachedPolicies:
 	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
 		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
 	}
+}
 
+// TestNamespacesPrinter_LabelSelector tests label selector filtering for Namespaces in 'get' command.
+func TestNamespacesPrinter_LabelSelector(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	namespace := func(name string, labels map[string]string) *corev1.Namespace {
+		return &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-46 * 24 * time.Hour),
+				},
+				Labels: labels,
+			},
+			Status: corev1.NamespaceStatus{
+				Phase: corev1.NamespaceActive,
+			},
+		}
+	}
+
+	objects := []runtime.Object{
+		namespace("namespace-1", map[string]string{"app": "foo"}),
+		namespace("namespace-2", map[string]string{"app": "foo", "env": "internal"}),
+	}
+
+	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
+	discoverer := resourcediscovery.Discoverer{
+		K8sClients:    params.K8sClients,
+		PolicyManager: params.PolicyManager,
+	}
+	labelSelector := "env=internal"
+	selector, err := labels.Parse(labelSelector)
+	if err != nil {
+		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+	}
+	resourceModel, err := discoverer.DiscoverResourcesForNamespace(resourcediscovery.Filter{Labels: selector})
+	if err != nil {
+		t.Fatalf("Failed to construct resourceModel: %v", resourceModel)
+	}
+
+	nsp := &NamespacesPrinter{
+		Out:   params.Out,
+		Clock: fakeClock,
+	}
+	nsp.Print(resourceModel)
+
+	got := params.Out.(*bytes.Buffer).String()
+	want := `
+NAME         STATUS  AGE
+namespace-2  Active  46d
+`
+
+	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2913

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add label filtering (-l) for get namespaces
```

```
➜  gwctl get namespaces -l kubernetes.io/metadata.name=monitoring
NAME        STATUS  AGE
monitoring  Active  29d
```
