### PR TITLE
promote HTTPRoute backend protocol from experimental to  extended

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -144,6 +144,12 @@ const (
 
 	// This option indicates support for HTTPRoute parentRef port (extended conformance).
 	SupportHTTPRouteParentRefPort SupportedFeature = "HTTPRouteParentRefPort"
+
+	// This option indicates support for HTTPRoute with a backendref with an appProtocol 'kubernetes.io/h2c' (extended conformance)
+	SupportHTTPRouteBackendProtocolH2C SupportedFeature = "HTTPRouteBackendProtocolH2C"
+
+	// This option indicates support for HTTPRoute with a backendref with an appProtoocol 'kubernetes.io/ws' (extended conformance)
+	SupportHTTPRouteBackendProtocolWebSocket SupportedFeature = "HTTPRouteBackendProtocolWebSocket"
 )
 
 // HTTPRouteExtendedFeatures includes all extended features for HTTPRoute
@@ -164,6 +170,8 @@ var HTTPRouteExtendedFeatures = sets.New(
 	SupportHTTPRouteBackendTimeout,
 	SupportHTTPRouteParentRefPort,
 	SupportHTTPRouteBackendRequestHeaderModification,
+	SupportHTTPRouteBackendProtocolH2C,
+	SupportHTTPRouteBackendProtocolWebSocket,
 )
 
 // -----------------------------------------------------------------------------
@@ -173,12 +181,6 @@ var HTTPRouteExtendedFeatures = sets.New(
 const (
 	// This option indicates support for Destination Port matching.
 	SupportHTTPRouteDestinationPortMatching SupportedFeature = "HTTPRouteDestinationPortMatching"
-
-	// This option indicates support for HTTPRoute with a backendref with an appProtocol 'kubernetes.io/h2c'
-	SupportHTTPRouteBackendProtocolH2C SupportedFeature = "HTTPRouteBackendProtocolH2C"
-
-	// This option indicates support for HTTPRoute with a backendref with an appProtoocol 'kubernetes.io/ws'
-	SupportHTTPRouteBackendProtocolWebSocket SupportedFeature = "HTTPRouteBackendProtocolWebSocket"
 )
 
 // HTTPRouteExperimentalFeatures includes all the supported experimental features, currently only
@@ -186,8 +188,6 @@ const (
 // Implementations have the flexibility to opt-in for either specific features or the entire set.
 var HTTPRouteExperimentalFeatures = sets.New(
 	SupportHTTPRouteDestinationPortMatching,
-	SupportHTTPRouteBackendProtocolH2C,
-	SupportHTTPRouteBackendProtocolWebSocket,
 )
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
**What type of PR is this?**
/kind gep
/area conformance

**What this PR does / why we need it**:
This promotes backend protocol selection as part of Gateway v1.2 release

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes-sigs/gateway-api/issues/1911

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Backend Protocol Selection is no longer experimental and is now part of HTTPRoute Extended Conformance
```
