### PR TITLE
Correct PR link for GEP-995 implementation

### DIFF
--- a/geps/gep-2648/index.md
+++ b/geps/gep-2648/index.md
@@ -162,7 +162,7 @@ of other resources, for example:
 
 * Service.Ports.Name
 * Gateway.Listeners.Name
-* HTTPRoute.Rules.Name (once they are added in GEP-995, PR at https://github.com/kubernetes-sigs/gateway-api/pull/2593)
+* HTTPRoute.Rules.Name (once they are added in GEP-995, implementation tracked by [#2985](https://github.com/kubernetes-sigs/gateway-api/pull/2985))
 
 Implementations SHOULD NOT use the name of a `backendRef` for applying Policy,
 since the `backendRef` both is not guaranteed to be unique across a Route's rules,


### PR DESCRIPTION
While reading https://gateway-api.sigs.k8s.io/geps/gep-2648/#migration-from-single-to-multiple-targets I saw this text:

> HTTPRoute.Rules.Name (once they are added in GEP-995, PR at `https://github.com/kubernetes-sigs/gateway-api/pull/2593`)

Following through I see that 2593 is merged but needs a second PR to actually implement it.  I've updated the text to say

> HTTPRoute.Rules.Name (once they are added in GEP-995, implementation tracked by [#2985](https://github.com/kubernetes-sigs/gateway-api/pull/2985))

so people don't have to walk the same path I did.