### PR TITLE
fix: the conformance suite FS is defaulted if not given

### DIFF
--- a/conformance/conformance.go
+++ b/conformance/conformance.go
@@ -110,6 +110,11 @@ func RunConformanceWithOptions(t *testing.T, opts suite.ConformanceOptions) {
 		require.NoError(t, err, "supplied Implementation details are not valid")
 	}
 
+	// if no FS is provided, use the default Manifests FS
+	if opts.ManifestFS == nil {
+		opts.ManifestFS = []fs.FS{&Manifests}
+	}
+
 	t.Log("Running conformance tests with:")
 	logOptions(t, opts)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/area conformance
/kind bug

**What this PR does / why we need it**:

If the suite is used as a library, the `DefaultOptions` method is not used, and instead the `Options` struct is provided by the implementation. In that case, the FS needs to be always set, otherwise the tests fail. We need to add a default on such a field, to that in case it is not set, we use the default FS value.

This problem has been surfaced by this discussion: https://github.com/kubernetes-sigs/gateway-api/pull/2864#discussion_r1564249514

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
