### PR TITLE
Outputs ns for gateways in gwctl

### DIFF
--- a/gwctl/pkg/printer/gateways.go
+++ b/gwctl/pkg/printer/gateways.go
@@ -41,7 +41,7 @@ func (gp *GatewaysPrinter) GetPrintableNodes(resourceModel *resourcediscovery.Re
 
 func (gp *GatewaysPrinter) PrintTable(resourceModel *resourcediscovery.ResourceModel) {
 	table := &Table{
-		ColumnNames:  []string{"NAME", "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE"},
+		ColumnNames:  []string{"NAMESPACE", "NAME", "CLASS", "ADDRESSES", "PORTS", "PROGRAMMED", "AGE"},
 		UseSeparator: false,
 	}
 
@@ -74,6 +74,7 @@ func (gp *GatewaysPrinter) PrintTable(resourceModel *resourcediscovery.ResourceM
 		age := duration.HumanDuration(gp.Clock.Since(gatewayNode.Gateway.GetCreationTimestamp().Time))
 
 		row := []string{
+			gatewayNode.Gateway.GetNamespace(),
 			gatewayNode.Gateway.GetName(),
 			string(gatewayNode.Gateway.Spec.GatewayClassName),
 			addressesOutput,

--- a/gwctl/pkg/printer/gateways_test.go
+++ b/gwctl/pkg/printer/gateways_test.go
@@ -71,7 +71,8 @@ func TestGatewaysPrinter_PrintTable(t *testing.T) {
 		},
 		&gatewayv1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "abc-gateway-12345",
+				Name:      "abc-gateway-12345",
+				Namespace: "default",
 				CreationTimestamp: metav1.Time{
 					Time: fakeClock.Now().Add(-20 * 24 * time.Hour),
 				},
@@ -107,7 +108,8 @@ func TestGatewaysPrinter_PrintTable(t *testing.T) {
 		},
 		&gatewayv1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "demo-gateway-2",
+				Name:      "demo-gateway-2",
+				Namespace: "default",
 				CreationTimestamp: metav1.Time{
 					Time: fakeClock.Now().Add(-5 * 24 * time.Hour),
 				},
@@ -144,7 +146,8 @@ func TestGatewaysPrinter_PrintTable(t *testing.T) {
 		},
 		&gatewayv1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "random-gateway",
+				Name:      "random-gateway",
+				Namespace: "default",
 				CreationTimestamp: metav1.Time{
 					Time: fakeClock.Now().Add(-3 * time.Second),
 				},
@@ -195,10 +198,10 @@ func TestGatewaysPrinter_PrintTable(t *testing.T) {
 
 	got := buff.String()
 	want := `
-NAME               CLASS                    ADDRESSES                   PORTS     PROGRAMMED  AGE
-abc-gateway-12345  internal-class           192.168.100.5               443,8080  False       20d
-demo-gateway-2     external-class           10.0.0.1,10.0.0.2 + 1 more  80        True        5d
-random-gateway     regional-internal-class  10.11.12.13                 8443      Unknown     3s
+NAMESPACE  NAME               CLASS                    ADDRESSES                   PORTS     PROGRAMMED  AGE
+default    abc-gateway-12345  internal-class           192.168.100.5               443,8080  False       20d
+default    demo-gateway-2     external-class           10.0.0.1,10.0.0.2 + 1 more  80        True        5d
+default    random-gateway     regional-internal-class  10.11.12.13                 8443      Unknown     3s
 `
 
 	if diff := cmp.Diff(common.YamlString(want), common.YamlString(got), common.YamlStringTransformer); diff != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind gwctl

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:
Related to small usability for `gwctl`.
Now the following output for `gwctl get gateways -A`
```
NAMESPACE  NAME    CLASS   ADDRESSES       PORTS  PROGRAMMED  AGE
cilium     cilium  cilium  172.18.255.200  80     True        2h
default    cilium  cilium  172.18.255.201  80     True        2h
```

**Which issue(s) this PR fixes**:
Related to https://github.com/kubernetes-sigs/gateway-api/issues/3133
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
