### PR TITLE
Fix rendering of list in GEP-713

### DIFF
--- a/geps/gep-713/index.md
+++ b/geps/gep-713/index.md
@@ -28,6 +28,7 @@ settings across either one object (this is "Direct Policy Attachment"), or objec
 in a hierarchy (this is "Inherited Policy Attachment").
 
 Individual policy APIs:
+
 - MUST be their own CRDs (e.g. `TimeoutPolicy`, `RetryPolicy` etc),
 - MUST include both `spec` and `status` stanzas
 - MUST have the `status` stanza include a `conditions` section using the standard


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind documentation

**What this PR does / why we need it**:

Fix rendering of the list of conditions on policy APIs.

<img width="845" alt="Screenshot 2024-05-24 at 7 38 18 PM" src="https://github.com/kubernetes-sigs/gateway-api/assets/132510/85b85b95-74d2-475d-8242-b7f3edc3d07a">

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
