### PR TITLE
Replace keithmattix as a mesh lead and replace with mikemorris

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -22,11 +22,11 @@ aliases:
 
   gateway-api-mesh-leads:
     - howardjohn
-    - keithmattix
+    - mikemorris
     - kflynn
 
   emeritus-gateway-api-mesh-leads:
-    - mikemorris
+    - keithmattix
 
   gateway-api-conformance-reviewers:
     - arkodg


### PR DESCRIPTION
Due to increasing responsibilities in other CNCF projects as well as internally, I'm opening this PR to begin the process of stepping down as one of the mesh lead within Gateway API. I've greatly enjoyed the privilege of leading the GAMMA initiative, and even though I think the project will be better served with someone else in my role, I still plan to be involved with the project moving forward.

With this PR, I'd also like to nominate @mikemorris as my replacement. Mike is an emeritus co-lead and has continued to be involved with Gateway API since he stepped down. I have no doubt he is capable to assume the role once again.