### PR TITLE
feat: add gateway-api-crds chart

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -1,0 +1,66 @@
+name: Release Charts
+
+on:
+  push:
+    paths:
+      - .github/workflows/release-charts.yaml
+      - charts/**
+    branches:
+      - main
+      - feat/gateway-api-crds-chart
+
+jobs:
+  release:
+    permissions:
+      contents: write # to push chart release and create a release (helm/chart-releaser-action)
+      packages: write # needed for ghcr access
+      id-token: write # needed for keyless signing
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Copy crds to chart templates
+        run: cp -v config/crd/standard/*.yaml charts/gateway-api-crds/templates/
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3.5
+        with:
+          version: v3.12.0
+
+      - name: Run chart-releaser
+        # TODO: pin chart-releaser, currently the latest release (v1.6.0) does not support skip_upload
+        uses: helm/chart-releaser-action@13fe82a5149cf0b212e16453d25b3c59f2b4d3ef
+        with:
+          skip_existing: true
+          skip_upload: true
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_GENERATE_RELEASE_NOTES: true
+
+      # see https://github.com/helm/chart-releaser/issues/183
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+          done

--- a/charts/gateway-api-crds/.helmignore
+++ b/charts/gateway-api-crds/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/gateway-api-crds/Chart.yaml
+++ b/charts/gateway-api-crds/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+type: application
+version: 0.0.1-alpha3
+name: gateway-api-crds
+icon: https://avatars.githubusercontent.com/u/36015203?s=400&v=4
+description: |
+  A Helm chart that collects custom resource definitions (CRDs) from the Kubernetes Gateway API,
+  allowing for seamless integration with GitOps tools
+keywords:
+  - kubernetes
+  - gateway-api
+  - crds
+appVersion: 1.0.0
+home: https://gateway-api.sigs.k8s.io
+sources:
+  - https://github.com/kubernetes-sigs/gateway-api
+maintainers:
+  - name: vac
+    email: dot.fun@protonmail.com

--- a/charts/gateway-api-crds/README.md
+++ b/charts/gateway-api-crds/README.md
@@ -1,0 +1,10 @@
+# Kubernetes Gateway API CRDs
+
+This chart brings Custom Resource Definitions (CRD) used by Kubernetes Gateway API.
+
+Inspired by the following great resources:
+
+* https://github.com/helm/chart-releaser-action
+* https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-operator-crds
+* https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server
+* https://github.com/kubernetes/dashboard/tree/master/charts/kubernetes-dashboard

--- a/charts/gateway-api-crds/templates/NOTES.txt
+++ b/charts/gateway-api-crds/templates/NOTES.txt
@@ -1,0 +1,1 @@
+See https://github.com/kubernetes-sigs/gateway-api/tree/main/config/crd/standard

--- a/charts/gateway-api-crds/values.yaml
+++ b/charts/gateway-api-crds/values.yaml
@@ -1,0 +1,4 @@
+## Annotations for CRDs
+##
+#crds:
+#  annotations: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1590 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
feat: add gateway-api-crds chart
```

## Summary

* crds only, no validating webhook in the same chart, just as [prometheus-operator-crds](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-operator-crds)
* use OCI based repositories (GHCR) as the charts storage, no need to set up gh-pages for chart index
* [helm/chart-releaser-action](https://github.com/helm/chart-releaser-action) will automatically create chart releases/tags on push: see https://github.com/bikesheddev/gateway-api/releases or https://github.com/prometheus-community/helm-charts/releases for showcase
* helm charts is stored on ghcr packages: see https://github.com/orgs/bikesheddev/packages?repo_name=gateway-api or https://github.com/orgs/prometheus-community/packages?repo_name=helm-charts for showcase
* as crds chart is fairly simple, currently it does not support helm customization to avoid unnecessary complexity and reduce maintaining burden

Inspired by the following great resources:

* https://github.com/helm/chart-releaser-action
* https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-operator-crds
* https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server
* https://github.com/kubernetes/dashboard/tree/master/charts/kubernetes-dashboard

## TODO

* if chart releated code is pushed without bumping the chart version, the oci package will [be forcefully updated](https://github.com/bikesheddev/gateway-api/actions/runs/8602898666/job/23573498942#step:9:11), thus break the tag immutability principle
* currently the latest release (v1.6.0) of helm/chart-releaser-action does not support `skip_upload`, we can wait for them to release a new version, or just pin the version to commit hash which is used by this pr

## Demo usage:

check chart packaging content:
```console
❯ helm pull oci://ghcr.io/bikesheddev/charts/gateway-api-crds --version 0.0.1-alpha3
Pulled: ghcr.io/bikesheddev/charts/gateway-api-crds:0.0.1-alpha3
Digest: sha256:57b6f4554bf1f23d1eba45b44bae83bee778bfc32ac454ead20003a20983b812

❯ tar xvzf gateway-api-crds-0.0.1-alpha3.tgz
gateway-api-crds/Chart.yaml
gateway-api-crds/values.yaml
gateway-api-crds/templates/NOTES.txt
gateway-api-crds/templates/gateway.networking.k8s.io_gatewayclasses.yaml
gateway-api-crds/templates/gateway.networking.k8s.io_gateways.yaml
gateway-api-crds/templates/gateway.networking.k8s.io_httproutes.yaml
gateway-api-crds/templates/gateway.networking.k8s.io_referencegrants.yaml
gateway-api-crds/.helmignore
gateway-api-crds/README.md
```

install gateway-api-crds:
```console
❯ helm install demo-crd oci://ghcr.io/bikesheddev/charts/gateway-api-crds --version 0.0.1-alpha3
Pulled: ghcr.io/bikesheddev/charts/gateway-api-crds:0.0.1-alpha3
Digest: sha256:57b6f4554bf1f23d1eba45b44bae83bee778bfc32ac454ead20003a20983b812
NAME: demo-crd
LAST DEPLOYED: Mon Apr  8 23:53:37 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
See https://github.com/kubernetes-sigs/gateway-api/tree/main/config/crd/standard

❯ kubectl get crd | grep gateway
gatewayclasses.gateway.networking.k8s.io      2024-04-08T15:53:50Z
gateways.gateway.networking.k8s.io            2024-04-08T15:53:50Z
httproutes.gateway.networking.k8s.io          2024-04-08T15:53:52Z
referencegrants.gateway.networking.k8s.io     2024-04-08T15:53:50Z

❯ helm list
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
demo-crd        default         1               2024-04-08 23:53:37.753943 +0800 CST    deployed        gateway-api-crds-0.0.1-alpha3   1.0.0
```

uninstall gateway-api-crds:
```console
❯ helm uninstall demo-crd
release "demo-crd" uninstalled

❯ kubectl get crd | grep gateway

```
