### PR TITLE
Make gwctl ReferenceGrant aware. Capture any errors observed while constructing the resource graph.

### DIFF
--- a/gwctl/cmd/describe.go
+++ b/gwctl/cmd/describe.go
@@ -122,7 +122,7 @@ func runDescribe(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 	case "httproute", "httproutes":
 		selector, err := labels.Parse(labelSelector)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+			fmt.Fprintf(os.Stderr, "Failed to parse label selector %q: %v\n", labelSelector, err)
 			os.Exit(1)
 		}
 		filter := resourcediscovery.Filter{
@@ -142,7 +142,7 @@ func runDescribe(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 	case "gateway", "gateways":
 		selector, err := labels.Parse(labelSelector)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+			fmt.Fprintf(os.Stderr, "Failed to parse label selector %q: %v\n", labelSelector, err)
 			os.Exit(1)
 		}
 		filter := resourcediscovery.Filter{
@@ -162,7 +162,7 @@ func runDescribe(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 	case "gatewayclass", "gatewayclasses":
 		selector, err := labels.Parse(labelSelector)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+			fmt.Fprintf(os.Stderr, "Failed to parse label selector %q: %v\n", labelSelector, err)
 			os.Exit(1)
 		}
 		filter := resourcediscovery.Filter{
@@ -181,7 +181,7 @@ func runDescribe(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 	case "backend", "backends":
 		selector, err := labels.Parse(labelSelector)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+			fmt.Fprintf(os.Stderr, "Failed to parse label selector %q: %v\n", labelSelector, err)
 			os.Exit(1)
 		}
 		filter := resourcediscovery.Filter{
@@ -201,7 +201,7 @@ func runDescribe(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 	case "namespace", "namespaces", "ns":
 		selector, err := labels.Parse(labelSelector)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+			fmt.Fprintf(os.Stderr, "Failed to parse label selector %q: %v\n", labelSelector, err)
 			os.Exit(1)
 		}
 		filter := resourcediscovery.Filter{

--- a/gwctl/cmd/get.go
+++ b/gwctl/cmd/get.go
@@ -104,7 +104,7 @@ func runGet(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 	case "namespace", "namespaces", "ns":
 		selector, err := labels.Parse(labelSelector)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+			fmt.Fprintf(os.Stderr, "Failed to parse label selector %q: %v\n", labelSelector, err)
 			os.Exit(1)
 		}
 		resourceModel, err = discoverer.DiscoverResourcesForNamespace(resourcediscovery.Filter{Labels: selector})
@@ -117,7 +117,7 @@ func runGet(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 	case "gateway", "gateways":
 		selector, err := labels.Parse(labelSelector)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+			fmt.Fprintf(os.Stderr, "Failed to parse label selector %q: %v\n", labelSelector, err)
 			os.Exit(1)
 		}
 		filter := resourcediscovery.Filter{Namespace: ns, Labels: selector}
@@ -134,7 +134,7 @@ func runGet(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 	case "gatewayclass", "gatewayclasses":
 		selector, err := labels.Parse(labelSelector)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+			fmt.Fprintf(os.Stderr, "Failed to parse label selector %q: %v\n", labelSelector, err)
 			os.Exit(1)
 		}
 		filter := resourcediscovery.Filter{Namespace: ns, Labels: selector}
@@ -161,7 +161,7 @@ func runGet(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 	case "httproute", "httproutes":
 		selector, err := labels.Parse(labelSelector)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+			fmt.Fprintf(os.Stderr, "Failed to parse label selector %q: %v\n", labelSelector, err)
 			os.Exit(1)
 		}
 		filter := resourcediscovery.Filter{Namespace: ns, Labels: selector}
@@ -178,7 +178,7 @@ func runGet(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 	case "backend", "backends":
 		selector, err := labels.Parse(labelSelector)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to find resources that match the label selector \"%s\": %v\n", labelSelector, err)
+			fmt.Fprintf(os.Stderr, "Failed to parse label selector %q: %v\n", labelSelector, err)
 			os.Exit(1)
 		}
 		filter := resourcediscovery.Filter{Namespace: ns, Labels: selector}

--- a/gwctl/pkg/common/testhelpers.go
+++ b/gwctl/pkg/common/testhelpers.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // YamlString defines a custom type for wrapping yaml texts. It makes use of
@@ -70,4 +72,15 @@ func (src JSONString) CmpDiff(tgt JSONString) (diff string, err error) {
 	}
 
 	return cmp.Diff(srcMap, targetMap), nil
+}
+
+func NamespaceForTest(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: corev1.NamespaceStatus{
+			Phase: corev1.NamespaceActive,
+		},
+	}
 }

--- a/gwctl/pkg/common/types.go
+++ b/gwctl/pkg/common/types.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+// ObjRef defines a reference to a Kubernetes resource, using plain strings for
+// easier comparison.
+type ObjRef struct {
+	Group     string `json:",omitempty"`
+	Kind      string `json:",omitempty"`
+	Name      string `json:",omitempty"`
+	Namespace string `json:",omitempty"`
+}

--- a/gwctl/pkg/printer/backends_test.go
+++ b/gwctl/pkg/printer/backends_test.go
@@ -21,20 +21,17 @@ import (
 	"testing"
 	"time"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/utils/ptr"
-
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	testingclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/utils"
@@ -43,16 +40,109 @@ import (
 func TestBackendsPrinter_Print(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
 
-	healthCheckPolicies := []runtime.Object{
+	httpRoute := func(namespace, name, serviceName, gatewayName string) *gatewayv1.HTTPRoute {
+		return &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-24 * time.Hour),
+				},
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{
+							Kind:      common.PtrTo(gatewayv1.Kind("Gateway")),
+							Group:     common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
+							Namespace: common.PtrTo(gatewayv1.Namespace(namespace)),
+							Name:      gatewayv1.ObjectName(gatewayName),
+						},
+					},
+				},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Port:      ptr.To(gatewayv1.PortNumber(8080)),
+										Name:      gatewayv1.ObjectName(serviceName),
+										Kind:      ptr.To(gatewayv1.Kind("Service")),
+										Namespace: ptr.To(gatewayv1.Namespace(namespace)),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	objects := []runtime.Object{
+		common.NamespaceForTest("ns1"),
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo-gatewayclass-1",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "example.net/gateway-controller",
+				Description:    common.PtrTo("random"),
+			},
+		},
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo-gateway-1",
+				Namespace: "ns1",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "foo-gatewayclass-1",
+			},
+		},
+		&corev1.Service{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Service",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo-svc-1",
+				Namespace: "ns1",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-72 * time.Hour),
+				},
+			},
+		},
+		&corev1.Service{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Service",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo-svc-2",
+				Namespace: "ns1",
+				CreationTimestamp: metav1.Time{
+					Time: fakeClock.Now().Add(-48 * time.Hour),
+				},
+			},
+		},
+		httpRoute("ns1", "foo-httproute-1", "foo-svc-1", "foo-gateway-1"),
+		httpRoute("ns1", "foo-httproute-2", "foo-svc-2", "foo-gateway-1"),
+		httpRoute("ns1", "foo-httproute-3", "foo-svc-2", "foo-gateway-1"),
+		httpRoute("ns1", "foo-httproute-4", "foo-svc-2", "foo-gateway-1"),
+		httpRoute("ns1", "foo-httproute-5", "foo-svc-2", "foo-gateway-1"),
+	}
+
+	backendPolicies := []runtime.Object{
 		&apiextensionsv1.CustomResourceDefinition{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "healthcheckpolicies.foo.com",
 				Labels: map[string]string{
-					gatewayv1alpha2.PolicyLabelKey: "inherited",
+					gatewayv1alpha2.PolicyLabelKey: "Direct",
 				},
 			},
 			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-				Scope:    apiextensionsv1.ClusterScoped,
+				Scope:    apiextensionsv1.NamespaceScoped,
 				Group:    "foo.com",
 				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{Name: "v1"}},
 				Names: apiextensionsv1.CustomResourceDefinitionNames{
@@ -67,42 +157,12 @@ func TestBackendsPrinter_Print(t *testing.T) {
 				"kind":       "HealthCheckPolicy",
 				"metadata": map[string]interface{}{
 					"name":              "health-check-gatewayclass",
+					"namespace":         "default",
 					"creationTimestamp": fakeClock.Now().Add(-6 * 24 * time.Hour).Format(time.RFC3339),
 				},
 				"spec": map[string]interface{}{
-					"override": map[string]interface{}{
-						"key1": "value-parent-1",
-						"key3": "value-parent-3",
-						"key5": "value-parent-5",
-					},
 					"default": map[string]interface{}{
 						"key2": "value-parent-2",
-						"key4": "value-parent-4",
-					},
-					"targetRef": map[string]interface{}{
-						"group":     "",
-						"kind":      "Service",
-						"name":      "foo-svc-0",
-						"namespace": "default",
-					},
-				},
-			},
-		},
-		&unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "foo.com/v1",
-				"kind":       "HealthCheckPolicy",
-				"metadata": map[string]interface{}{
-					"name":              "health-check-gateway",
-					"creationTimestamp": fakeClock.Now().Add(-20 * 24 * time.Hour).Format(time.RFC3339),
-				},
-				"spec": map[string]interface{}{
-					"override": map[string]interface{}{
-						"key1": "value-child-1",
-					},
-					"default": map[string]interface{}{
-						"key2": "value-child-2",
-						"key5": "value-child-5",
 					},
 					"targetRef": map[string]interface{}{
 						"group":     "",
@@ -115,364 +175,9 @@ func TestBackendsPrinter_Print(t *testing.T) {
 		},
 	}
 
-	timeoutPolicies := []runtime.Object{
-		&apiextensionsv1.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "timeoutpolicies.bar.com",
-				Labels: map[string]string{
-					gatewayv1alpha2.PolicyLabelKey: "direct",
-				},
-			},
-			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-				Scope:    apiextensionsv1.ClusterScoped,
-				Group:    "bar.com",
-				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{Name: "v1"}},
-				Names: apiextensionsv1.CustomResourceDefinitionNames{
-					Plural: "timeoutpolicies",
-					Kind:   "TimeoutPolicy",
-				},
-			},
-		},
-		&unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "bar.com/v1",
-				"kind":       "TimeoutPolicy",
-				"metadata": map[string]interface{}{
-					"name":              "timeout-policy-namespace",
-					"creationTimestamp": fakeClock.Now().Add(-5 * time.Minute).Format(time.RFC3339),
-				},
-				"spec": map[string]interface{}{
-					"condition": "path=/abc",
-					"seconds":   int64(30),
-					"targetRef": map[string]interface{}{
-						"kind": "Namespace",
-						"name": "default",
-					},
-				},
-			},
-		},
-		&unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "bar.com/v1",
-				"kind":       "TimeoutPolicy",
-				"metadata": map[string]interface{}{
-					"name":              "timeout-policy-httproute",
-					"creationTimestamp": fakeClock.Now().Add(-13 * time.Minute).Format(time.RFC3339),
-				},
-				"spec": map[string]interface{}{
-					"condition": "path=/def",
-					"seconds":   int64(60),
-					"targetRef": map[string]interface{}{
-						"group":     "gateway.networking.k8s.io",
-						"kind":      "HTTPRoute",
-						"name":      "bar-route-21",
-						"namespace": "ns1",
-					},
-				},
-			},
-		},
-	}
-
-	objects := []runtime.Object{
-		&gatewayv1.GatewayClass{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "demo-gatewayclass-1",
-			},
-			Spec: gatewayv1.GatewayClassSpec{
-				ControllerName: "example.net/gateway-controller",
-				Description:    common.PtrTo("random"),
-			},
-		},
-		&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "ns1",
-			},
-			Status: corev1.NamespaceStatus{
-				Phase: corev1.NamespaceActive,
-			},
-		},
-		&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "ns2",
-			},
-			Status: corev1.NamespaceStatus{
-				Phase: corev1.NamespaceActive,
-			},
-		},
-		&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "ns3",
-			},
-			Status: corev1.NamespaceStatus{
-				Phase: corev1.NamespaceActive,
-			},
-		},
-		&corev1.Service{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Service",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo-svc-0",
-				Namespace: "default",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-72 * time.Hour),
-				},
-			},
-		},
-		&corev1.Service{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Service",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo-svc-1",
-				Namespace: "ns1",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-48 * time.Hour),
-				},
-			},
-		},
-		&corev1.Service{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Service",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo-svc-2",
-				Namespace: "ns2",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-36 * time.Hour),
-				},
-			},
-		},
-		&corev1.Service{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Service",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo-svc-3",
-				Namespace: "ns3",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-24 * time.Hour),
-				},
-			},
-		},
-		&corev1.Service{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Service",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo-svc-4",
-				Namespace: "ns3",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-128 * time.Hour),
-				},
-			},
-		},
-		&gatewayv1.Gateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "demo-gateway-1",
-				Namespace: "default",
-			},
-			Spec: gatewayv1.GatewaySpec{
-				GatewayClassName: "demo-gatewayclass-1",
-			},
-		},
-		&gatewayv1.Gateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "demo-gateway-2",
-				Namespace: "ns2",
-			},
-			Spec: gatewayv1.GatewaySpec{
-				GatewayClassName: "demo-gatewayclass-1",
-			},
-		},
-		&gatewayv1.Gateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "demo-gateway-345",
-				Namespace: "ns1",
-			},
-			Spec: gatewayv1.GatewaySpec{
-				GatewayClassName: "demo-gatewayclass-1",
-			},
-		},
-		&gatewayv1.HTTPRoute{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo-httproute-1",
-				Namespace: "default",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-24 * time.Hour),
-				},
-			},
-			Spec: gatewayv1.HTTPRouteSpec{
-				Hostnames: []gatewayv1.Hostname{"example.com", "example2.com", "example3.com"},
-				CommonRouteSpec: gatewayv1.CommonRouteSpec{
-					ParentRefs: []gatewayv1.ParentReference{
-						{
-							Kind:      common.PtrTo(gatewayv1.Kind("Gateway")),
-							Group:     common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
-							Namespace: common.PtrTo(gatewayv1.Namespace("ns2")),
-							Name:      "demo-gateway-2",
-						},
-					},
-				},
-				Rules: []gatewayv1.HTTPRouteRule{
-					{
-						BackendRefs: []gatewayv1.HTTPBackendRef{
-							{
-								BackendRef: gatewayv1.BackendRef{
-									BackendObjectReference: gatewayv1.BackendObjectReference{
-										Port:      ptr.To(gatewayv1.PortNumber(8080)),
-										Name:      "foo-svc-0",
-										Kind:      ptr.To(gatewayv1.Kind("Service")),
-										Namespace: ptr.To(gatewayv1.Namespace("default")),
-									},
-								},
-							},
-							{
-								BackendRef: gatewayv1.BackendRef{
-									BackendObjectReference: gatewayv1.BackendObjectReference{
-										Port:      ptr.To(gatewayv1.PortNumber(8081)),
-										Name:      "foo-svc-1",
-										Kind:      ptr.To(gatewayv1.Kind("Service")),
-										Namespace: ptr.To(gatewayv1.Namespace("ns1")),
-									},
-								},
-							},
-							{
-								BackendRef: gatewayv1.BackendRef{
-									BackendObjectReference: gatewayv1.BackendObjectReference{
-										Port:      ptr.To(gatewayv1.PortNumber(8082)),
-										Name:      "foo-svc-2",
-										Kind:      ptr.To(gatewayv1.Kind("Service")),
-										Namespace: ptr.To(gatewayv1.Namespace("ns2")),
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		&gatewayv1.HTTPRoute{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "qmn-httproute-100",
-				Namespace: "default",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-11 * time.Hour),
-				},
-			},
-			Spec: gatewayv1.HTTPRouteSpec{
-				Hostnames: []gatewayv1.Hostname{"example.com"},
-				CommonRouteSpec: gatewayv1.CommonRouteSpec{
-					ParentRefs: []gatewayv1.ParentReference{
-						{
-							Kind:  common.PtrTo(gatewayv1.Kind("Gateway")),
-							Group: common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
-							Name:  "demo-gateway-1",
-						},
-						{
-							Kind:  common.PtrTo(gatewayv1.Kind("Gateway")),
-							Group: common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
-							Name:  "demo-gateway-345",
-						},
-					},
-				},
-				Rules: []gatewayv1.HTTPRouteRule{
-					{
-						BackendRefs: []gatewayv1.HTTPBackendRef{
-							{
-								BackendRef: gatewayv1.BackendRef{
-									BackendObjectReference: gatewayv1.BackendObjectReference{
-										Port:      ptr.To(gatewayv1.PortNumber(8081)),
-										Name:      "foo-svc-1",
-										Kind:      ptr.To(gatewayv1.Kind("Service")),
-										Namespace: ptr.To(gatewayv1.Namespace("ns1")),
-									},
-								},
-							},
-							{
-								BackendRef: gatewayv1.BackendRef{
-									BackendObjectReference: gatewayv1.BackendObjectReference{
-										Port:      ptr.To(gatewayv1.PortNumber(8082)),
-										Name:      "foo-svc-2",
-										Kind:      ptr.To(gatewayv1.Kind("Service")),
-										Namespace: ptr.To(gatewayv1.Namespace("ns2")),
-									},
-								},
-							},
-							{
-								BackendRef: gatewayv1.BackendRef{
-									BackendObjectReference: gatewayv1.BackendObjectReference{
-										Port:      ptr.To(gatewayv1.PortNumber(8083)),
-										Name:      "foo-svc-3",
-										Kind:      ptr.To(gatewayv1.Kind("Service")),
-										Namespace: ptr.To(gatewayv1.Namespace("ns3")),
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		&gatewayv1.HTTPRoute{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "bar-route-21",
-				Namespace: "ns1",
-				CreationTimestamp: metav1.Time{
-					Time: fakeClock.Now().Add(-9 * time.Hour),
-				},
-			},
-			Spec: gatewayv1.HTTPRouteSpec{
-				Hostnames: []gatewayv1.Hostname{"foo.com", "bar.com", "example.com", "example2.com", "example3.com", "example4.com", "example5.com"},
-				CommonRouteSpec: gatewayv1.CommonRouteSpec{
-					ParentRefs: []gatewayv1.ParentReference{
-						{
-							Kind:      common.PtrTo(gatewayv1.Kind("Gateway")),
-							Group:     common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
-							Namespace: common.PtrTo(gatewayv1.Namespace("default")),
-							Name:      "demo-gateway-2",
-						},
-					},
-				},
-				Rules: []gatewayv1.HTTPRouteRule{
-					{
-						BackendRefs: []gatewayv1.HTTPBackendRef{
-							{
-								BackendRef: gatewayv1.BackendRef{
-									BackendObjectReference: gatewayv1.BackendObjectReference{
-										Port:      ptr.To(gatewayv1.PortNumber(8082)),
-										Name:      "foo-svc-2",
-										Kind:      ptr.To(gatewayv1.Kind("Service")),
-										Namespace: ptr.To(gatewayv1.Namespace("ns2")),
-									},
-								},
-							},
-							{
-								BackendRef: gatewayv1.BackendRef{
-									BackendObjectReference: gatewayv1.BackendObjectReference{
-										Port:      ptr.To(gatewayv1.PortNumber(8083)),
-										Name:      "foo-svc-3",
-										Kind:      ptr.To(gatewayv1.Kind("Service")),
-										Namespace: ptr.To(gatewayv1.Namespace("ns3")),
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	finalObjects := []runtime.Object{}
-	finalObjects = append(finalObjects, healthCheckPolicies...)
-	finalObjects = append(finalObjects, timeoutPolicies...)
+	var finalObjects []runtime.Object
 	finalObjects = append(finalObjects, objects...)
+	finalObjects = append(finalObjects, backendPolicies...)
 
 	params := utils.MustParamsForTest(t, common.MustClientsForTest(t, finalObjects...))
 	discoverer := resourcediscovery.Discoverer{
@@ -493,12 +198,9 @@ func TestBackendsPrinter_Print(t *testing.T) {
 
 	got := params.Out.(*bytes.Buffer).String()
 	want := `
-NAMESPACE  NAME       TYPE     REFERRED BY ROUTES                                          AGE   POLICIES
-default    foo-svc-0  Service  default/foo-httproute-1                                     3d    1
-ns1        foo-svc-1  Service  default/foo-httproute-1,default/qmn-httproute-100           2d    1
-ns2        foo-svc-2  Service  default/foo-httproute-1,default/qmn-httproute-100 + 1 more  36h   0
-ns3        foo-svc-3  Service  default/qmn-httproute-100,ns1/bar-route-21                  24h   0
-ns3        foo-svc-4  Service  None                                                        5d8h  0
+NAMESPACE  NAME       TYPE     REFERRED BY ROUTES                                AGE  POLICIES
+ns1        foo-svc-1  Service  ns1/foo-httproute-1                               3d   1
+ns1        foo-svc-2  Service  ns1/foo-httproute-2,ns1/foo-httproute-3 + 2 more  2d   0
 `
 	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
 		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)

--- a/gwctl/pkg/relations/relations.go
+++ b/gwctl/pkg/relations/relations.go
@@ -21,19 +21,11 @@ package relations
 import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 )
-
-// ObjRef defines a reference to a Kubernetes resource, using plain strings for
-// easier comparison.
-type ObjRef struct {
-	Group     string `json:",omitempty"`
-	Kind      string `json:",omitempty"`
-	Name      string `json:",omitempty"`
-	Namespace string `json:",omitempty"`
-}
 
 // FindGatewayRefsForHTTPRoute returns Gateways which the HTTPRoute is attached
 // to.
@@ -62,7 +54,7 @@ func FindGatewayClassNameForGateway(gateway gatewayv1.Gateway) string {
 }
 
 // FindBackendRefsForHTTPRoute returns Backends which the HTTPRoute references.
-func FindBackendRefsForHTTPRoute(httpRoute gatewayv1.HTTPRoute) []ObjRef {
+func FindBackendRefsForHTTPRoute(httpRoute gatewayv1.HTTPRoute) []common.ObjRef {
 	// Aggregate all BackendRefs
 	var backendRefs []gatewayv1.BackendObjectReference
 	for _, rule := range httpRoute.Spec.Rules {
@@ -82,9 +74,9 @@ func FindBackendRefsForHTTPRoute(httpRoute gatewayv1.HTTPRoute) []ObjRef {
 
 	// Convert each BackendRef to ObjRef. ObjRef does not use pointers and thus is
 	// easily comparable.
-	resultSet := make(map[ObjRef]bool)
+	resultSet := make(map[common.ObjRef]bool)
 	for _, backendRef := range backendRefs {
-		objRef := ObjRef{
+		objRef := common.ObjRef{
 			Name: string(backendRef.Name),
 			// Assume namespace is unspecified in the backendRef and check later to
 			// override the default value.
@@ -103,7 +95,7 @@ func FindBackendRefsForHTTPRoute(httpRoute gatewayv1.HTTPRoute) []ObjRef {
 	}
 
 	// Return unique objRefs
-	var result []ObjRef
+	var result []common.ObjRef
 	for objRef := range resultSet {
 		result = append(result, objRef)
 	}
@@ -113,7 +105,7 @@ func FindBackendRefsForHTTPRoute(httpRoute gatewayv1.HTTPRoute) []ObjRef {
 // ReferenceGrantExposes returns true if the provided reference grant "exposes"
 // the given resource. "Exposes" means that the resource is part of the "To"
 // fields within the ReferenceGrant.
-func ReferenceGrantExposes(referenceGrant gatewayv1beta1.ReferenceGrant, resource ObjRef) bool {
+func ReferenceGrantExposes(referenceGrant gatewayv1beta1.ReferenceGrant, resource common.ObjRef) bool {
 	if referenceGrant.GetNamespace() != resource.Namespace {
 		return false
 	}
@@ -134,10 +126,10 @@ func ReferenceGrantExposes(referenceGrant gatewayv1beta1.ReferenceGrant, resourc
 // ReferenceGrantAccepts returns true if the provided reference grant "accepts"
 // references from the given resource. "Accepts" means that the resource is part
 // of the "From" fields within the ReferenceGrant.
-func ReferenceGrantAccepts(referenceGrant gatewayv1beta1.ReferenceGrant, resource ObjRef) bool {
+func ReferenceGrantAccepts(referenceGrant gatewayv1beta1.ReferenceGrant, resource common.ObjRef) bool {
 	resource.Name = ""
 	for _, from := range referenceGrant.Spec.From {
-		fromRef := ObjRef{
+		fromRef := common.ObjRef{
 			Group:     string(from.Group),
 			Kind:      string(from.Kind),
 			Namespace: string(from.Namespace),

--- a/gwctl/pkg/relations/relations.go
+++ b/gwctl/pkg/relations/relations.go
@@ -20,6 +20,7 @@ package relations
 
 import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -107,4 +108,43 @@ func FindBackendRefsForHTTPRoute(httpRoute gatewayv1.HTTPRoute) []ObjRef {
 		result = append(result, objRef)
 	}
 	return result
+}
+
+// ReferenceGrantExposes returns true if the provided reference grant "exposes"
+// the given resource. "Exposes" means that the resource is part of the "To"
+// fields within the ReferenceGrant.
+func ReferenceGrantExposes(referenceGrant gatewayv1beta1.ReferenceGrant, resource ObjRef) bool {
+	if referenceGrant.GetNamespace() != resource.Namespace {
+		return false
+	}
+	for _, to := range referenceGrant.Spec.To {
+		if to.Group != gatewayv1.Group(resource.Group) {
+			continue
+		}
+		if to.Kind != gatewayv1.Kind(resource.Kind) {
+			continue
+		}
+		if to.Name == nil || len(*to.Name) == 0 || *to.Name == gatewayv1.ObjectName(resource.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+// ReferenceGrantAccepts returns true if the provided reference grant "accepts"
+// references from the given resource. "Accepts" means that the resource is part
+// of the "From" fields within the ReferenceGrant.
+func ReferenceGrantAccepts(referenceGrant gatewayv1beta1.ReferenceGrant, resource ObjRef) bool {
+	resource.Name = ""
+	for _, from := range referenceGrant.Spec.From {
+		fromRef := ObjRef{
+			Group:     string(from.Group),
+			Kind:      string(from.Kind),
+			Namespace: string(from.Namespace),
+		}
+		if fromRef == resource {
+			return true
+		}
+	}
+	return false
 }

--- a/gwctl/pkg/resourcediscovery/discoverer.go
+++ b/gwctl/pkg/resourcediscovery/discoverer.go
@@ -76,9 +76,10 @@ type Discoverer struct {
 	// attempt will be made to discover this information from the discovery APIs.
 	// Failure to do so will mean we use the "default" versions defined in this
 	// file.
-	PreferredGatewayClassGroupVersion metav1.GroupVersion
-	PreferredGatewayGroupVersion      metav1.GroupVersion
-	PreferredHTTPRouteGroupVersion    metav1.GroupVersion
+	PreferredGatewayClassGroupVersion   metav1.GroupVersion
+	PreferredGatewayGroupVersion        metav1.GroupVersion
+	PreferredHTTPRouteGroupVersion      metav1.GroupVersion
+	PreferredReferenceGrantGroupVersion metav1.GroupVersion
 }
 
 func NewDiscoverer(k8sClients *common.K8sClients, policyManager *policymanager.PolicyManager) Discoverer {
@@ -647,11 +648,9 @@ func (d Discoverer) fetchReferenceGrants(ctx context.Context, filter Filter) ([]
 		Version:  defaultReferenceGrantGroupVersion.Version,
 		Resource: "referencegrants",
 	}
-	// TODO(gauravkghildiyal): Uncomment once
-	// https://github.com/kubernetes-sigs/gateway-api/pull/3001 merges
-	// if d.PreferredReferenceGrantGroupVersion != (metav1.GroupVersion{}) {
-	// 	gvr.Version = d.PreferredReferenceGrantGroupVersion.Version
-	// }
+	if d.PreferredReferenceGrantGroupVersion != (metav1.GroupVersion{}) {
+		gvr.Version = d.PreferredReferenceGrantGroupVersion.Version
+	}
 
 	if filter.Name != "" {
 		// Use Get call.

--- a/gwctl/pkg/resourcediscovery/discoverer.go
+++ b/gwctl/pkg/resourcediscovery/discoverer.go
@@ -364,7 +364,7 @@ func (d Discoverer) discoverHTTPRoutesFromBackends(ctx context.Context, resource
 			// Ensure that if this is a cross namespace reference, then it is accepted
 			// through some ReferenceGrant.
 			if httpRoute.GetNamespace() != backendRef.Namespace {
-				httpRouteRef := relations.ObjRef{
+				httpRouteRef := common.ObjRef{
 					Group:     httpRoute.GroupVersionKind().Group,
 					Kind:      httpRoute.GroupVersionKind().Kind,
 					Name:      httpRoute.GetName(),
@@ -448,7 +448,7 @@ func (d Discoverer) discoverReferenceGrantsFromBackends(ctx context.Context, res
 		}
 
 		for _, referenceGrant := range referenceGrants {
-			backendRef := relations.ObjRef{
+			backendRef := common.ObjRef{
 				Group:     backendNode.Backend.GroupVersionKind().Group,
 				Kind:      backendNode.Backend.GroupVersionKind().Kind,
 				Name:      backendNode.Backend.GetName(),

--- a/gwctl/pkg/resourcediscovery/discoverer_test.go
+++ b/gwctl/pkg/resourcediscovery/discoverer_test.go
@@ -146,6 +146,10 @@ func TestDiscoverResourcesForBackend(t *testing.T) {
 			objects: []runtime.Object{
 				common.NamespaceForTest("default"),
 				&corev1.Service{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Service",
+						APIVersion: "v1",
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo-svc",
 						Namespace: "default",
@@ -190,6 +194,10 @@ func TestDiscoverResourcesForBackend(t *testing.T) {
 				common.NamespaceForTest("default"),
 				common.NamespaceForTest("bar"),
 				&corev1.Service{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Service",
+						APIVersion: "v1",
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo-svc",
 						Namespace: "default",
@@ -237,6 +245,10 @@ func TestDiscoverResourcesForBackend(t *testing.T) {
 				common.NamespaceForTest("default"),
 				common.NamespaceForTest("bar"),
 				&corev1.Service{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Service",
+						APIVersion: "v1",
+					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo-svc",
 						Namespace: "default",

--- a/gwctl/pkg/resourcediscovery/errors.go
+++ b/gwctl/pkg/resourcediscovery/errors.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcediscovery
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
+)
+
+type ReferenceToNonExistentResourceError struct {
+	ReferenceFromTo
+}
+
+func (r ReferenceToNonExistentResourceError) Error() string {
+	return fmt.Sprintf("%v %q references a non-existent %v %q",
+		r.referringObjectKind(), r.referringObjectName(),
+		r.referredObjectKind(), r.referredObjectName())
+}
+
+type ReferenceNotPermittedError struct {
+	ReferenceFromTo
+}
+
+func (r ReferenceNotPermittedError) Error() string {
+	return fmt.Sprintf("%v %q is not permitted to reference %v %q",
+		r.referringObjectKind(), r.referringObjectName(),
+		r.referredObjectKind(), r.referredObjectName())
+}
+
+type ReferenceFromTo struct {
+	// ReferringObject is the "from" object which is referring "to" some other
+	// object.
+	ReferringObject common.ObjRef
+	// ReferredObject is the actual object which is being referenced by another
+	// object.
+	ReferredObject common.ObjRef
+}
+
+// referringObjectKind returns a human readable Kind.
+func (r ReferenceFromTo) referringObjectKind() string {
+	if r.ReferringObject.Group != "" {
+		return fmt.Sprintf("%v(.%v)", r.ReferringObject.Kind, r.ReferringObject.Group)
+	}
+	return r.ReferringObject.Kind
+}
+
+// referredObjectKind returns a human readable Kind.
+func (r ReferenceFromTo) referredObjectKind() string {
+	if r.ReferredObject.Group != "" {
+		return fmt.Sprintf("%v(.%v)", r.ReferredObject.Kind, r.ReferredObject.Group)
+	}
+	return r.ReferredObject.Kind
+}
+
+// referringObjectName returns a human readable Name.
+func (r ReferenceFromTo) referringObjectName() string {
+	if r.ReferringObject.Namespace != "" {
+		return fmt.Sprintf("%v/%v", r.ReferringObject.Namespace, r.ReferringObject.Name)
+	}
+	return r.ReferringObject.Name
+}
+
+// referredObjectName returns a human readable Name.
+func (r ReferenceFromTo) referredObjectName() string {
+	if r.ReferredObject.Namespace != "" {
+		return fmt.Sprintf("%v/%v", r.ReferredObject.Namespace, r.ReferredObject.Name)
+	}
+	return r.ReferredObject.Name
+}

--- a/gwctl/pkg/resourcediscovery/main_test.go
+++ b/gwctl/pkg/resourcediscovery/main_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcediscovery
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+func TestMain(m *testing.M) {
+	fs := flag.NewFlagSet("mock-flags", flag.PanicOnError)
+	klog.InitFlags(fs)
+	fs.Set("v", "3") // Set klog verbosity.
+
+	os.Exit(m.Run())
+}

--- a/gwctl/pkg/resourcediscovery/nodes.go
+++ b/gwctl/pkg/resourcediscovery/nodes.go
@@ -171,6 +171,8 @@ type GatewayNode struct {
 	EffectivePolicies map[policymanager.PolicyCrdID]policymanager.Policy
 	// Events contains the events associated with this Gateway.
 	Events []corev1.Event
+	// Errors contains any errorrs associated with this resource.
+	Errors []error
 }
 
 func NewGatewayNode(gateway *gatewayv1.Gateway) *GatewayNode {
@@ -180,6 +182,7 @@ func NewGatewayNode(gateway *gatewayv1.Gateway) *GatewayNode {
 		Policies:          make(map[policyID]*PolicyNode),
 		EffectivePolicies: make(map[policymanager.PolicyCrdID]policymanager.Policy),
 		Events:            []corev1.Event{},
+		Errors:            []error{},
 	}
 }
 
@@ -211,6 +214,8 @@ type HTTPRouteNode struct {
 	// EffectivePolicies reflects the effective policies applicable to this
 	// HTTPRoute, mapped per Gateway for context-specific enforcement.
 	EffectivePolicies map[gatewayID]map[policymanager.PolicyCrdID]policymanager.Policy
+	// Errors contains any errorrs associated with this resource.
+	Errors []error
 }
 
 func NewHTTPRouteNode(httpRoute *gatewayv1.HTTPRoute) *HTTPRouteNode {
@@ -220,6 +225,7 @@ func NewHTTPRouteNode(httpRoute *gatewayv1.HTTPRoute) *HTTPRouteNode {
 		Backends:          make(map[backendID]*BackendNode),
 		Policies:          make(map[policyID]*PolicyNode),
 		EffectivePolicies: make(map[gatewayID]map[policymanager.PolicyCrdID]policymanager.Policy),
+		Errors:            []error{},
 	}
 }
 
@@ -252,6 +258,8 @@ type BackendNode struct {
 	// EffectivePolicies reflects the effective policies applicable to this
 	// Backend, mapped per Gateway for context-specific enforcement.
 	EffectivePolicies map[gatewayID]map[policymanager.PolicyCrdID]policymanager.Policy
+	// Errors contains any errorrs associated with this resource.
+	Errors []error
 }
 
 func NewBackendNode(backend *unstructured.Unstructured) *BackendNode {
@@ -261,6 +269,7 @@ func NewBackendNode(backend *unstructured.Unstructured) *BackendNode {
 		Policies:          make(map[policyID]*PolicyNode),
 		ReferenceGrants:   make(map[referenceGrantID]*ReferenceGrantNode),
 		EffectivePolicies: make(map[gatewayID]map[policymanager.PolicyCrdID]policymanager.Policy),
+		Errors:            []error{},
 	}
 }
 

--- a/gwctl/pkg/resourcediscovery/nodes.go
+++ b/gwctl/pkg/resourcediscovery/nodes.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/policymanager"
 
 	corev1 "k8s.io/api/core/v1"
@@ -44,12 +45,13 @@ func (r resourceID) String() string {
 }
 
 type (
-	gatewayClassID resourceID
-	namespaceID    resourceID
-	gatewayID      resourceID
-	httpRouteID    resourceID
-	backendID      resourceID
-	policyID       resourceID
+	gatewayClassID   resourceID
+	namespaceID      resourceID
+	gatewayID        resourceID
+	httpRouteID      resourceID
+	backendID        resourceID
+	referenceGrantID resourceID
+	policyID         resourceID
 )
 
 // GatewayClassID returns an ID for a GatewayClass.
@@ -102,6 +104,14 @@ func PolicyID(group, kind, namespace, name string) policyID { //nolint:revive
 	return policyID(resourceID{
 		Group:     strings.ToLower(group),
 		Kind:      strings.ToLower(kind),
+		Namespace: namespace,
+		Name:      name,
+	})
+}
+
+// ReferenceGrantID returns an ID for a ReferenceGrant.
+func ReferenceGrantID(namespace, name string) referenceGrantID { //nolint:revive
+	return referenceGrantID(resourceID{
 		Namespace: namespace,
 		Name:      name,
 	})
@@ -237,6 +247,8 @@ type BackendNode struct {
 	HTTPRoutes map[httpRouteID]*HTTPRouteNode
 	// Policies stores Policies directly applied to the Backend.
 	Policies map[policyID]*PolicyNode
+	// ReferenceGrants contains ReferenceGrants that expose this Backend.
+	ReferenceGrants map[referenceGrantID]*ReferenceGrantNode
 	// EffectivePolicies reflects the effective policies applicable to this
 	// Backend, mapped per Gateway for context-specific enforcement.
 	EffectivePolicies map[gatewayID]map[policymanager.PolicyCrdID]policymanager.Policy
@@ -247,6 +259,7 @@ func NewBackendNode(backend *unstructured.Unstructured) *BackendNode {
 		Backend:           backend,
 		HTTPRoutes:        make(map[httpRouteID]*HTTPRouteNode),
 		Policies:          make(map[policyID]*PolicyNode),
+		ReferenceGrants:   make(map[referenceGrantID]*ReferenceGrantNode),
 		EffectivePolicies: make(map[gatewayID]map[policymanager.PolicyCrdID]policymanager.Policy),
 	}
 }
@@ -302,6 +315,30 @@ func (n *NamespaceNode) ID() namespaceID { //nolint:revive
 		return namespaceID(resourceID{})
 	}
 	return NamespaceID(n.Namespace.Name)
+}
+
+// ReferenceGrantNode models the relationships and dependencies of a ReferenceGrant.
+type ReferenceGrantNode struct {
+	// ReferenceGrantName identifies the ReferenceGrant.
+	ReferenceGrant *gatewayv1beta1.ReferenceGrant
+
+	// Backends lists Backends residing within the ReferenceGrant.
+	Backends map[backendID]*BackendNode
+}
+
+func NewReferenceGrantNode(referenceGrant *gatewayv1beta1.ReferenceGrant) *ReferenceGrantNode {
+	return &ReferenceGrantNode{
+		ReferenceGrant: referenceGrant,
+		Backends:       make(map[backendID]*BackendNode),
+	}
+}
+
+func (r *ReferenceGrantNode) ID() referenceGrantID { //nolint:revive
+	if r.ReferenceGrant.Name == "" {
+		klog.V(0).ErrorS(nil, "returning empty ID since ReferenceGrant is empty")
+		return referenceGrantID{}
+	}
+	return ReferenceGrantID(r.ReferenceGrant.GetNamespace(), r.ReferenceGrant.GetName())
 }
 
 // PolicyNode models the relationships and dependencies of a Policy resource

--- a/gwctl/pkg/resourcediscovery/resourcemodel.go
+++ b/gwctl/pkg/resourcediscovery/resourcemodel.go
@@ -316,6 +316,13 @@ func (rm *ResourceModel) calculateEffectivePolicies() error {
 // Namespace, and Gateway).
 func (rm *ResourceModel) calculateEffectivePoliciesForGateways() error {
 	for _, gatewayNode := range rm.Gateways {
+		// Do not calculate effective policy for the Gateway if the GatewayClass is
+		// incorrect. For now, we only calculate effective policy once the
+		// references are corrected.
+		if gatewayNode.GatewayClass == nil {
+			continue
+		}
+
 		// Fetch all policies.
 		gatewayClassPolicies := convertPoliciesMapToSlice(gatewayNode.GatewayClass.Policies)
 		gatewayNamespacePolicies := convertPoliciesMapToSlice(gatewayNode.Namespace.Policies)

--- a/gwctl/pkg/resourcediscovery/resourcemodel.go
+++ b/gwctl/pkg/resourcediscovery/resourcemodel.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/policymanager"
 
 	corev1 "k8s.io/api/core/v1"
@@ -38,12 +39,13 @@ import (
 //   - Identifying potential conflicts or issues in resource configuration
 //   - Visualizing the topology of Gateway API resources
 type ResourceModel struct {
-	GatewayClasses map[gatewayClassID]*GatewayClassNode
-	Namespaces     map[namespaceID]*NamespaceNode
-	Gateways       map[gatewayID]*GatewayNode
-	HTTPRoutes     map[httpRouteID]*HTTPRouteNode
-	Backends       map[backendID]*BackendNode
-	Policies       map[policyID]*PolicyNode
+	GatewayClasses  map[gatewayClassID]*GatewayClassNode
+	Namespaces      map[namespaceID]*NamespaceNode
+	Gateways        map[gatewayID]*GatewayNode
+	HTTPRoutes      map[httpRouteID]*HTTPRouteNode
+	Backends        map[backendID]*BackendNode
+	ReferenceGrants map[referenceGrantID]*ReferenceGrantNode
+	Policies        map[policyID]*PolicyNode
 }
 
 // addGatewayClasses adds nodes for GatewayClases.
@@ -111,6 +113,20 @@ func (rm *ResourceModel) addBackends(backends ...unstructured.Unstructured) {
 		backendNode := NewBackendNode(&backend)
 		if _, ok := rm.Backends[backendNode.ID()]; !ok {
 			rm.Backends[backendNode.ID()] = backendNode
+		}
+	}
+}
+
+// addReferenceGrants adds nodes for ReferenceGrants.
+func (rm *ResourceModel) addReferenceGrants(referenceGrants ...gatewayv1beta1.ReferenceGrant) {
+	if rm.ReferenceGrants == nil {
+		rm.ReferenceGrants = make(map[referenceGrantID]*ReferenceGrantNode)
+	}
+	for _, referenceGrant := range referenceGrants {
+		referenceGrant := referenceGrant
+		referenceGrantNode := NewReferenceGrantNode(&referenceGrant)
+		if _, ok := rm.ReferenceGrants[referenceGrantNode.ID()]; !ok {
+			rm.ReferenceGrants[referenceGrantNode.ID()] = referenceGrantNode
 		}
 	}
 }
@@ -294,6 +310,24 @@ func (rm *ResourceModel) connectBackendWithNamespace(backendID backendID, namesp
 
 	backendNode.Namespace = namespaceNode
 	namespaceNode.Backends[backendID] = backendNode
+}
+
+// connectReferenceGrantWithBackend establishes a connection between a ReferenceGrant and
+// a Backend.
+func (rm *ResourceModel) connectReferenceGrantWithBackend(referenceGrantID referenceGrantID, backendID backendID) {
+	referenceGrantNode, ok := rm.ReferenceGrants[referenceGrantID]
+	if !ok {
+		klog.V(1).ErrorS(nil, "ReferenceGrant does not exist in ResourceModel", "referenceGrantID", referenceGrantID)
+		return
+	}
+	backendNode, ok := rm.Backends[backendID]
+	if !ok {
+		klog.V(1).ErrorS(nil, "Backend does not exist in ResourceModel", "backendID", backendID)
+		return
+	}
+
+	referenceGrantNode.Backends[backendID] = backendNode
+	backendNode.ReferenceGrants[referenceGrantID] = referenceGrantNode
 }
 
 // calculateEffectivePolicies calculates the effective policies for all

--- a/gwctl/pkg/resourcediscovery/resourcemodel.go
+++ b/gwctl/pkg/resourcediscovery/resourcemodel.go
@@ -350,9 +350,9 @@ func (rm *ResourceModel) calculateEffectivePolicies() error {
 // Namespace, and Gateway).
 func (rm *ResourceModel) calculateEffectivePoliciesForGateways() error {
 	for _, gatewayNode := range rm.Gateways {
-		// Do not calculate effective policy for the Gateway if the GatewayClass is
-		// incorrect. For now, we only calculate effective policy once the
-		// references are corrected.
+		// Do not calculate effective policy for the Gateway if the referenced
+		// GatewayClass does not exist. For now, we only calculate effective policy
+		// once the references are corrected.
 		if gatewayNode.GatewayClass == nil {
 			continue
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

- Use ReferenceGrants to determine if a cross-namespace reference from HTTPRoute
    to a Backend is valid.
- Capture incorrect reference errors (like reference not found or not permitted)
    in the resourceModel. This will be available for consumption by the views.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/3039

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
gwctl now displays "incorrect" or "not-found" reference errors. It also uses ReferenceGrants to validate if a reference is correct or not (incorrect reference errors are made visible to the user)
```

/area gwctl
