### PR TITLE
Add Lior Lieberman and Mattia Lavacca as GEP Reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -44,6 +44,8 @@ aliases:
   gateway-api-gep-reviewers:
     - candita
     - gcs278
+    - LiorLieberman
+    - mlavacca
 
   gwctl-approvers:
     - gauravkghildiyal


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

@mlavacca and @LiorLieberman have both graciously agreed to help out with the GEP review cycles, as such we're promoting them both to GEP reviewers! Thank you @LiorLieberman and @mlavacca we appreciate your continued contributions to the project! :bow:

/cc @youngnick @robscott 