### PR TITLE
Drop experimental banner for backend-protocol selection

### DIFF
--- a/site-src/guides/backend-protocol.md
+++ b/site-src/guides/backend-protocol.md
@@ -1,5 +1,11 @@
 # Backend Protocol
 
+??? success "Standard Channel since v1.2.0"
+
+    This concept has been part of the Standard Channel since `v1.2.0`.
+    For more information on release channels, refer to our
+    [versioning guide](/concepts/versioning).
+
 Not all implementations of Gateway API support automatic protocol selection. In some cases protocols are disabled without an explicit opt-in. 
 
 When a Route's backend references a Kubernetes Service, application developers can specify the protocol using `ServicePort` [`appProtocol`][appProtocol] field.

--- a/site-src/guides/backend-protocol.md
+++ b/site-src/guides/backend-protocol.md
@@ -1,11 +1,5 @@
 # Backend Protocol
 
-??? example "Experimental Channel since v1.0.0"
-
-    This concept has been part of the Experimental Channel since `v1.0.0`.
-    For more information on release channels, refer to our
-    [versioning guide](/concepts/versioning).
-
 Not all implementations of Gateway API support automatic protocol selection. In some cases protocols are disabled without an explicit opt-in. 
 
 When a Route's backend references a Kubernetes Service, application developers can specify the protocol using `ServicePort` [`appProtocol`][appProtocol] field.


### PR DESCRIPTION

**What type of PR is this?**
/kind documentation
/gep

**What this PR does / why we need it**:
Docs changes for backend protocol selection for Gateway Release v1.2

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Part of https://github.com/kubernetes-sigs/gateway-api/issues/1911

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
