### PR TITLE
Expose peer certificates in round tripper response

### DIFF
--- a/conformance/utils/roundtripper/roundtripper.go
+++ b/conformance/utils/roundtripper/roundtripper.go
@@ -99,11 +99,12 @@ type RedirectRequest struct {
 
 // CapturedResponse contains response metadata.
 type CapturedResponse struct {
-	StatusCode      int
-	ContentLength   int64
-	Protocol        string
-	Headers         map[string][]string
-	RedirectRequest *RedirectRequest
+	StatusCode       int
+	ContentLength    int64
+	Protocol         string
+	Headers          map[string][]string
+	RedirectRequest  *RedirectRequest
+	PeerCertificates []*x509.Certificate
 }
 
 // DefaultRoundTripper is the default implementation of a RoundTripper. It will
@@ -256,6 +257,10 @@ func (d *DefaultRoundTripper) defaultRoundTrip(request Request, transport http.R
 		ContentLength: resp.ContentLength,
 		Protocol:      resp.Proto,
 		Headers:       resp.Header,
+	}
+
+	if resp.TLS != nil {
+		cRes.PeerCertificates = resp.TLS.PeerCertificates
 	}
 
 	if IsRedirect(resp.StatusCode) {


### PR DESCRIPTION
**What type of PR is this?**
Add one of the following kinds:

/kind test
/area conformance

**What this PR does / why we need it**:
This PR exposes the peer certificates from the http response in round tripper.

**Which issue(s) this PR fixes**:
Fixes #https://github.com/kubernetes-sigs/gateway-api/issues/3020

**Does this PR introduce a user-facing change?**:
```release-note

NONE

```
