### PR TITLE
Add label filtering (-l) for describe commands

### DIFF
--- a/gwctl/cmd/describe.go
+++ b/gwctl/cmd/describe.go
@@ -47,7 +47,7 @@ func NewDescribeCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&namespaceFlag, "namespace", "n", "default", "")
 	cmd.Flags().BoolVarP(&allNamespacesFlag, "all-namespaces", "A", false, "If present, list requested resources from all namespaces.")
-	cmd.Flags().StringVarP(&labelSelector, "selector", "l", "", "Label selector.")
+	cmd.Flags().StringVarP(&labelSelector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2). Matching objects must satisfy all of the specified label constraints.")
 
 	return cmd
 }
@@ -152,8 +152,7 @@ func runDescribe(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 			os.Exit(1)
 		}
 		filter := resourcediscovery.Filter{
-			Namespace: ns,
-			Labels:    selector,
+			Labels: selector,
 		}
 		if len(args) > 1 {
 			filter.Name = args[1]

--- a/gwctl/cmd/get.go
+++ b/gwctl/cmd/get.go
@@ -46,7 +46,7 @@ func NewGetCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&namespaceFlag, "namespace", "n", "default", "")
 	cmd.Flags().BoolVarP(&allNamespacesFlag, "all-namespaces", "A", false, "If present, list requested resources from all namespaces.")
-	cmd.Flags().StringVarP(&labelSelector, "selector", "l", "", "Label selector.")
+	cmd.Flags().StringVarP(&labelSelector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2). Matching objects must satisfy all of the specified label constraints.")
 
 	return cmd
 }

--- a/gwctl/go.mod
+++ b/gwctl/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/evanphx/json-patch v5.9.0+incompatible
 	github.com/google/go-cmp v0.6.0
 	github.com/spf13/cobra v1.8.0
-	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.29.3
 	k8s.io/apiextensions-apiserver v0.29.3
 	k8s.io/apimachinery v0.29.3
@@ -42,7 +41,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect

--- a/gwctl/go.mod
+++ b/gwctl/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/evanphx/json-patch v5.9.0+incompatible
 	github.com/google/go-cmp v0.6.0
 	github.com/spf13/cobra v1.8.0
+	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.29.3
 	k8s.io/apiextensions-apiserver v0.29.3
 	k8s.io/apimachinery v0.29.3
@@ -41,6 +42,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect

--- a/gwctl/pkg/printer/gatewayclasses_test.go
+++ b/gwctl/pkg/printer/gatewayclasses_test.go
@@ -296,3 +296,102 @@ foo-com-internal-gateway-class  foo-com-internal-gateway-class/controller  True 
 		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
 	}
 }
+
+// TestGatewayClassesPrinterDescribe_LabelSelector Tests label selector filtering for GatewayClasses in 'describe' command.
+func TestGatewayClassesPrinterDescribe_LabelSelector(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+
+	gatewayClass := func(name string, labels map[string]string) *gatewayv1.GatewayClass {
+		return &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: labels,
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-365 * 24 * time.Hour),
+				},
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: gatewayv1.GatewayController(name + "/controller"),
+				Description:    common.PtrTo("random"),
+			},
+			Status: gatewayv1.GatewayClassStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   "Accepted",
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		}
+	}
+	objects := []runtime.Object{
+		&apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "healthcheckpolicies.foo.com",
+				Labels: map[string]string{
+					gatewayv1alpha2.PolicyLabelKey: "true",
+				},
+			},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Group:    "foo.com",
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{Name: "v1"}},
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
+					Plural: "healthcheckpolicies",
+					Kind:   "HealthCheckPolicy",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "foo.com/v1",
+				"kind":       "HealthCheckPolicy",
+				"metadata": map[string]interface{}{
+					"name": "policy-name",
+				},
+				"spec": map[string]interface{}{
+					"targetRef": map[string]interface{}{
+						"group": "gateway.networking.k8s.io",
+						"kind":  "GatewayClass",
+						"name":  "foo-com-internal-gateway-class",
+					},
+				},
+			},
+		},
+		gatewayClass("foo-com-external-gateway-class", map[string]string{"app": "foo"}),
+		gatewayClass("foo-com-internal-gateway-class", map[string]string{"app": "foo", "env": "internal"}),
+	}
+	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
+	discoverer := resourcediscovery.Discoverer{
+		K8sClients:    params.K8sClients,
+		PolicyManager: params.PolicyManager,
+	}
+	labelSelector := "env=internal"
+	selector, err := labels.Parse(labelSelector)
+	if err != nil {
+		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+	}
+	resourceModel, err := discoverer.DiscoverResourcesForGatewayClass(resourcediscovery.Filter{Labels: selector})
+	if err != nil {
+		t.Fatalf("Failed to construct resourceModel: %v", resourceModel)
+	}
+
+	gcp := &GatewayClassesPrinter{
+		Out:   params.Out,
+		Clock: fakeClock,
+	}
+	gcp.PrintDescribeView(resourceModel)
+
+	got := params.Out.(*bytes.Buffer).String()
+	want := `
+Name: foo-com-internal-gateway-class
+ControllerName: foo-com-internal-gateway-class/controller
+Description: random
+DirectlyAttachedPolicies:
+- Group: foo.com
+  Kind: HealthCheckPolicy
+  Name: policy-name
+`
+	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
+	}
+}

--- a/gwctl/pkg/printer/gateways_test.go
+++ b/gwctl/pkg/printer/gateways_test.go
@@ -22,12 +22,10 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	testingclock "k8s.io/utils/clock/testing"
 
@@ -366,80 +364,4 @@ EffectivePolicies:
 	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
 		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
 	}
-}
-
-// TestGatewaysPrinter_LabelSelector tests label selector filtering for Gateways.
-func TestGatewaysPrinter_LabelSelector(t *testing.T) {
-	fakeClock := testingclock.NewFakeClock(time.Now())
-	gateway := func(name string, labels map[string]string) *gatewayv1.Gateway {
-		return &gatewayv1.Gateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   name,
-				Labels: labels,
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-5 * 24 * time.Hour),
-				},
-			},
-			Spec: gatewayv1.GatewaySpec{
-				GatewayClassName: "gatewayclass-1",
-				Listeners: []gatewayv1.Listener{
-					{
-						Name:     "http-8080",
-						Protocol: gatewayv1.HTTPProtocolType,
-						Port:     gatewayv1.PortNumber(8080),
-					},
-				},
-			},
-			Status: gatewayv1.GatewayStatus{
-				Addresses: []gatewayv1.GatewayStatusAddress{
-					{
-						Value: "192.168.100.5",
-					},
-				},
-				Conditions: []metav1.Condition{
-					{
-						Type:   "Programmed",
-						Status: "False",
-					},
-				},
-			},
-		}
-	}
-
-	objects := []runtime.Object{
-		&gatewayv1.GatewayClass{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "gatewayclass-1",
-			},
-			Spec: gatewayv1.GatewayClassSpec{
-				ControllerName: "example.net/gateway-controller",
-				Description:    common.PtrTo("random"),
-			},
-		},
-		gateway("gateway-1", map[string]string{"app": "foo"}),
-		gateway("gateway-2", map[string]string{"app": "foo", "env": "internal"}),
-	}
-
-	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
-	discoverer := resourcediscovery.Discoverer{
-		K8sClients:    params.K8sClients,
-		PolicyManager: params.PolicyManager,
-	}
-	labelSelector := "env=internal"
-	selector, err := labels.Parse(labelSelector)
-	if err != nil {
-		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
-	}
-	resourceModel, err := discoverer.DiscoverResourcesForGateway(resourcediscovery.Filter{Labels: selector})
-	if err != nil {
-		t.Fatalf("Failed to construct resourceModel: %v", resourceModel)
-	}
-
-	expectedGatewayNames := []string{"gateway-2"}
-	gatewayNames := make([]string, 0, len(resourceModel.Gateways))
-	for _, gatewayNode := range resourceModel.Gateways {
-		gatewayNames = append(gatewayNames, gatewayNode.Gateway.GetName())
-	}
-
-	assert.Equal(t, expectedGatewayNames, gatewayNames, "Expected Gateway name does not match the found one")
 }

--- a/gwctl/pkg/printer/gateways_test.go
+++ b/gwctl/pkg/printer/gateways_test.go
@@ -569,8 +569,8 @@ Name: gateway-2
 GatewayClass: gatewayclass-1
 EffectivePolicies:
   HealthCheckPolicy.foo.com:
-	key1: value-parent-1
-	key2: value-parent-2
+    key1: value-parent-1
+    key2: value-parent-2
 `
 
 	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {

--- a/gwctl/pkg/printer/gateways_test.go
+++ b/gwctl/pkg/printer/gateways_test.go
@@ -449,3 +449,131 @@ gateway-2  gatewayclass-1  192.168.100.5  8080   False       5d
 		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
 	}
 }
+
+// TestGatewaysPrinterDescribe_LabelSelector tests label selector filtering for Gateways in 'describe' command.
+func TestGatewaysPrinterDescribe_LabelSelector(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	gateway := func(name string, labels map[string]string) *gatewayv1.Gateway {
+		return &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: labels,
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-5 * 24 * time.Hour),
+				},
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "gatewayclass-1",
+				Listeners: []gatewayv1.Listener{
+					{
+						Name:     "http-8080",
+						Protocol: gatewayv1.HTTPProtocolType,
+						Port:     gatewayv1.PortNumber(8080),
+					},
+				},
+			},
+			Status: gatewayv1.GatewayStatus{
+				Addresses: []gatewayv1.GatewayStatusAddress{
+					{
+						Value: "192.168.100.5",
+					},
+				},
+				Conditions: []metav1.Condition{
+					{
+						Type:   "Programmed",
+						Status: "False",
+					},
+				},
+			},
+		}
+	}
+
+	objects := []runtime.Object{
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gatewayclass-1",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "example.net/gateway-controller",
+				Description:    common.PtrTo("random"),
+			},
+		},
+
+		&apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "healthcheckpolicies.foo.com",
+				Labels: map[string]string{
+					gatewayv1alpha2.PolicyLabelKey: "inherited",
+				},
+			},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Scope:    apiextensionsv1.ClusterScoped,
+				Group:    "foo.com",
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{Name: "v1"}},
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
+					Plural: "healthcheckpolicies",
+					Kind:   "HealthCheckPolicy",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "foo.com/v1",
+				"kind":       "HealthCheckPolicy",
+				"metadata": map[string]interface{}{
+					"name": "health-check-gatewayclass",
+				},
+				"spec": map[string]interface{}{
+					"override": map[string]interface{}{
+						"key1": "value-parent-1",
+					},
+					"default": map[string]interface{}{
+						"key2": "value-parent-2",
+					},
+					"targetRef": map[string]interface{}{
+						"group": "gateway.networking.k8s.io",
+						"kind":  "GatewayClass",
+						"name":  "gatewayclass-1",
+					},
+				},
+			},
+		},
+		gateway("gateway-1", map[string]string{"app": "foo"}),
+		gateway("gateway-2", map[string]string{"app": "foo", "env": "internal"}),
+	}
+
+	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
+	discoverer := resourcediscovery.Discoverer{
+		K8sClients:    params.K8sClients,
+		PolicyManager: params.PolicyManager,
+	}
+	labelSelector := "env=internal"
+	selector, err := labels.Parse(labelSelector)
+	if err != nil {
+		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+	}
+	resourceModel, err := discoverer.DiscoverResourcesForGateway(resourcediscovery.Filter{Labels: selector})
+	if err != nil {
+		t.Fatalf("Failed to construct resourceModel: %v", resourceModel)
+	}
+
+	nsp := &GatewaysPrinter{
+		Out:   params.Out,
+		Clock: fakeClock,
+	}
+	nsp.PrintDescribeView(resourceModel)
+
+	got := params.Out.(*bytes.Buffer).String()
+	want := `
+Name: gateway-2
+GatewayClass: gatewayclass-1
+EffectivePolicies:
+  HealthCheckPolicy.foo.com:
+	key1: value-parent-1
+	key2: value-parent-2
+`
+
+	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
+	}
+}

--- a/gwctl/pkg/printer/httproutes_test.go
+++ b/gwctl/pkg/printer/httproutes_test.go
@@ -21,10 +21,9 @@ import (
 	"testing"
 	"time"
 
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	testingclock "k8s.io/utils/clock/testing"
 
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/utils"
@@ -437,7 +438,7 @@ EffectivePolicies:
 	}
 }
 
-// TestHTTPRoutesPrinter_LabelSelector tests label selector filtering for HTTPRoute in 'get' command.
+// TestHTTPRoutesPrinter_LabelSelector tests label selector filtering for HTTPRoute.
 func TestHTTPRoutesPrinter_LabelSelector(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	httpRoute := func(name string, labels map[string]string) *gatewayv1.HTTPRoute {
@@ -503,108 +504,11 @@ func TestHTTPRoutesPrinter_LabelSelector(t *testing.T) {
 		t.Fatalf("Failed to discover resources: %v", err)
 	}
 
-	hp := &HTTPRoutesPrinter{
-		Out:   params.Out,
-		Clock: fakeClock,
-	}
-	hp.Print(resourceModel)
-
-	got := params.Out.(*bytes.Buffer).String()
-	want := `
-NAMESPACE  NAME         HOSTNAMES    PARENT REFS  AGE
-default    httproute-2  example.com  1            24h
-
-`
-	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
-		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
-	}
-}
-
-// TestHTTPRoutesPrinterDescribe_LabelSelector tests label selector filtering for HTTPRoute in 'describe' command.
-func TestHTTPRoutesPrinterDescribe_LabelSelector(t *testing.T) {
-	fakeClock := testingclock.NewFakeClock(time.Now())
-	httpRoute := func(name string, labels map[string]string) *gatewayv1.HTTPRoute {
-		return &gatewayv1.HTTPRoute{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: "default",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-24 * time.Hour),
-				},
-				Labels: labels,
-			},
-			Spec: gatewayv1.HTTPRouteSpec{
-				Hostnames: []gatewayv1.Hostname{"example.com"},
-				CommonRouteSpec: gatewayv1.CommonRouteSpec{
-					ParentRefs: []gatewayv1.ParentReference{
-						{
-							Name: "gateway-1",
-						},
-					},
-				},
-			},
-		}
+	expectedHTTPRouteNames := []string{"httproute-2"}
+	HTTPRouteNames := make([]string, 0, len(resourceModel.HTTPRoutes))
+	for _, HTTPRouteNode := range resourceModel.HTTPRoutes {
+		HTTPRouteNames = append(HTTPRouteNames, HTTPRouteNode.HTTPRoute.GetName())
 	}
 
-	objects := []runtime.Object{
-		&gatewayv1.GatewayClass{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "gatewayclass-1",
-			},
-			Spec: gatewayv1.GatewayClassSpec{
-				ControllerName: "example.net/gateway-controller",
-				Description:    common.PtrTo("random"),
-			},
-		},
-
-		&gatewayv1.Gateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "gateway-1",
-				Namespace: "default",
-			},
-			Spec: gatewayv1.GatewaySpec{
-				GatewayClassName: "gatewayclass-1",
-			},
-		},
-		httpRoute("httproute-1", map[string]string{"app": "foo"}),
-		httpRoute("httproute-2", map[string]string{"app": "foo", "env": "internal"}),
-	}
-
-	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
-	discoverer := resourcediscovery.Discoverer{
-		K8sClients:    params.K8sClients,
-		PolicyManager: params.PolicyManager,
-	}
-
-	labelSelector := "env=internal"
-	selector, err := labels.Parse(labelSelector)
-	if err != nil {
-		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
-	}
-	resourceModel, err := discoverer.DiscoverResourcesForHTTPRoute(resourcediscovery.Filter{Labels: selector})
-	if err != nil {
-		t.Fatalf("Failed to discover resources: %v", err)
-	}
-
-	nsp := &HTTPRoutesPrinter{
-		Out:   params.Out,
-		Clock: fakeClock,
-	}
-	nsp.PrintDescribeView(resourceModel)
-
-	got := params.Out.(*bytes.Buffer).String()
-	want := `
-Name: httproute-2
-Namespace: default
-Hostnames:
-- example.com
-ParentRefs:
-- name: gateway-1
-EffectivePolicies:
-  default/gateway-1: {}
-
-`
-	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
-		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
-	}
+	assert.Equal(t, expectedHTTPRouteNames, HTTPRouteNames, "Expected HTTPRoute name does not match the found one")
 }

--- a/gwctl/pkg/printer/namespace_test.go
+++ b/gwctl/pkg/printer/namespace_test.go
@@ -313,3 +313,62 @@ namespace-2  Active  46d
 		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
 	}
 }
+
+// TestNamespacesPrinterDescribe_LabelSelector tests label selector filtering for Namespaces in 'describe' command.
+func TestNamespacesPrinterDescribe_LabelSelector(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	namespace := func(name string, labels map[string]string) *corev1.Namespace {
+		return &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-46 * 24 * time.Hour),
+				},
+				Labels: labels,
+			},
+			Status: corev1.NamespaceStatus{
+				Phase: corev1.NamespaceActive,
+			},
+		}
+	}
+
+	objects := []runtime.Object{
+		namespace("namespace-1", map[string]string{"app": "foo"}),
+		namespace("namespace-2", map[string]string{"app": "foo", "env": "internal"}),
+	}
+
+	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
+	discoverer := resourcediscovery.Discoverer{
+		K8sClients:    params.K8sClients,
+		PolicyManager: params.PolicyManager,
+	}
+	labelSelector := "env=internal"
+	selector, err := labels.Parse(labelSelector)
+	if err != nil {
+		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+	}
+	resourceModel, err := discoverer.DiscoverResourcesForNamespace(resourcediscovery.Filter{Labels: selector})
+	if err != nil {
+		t.Fatalf("Failed to construct resourceModel: %v", resourceModel)
+	}
+
+	nsp := &NamespacesPrinter{
+		Out:   params.Out,
+		Clock: fakeClock,
+	}
+
+	nsp.PrintDescribeView(resourceModel)
+
+	got := params.Out.(*bytes.Buffer).String()
+	want := `
+Name: namespace-2
+Labels:
+  app: foo
+  env: internal
+Status: Active
+`
+
+	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
+	}
+}

--- a/gwctl/pkg/resourcediscovery/discoverer_test.go
+++ b/gwctl/pkg/resourcediscovery/discoverer_test.go
@@ -1,0 +1,293 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcediscovery
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	testingclock "k8s.io/utils/clock/testing"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
+	"sigs.k8s.io/gateway-api/gwctl/pkg/utils"
+)
+
+// TestDiscoverResourcesForGatewayClass_LabelSelector Tests label selector filtering for GatewayClasses.
+func TestDiscoverResourcesForGatewayClass_LabelSelector(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+
+	gatewayClass := func(name string, labels map[string]string) *gatewayv1.GatewayClass {
+		return &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: labels,
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-365 * 24 * time.Hour),
+				},
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: gatewayv1.GatewayController(name + "/controller"),
+			},
+			Status: gatewayv1.GatewayClassStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   "Accepted",
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		}
+	}
+	objects := []runtime.Object{
+		gatewayClass("foo-com-external-gateway-class", map[string]string{"app": "foo"}),
+		gatewayClass("foo-com-internal-gateway-class", map[string]string{"app": "foo", "env": "internal"}),
+	}
+	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
+	discoverer := Discoverer{
+		K8sClients:    params.K8sClients,
+		PolicyManager: params.PolicyManager,
+	}
+	labelSelector := "env=internal"
+	selector, err := labels.Parse(labelSelector)
+	if err != nil {
+		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+	}
+	resourceModel, err := discoverer.DiscoverResourcesForGatewayClass(Filter{Labels: selector})
+	if err != nil {
+		t.Fatalf("Failed to construct resourceModel: %v", resourceModel)
+	}
+
+	expectedGatewayClassNames := []string{"foo-com-internal-gateway-class"}
+	gatewayClassNames := make([]string, 0, len(resourceModel.GatewayClasses))
+	for _, gatewayClassNode := range resourceModel.GatewayClasses {
+		gatewayClassNames = append(gatewayClassNames, gatewayClassNode.GatewayClass.GetName())
+	}
+	if diff := cmp.Diff(expectedGatewayClassNames, gatewayClassNames); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", gatewayClassNames, expectedGatewayClassNames, diff)
+	}
+}
+
+// TestDiscoverResourcesForGateway_LabelSelector tests label selector filtering for Gateways.
+func TestDiscoverResourcesForGateway_LabelSelector(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	gateway := func(name string, labels map[string]string) *gatewayv1.Gateway {
+		return &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: labels,
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-5 * 24 * time.Hour),
+				},
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "gatewayclass-1",
+				Listeners: []gatewayv1.Listener{
+					{
+						Name:     "http-8080",
+						Protocol: gatewayv1.HTTPProtocolType,
+						Port:     gatewayv1.PortNumber(8080),
+					},
+				},
+			},
+			Status: gatewayv1.GatewayStatus{
+				Addresses: []gatewayv1.GatewayStatusAddress{
+					{
+						Value: "192.168.100.5",
+					},
+				},
+				Conditions: []metav1.Condition{
+					{
+						Type:   "Programmed",
+						Status: "False",
+					},
+				},
+			},
+		}
+	}
+
+	objects := []runtime.Object{
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gatewayclass-1",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "example.net/gateway-controller",
+				Description:    common.PtrTo("random"),
+			},
+		},
+		gateway("gateway-1", map[string]string{"app": "foo"}),
+		gateway("gateway-2", map[string]string{"app": "foo", "env": "internal"}),
+	}
+
+	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
+	discoverer := Discoverer{
+		K8sClients:    params.K8sClients,
+		PolicyManager: params.PolicyManager,
+	}
+	labelSelector := "env=internal"
+	selector, err := labels.Parse(labelSelector)
+	if err != nil {
+		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+	}
+	resourceModel, err := discoverer.DiscoverResourcesForGateway(Filter{Labels: selector})
+	if err != nil {
+		t.Fatalf("Failed to construct resourceModel: %v", resourceModel)
+	}
+
+	expectedGatewayNames := []string{"gateway-2"}
+	gatewayNames := make([]string, 0, len(resourceModel.Gateways))
+	for _, gatewayNode := range resourceModel.Gateways {
+		gatewayNames = append(gatewayNames, gatewayNode.Gateway.GetName())
+	}
+
+	if diff := cmp.Diff(expectedGatewayNames, gatewayNames); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", gatewayNames, expectedGatewayNames, diff)
+	}
+}
+
+// TestDiscoverResourcesForHTTPRoute_LabelSelector tests label selector filtering for HTTPRoute.
+func TestDiscoverResourcesForHTTPRoute_LabelSelector(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	httpRoute := func(name string, labels map[string]string) *gatewayv1.HTTPRoute {
+		return &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-24 * time.Hour),
+				},
+				Labels: labels,
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Name: "gateway-1",
+						},
+					},
+				},
+			},
+		}
+	}
+
+	objects := []runtime.Object{
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gatewayclass-1",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "example.net/gateway-controller",
+				Description:    common.PtrTo("random"),
+			},
+		},
+
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gateway-1",
+				Namespace: "default",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "gatewayclass-1",
+			},
+		},
+		httpRoute("httproute-1", map[string]string{"app": "foo"}),
+		httpRoute("httproute-2", map[string]string{"app": "foo", "env": "internal"}),
+	}
+
+	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
+	discoverer := Discoverer{
+		K8sClients:    params.K8sClients,
+		PolicyManager: params.PolicyManager,
+	}
+
+	labelSelector := "env=internal"
+	selector, err := labels.Parse(labelSelector)
+	if err != nil {
+		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+	}
+	resourceModel, err := discoverer.DiscoverResourcesForHTTPRoute(Filter{Labels: selector})
+	if err != nil {
+		t.Fatalf("Failed to discover resources: %v", err)
+	}
+
+	expectedHTTPRouteNames := []string{"httproute-2"}
+	HTTPRouteNames := make([]string, 0, len(resourceModel.HTTPRoutes))
+	for _, HTTPRouteNode := range resourceModel.HTTPRoutes {
+		HTTPRouteNames = append(HTTPRouteNames, HTTPRouteNode.HTTPRoute.GetName())
+	}
+
+	if diff := cmp.Diff(expectedHTTPRouteNames, HTTPRouteNames); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", expectedHTTPRouteNames, HTTPRouteNames, diff)
+	}
+}
+
+// TestDiscoverResourcesForNamespace_LabelSelector tests label selector filtering for Namespaces.
+func TestDiscoverResourcesForNamespace_LabelSelector(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	namespace := func(name string, labels map[string]string) *corev1.Namespace {
+		return &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-46 * 24 * time.Hour),
+				},
+				Labels: labels,
+			},
+			Status: corev1.NamespaceStatus{
+				Phase: corev1.NamespaceActive,
+			},
+		}
+	}
+
+	objects := []runtime.Object{
+		namespace("namespace-1", map[string]string{"app": "foo"}),
+		namespace("namespace-2", map[string]string{"app": "foo", "env": "internal"}),
+	}
+
+	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, objects...))
+	discoverer := Discoverer{
+		K8sClients:    params.K8sClients,
+		PolicyManager: params.PolicyManager,
+	}
+	labelSelector := "env=internal"
+	selector, err := labels.Parse(labelSelector)
+	if err != nil {
+		t.Errorf("Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+	}
+	resourceModel, err := discoverer.DiscoverResourcesForNamespace(Filter{Labels: selector})
+	if err != nil {
+		t.Fatalf("Failed to construct resourceModel: %v", resourceModel)
+	}
+
+	expectedNamespaceNames := []string{"namespace-2"}
+	namespaceNames := make([]string, 0, len(resourceModel.Namespaces))
+	for _, namespaceNode := range resourceModel.Namespaces {
+		namespaceNames = append(namespaceNames, namespaceNode.Namespace.Name)
+	}
+
+	if diff := cmp.Diff(expectedNamespaceNames, namespaceNames); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", expectedNamespaceNames, namespaceNames, diff)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2933

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add label filtering (-l) for describe commands
```

```
➜  gwctl describe httproute -l app=backend
Name: backend
Namespace: default
Hostnames:
- www.example.com
ParentRefs:
- group: gateway.networking.k8s.io
  kind: Gateway
  name: eg
EffectivePolicies:
  default/eg: {}
```

```
➜  gwctl describe ns -l kubernetes.io/metadata.name=envoy-gateway-system
Name: envoy-gateway-system
Annotations:
  kubectl.kubernetes.io/last-applied-configuration: |
    {"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{},"name":"envoy-gateway-system"}}
Labels:
  kubernetes.io/metadata.name: envoy-gateway-system
  name: envoy-gateway-system
Status: Active
```
