### PR TITLE
Fix GRPCRoute parent status check

### DIFF
--- a/conformance/tests/grpcroute-header-matching.go
+++ b/conformance/tests/grpcroute-header-matching.go
@@ -24,6 +24,7 @@ import (
 
 	pb "sigs.k8s.io/gateway-api/conformance/echo-basic/grpcechoserver"
 
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/conformance/utils/grpc"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
@@ -43,9 +44,9 @@ var GRPCRouteHeaderMatching = suite.ConformanceTest{
 	},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		ns := "gateway-conformance-infra"
-		routeNN := types.NamespacedName{Name: "header-matching", Namespace: ns}
+		routeNN := types.NamespacedName{Name: "grpc-header-matching", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &v1alpha2.GRPCRoute{}, routeNN)
 
 		testCases := []grpc.ExpectedResponse{{
 			EchoRequest: &pb.EchoRequest{},

--- a/conformance/tests/grpcroute-listener-hostname-matching.go
+++ b/conformance/tests/grpcroute-listener-hostname-matching.go
@@ -24,6 +24,7 @@ import (
 
 	pb "sigs.k8s.io/gateway-api/conformance/echo-basic/grpcechoserver"
 
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/conformance/utils/grpc"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
@@ -50,13 +51,13 @@ var GRPCRouteListenerHostnameMatching = suite.ConformanceTest{
 
 		gwNN := types.NamespacedName{Name: "grpcroute-listener-hostname-matching", Namespace: ns}
 
-		_ = kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-1"),
+		_ = kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-1"), &v1alpha2.GRPCRoute{},
 			types.NamespacedName{Namespace: ns, Name: "backend-v1"},
 		)
-		_ = kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-2"),
+		_ = kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-2"), &v1alpha2.GRPCRoute{},
 			types.NamespacedName{Namespace: ns, Name: "backend-v2"},
 		)
-		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-3", "listener-4"),
+		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "listener-3", "listener-4"), &v1alpha2.GRPCRoute{},
 			types.NamespacedName{Namespace: ns, Name: "backend-v3"},
 		)
 

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -333,7 +333,9 @@ func MeshNamespacesMustBeReady(t *testing.T, c client.Client, timeoutConfig conf
 func GatewayAndRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, controllerName string, gw GatewayRef, routeType any, routeNNs ...types.NamespacedName) string {
 	t.Helper()
 
+	RouteTypeMustHaveParentsField(t, routeType)
 	gwAddr, err := WaitForGatewayAddress(t, c, timeoutConfig, gw)
+
 	require.NoErrorf(t, err, "timed out waiting for Gateway address to be assigned")
 
 	ns := gatewayv1.Namespace(gw.Namespace)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind test

Optionally add one or more of the following kinds if applicable:

/area conformance
-->

**What this PR does / why we need it**:

Previously, there were several places in the GRPCRoute conformance tests where the `routeType` parameter was not being supplied to `GatewayAndRoutesMustBeAccepted`. Instead, the variadic `routeNNs` was being consumed as the `routeType` argument, leaving `routeNNs` with size 0. (since in all of these cases, there was only one route intended). This resulted in no routes being checked and [the type assertion helper for `HTTPRoute`-like types](https://github.com/kubernetes-sigs/gateway-api/blob/f7fa7d4d31b3d9a8c5164f573db34d75830dfafb/conformance/utils/kubernetes/helpers.go#L564) never being called.

This PR:
- Adds a call to `RouteTypeMustHaveParentsField` directly within GatewayAndRoutesMustBeAccepted to ensure such an error doesn't happen again.
- Adds the proper `GRPCRoute` type to the faulty `GRPCRoute` conformance tests
- Fixes one faulty route name

I don't think the scope of this issue is terribly large because one of the test cases _did_ get this right and it is unlikely that an implementation would accept routes in some cases but not others while also flowing traffic appropriately.

```release-note
NONE
```
