### PR TITLE
gwctl: Show Events, Analysis and few other fields for various resources.

### DIFF
--- a/gwctl/cmd/describe.go
+++ b/gwctl/cmd/describe.go
@@ -84,7 +84,7 @@ func runDescribe(cmd *cobra.Command, args []string, params *utils.CmdParams) {
 	httpRoutesPrinter := &printer.HTTPRoutesPrinter{Writer: params.Out, Clock: clock.RealClock{}}
 	gwPrinter := &printer.GatewaysPrinter{Writer: params.Out, Clock: clock.RealClock{}}
 	gwcPrinter := &printer.GatewayClassesPrinter{Writer: params.Out, Clock: clock.RealClock{}}
-	backendsPrinter := &printer.BackendsPrinter{Writer: params.Out}
+	backendsPrinter := &printer.BackendsPrinter{Writer: params.Out, Clock: clock.RealClock{}}
 	namespacesPrinter := &printer.NamespacesPrinter{Writer: params.Out, Clock: clock.RealClock{}}
 
 	switch kind {

--- a/gwctl/pkg/policymanager/helpers.go
+++ b/gwctl/pkg/policymanager/helpers.go
@@ -16,13 +16,15 @@ limitations under the License.
 
 package policymanager
 
+import "sigs.k8s.io/gateway-api/gwctl/pkg/common"
+
 // ToPolicyRefs returns the Object references of all given policies. Note that
 // these are not the value of targetRef within the Policies but rather the
 // reference to the Policy object itself.
-func ToPolicyRefs(policies []Policy) []ObjRef {
-	var result []ObjRef
+func ToPolicyRefs(policies []Policy) []common.ObjRef {
+	var result []common.ObjRef
 	for _, policy := range policies {
-		result = append(result, ObjRef{
+		result = append(result, common.ObjRef{
 			Group:     policy.Unstructured().GroupVersionKind().Group,
 			Kind:      policy.Unstructured().GroupVersionKind().Kind,
 			Name:      policy.Unstructured().GetName(),

--- a/gwctl/pkg/policymanager/merger.go
+++ b/gwctl/pkg/policymanager/merger.go
@@ -22,6 +22,8 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
 )
 
 // MergePoliciesOfSimilarKind will convert a slice a policies to a map of
@@ -147,7 +149,7 @@ func mergePolicy(parent, child Policy) (Policy, error) {
 	result.u.SetUnstructuredContent(resultUnstructured)
 	// Merging two policies means the targetRef no longer makes any sense since
 	// since they can be conflicting. So we unset the targetRef.
-	result.targetRef = ObjRef{}
+	result.targetRef = common.ObjRef{}
 	return result, nil
 }
 

--- a/gwctl/pkg/printer/backends.go
+++ b/gwctl/pkg/printer/backends.go
@@ -138,6 +138,11 @@ func (bp *BackendsPrinter) PrintDescribeView(resourceModel *resourcediscovery.Re
 			pairs = append(pairs, &DescriberKV{Key: "ReferenceGrants", Value: names})
 		}
 
+		// Analysis
+		if len(backendNode.Errors) != 0 {
+			pairs = append(pairs, &DescriberKV{Key: "Analysis", Value: convertErrorsToString(backendNode.Errors)})
+		}
+
 		// Events
 		pairs = append(pairs, &DescriberKV{Key: "Events", Value: convertEventsSliceToTable(backendNode.Events, bp.Clock)})
 

--- a/gwctl/pkg/printer/backends.go
+++ b/gwctl/pkg/printer/backends.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	"sigs.k8s.io/gateway-api/gwctl/pkg/policymanager"
+	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery"
 )
 
@@ -101,12 +101,12 @@ func (bp *BackendsPrinter) Print(resourceModel *resourcediscovery.ResourceModel)
 }
 
 type backendDescribeView struct {
-	Group                    string                 `json:",omitempty"`
-	Kind                     string                 `json:",omitempty"`
-	Name                     string                 `json:",omitempty"`
-	Namespace                string                 `json:",omitempty"`
-	DirectlyAttachedPolicies []policymanager.ObjRef `json:",omitempty"`
-	EffectivePolicies        any                    `json:",omitempty"`
+	Group                    string          `json:",omitempty"`
+	Kind                     string          `json:",omitempty"`
+	Name                     string          `json:",omitempty"`
+	Namespace                string          `json:",omitempty"`
+	DirectlyAttachedPolicies []common.ObjRef `json:",omitempty"`
+	EffectivePolicies        any             `json:",omitempty"`
 }
 
 func (bp *BackendsPrinter) PrintDescribeView(resourceModel *resourcediscovery.ResourceModel) {

--- a/gwctl/pkg/printer/common.go
+++ b/gwctl/pkg/printer/common.go
@@ -153,6 +153,25 @@ func convertEventsSliceToTable(events []corev1.Event, clock clock.Clock) *Table 
 	return table
 }
 
+func convertPolicyRefsToTable(policyRefs []common.ObjRef) *Table {
+	table := &Table{
+		ColumnNames:  []string{"Type", "Name"},
+		UseSeparator: true,
+	}
+	for _, policyRef := range policyRefs {
+		name := policyRef.Name
+		if policyRef.Namespace != "" {
+			name = fmt.Sprintf("%v/%v", policyRef.Namespace, name)
+		}
+		row := []string{
+			fmt.Sprintf("%v.%v", policyRef.Kind, policyRef.Group), // Type
+			name, // Name
+		}
+		table.Rows = append(table.Rows, row)
+	}
+	return table
+}
+
 type NodeResource interface {
 	ClientObject() client.Object
 }

--- a/gwctl/pkg/printer/common.go
+++ b/gwctl/pkg/printer/common.go
@@ -54,7 +54,7 @@ func Describe(w io.Writer, pairs []*DescriberKV) {
 				fmt.Fprintf(w, "%v: <none>\n", pair.Key)
 			} else {
 				fmt.Fprintf(w, "%v:\n", pair.Key)
-				table.writeTable(w, defaultDescribeTableIndentSpaces)
+				table.Write(w, defaultDescribeTableIndentSpaces)
 			}
 			continue
 		}
@@ -78,9 +78,9 @@ type Table struct {
 	UseSeparator bool
 }
 
-// writeTable will write a formatted table to the writer. indent controls the
+// Write will write a formatted table to the writer. indent controls the
 // number of spaces at the beginning of each row.
-func (t *Table) writeTable(w io.Writer, indent int) {
+func (t *Table) Write(w io.Writer, indent int) {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 
 	// Print column names.

--- a/gwctl/pkg/printer/common.go
+++ b/gwctl/pkg/printer/common.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
+
+	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
 )
 
 // DescriberKV stores key-value pairs that are used with Describing a resource.

--- a/gwctl/pkg/printer/common.go
+++ b/gwctl/pkg/printer/common.go
@@ -172,6 +172,14 @@ func convertPolicyRefsToTable(policyRefs []common.ObjRef) *Table {
 	return table
 }
 
+func convertErrorsToString(errors []error) []string {
+	var result []string
+	for _, err := range errors {
+		result = append(result, err.Error())
+	}
+	return result
+}
+
 type NodeResource interface {
 	ClientObject() client.Object
 }

--- a/gwctl/pkg/printer/common_test.go
+++ b/gwctl/pkg/printer/common_test.go
@@ -147,7 +147,7 @@ TCPRoute   ns2/my-tcproute
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			writable := &bytes.Buffer{}
-			tc.table.writeTable(writable, tc.indent)
+			tc.table.Write(writable, tc.indent)
 
 			got := writable.String()
 			if diff := cmp.Diff(common.YamlString(tc.want), common.YamlString(got), common.YamlStringTransformer); diff != "" {

--- a/gwctl/pkg/printer/gatewayclasses.go
+++ b/gwctl/pkg/printer/gatewayclasses.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"text/tabwriter"
 
 	"golang.org/x/exp/maps"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,12 +63,9 @@ func (gcp *GatewayClassesPrinter) GetPrintableNodes(resourceModel *resourcedisco
 }
 
 func (gcp *GatewayClassesPrinter) PrintTable(resourceModel *resourcediscovery.ResourceModel) {
-	tw := tabwriter.NewWriter(gcp, 0, 0, 2, ' ', 0)
-	row := []string{"NAME", "CONTROLLER", "ACCEPTED", "AGE"}
-	_, err := tw.Write([]byte(strings.Join(row, "\t") + "\n"))
-	if err != nil {
-		fmt.Fprint(os.Stderr, err)
-		os.Exit(1)
+	table := &Table{
+		ColumnNames:  []string{"NAME", "CONTROLLER", "ACCEPTED", "AGE"},
+		UseSeparator: false,
 	}
 
 	gatewayClassNodes := maps.Values(resourceModel.GatewayClasses)
@@ -90,13 +86,10 @@ func (gcp *GatewayClassesPrinter) PrintTable(resourceModel *resourcediscovery.Re
 			accepted,
 			age,
 		}
-		_, err := tw.Write([]byte(strings.Join(row, "\t") + "\n"))
-		if err != nil {
-			fmt.Fprint(os.Stderr, err)
-			os.Exit(1)
-		}
+		table.Rows = append(table.Rows, row)
 	}
-	tw.Flush()
+
+	table.Write(gcp, 0)
 }
 
 func (gcp *GatewayClassesPrinter) PrintDescribeView(resourceModel *resourcediscovery.ResourceModel) {

--- a/gwctl/pkg/printer/gatewayclasses.go
+++ b/gwctl/pkg/printer/gatewayclasses.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/gwctl/pkg/policymanager"
+	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery"
 )
 
@@ -56,7 +56,7 @@ type gatewayClassDescribeView struct {
 	Description *string `json:",omitempty"`
 
 	Status                   *gatewayv1.GatewayClassStatus `json:",omitempty"`
-	DirectlyAttachedPolicies []policymanager.ObjRef        `json:",omitempty"`
+	DirectlyAttachedPolicies []common.ObjRef               `json:",omitempty"`
 }
 
 func (gcp *GatewayClassesPrinter) GetPrintableNodes(resourceModel *resourcediscovery.ResourceModel) []NodeResource {

--- a/gwctl/pkg/printer/gateways.go
+++ b/gwctl/pkg/printer/gateways.go
@@ -19,9 +19,7 @@ package printer
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
-	"text/tabwriter"
 
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/util/duration"
@@ -42,12 +40,9 @@ func (gp *GatewaysPrinter) GetPrintableNodes(resourceModel *resourcediscovery.Re
 }
 
 func (gp *GatewaysPrinter) PrintTable(resourceModel *resourcediscovery.ResourceModel) {
-	tw := tabwriter.NewWriter(gp, 0, 0, 2, ' ', 0)
-	row := []string{"NAME", "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE"}
-	_, err := tw.Write([]byte(strings.Join(row, "\t") + "\n"))
-	if err != nil {
-		fmt.Fprint(os.Stderr, err)
-		os.Exit(1)
+	table := &Table{
+		ColumnNames:  []string{"NAME", "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE"},
+		UseSeparator: false,
 	}
 
 	gatewayNodes := maps.Values(resourceModel.Gateways)
@@ -86,13 +81,10 @@ func (gp *GatewaysPrinter) PrintTable(resourceModel *resourcediscovery.ResourceM
 			programmedStatus,
 			age,
 		}
-		_, err := tw.Write([]byte(strings.Join(row, "\t") + "\n"))
-		if err != nil {
-			fmt.Fprint(os.Stderr, err)
-			os.Exit(1)
-		}
+		table.Rows = append(table.Rows, row)
 	}
-	tw.Flush()
+
+	table.Write(gp, 0)
 }
 
 func (gp *GatewaysPrinter) PrintDescribeView(resourceModel *resourcediscovery.ResourceModel) {

--- a/gwctl/pkg/printer/gateways.go
+++ b/gwctl/pkg/printer/gateways.go
@@ -97,6 +97,7 @@ func (gp *GatewaysPrinter) PrintDescribeView(resourceModel *resourcediscovery.Re
 		metadata.Annotations = nil
 		metadata.Name = ""
 		metadata.Namespace = ""
+		metadata.ManagedFields = nil
 
 		pairs := []*DescriberKV{
 			{Key: "Name", Value: gatewayNode.Gateway.GetName()},
@@ -125,20 +126,8 @@ func (gp *GatewaysPrinter) PrintDescribeView(resourceModel *resourcediscovery.Re
 		pairs = append(pairs, &DescriberKV{Key: "AttachedRoutes", Value: attachedRoutes})
 
 		// DirectlyAttachedPolicies
-		if policyRefs := resourcediscovery.ConvertPoliciesMapToPolicyRefs(gatewayNode.Policies); len(policyRefs) != 0 {
-			directlyAttachedPolicies := &Table{
-				ColumnNames:  []string{"Type", "Name"},
-				UseSeparator: true,
-			}
-			for _, policyRef := range policyRefs {
-				row := []string{
-					fmt.Sprintf("%v.%v", policyRef.Kind, policyRef.Group),     // Type
-					fmt.Sprintf("%v/%v", policyRef.Namespace, policyRef.Name), // Name
-				}
-				directlyAttachedPolicies.Rows = append(directlyAttachedPolicies.Rows, row)
-			}
-			pairs = append(pairs, &DescriberKV{Key: "DirectlyAttachedPolicies", Value: directlyAttachedPolicies})
-		}
+		policyRefs := resourcediscovery.ConvertPoliciesMapToPolicyRefs(gatewayNode.Policies)
+		pairs = append(pairs, &DescriberKV{Key: "DirectlyAttachedPolicies", Value: convertPolicyRefsToTable(policyRefs)})
 
 		// EffectivePolicies
 		if len(gatewayNode.EffectivePolicies) != 0 {

--- a/gwctl/pkg/printer/gateways.go
+++ b/gwctl/pkg/printer/gateways.go
@@ -134,6 +134,11 @@ func (gp *GatewaysPrinter) PrintDescribeView(resourceModel *resourcediscovery.Re
 			pairs = append(pairs, &DescriberKV{Key: "EffectivePolicies", Value: gatewayNode.EffectivePolicies})
 		}
 
+		// Analysis
+		if len(gatewayNode.Errors) != 0 {
+			pairs = append(pairs, &DescriberKV{Key: "Analysis", Value: convertErrorsToString(gatewayNode.Errors)})
+		}
+
 		// Events
 		pairs = append(pairs, &DescriberKV{Key: "Events", Value: convertEventsSliceToTable(gatewayNode.Events, gp.Clock)})
 

--- a/gwctl/pkg/printer/gateways_test.go
+++ b/gwctl/pkg/printer/gateways_test.go
@@ -404,7 +404,7 @@ AttachedRoutes:
 DirectlyAttachedPolicies:
   Type                       Name
   ----                       ----
-  HealthCheckPolicy.foo.com  /health-check-gateway
+  HealthCheckPolicy.foo.com  health-check-gateway
 EffectivePolicies:
   HealthCheckPolicy.foo.com:
     key1: value-parent-1

--- a/gwctl/pkg/printer/httproutes.go
+++ b/gwctl/pkg/printer/httproutes.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/gwctl/pkg/policymanager"
+	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery"
 )
 
@@ -94,7 +94,7 @@ type httpRouteDescribeView struct {
 	Namespace                string                      `json:",omitempty"`
 	Hostnames                []gatewayv1.Hostname        `json:",omitempty"`
 	ParentRefs               []gatewayv1.ParentReference `json:",omitempty"`
-	DirectlyAttachedPolicies []policymanager.ObjRef      `json:",omitempty"`
+	DirectlyAttachedPolicies []common.ObjRef             `json:",omitempty"`
 	EffectivePolicies        any                         `json:",omitempty"`
 }
 

--- a/gwctl/pkg/printer/httproutes.go
+++ b/gwctl/pkg/printer/httproutes.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"text/tabwriter"
 
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/util/duration"
@@ -45,12 +44,9 @@ func (hp *HTTPRoutesPrinter) GetPrintableNodes(resourceModel *resourcediscovery.
 }
 
 func (hp *HTTPRoutesPrinter) PrintTable(resourceModel *resourcediscovery.ResourceModel) {
-	tw := tabwriter.NewWriter(hp, 0, 0, 2, ' ', 0)
-	row := []string{"NAMESPACE", "NAME", "HOSTNAMES", "PARENT REFS", "AGE"}
-	_, err := tw.Write([]byte(strings.Join(row, "\t") + "\n"))
-	if err != nil {
-		fmt.Fprint(os.Stderr, err)
-		os.Exit(1)
+	table := &Table{
+		ColumnNames:  []string{"NAMESPACE", "NAME", "HOSTNAMES", "PARENT REFS", "AGE"},
+		UseSeparator: false,
 	}
 
 	httpRouteNodes := maps.Values(resourceModel.HTTPRoutes)
@@ -80,13 +76,9 @@ func (hp *HTTPRoutesPrinter) PrintTable(resourceModel *resourcediscovery.Resourc
 			parentRefsCount,
 			age,
 		}
-		_, err := tw.Write([]byte(strings.Join(row, "\t") + "\n"))
-		if err != nil {
-			fmt.Fprint(os.Stderr, err)
-			os.Exit(1)
-		}
+		table.Rows = append(table.Rows, row)
 	}
-	tw.Flush()
+	table.Write(hp, 0)
 }
 
 type httpRouteDescribeView struct {

--- a/gwctl/pkg/printer/namespace.go
+++ b/gwctl/pkg/printer/namespace.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
-	"text/tabwriter"
 
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/util/duration"
@@ -52,12 +50,9 @@ func (nsp *NamespacesPrinter) GetPrintableNodes(resourceModel *resourcediscovery
 }
 
 func (nsp *NamespacesPrinter) PrintTable(resourceModel *resourcediscovery.ResourceModel) {
-	tw := tabwriter.NewWriter(nsp, 0, 0, 2, ' ', 0)
-	row := []string{"NAME", "STATUS", "AGE"}
-	_, err := tw.Write([]byte(strings.Join(row, "\t") + "\n"))
-	if err != nil {
-		fmt.Fprint(os.Stderr, err)
-		os.Exit(1)
+	table := &Table{
+		ColumnNames:  []string{"NAME", "STATUS", "AGE"},
+		UseSeparator: false,
 	}
 
 	namespaceNodes := maps.Values(resourceModel.Namespaces)
@@ -68,13 +63,10 @@ func (nsp *NamespacesPrinter) PrintTable(resourceModel *resourcediscovery.Resour
 			string(namespaceNode.Namespace.Status.Phase),
 			age,
 		}
-		_, err := tw.Write([]byte(strings.Join(row, "\t") + "\n"))
-		if err != nil {
-			fmt.Fprint(os.Stderr, err)
-			os.Exit(1)
-		}
+		table.Rows = append(table.Rows, row)
 	}
-	tw.Flush()
+
+	table.Write(nsp, 0)
 }
 
 func (nsp *NamespacesPrinter) PrintDescribeView(resourceModel *resourcediscovery.ResourceModel) {

--- a/gwctl/pkg/printer/namespace.go
+++ b/gwctl/pkg/printer/namespace.go
@@ -23,9 +23,7 @@ import (
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/utils/clock"
-	"sigs.k8s.io/yaml"
 
-	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery"
 )
 

--- a/gwctl/pkg/printer/namespace.go
+++ b/gwctl/pkg/printer/namespace.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/yaml"
 
-	"sigs.k8s.io/gateway-api/gwctl/pkg/policymanager"
+	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/resourcediscovery"
 )
 
@@ -40,11 +40,11 @@ type NamespacesPrinter struct {
 }
 
 type namespaceDescribeView struct {
-	Name                     string                 `json:",omitempty"`
-	Labels                   map[string]string      `json:",omitempty"`
-	Annotations              map[string]string      `json:",omitempty"`
-	Status                   string                 `json:",omitempty"`
-	DirectlyAttachedPolicies []policymanager.ObjRef `json:",omitempty"`
+	Name                     string            `json:",omitempty"`
+	Labels                   map[string]string `json:",omitempty"`
+	Annotations              map[string]string `json:",omitempty"`
+	Status                   string            `json:",omitempty"`
+	DirectlyAttachedPolicies []common.ObjRef   `json:",omitempty"`
 }
 
 func (nsp *NamespacesPrinter) GetPrintableNodes(resourceModel *resourcediscovery.ResourceModel) []NodeResource {

--- a/gwctl/pkg/printer/namespace_test.go
+++ b/gwctl/pkg/printer/namespace_test.go
@@ -234,25 +234,30 @@ func TestNamespacePrinter_PrintDescribeView(t *testing.T) {
 	got := params.Out.(*bytes.Buffer).String()
 	want := `
 Name: development
-Annotations:
-  test-annotation: development-annotation
 Labels:
   type: test-namespace
-Status: Active
+Annotations:
+  test-annotation: development-annotation
+Status:
+  phase: Active
 DirectlyAttachedPolicies:
-- Group: foo.com
-  Kind: HealthCheckPolicy
-  Name: health-check-gatewayclass
+  Type                       Name
+  ----                       ----
+  HealthCheckPolicy.foo.com  health-check-gatewayclass
+Events: <none>
 
 
 Name: production
 Labels:
   type: production-namespace
-Status: Active
+Annotations: null
+Status:
+  phase: Active
 DirectlyAttachedPolicies:
-- Group: bar.com
-  Kind: TimeoutPolicy
-  Name: timeout-policy-namespace
+  Type                   Name
+  ----                   ----
+  TimeoutPolicy.bar.com  timeout-policy-namespace
+Events: <none>
 `
 	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
 		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)

--- a/gwctl/pkg/printer/policies.go
+++ b/gwctl/pkg/printer/policies.go
@@ -21,8 +21,6 @@ import (
 	"io"
 	"os"
 	"sort"
-	"strings"
-	"text/tabwriter"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,12 +53,9 @@ func (pp *PoliciesPrinter) printClientObjects(objects []client.Object, format ut
 }
 
 func (pp *PoliciesPrinter) printPoliciesTable(sortedPoliciesList []policymanager.Policy) {
-	tw := tabwriter.NewWriter(pp, 0, 0, 2, ' ', 0)
-	row := []string{"NAME", "KIND", "TARGET NAME", "TARGET KIND", "POLICY TYPE", "AGE"}
-	_, err := tw.Write([]byte(strings.Join(row, "\t") + "\n"))
-	if err != nil {
-		fmt.Fprint(os.Stderr, err)
-		os.Exit(1)
+	table := &Table{
+		ColumnNames:  []string{"NAME", "KIND", "TARGET NAME", "TARGET KIND", "POLICY TYPE", "AGE"},
+		UseSeparator: false,
 	}
 
 	for _, policy := range sortedPoliciesList {
@@ -81,13 +76,9 @@ func (pp *PoliciesPrinter) printPoliciesTable(sortedPoliciesList []policymanager
 			policyType,
 			age,
 		}
-		_, err := tw.Write([]byte(strings.Join(row, "\t") + "\n"))
-		if err != nil {
-			fmt.Fprint(os.Stderr, err)
-			os.Exit(1)
-		}
+		table.Rows = append(table.Rows, row)
 	}
-	tw.Flush()
+	table.Write(pp, 0)
 }
 
 func (pp *PoliciesPrinter) PrintPolicies(policies []policymanager.Policy, format utils.OutputFormat) {
@@ -106,12 +97,9 @@ func (pp *PoliciesPrinter) PrintPolicies(policies []policymanager.Policy, format
 }
 
 func (pp *PoliciesPrinter) printCRDsTable(sortedPolicyCRDsList []policymanager.PolicyCRD) {
-	tw := tabwriter.NewWriter(pp, 0, 0, 2, ' ', 0)
-	row := []string{"NAME", "POLICY TYPE", "SCOPE", "AGE"}
-	_, err := tw.Write([]byte(strings.Join(row, "\t") + "\n"))
-	if err != nil {
-		fmt.Fprint(os.Stderr, err)
-		os.Exit(1)
+	table := &Table{
+		ColumnNames:  []string{"NAME", "POLICY TYPE", "SCOPE", "AGE"},
+		UseSeparator: false,
 	}
 
 	for _, policyCRD := range sortedPolicyCRDsList {
@@ -128,13 +116,10 @@ func (pp *PoliciesPrinter) printCRDsTable(sortedPolicyCRDsList []policymanager.P
 			string(policyCRD.CRD().Spec.Scope),
 			age,
 		}
-		_, err := tw.Write([]byte(strings.Join(row, "\t") + "\n"))
-		if err != nil {
-			fmt.Fprint(os.Stderr, err)
-			os.Exit(1)
-		}
+		table.Rows = append(table.Rows, row)
 	}
-	tw.Flush()
+
+	table.Write(pp, 0)
 }
 
 func (pp *PoliciesPrinter) PrintCRDs(policyCRDs []policymanager.PolicyCRD, format utils.OutputFormat) {

--- a/gwctl/pkg/resourcediscovery/nodes.go
+++ b/gwctl/pkg/resourcediscovery/nodes.go
@@ -133,6 +133,8 @@ type GatewayClassNode struct {
 	Gateways map[gatewayID]*GatewayNode
 	// Policies stores Policies that directly apply to this GatewayClass.
 	Policies map[policyID]*PolicyNode
+	// Events contains the events associated with this Gateway.
+	Events []corev1.Event
 }
 
 func NewGatewayClassNode(gatewayClass *gatewayv1.GatewayClass) *GatewayClassNode {
@@ -140,6 +142,7 @@ func NewGatewayClassNode(gatewayClass *gatewayv1.GatewayClass) *GatewayClassNode
 		GatewayClass: gatewayClass,
 		Gateways:     make(map[gatewayID]*GatewayNode),
 		Policies:     make(map[policyID]*PolicyNode),
+		Events:       []corev1.Event{},
 	}
 }
 
@@ -214,6 +217,8 @@ type HTTPRouteNode struct {
 	// EffectivePolicies reflects the effective policies applicable to this
 	// HTTPRoute, mapped per Gateway for context-specific enforcement.
 	EffectivePolicies map[gatewayID]map[policymanager.PolicyCrdID]policymanager.Policy
+	// Events contains the events associated with this Gateway.
+	Events []corev1.Event
 	// Errors contains any errorrs associated with this resource.
 	Errors []error
 }
@@ -225,6 +230,7 @@ func NewHTTPRouteNode(httpRoute *gatewayv1.HTTPRoute) *HTTPRouteNode {
 		Backends:          make(map[backendID]*BackendNode),
 		Policies:          make(map[policyID]*PolicyNode),
 		EffectivePolicies: make(map[gatewayID]map[policymanager.PolicyCrdID]policymanager.Policy),
+		Events:            []corev1.Event{},
 		Errors:            []error{},
 	}
 }
@@ -258,6 +264,8 @@ type BackendNode struct {
 	// EffectivePolicies reflects the effective policies applicable to this
 	// Backend, mapped per Gateway for context-specific enforcement.
 	EffectivePolicies map[gatewayID]map[policymanager.PolicyCrdID]policymanager.Policy
+	// Events contains the events associated with this Gateway.
+	Events []corev1.Event
 	// Errors contains any errorrs associated with this resource.
 	Errors []error
 }
@@ -269,6 +277,7 @@ func NewBackendNode(backend *unstructured.Unstructured) *BackendNode {
 		Policies:          make(map[policyID]*PolicyNode),
 		ReferenceGrants:   make(map[referenceGrantID]*ReferenceGrantNode),
 		EffectivePolicies: make(map[gatewayID]map[policymanager.PolicyCrdID]policymanager.Policy),
+		Events:            []corev1.Event{},
 		Errors:            []error{},
 	}
 }
@@ -301,6 +310,8 @@ type NamespaceNode struct {
 	Backends map[backendID]*BackendNode
 	// Policies stores Policies directly applied to the Namespace.
 	Policies map[policyID]*PolicyNode
+	// Events contains the events associated with this Gateway.
+	Events []corev1.Event
 }
 
 func NewNamespaceNode(namespace corev1.Namespace) *NamespaceNode {
@@ -313,6 +324,7 @@ func NewNamespaceNode(namespace corev1.Namespace) *NamespaceNode {
 		HTTPRoutes: make(map[httpRouteID]*HTTPRouteNode),
 		Backends:   make(map[backendID]*BackendNode),
 		Policies:   make(map[policyID]*PolicyNode),
+		Events:     []corev1.Event{},
 	}
 }
 

--- a/gwctl/pkg/resourcediscovery/resourcemodel.go
+++ b/gwctl/pkg/resourcediscovery/resourcemodel.go
@@ -22,6 +22,7 @@ import (
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/gateway-api/gwctl/pkg/common"
 	"sigs.k8s.io/gateway-api/gwctl/pkg/policymanager"
 
 	corev1 "k8s.io/api/core/v1"
@@ -512,10 +513,10 @@ func convertPoliciesMapToSlice(policies map[policyID]*PolicyNode) []policymanage
 // ConvertPoliciesMapToPolicyRefs returns the Object references of all given
 // policies. Note that these are not the value of targetRef within the Policies
 // but rather the reference to the Policy object itself.
-func ConvertPoliciesMapToPolicyRefs(policies map[policyID]*PolicyNode) []policymanager.ObjRef {
-	var result []policymanager.ObjRef
+func ConvertPoliciesMapToPolicyRefs(policies map[policyID]*PolicyNode) []common.ObjRef {
+	var result []common.ObjRef
 	for _, policyNode := range policies {
-		result = append(result, policymanager.ObjRef{
+		result = append(result, common.ObjRef{
 			Group:     policyNode.Policy.Unstructured().GroupVersionKind().Group,
 			Kind:      policyNode.Policy.Unstructured().GroupVersionKind().Kind,
 			Name:      policyNode.Policy.Unstructured().GetName(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

This PR addresses missing information in the display of various resources and
enhances the presentation of printed information. After this and the related
issue #3037 get completed, all gwctl describe views will have the relevant
information and some visual appeal.


Examples:
<details>
  <summary>$ gwctl describe backends</summary>
  
  ```yaml
    ...
    (truncated)
    ...
    ReferencedByRoutes:
      Kind       Name
      ----       ----
      HTTPRoute  default/grpc-httproute
      HTTPRoute  default/grpc-httproute-2
    DirectlyAttachedPolicies:
      Type                                 Name
      ----                                 ----
      HealthCheckPolicy.networking.gke.io  default/grpc-gateway-healthcheck
    EffectivePolicies:
      default/grpc-gateway:
        HealthCheckPolicy.networking.k8s.io:
          default:
            checkIntervalSec: 15
            config:
              http2HealthCheck:
                port: 1234
                portSpecification: USE_FIXED_PORT
              type: HTTP2
            healthyThreshold: 1
            logConfig:
              enabled: true
            timeoutSec: 15
            unhealthyThreshold: 2
    Events:
      Type    Reason  Age  From                   Message
      ----    ------  ---  ----                   -------
      Normal  SYNC    36h  sc-gateway-controller  SYNC on default/grpc-svc was a success
  ```
</details>



<details>
  <summary>$ gwctl describe gateway</summary>
  
  ```yaml
    ...
    (truncated)
    ...
    AttachedRoutes:
      Kind       Name
      ----       ----
      HTTPRoute  default/grpc-httproute-2
    DirectlyAttachedPolicies: <none>
    Analysis:
    - Gateway "default/random-gateway" references a non-existent GatewayClass "random"
    Events:
      Type    Reason  Age  From                   Message
      ----    ------  ---  ----                   -------
      Normal  SYNC    36h  sc-gateway-controller  SYNC on default/grpc-gateway-2 was a success
  ```
</details>

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Closes a couple of items from https://github.com/kubernetes-sigs/gateway-api/issues/2761
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/2994

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Show Events and Analysis when describing resources.
```
