### PR TITLE
Improve utilities for gwctl describe and add more info to gateway descriptions

### DIFF
--- a/gwctl/cmd/describe.go
+++ b/gwctl/cmd/describe.go
@@ -29,6 +29,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/clock"
 )
 
 func NewDescribeCommand() *cobra.Command {
@@ -81,12 +82,12 @@ func runDescribe(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 		K8sClients:    params.K8sClients,
 		PolicyManager: params.PolicyManager,
 	}
-	policiesPrinter := &printer.PoliciesPrinter{Out: params.Out}
-	httpRoutesPrinter := &printer.HTTPRoutesPrinter{Out: params.Out}
-	gwPrinter := &printer.GatewaysPrinter{Out: params.Out}
-	gwcPrinter := &printer.GatewayClassesPrinter{Out: params.Out}
+	policiesPrinter := &printer.PoliciesPrinter{Out: params.Out, Clock: clock.RealClock{}}
+	httpRoutesPrinter := &printer.HTTPRoutesPrinter{Out: params.Out, Clock: clock.RealClock{}}
+	gwPrinter := &printer.GatewaysPrinter{Out: params.Out, Clock: clock.RealClock{}}
+	gwcPrinter := &printer.GatewayClassesPrinter{Out: params.Out, Clock: clock.RealClock{}}
 	backendsPrinter := &printer.BackendsPrinter{Out: params.Out}
-	namespacesPrinter := &printer.NamespacesPrinter{Out: params.Out}
+	namespacesPrinter := &printer.NamespacesPrinter{Out: params.Out, Clock: clock.RealClock{}}
 
 	switch kind {
 	case "policy", "policies":

--- a/gwctl/pkg/printer/common.go
+++ b/gwctl/pkg/printer/common.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printer
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"sigs.k8s.io/yaml"
+)
+
+// DescriberKV stores key-value pairs that are used with Describing a resource.
+type DescriberKV struct {
+	Key   string
+	Value any
+}
+
+const (
+	// Default indentation for Tables that are printed in the Describe view.
+	defaultDescribeTableIndentSpaces = 2
+)
+
+// Describe writes the key-value paris to the writer. It handles things like
+// properly writing special data types like Tables.
+func Describe(w io.Writer, pairs []*DescriberKV) {
+	for _, pair := range pairs {
+		// If the Value is of type Table, it needs special handling.
+		if table, ok := pair.Value.(*Table); ok {
+			if len(table.Rows) == 0 {
+				fmt.Fprintf(w, "%v: <none>\n", pair.Key)
+			} else {
+				fmt.Fprintf(w, "%v:\n", pair.Key)
+				table.writeTable(w, defaultDescribeTableIndentSpaces)
+			}
+			continue
+		}
+
+		// If Value is NOT a Table, it can be handled through the yaml Marshaller.
+		data := map[string]any{pair.Key: pair.Value}
+		b, err := yaml.Marshal(data)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to marshal to yaml: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprint(w, string(b))
+	}
+}
+
+type Table struct {
+	ColumnNames []string
+	Rows        [][]string
+	// UseSeparator indicates whether the header row and data rows will be
+	// separated through a separator.
+	UseSeparator bool
+}
+
+// writeTable will write a formatted table to the writer. indent controls the
+// number of spaces at the beginning of each row.
+func (t *Table) writeTable(w io.Writer, indent int) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	// Print column names.
+	if len(t.ColumnNames) > 0 {
+		row := t.indentRow(t.ColumnNames, indent)
+		_, err := tw.Write([]byte(strings.Join(row, "\t") + "\n"))
+		if err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+
+	// Optionally print a separator between header row and data rows.
+	if t.UseSeparator {
+		row := make([]string, len(t.ColumnNames))
+		for i, value := range t.ColumnNames {
+			row[i] = strings.Repeat("-", len(value))
+		}
+		row = t.indentRow(row, indent)
+		_, err := tw.Write([]byte(strings.Join(row, "\t") + "\n"))
+		if err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+
+	// Print data rows.
+	for _, row := range t.Rows {
+		row = t.indentRow(row, indent)
+		_, err := tw.Write([]byte(strings.Join(row, "\t") + "\n"))
+		if err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	tw.Flush()
+}
+
+// indentRow will add 'indent' spaces to the beginning of the row.
+func (t *Table) indentRow(row []string, indent int) []string {
+	if len(row) == 0 {
+		return row
+	}
+
+	newRow := append([]string{}, row...)
+	newRow[0] = fmt.Sprintf("%s%s", strings.Repeat(" ", indent), newRow[0])
+	return newRow
+}

--- a/gwctl/pkg/printer/common_test.go
+++ b/gwctl/pkg/printer/common_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printer
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
+)
+
+func TestDescribe(t *testing.T) {
+	pairs := []*DescriberKV{
+		{Key: "Key1", Value: "string"},
+		{Key: "Key2", Value: []any{"list-string1", 1234, "list-string-3"}},
+		{
+			Key: "Key3-with-nested-structures",
+			Value: map[string]any{
+				"a": "b",
+				"d": map[string]any{
+					"e": []string{"v1", "v2", "v3"},
+				},
+				"c": 123,
+			},
+		},
+		{
+			Key: "Key4-table",
+			Value: &Table{
+				ColumnNames: []string{"col1", "col2", "col3"},
+				Rows: [][]string{
+					{"row1-a", "row1-b", "row1-c"},
+					{"row2-a", "row2-b", "row2-c"},
+					{"row3-a", "row3-b", "row3-c"},
+				},
+				UseSeparator: true,
+			},
+		},
+	}
+
+	writable := &bytes.Buffer{}
+	Describe(writable, pairs)
+
+	got := writable.String()
+	want := `
+Key1: string
+Key2:
+- list-string1
+- 1234
+- list-string-3
+Key3-with-nested-structures:
+  a: b
+  c: 123
+  d:
+    e:
+    - v1
+    - v2
+    - v3
+Key4-table:
+  col1    col2    col3
+  ----    ----    ----
+  row1-a  row1-b  row1-c
+  row2-a  row2-b  row2-c
+  row3-a  row3-b  row3-c
+`
+	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
+	}
+}
+
+func TestTable_writeTable(t *testing.T) {
+	testcases := []struct {
+		name   string
+		table  *Table
+		indent int
+		want   string
+	}{
+		{
+			name: "without separator",
+			table: &Table{
+				ColumnNames: []string{"Kind", "Name"},
+				Rows: [][]string{
+					{"HTTPRoute", "default/my-httproute"},
+					{"TCPRoute", "ns2/my-tcproute"},
+				},
+			},
+			indent: 0,
+			want: `
+Kind       Name
+HTTPRoute  default/my-httproute
+TCPRoute   ns2/my-tcproute
+`,
+		},
+		{
+			name: "with separator",
+			table: &Table{
+				ColumnNames: []string{"Kind", "Name"},
+				Rows: [][]string{
+					{"HTTPRoute", "default/my-httproute"},
+					{"TCPRoute", "ns2/my-tcproute"},
+				},
+				UseSeparator: true,
+			},
+			indent: 0,
+			want: `
+Kind       Name
+----       ----
+HTTPRoute  default/my-httproute
+TCPRoute   ns2/my-tcproute
+`,
+		},
+		{
+			name: "with indent and separator",
+			table: &Table{
+				ColumnNames: []string{"Kind", "Name"},
+				Rows: [][]string{
+					{"HTTPRoute", "default/my-httproute"},
+					{"TCPRoute", "ns2/my-tcproute"},
+				},
+				UseSeparator: true,
+			},
+			indent: 3, // We want 3 spaces at the start of each row.
+			want: `
+   Kind       Name
+   ----       ----
+   HTTPRoute  default/my-httproute
+   TCPRoute   ns2/my-tcproute
+`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			writable := &bytes.Buffer{}
+			tc.table.writeTable(writable, tc.indent)
+
+			got := writable.String()
+			if diff := cmp.Diff(common.YamlString(tc.want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
+				t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, tc.want, diff)
+			}
+		})
+	}
+}

--- a/gwctl/pkg/printer/gateways.go
+++ b/gwctl/pkg/printer/gateways.go
@@ -24,27 +24,15 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"sigs.k8s.io/gateway-api/gwctl/pkg/policymanager"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery"
 
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/utils/clock"
-	"sigs.k8s.io/yaml"
 )
 
 type GatewaysPrinter struct {
 	Out   io.Writer
 	Clock clock.Clock
-}
-
-type gatewayDescribeView struct {
-	// Gateway name
-	Name string `json:",omitempty"`
-	// Gateway namespace
-	Namespace                string                                             `json:",omitempty"`
-	GatewayClass             string                                             `json:",omitempty"`
-	DirectlyAttachedPolicies []policymanager.ObjRef                             `json:",omitempty"`
-	EffectivePolicies        map[policymanager.PolicyCrdID]policymanager.Policy `json:",omitempty"`
 }
 
 func (gp *GatewaysPrinter) Print(resourceModel *resourcediscovery.ResourceModel) {
@@ -115,34 +103,61 @@ func (gp *GatewaysPrinter) PrintDescribeView(resourceModel *resourcediscovery.Re
 	index := 0
 	for _, gatewayNode := range resourceModel.Gateways {
 		index++
-		views := []gatewayDescribeView{
-			{
-				Name:      gatewayNode.Gateway.GetName(),
-				Namespace: gatewayNode.Gateway.GetNamespace(),
-			},
-			{
-				GatewayClass: string(gatewayNode.Gateway.Spec.GatewayClassName),
-			},
-		}
-		if policyRefs := resourcediscovery.ConvertPoliciesMapToPolicyRefs(gatewayNode.Policies); len(policyRefs) != 0 {
-			views = append(views, gatewayDescribeView{
-				DirectlyAttachedPolicies: policyRefs,
-			})
-		}
-		if len(gatewayNode.EffectivePolicies) != 0 {
-			views = append(views, gatewayDescribeView{
-				EffectivePolicies: gatewayNode.EffectivePolicies,
-			})
+
+		metadata := gatewayNode.Gateway.ObjectMeta.DeepCopy()
+		metadata.Labels = nil
+		metadata.Annotations = nil
+		metadata.Name = ""
+		metadata.Namespace = ""
+
+		pairs := []*DescriberKV{
+			{Key: "Name", Value: gatewayNode.Gateway.GetName()},
+			{Key: "Namespace", Value: gatewayNode.Gateway.GetNamespace()},
+			{Key: "Labels", Value: gatewayNode.Gateway.Labels},
+			{Key: "Annotations", Value: gatewayNode.Gateway.Annotations},
+			{Key: "APIVersion", Value: gatewayNode.Gateway.APIVersion},
+			{Key: "Kind", Value: gatewayNode.Gateway.Kind},
+			{Key: "Metadata", Value: metadata},
+			{Key: "Spec", Value: &gatewayNode.Gateway.Spec},
+			{Key: "Status", Value: &gatewayNode.Gateway.Status},
 		}
 
-		for _, view := range views {
-			b, err := yaml.Marshal(view)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to marshal to yaml: %v\n", err)
-				os.Exit(1)
-			}
-			fmt.Fprint(gp.Out, string(b))
+		// AttachedRoutes
+		attachedRoutes := &Table{
+			ColumnNames:  []string{"Kind", "Name"},
+			UseSeparator: true,
 		}
+		for _, httpRouteNode := range gatewayNode.HTTPRoutes {
+			row := []string{
+				httpRouteNode.HTTPRoute.Kind, // Kind
+				fmt.Sprintf("%v/%v", httpRouteNode.HTTPRoute.Namespace, httpRouteNode.HTTPRoute.Name), // Name
+			}
+			attachedRoutes.Rows = append(attachedRoutes.Rows, row)
+		}
+		pairs = append(pairs, &DescriberKV{Key: "AttachedRoutes", Value: attachedRoutes})
+
+		// DirectlyAttachedPolicies
+		if policyRefs := resourcediscovery.ConvertPoliciesMapToPolicyRefs(gatewayNode.Policies); len(policyRefs) != 0 {
+			directlyAttachedPolicies := &Table{
+				ColumnNames:  []string{"Type", "Name"},
+				UseSeparator: true,
+			}
+			for _, policyRef := range policyRefs {
+				row := []string{
+					fmt.Sprintf("%v.%v", policyRef.Kind, policyRef.Group),     // Type
+					fmt.Sprintf("%v/%v", policyRef.Namespace, policyRef.Name), // Name
+				}
+				directlyAttachedPolicies.Rows = append(directlyAttachedPolicies.Rows, row)
+			}
+			pairs = append(pairs, &DescriberKV{Key: "DirectlyAttachedPolicies", Value: directlyAttachedPolicies})
+		}
+
+		// EffectivePolicies
+		if len(gatewayNode.EffectivePolicies) != 0 {
+			pairs = append(pairs, &DescriberKV{Key: "EffectivePolicies", Value: gatewayNode.EffectivePolicies})
+		}
+
+		Describe(gp.Out, pairs)
 
 		if index+1 <= len(resourceModel.Gateways) {
 			fmt.Fprintf(gp.Out, "\n\n")

--- a/gwctl/pkg/printer/gateways.go
+++ b/gwctl/pkg/printer/gateways.go
@@ -157,6 +157,9 @@ func (gp *GatewaysPrinter) PrintDescribeView(resourceModel *resourcediscovery.Re
 			pairs = append(pairs, &DescriberKV{Key: "EffectivePolicies", Value: gatewayNode.EffectivePolicies})
 		}
 
+		// Events
+		pairs = append(pairs, &DescriberKV{Key: "Events", Value: convertEventsSliceToTable(gatewayNode.Events, gp.Clock)})
+
 		Describe(gp.Out, pairs)
 
 		if index+1 <= len(resourceModel.Gateways) {

--- a/gwctl/pkg/printer/gateways_test.go
+++ b/gwctl/pkg/printer/gateways_test.go
@@ -218,6 +218,7 @@ func TestGatewaysPrinter_PrintDescribeView(t *testing.T) {
 		&gatewayv1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo-gateway",
+				UID:  "00000000-0000-0000-0000-000000000001",
 			},
 			Spec: gatewayv1.GatewaySpec{
 				GatewayClassName: "foo-gatewayclass",
@@ -356,6 +357,7 @@ func TestGatewaysPrinter_PrintDescribeView(t *testing.T) {
 			InvolvedObject: corev1.ObjectReference{
 				Kind: "Gateway",
 				Name: "foo-gateway",
+				UID:  "00000000-0000-0000-0000-000000000001",
 			},
 			Message: "some random message",
 		},
@@ -388,6 +390,7 @@ Kind: ""
 Metadata:
   creationTimestamp: null
   resourceVersion: "999"
+  uid: 00000000-0000-0000-0000-000000000001
 Spec:
   gatewayClassName: foo-gatewayclass
   listeners: null

--- a/gwctl/pkg/printer/gateways_test.go
+++ b/gwctl/pkg/printer/gateways_test.go
@@ -223,6 +223,24 @@ func TestGatewaysPrinter_PrintDescribeView(t *testing.T) {
 			},
 		},
 
+		&gatewayv1.HTTPRoute{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "HTTPRoute",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo-httproute",
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{{
+						Kind:  common.PtrTo(gatewayv1.Kind("Gateway")),
+						Group: common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
+						Name:  "foo-gateway",
+					}},
+				},
+			},
+		},
+
 		&apiextensionsv1.CustomResourceDefinition{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "healthcheckpolicies.foo.com",
@@ -345,11 +363,26 @@ func TestGatewaysPrinter_PrintDescribeView(t *testing.T) {
 	got := params.Out.(*bytes.Buffer).String()
 	want := `
 Name: foo-gateway
-GatewayClass: foo-gatewayclass
+Namespace: ""
+Labels: null
+Annotations: null
+APIVersion: ""
+Kind: ""
+Metadata:
+  creationTimestamp: null
+  resourceVersion: "999"
+Spec:
+  gatewayClassName: foo-gatewayclass
+  listeners: null
+Status: {}
+AttachedRoutes:
+  Kind       Name
+  ----       ----
+  HTTPRoute  /foo-httproute
 DirectlyAttachedPolicies:
-- Group: foo.com
-  Kind: HealthCheckPolicy
-  Name: health-check-gateway
+  Type                       Name
+  ----                       ----
+  HealthCheckPolicy.foo.com  /health-check-gateway
 EffectivePolicies:
   HealthCheckPolicy.foo.com:
     key1: value-parent-1

--- a/gwctl/pkg/resourcediscovery/discoverer.go
+++ b/gwctl/pkg/resourcediscovery/discoverer.go
@@ -346,6 +346,7 @@ func (d Discoverer) discoverEventsForGateways(ctx context.Context, resourceModel
 				fields.OneTermEqualSelector("involvedObject.kind", "Gateway"),
 				fields.OneTermEqualSelector("involvedObject.name", gatewayNode.Gateway.Name),
 				fields.OneTermEqualSelector("involvedObject.namespace", gatewayNode.Gateway.Namespace),
+				fields.OneTermEqualSelector("involvedObject.uid", string(gatewayNode.Gateway.UID)),
 			),
 			Limit: maxEventsPerResource,
 		}

--- a/gwctl/pkg/resourcediscovery/nodes.go
+++ b/gwctl/pkg/resourcediscovery/nodes.go
@@ -151,6 +151,8 @@ type GatewayNode struct {
 	// EffectivePolicies reflects the effective policies applicable to this Gateway,
 	// considering inheritance and hierarchy.
 	EffectivePolicies map[policymanager.PolicyCrdID]policymanager.Policy
+	// Events contains the events associated with this Gateway.
+	Events []corev1.Event
 }
 
 func NewGatewayNode(gateway *gatewayv1.Gateway) *GatewayNode {
@@ -159,6 +161,7 @@ func NewGatewayNode(gateway *gatewayv1.Gateway) *GatewayNode {
 		HTTPRoutes:        make(map[httpRouteID]*HTTPRouteNode),
 		Policies:          make(map[policyID]*PolicyNode),
 		EffectivePolicies: make(map[policymanager.PolicyCrdID]policymanager.Policy),
+		Events:            []corev1.Event{},
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What this PR does / why we need it**:

- Add helpers to print `gwctl describe` views and Tables
- Add more information when describing Gateways (like attached routes)
- Discover events associated with Gateways and output them when describing Gateways.

<details>
  <summary>Example:</summary>

  ```yaml
  ❯ gwctl describe gateways
  Name: demo-gateway-1
  Namespace: default
  Labels: null
  Annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"gateway.networking.k8s.io/v1beta1","kind":"Gateway","metadata":{"annotations":{},"name":"demo-gateway-1","namespace":"default"},"spec":{"gatewayClassName":"foo-com-external-gateway-class","listeners":[{"name":"http","port":80,"protocol":"HTTP"}]}}
  APIVersion: gateway.networking.k8s.io/v1
  Kind: Gateway
  Metadata:
    creationTimestamp: "2024-04-03T04:27:12Z"
    generation: 1
    managedFields:
    - apiVersion: gateway.networking.k8s.io/v1beta1
      fieldsType: FieldsV1
      fieldsV1:
        f:metadata:
          f:annotations:
            .: {}
            f:kubectl.kubernetes.io/last-applied-configuration: {}
        f:spec:
          .: {}
          f:gatewayClassName: {}
          f:listeners:
            .: {}
            k:{"name":"http"}:
              .: {}
              f:allowedRoutes:
                .: {}
                f:namespaces:
                  .: {}
                  f:from: {}
              f:name: {}
              f:port: {}
              f:protocol: {}
      manager: kubectl-client-side-apply
      operation: Update
      time: "2024-04-03T04:27:12Z"
    resourceVersion: "2531077"
    uid: 034c4490-6b0d-41f0-8d90-3948dbae4b6c
  Spec:
    gatewayClassName: foo-com-external-gateway-class
    listeners:
    - allowedRoutes:
        namespaces:
          from: Same
      name: http
      port: 80
      protocol: HTTP
  Status:
    conditions:
    - lastTransitionTime: "1970-01-01T00:00:00Z"
      message: Waiting for controller
      reason: Pending
      status: Unknown
      type: Accepted
    - lastTransitionTime: "1970-01-01T00:00:00Z"
      message: Waiting for controller
      reason: Pending
      status: Unknown
      type: Programmed
  AttachedRoutes:
    Kind       Name
    ----       ----
    HTTPRoute  default/demo-httproute-1
    HTTPRoute  default/demo-httproute-2
    HTTPRoute  default/demo-httproute-3
    HTTPRoute  ns2/demo-httproute-4
  DirectlyAttachedPolicies:
    Type                       Name
    ----                       ----
    HealthCheckPolicy.foo.com  default/demo-health-check-1
    RetryOnPolicy.foo.com      default/demo-retry-policy-1
  EffectivePolicies:
    HealthCheckPolicy.foo.com:
      sampleParentField:
        sampleField: hello
    RetryOnPolicy.foo.com:
      sampleParentField:
        sampleField: namaste
    TimeoutPolicy.bar.com:
      timeout1: parent
      timeout2: child
      timeout3: parent
      timeout4: child
  Events:
    Type     Reason  Age  From                   Message
    ----     ------  ---  ----                   -------
    Warning  SYNC    12h  my-gateway-controller  Some message here
  ```
</details>

**Notes for reviewer**:
Reviewing individual commits in order might be easier

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
