### PR TITLE
Updating one last caCertRefs reference to caCertificateRefs

### DIFF
--- a/apis/v1alpha3/backendtlspolicy_types.go
+++ b/apis/v1alpha3/backendtlspolicy_types.go
@@ -133,8 +133,8 @@ type BackendTLSPolicyValidation struct {
 	Hostname v1.PreciseHostname `json:"hostname"`
 }
 
-// WellKnownCACertificatesType is the type of CA certificate that will be used when
-// the TLS.caCertRefs is unspecified.
+// WellKnownCACertificatesType is the type of CA certificate that will be used
+// when the caCertificateRefs field is unspecified.
 // +kubebuilder:validation:Enum=System
 type WellKnownCACertificatesType string
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixes an old reference caught by @aojea in https://github.com/kubernetes-sigs/gateway-api/pull/2997#discussion_r1577799591.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @candita @aojea 
