### PR TITLE
fix: nil dereference checks during the calculation of effective policies

### DIFF
--- a/gwctl/pkg/resourcediscovery/resourcemodel.go
+++ b/gwctl/pkg/resourcediscovery/resourcemodel.go
@@ -317,8 +317,18 @@ func (rm *ResourceModel) calculateEffectivePolicies() error {
 func (rm *ResourceModel) calculateEffectivePoliciesForGateways() error {
 	for _, gatewayNode := range rm.Gateways {
 		// Fetch all policies.
-		gatewayClassPolicies := convertPoliciesMapToSlice(gatewayNode.GatewayClass.Policies)
-		gatewayNamespacePolicies := convertPoliciesMapToSlice(gatewayNode.Namespace.Policies)
+		var gatewayClassPolicies []policymanager.Policy
+		var gatewayNamespacePolicies []policymanager.Policy
+
+		if gatewayNode.GatewayClass != nil {
+			gatewayClassPolicies = convertPoliciesMapToSlice(gatewayNode.GatewayClass.Policies)
+		}
+
+		// although this should never happen under the assumption that .discoverNamespaces is called on the resourceModel beforehand
+		// yet this has been added as a fail-safe if in the future the above (unguarded) assumption breaks
+		if gatewayNode.Namespace != nil {
+			gatewayNamespacePolicies = convertPoliciesMapToSlice(gatewayNode.Namespace.Policies)
+		}
 		gatewayPolicies := convertPoliciesMapToSlice(gatewayNode.Policies)
 
 		// Merge policies by their kind.
@@ -361,7 +371,13 @@ func (rm *ResourceModel) calculateEffectivePoliciesForHTTPRoutes() error {
 		// Step 1: Aggregate all policies of the HTTPRoute and the
 		// HTTPRoute-namespace.
 		httpRoutePolicies := convertPoliciesMapToSlice(httpRouteNode.Policies)
-		httpRouteNamespacePolicies := convertPoliciesMapToSlice(httpRouteNode.Namespace.Policies)
+
+		var httpRouteNamespacePolicies []policymanager.Policy
+		// although this should never happen under the assumption that .discoverNamespaces is called on the resourceModel beforehand
+		// yet this has been added as a fail-safe if in the future the above (unguarded) assumption breaks
+		if httpRouteNode.Namespace != nil {
+			httpRouteNamespacePolicies = convertPoliciesMapToSlice(httpRouteNode.Namespace.Policies)
+		}
 
 		// Step 2: Merge HTTPRoute and HTTPRoute-namespace policies by their kind.
 		httpRoutePoliciesByKind, err := policymanager.MergePoliciesOfSimilarKind(httpRoutePolicies)
@@ -406,7 +422,13 @@ func (rm *ResourceModel) calculateEffectivePoliciesForBackends() error {
 
 		// Step 1: Aggregate all policies of the Backend and the Backend-namespace.
 		backendPolicies := convertPoliciesMapToSlice(backendNode.Policies)
-		backendNamespacePolicies := convertPoliciesMapToSlice(backendNode.Namespace.Policies)
+
+		var backendNamespacePolicies []policymanager.Policy
+		// although this should never happen under the assumption that .discoverNamespaces is called on the resourceModel beforehand
+		// yet this has been added as a fail-safe if in the future the above (unguarded) assumption breaks
+		if backendNode.Namespace != nil {
+			backendNamespacePolicies = convertPoliciesMapToSlice(backendNode.Namespace.Policies)
+		}
 
 		// Step 2: Merge Backend and Backend-namespace policies by their kind.
 		backendPoliciesByKind, err := policymanager.MergePoliciesOfSimilarKind(backendPolicies)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind bug

**What this PR does / why we need it**:

This PR introduces a bunch of nil-dereference checks to the functions calculating effective policies for backends and gateways.

For example, there are possible situation when an HTTPRouteNode points to no (nil) GatewayClass but one of the effective-policies-calculators doesn't consider this and tries to dereference the nil reference causing things to panic.

Moreover, this PR introduces some seemingly redundant nil checks to <Node>.Namespace because write those checks weren't performed under the assumption that `.discoverNamespaces(..)` would've been called on the resourceModel. Considering this assumption's fragility due to being unguarded, this PR involves the specified nil checks to avoid any future bugs to creep due to not calling `.discoverNamespaces(...)` at the right places.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #3039 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Yes, the user would see graceful outputs instead of panics whenever running gwctl describe httproutes command
```

### Before this PR

```
❯ ./bin/gwctl describe httproutes
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x10 pc=0x101e35e70]

goroutine 1 [running]:
sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery.(*ResourceModel).calculateEffectivePoliciesForGateways(0x14000480c68?)
        /Users/ykukreja/Projects/GoProjects/gateway-api/gwctl/pkg/resourcediscovery/resourcemodel.go:320 +0x70
sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery.(*ResourceModel).calculateEffectivePolicies(0x1400096db90)
        /Users/ykukreja/Projects/GoProjects/gateway-api/gwctl/pkg/resourcediscovery/resourcemodel.go:302 +0x20
sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery.Discoverer.DiscoverResourcesForHTTPRoute({0x140003aad80?, 0x140003fe9e0?}, {{0x101e449a2, 0x7}, {0x0, 0x0}, {0x1023a5a70, 0x102f539c0}})
        /Users/ykukreja/Projects/GoProjects/gateway-api/gwctl/pkg/resourcediscovery/discoverer.go:124 +0x240
sigs.k8s.io/gateway-api/gwctl/cmd.runDescribe(0x1400025af08, {0x140004224c0, 0x1, 0x0?}, 0x1400007ef80)
        /Users/ykukreja/Projects/GoProjects/gateway-api/gwctl/cmd/describe.go:137 +0xaa4
sigs.k8s.io/gateway-api/gwctl/cmd.NewDescribeCommand.func1(0x1400025af08, {0x140004224c0, 0x1, 0x1})
        /Users/ykukreja/Projects/GoProjects/gateway-api/gwctl/cmd/describe.go:46 +0x5c
github.com/spf13/cobra.(*Command).execute(0x1400025af08, {0x14000422490, 0x1, 0x1})
        /Users/ykukreja/Projects/GoProjects/gateway-api/gwctl/vendor/github.com/spf13/cobra/command.go:987 +0x828
github.com/spf13/cobra.(*Command).ExecuteC(0x1400025a908)
        /Users/ykukreja/Projects/GoProjects/gateway-api/gwctl/vendor/github.com/spf13/cobra/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/ykukreja/Projects/GoProjects/gateway-api/gwctl/vendor/github.com/spf13/cobra/command.go:1039
sigs.k8s.io/gateway-api/gwctl/cmd.Execute()
        /Users/ykukreja/Projects/GoProjects/gateway-api/gwctl/cmd/root.go:60 +0x24
main.main()
        /Users/ykukreja/Projects/GoProjects/gateway-api/gwctl/main.go:22 +0x1c

```


### After this PR

```
❯ ./bin/gwctl describe httproutes
Name: example-route
Namespace: default
Hostnames:
- example.com
ParentRefs:
- group: gateway.networking.k8s.io
  kind: Gateway
  name: example-gateway
EffectivePolicies:
  default/example-gateway: {}


Name: http-app-1
Namespace: default
Hostnames:
- foo.com
ParentRefs:
- group: gateway.networking.k8s.io
  kind: Gateway
  name: my-gateway
EffectivePolicies:
  default/my-gateway: {}
...
...
...
```
