### PR TITLE
[gwctl ] feat: `gwctl get backends` support

### DIFF
--- a/gwctl/pkg/printer/backends.go
+++ b/gwctl/pkg/printer/backends.go
@@ -20,6 +20,14 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/utils/clock"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/yaml"
 
@@ -28,7 +36,91 @@ import (
 )
 
 type BackendsPrinter struct {
-	Out io.Writer
+	Out   io.Writer
+	Clock clock.Clock
+}
+
+func (bp *BackendsPrinter) Print(resourceModel *resourcediscovery.ResourceModel) {
+	tw := tabwriter.NewWriter(bp.Out, 0, 0, 2, ' ', 0)
+	row := []string{"NAMESPACE", "NAME", "TYPE", "REFERRED BY ROUTES", "AGE", "POLICIES"}
+	tw.Write([]byte(strings.Join(row, "\t") + "\n"))
+
+	backendNodes := make([]*resourcediscovery.BackendNode, 0, len(resourceModel.Backends))
+	for _, backendNode := range resourceModel.Backends {
+		backendNodes = append(backendNodes, backendNode)
+	}
+
+	sort.Slice(backendNodes, func(i, j int) bool {
+		if backendNodes[i].Backend.GetNamespace() != backendNodes[j].Backend.GetNamespace() {
+			return backendNodes[i].Backend.GetNamespace() < backendNodes[j].Backend.GetNamespace()
+		}
+		return backendNodes[i].Backend.GetName() < backendNodes[j].Backend.GetName()
+	})
+
+	for _, backendNode := range backendNodes {
+		backend := backendNode.Backend
+
+		parentHttpRoutes := []string{}
+		remainderHttpRoutes := 0
+		associatedDistinctPolicies := map[string]any{}
+
+		httpRouteNodes := make([]*resourcediscovery.HTTPRouteNode, len(backendNode.HTTPRoutes))
+		i := 0
+		for _, node := range backendNode.HTTPRoutes {
+			httpRouteNodes[i] = node
+			i++
+		}
+		sort.Slice(httpRouteNodes, func(i, j int) bool {
+			if httpRouteNodes[i].HTTPRoute.GetNamespace() != httpRouteNodes[j].HTTPRoute.GetNamespace() {
+				return httpRouteNodes[i].HTTPRoute.GetNamespace() < httpRouteNodes[j].HTTPRoute.GetNamespace()
+			}
+			return httpRouteNodes[i].HTTPRoute.GetName() < httpRouteNodes[j].HTTPRoute.GetName()
+		})
+
+		for _, httpRouteNode := range httpRouteNodes {
+			httpRoute := httpRouteNode.HTTPRoute
+
+			if len(parentHttpRoutes) < 2 {
+				namespacedName := client.ObjectKeyFromObject(httpRoute).String()
+				parentHttpRoutes = append(parentHttpRoutes, namespacedName)
+			} else {
+				remainderHttpRoutes += 1
+			}
+
+			// TODO(yashvardhan-kukreja): change this to httpRouteNode.EffectivePolicies once the work around inherited policies is matured
+			for _, policy := range httpRouteNode.Policies {
+				unstructuredPolicy := policy.Policy.Unstructured()
+				key := fmt.Sprintf("%s/%s/%s",
+					unstructuredPolicy.GetKind(), unstructuredPolicy.GetNamespace(), unstructuredPolicy.GetName())
+				associatedDistinctPolicies[key] = true
+			}
+		}
+
+		referredByRoutes := "None"
+		if len(parentHttpRoutes) != 0 {
+			referredByRoutes = strings.Join(parentHttpRoutes, ",")
+			if remainderHttpRoutes != 0 {
+				referredByRoutes += fmt.Sprintf(" + %d more", remainderHttpRoutes)
+			}
+		}
+
+		namespace := backendNode.Backend.GetNamespace()
+		name := backendNode.Backend.GetName()
+		backendType := backendNode.Backend.GetKind()
+		age := duration.HumanDuration(bp.Clock.Since(backend.GetCreationTimestamp().Time))
+		policiesCount := fmt.Sprintf("%d", len(associatedDistinctPolicies))
+
+		row := []string{
+			namespace,
+			name,
+			backendType,
+			referredByRoutes,
+			age,
+			policiesCount,
+		}
+		tw.Write([]byte(strings.Join(row, "\t") + "\n"))
+	}
+	tw.Flush()
 }
 
 type backendDescribeView struct {

--- a/gwctl/pkg/printer/backends.go
+++ b/gwctl/pkg/printer/backends.go
@@ -66,7 +66,6 @@ func (bp *BackendsPrinter) Print(resourceModel *resourcediscovery.ResourceModel)
 
 		parentHTTPRoutes := []string{}
 		remainderHTTPRoutes := 0
-		associatedDistinctPolicies := map[string]any{}
 
 		httpRouteNodes := make([]*resourcediscovery.HTTPRouteNode, len(backendNode.HTTPRoutes))
 		i := 0
@@ -90,14 +89,6 @@ func (bp *BackendsPrinter) Print(resourceModel *resourcediscovery.ResourceModel)
 			} else {
 				remainderHTTPRoutes++
 			}
-
-			// TODO(yashvardhan-kukreja): change this to httpRouteNode.EffectivePolicies once the work around inherited policies is matured
-			for _, policy := range httpRouteNode.Policies {
-				unstructuredPolicy := policy.Policy.Unstructured()
-				key := fmt.Sprintf("%s/%s/%s",
-					unstructuredPolicy.GetKind(), unstructuredPolicy.GetNamespace(), unstructuredPolicy.GetName())
-				associatedDistinctPolicies[key] = true
-			}
 		}
 
 		referredByRoutes := "None"
@@ -112,7 +103,7 @@ func (bp *BackendsPrinter) Print(resourceModel *resourcediscovery.ResourceModel)
 		name := backendNode.Backend.GetName()
 		backendType := backendNode.Backend.GetKind()
 		age := duration.HumanDuration(bp.Clock.Since(backend.GetCreationTimestamp().Time))
-		policiesCount := fmt.Sprintf("%d", len(associatedDistinctPolicies))
+		policiesCount := fmt.Sprintf("%d", len(backendNode.Policies))
 
 		row := []string{
 			namespace,

--- a/gwctl/pkg/printer/backends_test.go
+++ b/gwctl/pkg/printer/backends_test.go
@@ -80,9 +80,10 @@ func TestBackendsPrinter_Print(t *testing.T) {
 						"key4": "value-parent-4",
 					},
 					"targetRef": map[string]interface{}{
-						"group": "gateway.networking.k8s.io",
-						"kind":  "GatewayClass",
-						"name":  "demo-gatewayclass-1",
+						"group":     "",
+						"kind":      "Service",
+						"name":      "foo-svc-0",
+						"namespace": "default",
 					},
 				},
 			},
@@ -104,10 +105,10 @@ func TestBackendsPrinter_Print(t *testing.T) {
 						"key5": "value-child-5",
 					},
 					"targetRef": map[string]interface{}{
-						"group":     "gateway.networking.k8s.io",
-						"kind":      "Gateway",
-						"name":      "demo-gateway-1",
-						"namespace": "default",
+						"group":     "",
+						"kind":      "Service",
+						"name":      "foo-svc-1",
+						"namespace": "ns1",
 					},
 				},
 			},
@@ -460,7 +461,7 @@ func TestBackendsPrinter_Print(t *testing.T) {
 	}
 	resourceModel, err := discoverer.DiscoverResourcesForBackend(resourcediscovery.Filter{})
 	if err != nil {
-		t.Fatalf("Failed to construct resourceModel: %v", resourceModel)
+		t.Fatalf("Failed to construct resourceModel %v: %v", resourceModel, err)
 	}
 
 	bp := &BackendsPrinter{
@@ -473,10 +474,10 @@ func TestBackendsPrinter_Print(t *testing.T) {
 	got := params.Out.(*bytes.Buffer).String()
 	want := `
 NAMESPACE  NAME       TYPE     REFERRED BY ROUTES                                          AGE   POLICIES
-default    foo-svc-0  Service  default/foo-httproute-1                                     3d    0
-ns1        foo-svc-1  Service  default/foo-httproute-1,default/qmn-httproute-100           2d    0
-ns2        foo-svc-2  Service  default/foo-httproute-1,default/qmn-httproute-100 + 1 more  36h   1
-ns3        foo-svc-3  Service  default/qmn-httproute-100,ns1/bar-route-21                  24h   1
+default    foo-svc-0  Service  default/foo-httproute-1                                     3d    1
+ns1        foo-svc-1  Service  default/foo-httproute-1,default/qmn-httproute-100           2d    1
+ns2        foo-svc-2  Service  default/foo-httproute-1,default/qmn-httproute-100 + 1 more  36h   0
+ns3        foo-svc-3  Service  default/qmn-httproute-100,ns1/bar-route-21                  24h   0
 ns3        foo-svc-4  Service  None                                                        5d8h  0
 `
 	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {

--- a/gwctl/pkg/printer/backends_test.go
+++ b/gwctl/pkg/printer/backends_test.go
@@ -1,0 +1,485 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printer
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	testingclock "k8s.io/utils/clock/testing"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
+	"sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery"
+	"sigs.k8s.io/gateway-api/gwctl/pkg/utils"
+)
+
+func TestBackendsPrinter_Print(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+
+	healthCheckPolicies := []runtime.Object{
+		&apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "healthcheckpolicies.foo.com",
+				Labels: map[string]string{
+					gatewayv1alpha2.PolicyLabelKey: "inherited",
+				},
+			},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Scope:    apiextensionsv1.ClusterScoped,
+				Group:    "foo.com",
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{Name: "v1"}},
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
+					Plural: "healthcheckpolicies",
+					Kind:   "HealthCheckPolicy",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "foo.com/v1",
+				"kind":       "HealthCheckPolicy",
+				"metadata": map[string]interface{}{
+					"name":              "health-check-gatewayclass",
+					"creationTimestamp": fakeClock.Now().Add(-6 * 24 * time.Hour).Format(time.RFC3339),
+				},
+				"spec": map[string]interface{}{
+					"override": map[string]interface{}{
+						"key1": "value-parent-1",
+						"key3": "value-parent-3",
+						"key5": "value-parent-5",
+					},
+					"default": map[string]interface{}{
+						"key2": "value-parent-2",
+						"key4": "value-parent-4",
+					},
+					"targetRef": map[string]interface{}{
+						"group": "gateway.networking.k8s.io",
+						"kind":  "GatewayClass",
+						"name":  "demo-gatewayclass-1",
+					},
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "foo.com/v1",
+				"kind":       "HealthCheckPolicy",
+				"metadata": map[string]interface{}{
+					"name":              "health-check-gateway",
+					"creationTimestamp": fakeClock.Now().Add(-20 * 24 * time.Hour).Format(time.RFC3339),
+				},
+				"spec": map[string]interface{}{
+					"override": map[string]interface{}{
+						"key1": "value-child-1",
+					},
+					"default": map[string]interface{}{
+						"key2": "value-child-2",
+						"key5": "value-child-5",
+					},
+					"targetRef": map[string]interface{}{
+						"group":     "gateway.networking.k8s.io",
+						"kind":      "Gateway",
+						"name":      "demo-gateway-1",
+						"namespace": "default",
+					},
+				},
+			},
+		},
+	}
+
+	timeoutPolicies := []runtime.Object{
+		&apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "timeoutpolicies.bar.com",
+				Labels: map[string]string{
+					gatewayv1alpha2.PolicyLabelKey: "direct",
+				},
+			},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Scope:    apiextensionsv1.ClusterScoped,
+				Group:    "bar.com",
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{Name: "v1"}},
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
+					Plural: "timeoutpolicies",
+					Kind:   "TimeoutPolicy",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "bar.com/v1",
+				"kind":       "TimeoutPolicy",
+				"metadata": map[string]interface{}{
+					"name":              "timeout-policy-namespace",
+					"creationTimestamp": fakeClock.Now().Add(-5 * time.Minute).Format(time.RFC3339),
+				},
+				"spec": map[string]interface{}{
+					"condition": "path=/abc",
+					"seconds":   int64(30),
+					"targetRef": map[string]interface{}{
+						"kind": "Namespace",
+						"name": "default",
+					},
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "bar.com/v1",
+				"kind":       "TimeoutPolicy",
+				"metadata": map[string]interface{}{
+					"name":              "timeout-policy-httproute",
+					"creationTimestamp": fakeClock.Now().Add(-13 * time.Minute).Format(time.RFC3339),
+				},
+				"spec": map[string]interface{}{
+					"condition": "path=/def",
+					"seconds":   int64(60),
+					"targetRef": map[string]interface{}{
+						"group":     "gateway.networking.k8s.io",
+						"kind":      "HTTPRoute",
+						"name":      "bar-route-21",
+						"namespace": "ns1",
+					},
+				},
+			},
+		},
+	}
+
+	objects := []runtime.Object{
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "demo-gatewayclass-1",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "example.net/gateway-controller",
+				Description:    common.PtrTo("random"),
+			},
+		},
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns1",
+			},
+			Status: corev1.NamespaceStatus{
+				Phase: corev1.NamespaceActive,
+			},
+		},
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns2",
+			},
+			Status: corev1.NamespaceStatus{
+				Phase: corev1.NamespaceActive,
+			},
+		},
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ns3",
+			},
+			Status: corev1.NamespaceStatus{
+				Phase: corev1.NamespaceActive,
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo-svc-0",
+				Namespace: "default",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-72 * time.Hour),
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo-svc-1",
+				Namespace: "ns1",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-48 * time.Hour),
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo-svc-2",
+				Namespace: "ns2",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-36 * time.Hour),
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo-svc-3",
+				Namespace: "ns3",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-24 * time.Hour),
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo-svc-4",
+				Namespace: "ns3",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-128 * time.Hour),
+				},
+			},
+		},
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "demo-gateway-1",
+				Namespace: "default",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "demo-gatewayclass-1",
+			},
+		},
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "demo-gateway-2",
+				Namespace: "ns2",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "demo-gatewayclass-1",
+			},
+		},
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "demo-gateway-345",
+				Namespace: "ns1",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "demo-gatewayclass-1",
+			},
+		},
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo-httproute-1",
+				Namespace: "default",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-24 * time.Hour),
+				},
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com", "example2.com", "example3.com"},
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Kind:      common.PtrTo(gatewayv1.Kind("Gateway")),
+							Group:     common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
+							Namespace: common.PtrTo(gatewayv1.Namespace("ns2")),
+							Name:      "demo-gateway-2",
+						},
+					},
+				},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Port:      ptr.To(gatewayv1.PortNumber(8080)),
+										Name:      "foo-svc-0",
+										Kind:      ptr.To(gatewayv1.Kind("Service")),
+										Namespace: ptr.To(gatewayv1.Namespace("default")),
+									},
+								},
+							},
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Port:      ptr.To(gatewayv1.PortNumber(8081)),
+										Name:      "foo-svc-1",
+										Kind:      ptr.To(gatewayv1.Kind("Service")),
+										Namespace: ptr.To(gatewayv1.Namespace("ns1")),
+									},
+								},
+							},
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Port:      ptr.To(gatewayv1.PortNumber(8082)),
+										Name:      "foo-svc-2",
+										Kind:      ptr.To(gatewayv1.Kind("Service")),
+										Namespace: ptr.To(gatewayv1.Namespace("ns2")),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "qmn-httproute-100",
+				Namespace: "default",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-11 * time.Hour),
+				},
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"example.com"},
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Kind:  common.PtrTo(gatewayv1.Kind("Gateway")),
+							Group: common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
+							Name:  "demo-gateway-1",
+						},
+						{
+							Kind:  common.PtrTo(gatewayv1.Kind("Gateway")),
+							Group: common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
+							Name:  "demo-gateway-345",
+						},
+					},
+				},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Port:      ptr.To(gatewayv1.PortNumber(8081)),
+										Name:      "foo-svc-1",
+										Kind:      ptr.To(gatewayv1.Kind("Service")),
+										Namespace: ptr.To(gatewayv1.Namespace("ns1")),
+									},
+								},
+							},
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Port:      ptr.To(gatewayv1.PortNumber(8082)),
+										Name:      "foo-svc-2",
+										Kind:      ptr.To(gatewayv1.Kind("Service")),
+										Namespace: ptr.To(gatewayv1.Namespace("ns2")),
+									},
+								},
+							},
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Port:      ptr.To(gatewayv1.PortNumber(8083)),
+										Name:      "foo-svc-3",
+										Kind:      ptr.To(gatewayv1.Kind("Service")),
+										Namespace: ptr.To(gatewayv1.Namespace("ns3")),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar-route-21",
+				Namespace: "ns1",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-9 * time.Hour),
+				},
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"foo.com", "bar.com", "example.com", "example2.com", "example3.com", "example4.com", "example5.com"},
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Kind:      common.PtrTo(gatewayv1.Kind("Gateway")),
+							Group:     common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
+							Namespace: common.PtrTo(gatewayv1.Namespace("default")),
+							Name:      "demo-gateway-2",
+						},
+					},
+				},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Port:      ptr.To(gatewayv1.PortNumber(8082)),
+										Name:      "foo-svc-2",
+										Kind:      ptr.To(gatewayv1.Kind("Service")),
+										Namespace: ptr.To(gatewayv1.Namespace("ns2")),
+									},
+								},
+							},
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Port:      ptr.To(gatewayv1.PortNumber(8083)),
+										Name:      "foo-svc-3",
+										Kind:      ptr.To(gatewayv1.Kind("Service")),
+										Namespace: ptr.To(gatewayv1.Namespace("ns3")),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	finalObjects := []runtime.Object{}
+	finalObjects = append(finalObjects, healthCheckPolicies...)
+	finalObjects = append(finalObjects, timeoutPolicies...)
+	finalObjects = append(finalObjects, objects...)
+
+	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, finalObjects...))
+	discoverer := resourcediscovery.Discoverer{
+		K8sClients:    params.K8sClients,
+		PolicyManager: params.PolicyManager,
+	}
+	resourceModel, err := discoverer.DiscoverResourcesForBackend(resourcediscovery.Filter{})
+	if err != nil {
+		t.Fatalf("Failed to construct resourceModel: %v", resourceModel)
+	}
+
+	bp := &BackendsPrinter{
+		Out:   params.Out,
+		Clock: fakeClock,
+	}
+
+	bp.Print(resourceModel)
+
+	got := params.Out.(*bytes.Buffer).String()
+	want := `
+NAMESPACE  NAME       TYPE     REFERRED BY ROUTES                                          AGE   POLICIES
+default    foo-svc-0  Service  default/foo-httproute-1                                     3d    0
+ns1        foo-svc-1  Service  default/foo-httproute-1,default/qmn-httproute-100           2d    0
+ns2        foo-svc-2  Service  default/foo-httproute-1,default/qmn-httproute-100 + 1 more  36h   1
+ns3        foo-svc-3  Service  default/qmn-httproute-100,ns1/bar-route-21                  24h   1
+ns3        foo-svc-4  Service  None                                                        5d8h  0
+`
+	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
+	}
+}

--- a/gwctl/pkg/printer/httproutes.go
+++ b/gwctl/pkg/printer/httproutes.go
@@ -24,13 +24,14 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"sigs.k8s.io/yaml"
+
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/policymanager"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery"
 
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/utils/clock"
-	"sigs.k8s.io/yaml"
 )
 
 type HTTPRoutesPrinter struct {

--- a/gwctl/pkg/printer/policies.go
+++ b/gwctl/pkg/printer/policies.go
@@ -24,13 +24,14 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"sigs.k8s.io/yaml"
+
 	"sigs.k8s.io/gateway-api/gwctl/pkg/policymanager"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/utils/clock"
-	"sigs.k8s.io/yaml"
 )
 
 type PoliciesPrinter struct {

--- a/gwctl/pkg/resourcediscovery/discoverer.go
+++ b/gwctl/pkg/resourcediscovery/discoverer.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/policymanager"
@@ -34,7 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -465,8 +466,12 @@ func fetchBackends(ctx context.Context, k8sClients *common.K8sClients, filter Fi
 	}
 
 	// Use List call.
+	labelSelector := ""
+	if filter.Labels != nil {
+		labelSelector = filter.Labels.String()
+	}
 	listOptions := metav1.ListOptions{
-		LabelSelector: filter.Labels.String(),
+		LabelSelector: labelSelector,
 	}
 	var backendsList *unstructured.UnstructuredList
 	backendsList, err := k8sClients.DC.Resource(gvr).Namespace(filter.Namespace).List(ctx, listOptions)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

/kind feature

This PR introduces the `gwctl get backends` subcommand in favor of the requirements of this [GEP](https://deploy-preview-2723--kubernetes-sigs-gateway-api.netlify.app/geps/gep-2722/)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2866 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
Yes, it introduces the `gwctl get backends` command to support returning backends to the console.
For example:
```release-note
gwctl get backends

NAMESPACE  NAME       TYPE     REFERRED BY ROUTES                                   AGE   POLICIES
default    foo-svc-0  Service  default/foo-httproute-1                              3d    2
ns1        foo-svc-1  Service  default/qmn-httproute-100,default/foo-httproute-1    2d    3
ns2        foo-svc-2  Service  default/qmn-httproute-100,ns1/bar-route-21 + 1 more  36h   3
ns3        foo-svc-3  Service  default/qmn-httproute-100,ns1/bar-route-21           24h   2
ns3        foo-svc-4  Service  None                                                 5d8h  0
```
