### PR TITLE
Update GEP-1762 with Gateway name limit recommendations

### DIFF
--- a/apis/v1/gateway_types.go
+++ b/apis/v1/gateway_types.go
@@ -32,6 +32,10 @@ import (
 
 // Gateway represents an instance of a service-traffic handling infrastructure
 // by binding Listeners to a set of IP addresses.
+//
+// It is recommended that the Gateway name field be limited to a maximum length
+// of 63 characters. Gateway names may be used in label values on generated
+// in-cluster resources which have a length limit of 63 characters.
 type Gateway struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -39,6 +39,11 @@ spec:
         description: |-
           Gateway represents an instance of a service-traffic handling infrastructure
           by binding Listeners to a set of IP addresses.
+
+
+          It is recommended that the Gateway name field be limited to a maximum length
+          of 63 characters. Gateway names may be used in label values on generated
+          in-cluster resources which have a length limit of 63 characters.
         properties:
           apiVersion:
             description: |-

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -39,6 +39,11 @@ spec:
         description: |-
           Gateway represents an instance of a service-traffic handling infrastructure
           by binding Listeners to a set of IP addresses.
+
+
+          It is recommended that the Gateway name field be limited to a maximum length
+          of 63 characters. Gateway names may be used in label values on generated
+          in-cluster resources which have a length limit of 63 characters.
         properties:
           apiVersion:
             description: |-

--- a/geps/gep-1762/index.md
+++ b/geps/gep-1762/index.md
@@ -59,6 +59,9 @@ With this configuration, an implementation:
 
 * MUST mark the Gateway as `Programmed` and provide an address in `Status.Addresses` where the Gateway can be reached on each configured port.
 * MUST label all generated resources (Service, Deployment, etc) with `gateway.networking.k8s.io/gateway-name: my-gateway` (where `my-gateway` is the name of the Gateway resource).
+  * In the case that a Gateway resource name is longer than the maximum label value length of 63 characters, implementations MUST set the value of the label to the first 20 characters of the Gateway name with a `-` character appended and then the `sha1` checksum of the remainder of the name (40 characters long) appended.
+  * For example for a Gateway with name `example-very-very-very-very-very-very-very-very-very-long-gateway-name` (70 characters long), the resulting label value would be `example-very-very-ve-65cb6f84bc9e50270d0a6c2f845fd98c6fe8d89f`.
+  * Cluster Operators creating Gateways are encouraged to limit Gateway names to a maximum of 63 characters to ensure the label value avoids this truncation/hashing and is human readable.
 * MUST provision generated resources in the same namespace as the Gateway if they are namespace scoped resources.
   * Cluster scoped resources are not recommended.
 * SHOULD name all generated resources `my-gateway-example` (`<NAME>-<GATEWAY CLASS>`).

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3432,7 +3432,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_Gateway(ref common.ReferenceCallback) 
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Gateway represents an instance of a service-traffic handling infrastructure by binding Listeners to a set of IP addresses.",
+				Description: "Gateway represents an instance of a service-traffic handling infrastructure by binding Listeners to a set of IP addresses.\n\nIt is recommended that the Gateway name field be limited to a maximum length of 63 characters. Gateway names may be used in label values on generated in-cluster resources which have a length limit of 63 characters.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind documentation
/kind gep

**What this PR does / why we need it**:

Updates GEP-1762 to provide guidance for implementers on what to do with the `gateway.networking.k8s.io/gateway-name` (to be put on generated in-cluster resources) when a Gateway's name exceeds 63 characters (the label value length limit).

Also updates Gateway resource to recommend users create Gateways with <= 63 character names.

**Which issue(s) this PR fixes**:

Fixes #2592 

**Does this PR introduce a user-facing change?**:

```release-note
Gateway names are recommended to be no longer than the maximum label value length of 63 characters to ensure compatibility with in-cluster implementations which set the Gateway name as a label on generated resources.
```
