### PR TITLE
Remove HTTPRouteHTTPSListener unknown host test case

### DIFF
--- a/conformance/tests/httproute-https-listener.go
+++ b/conformance/tests/httproute-https-listener.go
@@ -62,7 +62,6 @@ var HTTPRouteHTTPSListener = suite.ConformanceTest{
 			backend    string
 		}{
 			{host: "example.org", statusCode: 200, backend: "infra-backend-v1"},
-			{host: "unknown-example.org", statusCode: 404},
 			{host: "second-example.org", statusCode: 200, backend: "infra-backend-v2"},
 		}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind test

/area conformance

**What this PR does / why we need it**:

While validating v1.1.0-rc1 with Contour, we are running into this test failing

The request to unknown-example.com never succeeds to get an HTTP response (the test expects a 404), since there is no Listener/certificate configured that will allow the gateway to terminate the TLS connection

See https://github.com/kubernetes-sigs/gateway-api/issues/3044

**Which issue(s) this PR fixes**:

Updates #3044 but does not close it

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
