### PR TITLE
Remove description of GAMMA concepts as "experimental in v0.8".

### DIFF
--- a/site-src/concepts/api-overview.md
+++ b/site-src/concepts/api-overview.md
@@ -320,16 +320,6 @@ Please refer to the [TLS details](/guides/tls) guide for a deep dive on TLS.
 
 ## Attaching Routes to Services
 
-!!! danger "Experimental in v0.8.0"
-
-    The [GAMMA initiative][gamma] work for supporting service mesh use cases
-    is _experimental_ in `v0.8.0`. It is possible that it will change; we do
-    not recommend it in production at this point.
-
-    In particular, binding Routes directly to Services seems to be the current
-    best choice for configuring mesh routing, but it is still **experimental**
-    and thus **subject to change**.
-
 When using Gateway API to configure a [service mesh], the Route will
 attach directly to a Service, representing configuration meant to be applied
 to any traffic directed to the Service. How and which Routes attach to a given

--- a/site-src/concepts/use-cases.md
+++ b/site-src/concepts/use-cases.md
@@ -125,12 +125,6 @@ that Chihiro and Ian are handling.
 
 ## Basic [east/west] use case
 
-!!! danger "Experimental in v0.8.0"
-
-    The [GAMMA initiative][gamma] work for supporting service mesh use cases
-    is _experimental_ in `v0.8.0`. It is possible that it will change; we do
-    not recommend it in production at this point.
-
 In this scenario, Ana has built a workload which is already running in a
 cluster with a [GAMMA]-compliant [service mesh]. She wants to use the mesh to
 protect her workload by rejecting calls to her workload with incorrect
@@ -157,12 +151,6 @@ bottlenecks in requests to Chihiro or Ian.
 [service mesh]:/concepts/glossary#service-mesh
 
 ## Gateway and mesh use case
-
-!!! danger "Experimental in v0.8.0"
-
-    The [GAMMA initiative][gamma] work for supporting service mesh use cases
-    is _experimental_ in `v0.8.0`. It is possible that it will change; we do
-    not recommend it in production at this point.
 
 This is effectively a combination of the [multiple applications behind a
 single Gateway](#multiple-applications-behind-a-single-gateway) and [basic


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
A few pages talked about binding routes to Services as experimental; that is the implementation that carried forward so these can be removed.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
