### PR TITLE
SessionPersistence pointer field should have omitempty tag

### DIFF
--- a/apis/v1/grpcroute_types.go
+++ b/apis/v1/grpcroute_types.go
@@ -275,7 +275,7 @@ type GRPCRouteRule struct {
 	//
 	// +optional
 	// <gateway:experimental>
-	SessionPersistence *SessionPersistence `json:"sessionPersistence"`
+	SessionPersistence *SessionPersistence `json:"sessionPersistence,omitempty"`
 }
 
 // GRPCRouteMatch defines the predicate used to match requests to a given

--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -290,7 +290,7 @@ type HTTPRouteRule struct {
 	//
 	// +optional
 	// <gateway:experimental>
-	SessionPersistence *SessionPersistence `json:"sessionPersistence"`
+	SessionPersistence *SessionPersistence `json:"sessionPersistence,omitempty"`
 }
 
 // HTTPRouteTimeouts defines timeouts that can be configured for an HTTPRoute.

--- a/apis/v1alpha2/backendlbpolicy_types.go
+++ b/apis/v1alpha2/backendlbpolicy_types.go
@@ -70,5 +70,5 @@ type BackendLBPolicySpec struct {
 	// Support: Extended
 	//
 	// +optional
-	SessionPersistence *SessionPersistence `json:"sessionPersistence"`
+	SessionPersistence *SessionPersistence `json:"sessionPersistence,omitempty"`
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

SessionPersistence pointer field should have an omitempty tag, this is the idiomatic way to tag such pointer fields and matches other such instances in the golang API

Not a huge issue per se, but when using the updated gateway-api v1.1.0 go module with an API server that has v1.0.0 CRDs, avoids warnings like:

```
time="2024-05-06T16:19:19Z" level=info msg="unknown field \"spec.rules[0].sessionPersistence\"" logger=KubeAPIWarningLogger
```

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
