### PR TITLE
Pass testing.T to roundtripper as context value.

### DIFF
--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -127,6 +127,7 @@ func MakeRequest(t *testing.T, expected *ExpectedResponse, gwAddr, protocol, sch
 	tlog.Logf(t, "Making %s request to %s", expected.Request.Method, reqURL.String())
 
 	req := roundtripper.Request{
+		T:                t,
 		Method:           expected.Request.Method,
 		Host:             expected.Request.Host,
 		URL:              reqURL,


### PR DESCRIPTION
**What type of PR is this?**
/kind test
/area conformance

**What this PR does / why we need it**:

When using a custom round tripper it can useful to log messages during the request.  Propagate the `*testing.T* to the `http.Requst` to allow custom round trip implementations to log to the appropriate test stream.

**Which issue(s) this PR fixes**:
Fixes #2939

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
