### PR TITLE
GEP-957: Remove from experimental

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,7 +120,6 @@ nav:
     # - Implementable:
     #   -
     - Experimental:
-      - geps/gep-957/index.md
       - geps/gep-1016/index.md
       - geps/gep-1742/index.md
       - geps/gep-1748/index.md


### PR DESCRIPTION
GEP-957 was in both experimental and standard in the mkdocs.yml which caused some weird buggy behavior on the web page.

**What type of PR is this?**
Add one of the following kinds:
/kind gep

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
