### PR TITLE
Update README for 1.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ the specification and Custom Resource Definitions (CRDs).
 ## Status
 
 The latest supported version is `v1` as released by
-the [v1.0.0 release][gh_release] of this project.
+the [v1.1.0 release][gh_release] of this project.
 
 This version of the API is has GA level support for the following resources:
 
 - `v1.GatewayClass`
 - `v1.Gateway`
 - `v1.HTTPRoute`
+- `v1.GRPCRoute`
 
 For all the other APIs and their support levels please consult [the spec][spec].
 
@@ -70,7 +71,7 @@ Participation in the Kubernetes community is governed by the
 [spec]: https://gateway-api.sigs.k8s.io/reference/spec/
 [concepts]: https://gateway-api.sigs.k8s.io/concepts/api-overview
 [security-model]: https://gateway-api.sigs.k8s.io/concepts/security-model
-[gh_release]: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.0.0
+[gh_release]: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.1.0
 [godoc]: https://pkg.go.dev/sigs.k8s.io/gateway-api
 [conformance-docs]: https://gateway-api.sigs.k8s.io/concepts/conformance/
 [reports-readme]: ./conformance/reports/README.md


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Update README to point to 1.1.0 release and mark GRPCRoute as GA.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
