### PR TITLE
Fix v1beta1 HTTPHeaderName alias

### DIFF
--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -111,7 +111,7 @@ type HeaderMatchType = v1.HeaderMatchType
 //
 // * "/invalid" - "/" is an invalid character
 // +k8s:deepcopy-gen=false
-type HTTPHeaderName = v1.HeaderName
+type HTTPHeaderName = v1.HTTPHeaderName
 
 // HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
 // headers.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently, the v1beta1 HTTPHeaderName aliases directly to v1.HeaderName instead of v1.HTTPHeaderName (which then aliases to v1.HeaderName).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
