### PR TITLE
Support wide output format for get commands (-o wide)

### DIFF
--- a/gwctl/cmd/subcommand.go
+++ b/gwctl/cmd/subcommand.go
@@ -349,7 +349,7 @@ func runGetOrDescribeBackends(f cmdutils.Factory, o *getOrDescribeOptions) {
 	realClock := clock.RealClock{}
 	backendsPrinter := &printer.BackendsPrinter{Writer: o.out, Clock: realClock}
 	if o.cmdName == commandNameGet {
-		backendsPrinter.Print(resourceModel)
+		printer.Print(backendsPrinter, resourceModel, o.outputFormat)
 	} else {
 		backendsPrinter.PrintDescribeView(resourceModel)
 	}

--- a/gwctl/pkg/printer/backends_test.go
+++ b/gwctl/pkg/printer/backends_test.go
@@ -196,15 +196,32 @@ func TestBackendsPrinter_Print(t *testing.T) {
 		Clock:  fakeClock,
 	}
 
-	bp.Print(resourceModel)
+	bp.PrintTable(resourceModel, false)
 
 	got := buff.String()
 	want := `
+NAMESPACE  NAME       TYPE     REFERRED BY ROUTES                                 AGE
+ns1        foo-svc-1  Service  ns1/foo-httproute-1                                3d
+ns1        foo-svc-2  Service  ns1/foo-httproute-2, ns1/foo-httproute-3 + 2 more  2d
+`
+	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
+	}
+
+	buff.Reset()
+	nsp2 := &BackendsPrinter{
+		Writer: buff,
+		Clock:  fakeClock,
+	}
+	nsp2.PrintTable(resourceModel, true)
+
+	got2 := buff.String()
+	want2 := `
 NAMESPACE  NAME       TYPE     REFERRED BY ROUTES                                 AGE  POLICIES
 ns1        foo-svc-1  Service  ns1/foo-httproute-1                                3d   1
 ns1        foo-svc-2  Service  ns1/foo-httproute-2, ns1/foo-httproute-3 + 2 more  2d   0
 `
-	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
-		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
+	if diff := cmp.Diff(common.YamlString(want2), common.YamlString(got2), common.YamlStringTransformer); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got2, want2, diff)
 	}
 }

--- a/gwctl/pkg/printer/backends_test.go
+++ b/gwctl/pkg/printer/backends_test.go
@@ -200,9 +200,9 @@ func TestBackendsPrinter_Print(t *testing.T) {
 
 	got := buff.String()
 	want := `
-NAMESPACE  NAME       TYPE     REFERRED BY ROUTES                                 AGE
-ns1        foo-svc-1  Service  ns1/foo-httproute-1                                3d
-ns1        foo-svc-2  Service  ns1/foo-httproute-2, ns1/foo-httproute-3 + 2 more  2d
+NAMESPACE  NAME       TYPE     AGE
+ns1        foo-svc-1  Service  3d
+ns1        foo-svc-2  Service  2d
 `
 	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
 		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
@@ -217,9 +217,9 @@ ns1        foo-svc-2  Service  ns1/foo-httproute-2, ns1/foo-httproute-3 + 2 more
 
 	got2 := buff.String()
 	want2 := `
-NAMESPACE  NAME       TYPE     REFERRED BY ROUTES                                 AGE  POLICIES
-ns1        foo-svc-1  Service  ns1/foo-httproute-1                                3d   1
-ns1        foo-svc-2  Service  ns1/foo-httproute-2, ns1/foo-httproute-3 + 2 more  2d   0
+NAMESPACE  NAME       TYPE     AGE  REFERRED BY ROUTES                                 POLICIES
+ns1        foo-svc-1  Service  3d   ns1/foo-httproute-1                                1
+ns1        foo-svc-2  Service  2d   ns1/foo-httproute-2, ns1/foo-httproute-3 + 2 more  0
 `
 	if diff := cmp.Diff(common.YamlString(want2), common.YamlString(got2), common.YamlStringTransformer); diff != "" {
 		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got2, want2, diff)

--- a/gwctl/pkg/printer/gatewayclasses.go
+++ b/gwctl/pkg/printer/gatewayclasses.go
@@ -38,9 +38,15 @@ func (gcp *GatewayClassesPrinter) GetPrintableNodes(resourceModel *resourcedisco
 	return NodeResources(maps.Values(resourceModel.GatewayClasses))
 }
 
-func (gcp *GatewayClassesPrinter) PrintTable(resourceModel *resourcediscovery.ResourceModel) {
+func (gcp *GatewayClassesPrinter) PrintTable(resourceModel *resourcediscovery.ResourceModel, wide bool) {
+	var columnNames []string
+	if wide {
+		columnNames = []string{"NAME", "CONTROLLER", "ACCEPTED", "AGE", "GATEWAYS"}
+	} else {
+		columnNames = []string{"NAME", "CONTROLLER", "ACCEPTED", "AGE"}
+	}
 	table := &Table{
-		ColumnNames:  []string{"NAME", "CONTROLLER", "ACCEPTED", "AGE"},
+		ColumnNames:  columnNames,
 		UseSeparator: false,
 	}
 
@@ -61,6 +67,10 @@ func (gcp *GatewayClassesPrinter) PrintTable(resourceModel *resourcediscovery.Re
 			string(gatewayClassNode.GatewayClass.Spec.ControllerName),
 			accepted,
 			age,
+		}
+		if wide {
+			gatewayCount := fmt.Sprintf("%d", len(gatewayClassNode.Gateways))
+			row = append(row, gatewayCount)
 		}
 		table.Rows = append(table.Rows, row)
 	}

--- a/gwctl/pkg/printer/gateways.go
+++ b/gwctl/pkg/printer/gateways.go
@@ -42,9 +42,9 @@ func (gp *GatewaysPrinter) GetPrintableNodes(resourceModel *resourcediscovery.Re
 func (gp *GatewaysPrinter) PrintTable(resourceModel *resourcediscovery.ResourceModel, wide bool) {
 	var columnNames []string
 	if wide {
-		columnNames = []string{"NAME", "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE", "POLICIES", "HTTPROUTES"}
+		columnNames = []string{"NAMESPACE", "NAME", "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE", "POLICIES", "HTTPROUTES"}
 	} else {
-		columnNames = []string{"NAME", "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE"}
+		columnNames = []string{"NAMESPACE", "NAME", "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE"}
 	}
 	table := &Table{
 		ColumnNames:  columnNames,

--- a/gwctl/pkg/printer/gateways.go
+++ b/gwctl/pkg/printer/gateways.go
@@ -39,9 +39,15 @@ func (gp *GatewaysPrinter) GetPrintableNodes(resourceModel *resourcediscovery.Re
 	return NodeResources(maps.Values(resourceModel.Gateways))
 }
 
-func (gp *GatewaysPrinter) PrintTable(resourceModel *resourcediscovery.ResourceModel) {
+func (gp *GatewaysPrinter) PrintTable(resourceModel *resourcediscovery.ResourceModel, wide bool) {
+	var columnNames []string
+	if wide {
+		columnNames = []string{"NAME", "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE", "POLICIES", "HTTPROUTES"}
+	} else {
+		columnNames = []string{"NAME", "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE"}
+	}
 	table := &Table{
-		ColumnNames:  []string{"NAME", "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE"},
+		ColumnNames:  columnNames,
 		UseSeparator: false,
 	}
 
@@ -80,6 +86,11 @@ func (gp *GatewaysPrinter) PrintTable(resourceModel *resourcediscovery.ResourceM
 			portsOutput,
 			programmedStatus,
 			age,
+		}
+		if wide {
+			policiesCount := fmt.Sprintf("%d", len(gatewayNode.Policies))
+			httpRoutesCount := fmt.Sprintf("%d", len(gatewayNode.HTTPRoutes))
+			row = append(row, policiesCount, httpRoutesCount)
 		}
 		table.Rows = append(table.Rows, row)
 	}

--- a/gwctl/pkg/printer/gateways_test.go
+++ b/gwctl/pkg/printer/gateways_test.go
@@ -301,10 +301,10 @@ default    random-gateway     regional-internal-class  10.11.12.13              
 
 	got2 := buff.String()
 	want2 := `
-NAME               CLASS                    ADDRESSES                   PORTS     PROGRAMMED  AGE  POLICIES  HTTPROUTES
-abc-gateway-12345  internal-class           192.168.100.5               443,8080  False       20d  0         1
-demo-gateway-2     external-class           10.0.0.1,10.0.0.2 + 1 more  80        True        5d   0         0
-random-gateway     regional-internal-class  10.11.12.13                 8443      Unknown     3s   1         0
+NAMESPACE  NAME               CLASS                    ADDRESSES                   PORTS     PROGRAMMED  AGE  POLICIES  HTTPROUTES
+default    abc-gateway-12345  internal-class           192.168.100.5               443,8080  False       20d  0         1
+default    demo-gateway-2     external-class           10.0.0.1,10.0.0.2 + 1 more  80        True        5d   0         0
+default    random-gateway     regional-internal-class  10.11.12.13                 8443      Unknown     3s   1         0
 `
 	if diff := cmp.Diff(common.YamlString(want2), common.YamlString(got2), common.YamlStringTransformer); diff != "" {
 		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got2, want2, diff)

--- a/gwctl/pkg/printer/gateways_test.go
+++ b/gwctl/pkg/printer/gateways_test.go
@@ -173,6 +173,90 @@ func TestGatewaysPrinter_PrintTable(t *testing.T) {
 				},
 			},
 		},
+		&gatewayv1.HTTPRoute{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "HTTPRoute",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo-httproute",
+			},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{{
+						Kind:  common.PtrTo(gatewayv1.Kind("Gateway")),
+						Group: common.PtrTo(gatewayv1.Group("gateway.networking.k8s.io")),
+						Name:  "abc-gateway-12345",
+					}},
+				},
+			},
+		},
+
+		&apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "healthcheckpolicies.foo.com",
+				Labels: map[string]string{
+					gatewayv1alpha2.PolicyLabelKey: "inherited",
+				},
+			},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Scope:    apiextensionsv1.ClusterScoped,
+				Group:    "foo.com",
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{Name: "v1"}},
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
+					Plural: "healthcheckpolicies",
+					Kind:   "HealthCheckPolicy",
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "foo.com/v1",
+				"kind":       "HealthCheckPolicy",
+				"metadata": map[string]interface{}{
+					"name": "health-check-gatewayclass",
+				},
+				"spec": map[string]interface{}{
+					"override": map[string]interface{}{
+						"key1": "value-parent-1",
+						"key3": "value-parent-3",
+						"key5": "value-parent-5",
+					},
+					"default": map[string]interface{}{
+						"key2": "value-parent-2",
+						"key4": "value-parent-4",
+					},
+					"targetRef": map[string]interface{}{
+						"group": "gateway.networking.k8s.io",
+						"kind":  "GatewayClass",
+						"name":  "regional-internal-class",
+					},
+				},
+			},
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "foo.com/v1",
+				"kind":       "HealthCheckPolicy",
+				"metadata": map[string]interface{}{
+					"name": "health-check-gateway",
+				},
+				"spec": map[string]interface{}{
+					"override": map[string]interface{}{
+						"key1": "value-child-1",
+					},
+					"default": map[string]interface{}{
+						"key2": "value-child-2",
+						"key5": "value-child-5",
+					},
+					"targetRef": map[string]interface{}{
+						"group":     "gateway.networking.k8s.io",
+						"kind":      "Gateway",
+						"name":      "random-gateway",
+						"namespace": "default",
+					},
+				},
+			},
+		},
 	}
 
 	k8sClients := common.MustClientsForTest(t, objects...)
@@ -191,7 +275,7 @@ func TestGatewaysPrinter_PrintTable(t *testing.T) {
 		Writer: buff,
 		Clock:  fakeClock,
 	}
-	gp.PrintTable(resourceModel)
+	gp.PrintTable(resourceModel, false)
 
 	got := buff.String()
 	want := `
@@ -203,6 +287,24 @@ random-gateway     regional-internal-class  10.11.12.13                 8443    
 
 	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {
 		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got, want, diff)
+	}
+
+	buff.Reset()
+	nsp2 := &GatewaysPrinter{
+		Writer: buff,
+		Clock:  fakeClock,
+	}
+	nsp2.PrintTable(resourceModel, true)
+
+	got2 := buff.String()
+	want2 := `
+NAME               CLASS                    ADDRESSES                   PORTS     PROGRAMMED  AGE  POLICIES  HTTPROUTES
+abc-gateway-12345  internal-class           192.168.100.5               443,8080  False       20d  0         1
+demo-gateway-2     external-class           10.0.0.1,10.0.0.2 + 1 more  80        True        5d   0         0
+random-gateway     regional-internal-class  10.11.12.13                 8443      Unknown     3s   1         0
+`
+	if diff := cmp.Diff(common.YamlString(want2), common.YamlString(got2), common.YamlStringTransformer); diff != "" {
+		t.Errorf("Unexpected diff\ngot=\n%v\nwant=\n%v\ndiff (-want +got)=\n%v", got2, want2, diff)
 	}
 }
 

--- a/gwctl/pkg/printer/httproutes.go
+++ b/gwctl/pkg/printer/httproutes.go
@@ -43,12 +43,18 @@ func (hp *HTTPRoutesPrinter) GetPrintableNodes(resourceModel *resourcediscovery.
 	return NodeResources(maps.Values(resourceModel.HTTPRoutes))
 }
 
-func (hp *HTTPRoutesPrinter) PrintTable(resourceModel *resourcediscovery.ResourceModel) {
-	table := &Table{
-		ColumnNames:  []string{"NAMESPACE", "NAME", "HOSTNAMES", "PARENT REFS", "AGE"},
-		UseSeparator: false,
+func (hp *HTTPRoutesPrinter) PrintTable(resourceModel *resourcediscovery.ResourceModel, wide bool) {
+	var columnNames []string
+	if wide {
+		columnNames = []string{"NAMESPACE", "NAME", "HOSTNAMES", "PARENT REFS", "AGE", "POLICIES"}
+	} else {
+		columnNames = []string{"NAMESPACE", "NAME", "HOSTNAMES", "PARENT REFS", "AGE"}
 	}
 
+	table := &Table{
+		ColumnNames:  columnNames,
+		UseSeparator: false,
+	}
 	httpRouteNodes := maps.Values(resourceModel.HTTPRoutes)
 
 	for _, httpRouteNode := range SortByString(httpRouteNodes) {
@@ -75,6 +81,10 @@ func (hp *HTTPRoutesPrinter) PrintTable(resourceModel *resourcediscovery.Resourc
 			hostNamesOutput,
 			parentRefsCount,
 			age,
+		}
+		if wide {
+			policiesCount := fmt.Sprintf("%d", len(httpRouteNode.Policies))
+			row = append(row, policiesCount)
 		}
 		table.Rows = append(table.Rows, row)
 	}

--- a/gwctl/pkg/printer/namespace.go
+++ b/gwctl/pkg/printer/namespace.go
@@ -38,9 +38,16 @@ func (nsp *NamespacesPrinter) GetPrintableNodes(resourceModel *resourcediscovery
 	return NodeResources(maps.Values(resourceModel.Namespaces))
 }
 
-func (nsp *NamespacesPrinter) PrintTable(resourceModel *resourcediscovery.ResourceModel) {
+func (nsp *NamespacesPrinter) PrintTable(resourceModel *resourcediscovery.ResourceModel, wide bool) {
+	var columnNames []string
+	if wide {
+		columnNames = []string{"NAME", "STATUS", "AGE", "POLICIES"}
+	} else {
+		columnNames = []string{"NAME", "STATUS", "AGE"}
+	}
+
 	table := &Table{
-		ColumnNames:  []string{"NAME", "STATUS", "AGE"},
+		ColumnNames:  columnNames,
 		UseSeparator: false,
 	}
 
@@ -51,6 +58,10 @@ func (nsp *NamespacesPrinter) PrintTable(resourceModel *resourcediscovery.Resour
 			namespaceNode.Namespace.Name,
 			string(namespaceNode.Namespace.Status.Phase),
 			age,
+		}
+		if wide {
+			policiesCount := fmt.Sprintf("%d", len(namespaceNode.Policies))
+			row = append(row, policiesCount)
 		}
 		table.Rows = append(table.Rows, row)
 	}

--- a/gwctl/pkg/printer/policies.go
+++ b/gwctl/pkg/printer/policies.go
@@ -88,7 +88,7 @@ func (pp *PoliciesPrinter) PrintPolicies(policies []policymanager.Policy, format
 	switch format {
 	case utils.OutputFormatJSON, utils.OutputFormatYAML:
 		pp.printClientObjects(clientObjects, format)
-	case utils.OutputFormatTable:
+	case utils.OutputFormatTable, utils.OutputFormatWide:
 		pp.printPoliciesTable(sortedPolicies)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown output format '%s' found\n", format)
@@ -129,7 +129,7 @@ func (pp *PoliciesPrinter) PrintCRDs(policyCRDs []policymanager.PolicyCRD, forma
 	switch format {
 	case utils.OutputFormatJSON, utils.OutputFormatYAML:
 		pp.printClientObjects(clientObjects, format)
-	case utils.OutputFormatTable:
+	case utils.OutputFormatTable, utils.OutputFormatWide:
 		pp.printCRDsTable(sortedPolicyCRDs)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown output format '%s' found\n", format)

--- a/gwctl/pkg/printer/printer.go
+++ b/gwctl/pkg/printer/printer.go
@@ -32,13 +32,15 @@ import (
 type Printer interface {
 	io.Writer
 	GetPrintableNodes(resourceModel *resourcediscovery.ResourceModel) []NodeResource
-	PrintTable(resourceModel *resourcediscovery.ResourceModel)
+	PrintTable(resourceModel *resourcediscovery.ResourceModel, wide bool)
 }
 
 func Print(p Printer, resourceModel *resourcediscovery.ResourceModel, format utils.OutputFormat) {
 	switch format {
 	case utils.OutputFormatTable:
-		p.PrintTable(resourceModel)
+		p.PrintTable(resourceModel, false)
+	case utils.OutputFormatWIDE:
+		p.PrintTable(resourceModel, true)
 	case utils.OutputFormatJSON, utils.OutputFormatYAML:
 		nodes := SortByString(p.GetPrintableNodes(resourceModel))
 		clientObjects := ClientObjects(nodes)

--- a/gwctl/pkg/printer/printer.go
+++ b/gwctl/pkg/printer/printer.go
@@ -39,7 +39,7 @@ func Print(p Printer, resourceModel *resourcediscovery.ResourceModel, format uti
 	switch format {
 	case utils.OutputFormatTable:
 		p.PrintTable(resourceModel, false)
-	case utils.OutputFormatWIDE:
+	case utils.OutputFormatWide:
 		p.PrintTable(resourceModel, true)
 	case utils.OutputFormatJSON, utils.OutputFormatYAML:
 		nodes := SortByString(p.GetPrintableNodes(resourceModel))

--- a/gwctl/pkg/utils/types.go
+++ b/gwctl/pkg/utils/types.go
@@ -100,6 +100,7 @@ func MustPolicyManagerForTest(t *testing.T, fakeClients *common.K8sClients) *pol
 type OutputFormat string
 
 const (
+	OutputFormatWIDE  OutputFormat = "wide"
 	OutputFormatJSON  OutputFormat = "json"
 	OutputFormatYAML  OutputFormat = "yaml"
 	OutputFormatTable OutputFormat = ""
@@ -107,6 +108,8 @@ const (
 
 func ValidateAndReturnOutputFormat(format string) (OutputFormat, error) {
 	switch format {
+	case "wide":
+		return OutputFormatWIDE, nil
 	case "json":
 		return OutputFormatJSON, nil
 	case "yaml":

--- a/gwctl/pkg/utils/types.go
+++ b/gwctl/pkg/utils/types.go
@@ -100,7 +100,7 @@ func MustPolicyManagerForTest(t *testing.T, fakeClients *common.K8sClients) *pol
 type OutputFormat string
 
 const (
-	OutputFormatWIDE  OutputFormat = "wide"
+	OutputFormatWide  OutputFormat = "wide"
 	OutputFormatJSON  OutputFormat = "json"
 	OutputFormatYAML  OutputFormat = "yaml"
 	OutputFormatTable OutputFormat = ""
@@ -109,7 +109,7 @@ const (
 func ValidateAndReturnOutputFormat(format string) (OutputFormat, error) {
 	switch format {
 	case "wide":
-		return OutputFormatWIDE, nil
+		return OutputFormatWide, nil
 	case "json":
 		return OutputFormatJSON, nil
 	case "yaml":


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2889

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
1.Support wide output format for get commands (-o wide)
2.Replace `Print` in BackendsPrinter with `PrintTable`
```

```yaml
cat <<EOF | kubectl apply -f -
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: BackendTLSPolicy
metadata:
  name: enable-backend-tls
  namespace: default
spec:
  targetRef:
    group: ''
    kind: Service
    name: tls-backend
    sectionName: "443"
  tls:
    caCertRefs:
    - name: example-ca
      group: ''
      kind: ConfigMap
    hostname: www.example.com
EOF

```
- **backend**
```
➜  ✗ gwctl get backend       
NAMESPACE  NAME         TYPE     AGE
default    backend      Service  106d
default    kubernetes   Service  106d
default    tls-backend  Service  44h

➜  ✗ gwctl get backend -owide
NAMESPACE  NAME         TYPE     AGE   REFERRED BY ROUTES  POLICIES
default    backend      Service  106d  None                0
default    kubernetes   Service  106d  None                0
default    tls-backend  Service  44h   default/backend     1
```

- **gatewayclass**
```
➜  ✗ gwctl get gatewayclass       
NAME           CONTROLLER                                     ACCEPTED  AGE
eg             gateway.envoyproxy.io/gatewayclass-controller  True      104d
envoy-gateway  gateway.envoyproxy.io/gatewayclass-controller  True      95d

➜  ✗ gwctl get gatewayclass -owide
NAME           CONTROLLER                                     ACCEPTED  AGE   GATEWAYS
eg             gateway.envoyproxy.io/gatewayclass-controller  True      104d  1
envoy-gateway  gateway.envoyproxy.io/gatewayclass-controller  True      95d   0
```

- **gateway**
```
➜  ✗ gwctl get gateway      
NAMESPACE  NAME  CLASS  ADDRESSES       PORTS  PROGRAMMED  AGE
default    eg    eg     172.18.255.201  80     True        106d

➜  ✗ gwctl get gateway -owide
NAMESPACE  NAME  CLASS  ADDRESSES       PORTS  PROGRAMMED  AGE   POLICIES  HTTPROUTES
default    eg    eg     172.18.255.201  80     True        106d  0         1
```

- **httproute**
```
➜  ✗ gwctl get httproute
NAMESPACE  NAME     HOSTNAMES        PARENT REFS  AGE
default    backend  www.example.com  1            104d
➜  ✗ gwctl get httproute -owide
NAMESPACE  NAME     HOSTNAMES        PARENT REFS  AGE   POLICIES
default    backend  www.example.com  1            104d  0

```

- **namespace**
```
➜  ✗ gwctl get ns
NAME                  STATUS  AGE
default               Active  104d
envoy-gateway-system  Active  104d
kube-node-lease       Active  104d
kube-public           Active  104d
kube-system           Active  104d
local-path-storage    Active  104d
metallb-system        Active  95d
monitoring            Active  94d
➜  ✗ gwctl get ns -owide
NAME                  STATUS  AGE   POLICIES
default               Active  104d  0
envoy-gateway-system  Active  104d  0
kube-node-lease       Active  104d  0
kube-public           Active  104d  0
kube-system           Active  104d  0
local-path-storage    Active  104d  0
metallb-system        Active  95d   0
monitoring            Active  94d   0
```

