### PR TITLE
Bump Go version to 1.22

### DIFF
--- a/docker/Dockerfile.echo-advanced
+++ b/docker/Dockerfile.echo-advanced
@@ -1,1 +1,1 @@
-FROM gcr.io/istio-release/app:1.20.1
+FROM gcr.io/istio-release/app:1.21.1

--- a/docker/Dockerfile.echo-basic
+++ b/docker/Dockerfile.echo-basic
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build
-FROM golang:1.21.5 as builder
+FROM golang:1.22.2 as builder
 
 ENV CGO_ENABLED=0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/gateway-api
 
-go 1.21
+go 1.22
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0

--- a/gwctl/go.mod
+++ b/gwctl/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/gateway-api/gwctl
 
-go 1.21
+go 1.22
 
 require (
 	github.com/evanphx/json-patch v5.9.0+incompatible

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly VERSION="v1.56.2"
+readonly VERSION="v1.57.2"
 readonly KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 cd "${KUBE_ROOT}"


### PR DESCRIPTION
## What is this PR

This bumps the go version to 1.22

## Release Note
```release-note
Bump Go Version to 1.22
```