### PR TITLE
Remove the last references to static context timeouts in conformance tests

### DIFF
--- a/conformance/tests/gateway-modify-listeners.go
+++ b/conformance/tests/gateway-modify-listeners.go
@@ -19,7 +19,6 @@ package tests
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +50,7 @@ var GatewayModifyListeners = suite.ConformanceTest{
 			// verify that the implementation is tracking the most recent resource changes
 			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.DefaultTestTimeout)
 			defer cancel()
 			original := &v1.Gateway{}
 			err := s.Client.Get(ctx, gwNN, original)
@@ -142,7 +141,7 @@ var GatewayModifyListeners = suite.ConformanceTest{
 			// verify that the implementation is tracking the most recent resource changes
 			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.DefaultTestTimeout)
 			defer cancel()
 			original := &v1.Gateway{}
 			err := s.Client.Get(ctx, gwNN, original)

--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -19,7 +19,6 @@ package tests
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
@@ -52,7 +51,7 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			// Sanity check
 			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.LatestObservedGenerationSet)
 			defer cancel()
 			original := &v1.Gateway{}
 			err := s.Client.Get(ctx, gwNN, original)

--- a/conformance/tests/gateway-static-addresses.go
+++ b/conformance/tests/gateway-static-addresses.go
@@ -19,7 +19,6 @@ package tests
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,7 +68,7 @@ var GatewayStaticAddresses = suite.ConformanceTest{
 			Name:      "gateway-static-addresses",
 			Namespace: "gateway-conformance-infra",
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.DefaultTestTimeout)
 		defer cancel()
 
 		t.Logf("waiting for namespace %s and Gateway %s to be ready for testing", gwNN.Namespace, gwNN.Name)

--- a/conformance/tests/gatewayclass-observed-generation-bump.go
+++ b/conformance/tests/gatewayclass-observed-generation-bump.go
@@ -19,7 +19,6 @@ package tests
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
@@ -45,7 +44,7 @@ var GatewayClassObservedGenerationBump = suite.ConformanceTest{
 		gwc := types.NamespacedName{Name: "gatewayclass-observed-generation-bump"}
 
 		t.Run("observedGeneration should increment", func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.LatestObservedGenerationSet)
 			defer cancel()
 
 			kubernetes.GWCMustHaveAcceptedConditionAny(t, s.Client, s.TimeoutConfig, gwc.Name)

--- a/conformance/tests/httproute-observed-generation-bump.go
+++ b/conformance/tests/httproute-observed-generation-bump.go
@@ -19,7 +19,6 @@ package tests
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,7 +47,7 @@ var HTTPRouteObservedGenerationBump = suite.ConformanceTest{
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 
 		t.Run("observedGeneration should increment", func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), suite.TimeoutConfig.LatestObservedGenerationSet)
 			defer cancel()
 
 			namespaces := []string{"gateway-conformance-infra"}

--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -91,6 +91,9 @@ type TimeoutConfig struct {
 	// Max value for conformant implementation: None
 	LatestObservedGenerationSet time.Duration
 
+	// DefaultTestTimeout is the default amount of time to wait for a test to complete
+	DefaultTestTimeout time.Duration
+
 	// RequiredConsecutiveSuccesses is the number of requests that must succeed in a row
 	// to consider a response "consistent" before making additional assertions on the response body.
 	// If this number is not reached within MaxTimeToConsistency, the test will fail.
@@ -117,6 +120,7 @@ func DefaultTimeoutConfig() TimeoutConfig {
 		NamespacesMustBeReady:              300 * time.Second,
 		RequestTimeout:                     10 * time.Second,
 		LatestObservedGenerationSet:        60 * time.Second,
+		DefaultTestTimeout:                 60 * time.Second,
 		RequiredConsecutiveSuccesses:       3,
 	}
 }
@@ -173,5 +177,8 @@ func SetupTimeoutConfig(timeoutConfig *TimeoutConfig) {
 	}
 	if timeoutConfig.TLSRouteMustHaveCondition == 0 {
 		timeoutConfig.TLSRouteMustHaveCondition = defaultTimeoutConfig.TLSRouteMustHaveCondition
+	}
+	if timeoutConfig.DefaultTestTimeout == 0 {
+		timeoutConfig.DefaultTestTimeout = defaultTimeoutConfig.DefaultTestTimeout
 	}
 }


### PR DESCRIPTION
/kind test

**What this PR does / why we need it**:
This PR removes the last references to static conformance test context timeouts so that implementations can tailor the timeouts to the environment they're run in (e.g. VMs with slower LB address provisioning)