### PR TITLE
Gateway ObservedGeneration bumping should be a core test

### DIFF
--- a/conformance/tests/gateway-observed-generation-bump.go
+++ b/conformance/tests/gateway-observed-generation-bump.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -39,7 +40,6 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 	Description: "A Gateway in the gateway-conformance-infra namespace should update the observedGeneration in all of its Status.Conditions after an update to the spec",
 	Features: []features.SupportedFeature{
 		features.SupportGateway,
-		features.SupportGatewayPort8080,
 	},
 	Manifests: []string{"tests/gateway-observed-generation-bump.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
@@ -65,7 +65,8 @@ var GatewayObservedGenerationBump = suite.ConformanceTest{
 			// mutate the Gateway Spec
 			mutate.Spec.Listeners = append(mutate.Spec.Listeners, v1.Listener{
 				Name:     "alternate",
-				Port:     8080,
+				Hostname: ptr.To[v1.Hostname]("foo.com"),
+				Port:     80,
 				Protocol: v1.HTTPProtocolType,
 				AllowedRoutes: &v1.AllowedRoutes{
 					Namespaces: &v1.RouteNamespaces{From: &all},

--- a/conformance/tests/gateway-observed-generation-bump.yaml
+++ b/conformance/tests/gateway-observed-generation-bump.yaml
@@ -7,6 +7,7 @@ spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
   listeners:
     - name: http
+      hostname: "bar.com"
       port: 80
       protocol: HTTP
       allowedRoutes:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind test
/area conformance

**What this PR does / why we need it**:
The original intent of the test was to make sure observedGeneration was incremented when the Gateway's spec was modified. This is core functionality.

The test originally used port 8080 some time later it was put behind a feature flag. 

The changes removes the use of port 8080 in order to make the test 'core' again. It add's unique listeners with different hostnames

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
