### PR TITLE
chore: add conformance report for KIC 3.2.0

### DIFF
--- a/conformance/reports/v1.1.0/kong-kubernetes-ingress-controller/README.md
+++ b/conformance/reports/v1.1.0/kong-kubernetes-ingress-controller/README.md
@@ -1,0 +1,42 @@
+# Kong Kubernetes Ingress Controller
+
+## Table of Contents
+
+| API channel  | Implementation version                                                              | Mode        | Report                                                |
+|--------------|-------------------------------------------------------------------------------------|-------------|-------------------------------------------------------|
+| experimental | [v3.2.0](https://github.com/Kong/kubernetes-ingress-controller/releases/tag/v3.2.0) | expressions | [link](./experimental-v3.2.0-expressions-report.yaml) |
+## Reproduce
+
+### Prerequisites
+
+In order to properly run the conformance tests, you need to have [KinD](https://github.com/kubernetes-sigs/kind)
+and [Helm](https://github.com/helm/helm) installed on your local machine, as the
+test suite will create a fresh KinD cluster and will use Helm to deploy some additional
+components.
+
+### Steps
+
+1. Clone the Kong Ingress Controller GitHub repository
+
+   ```bash
+   git clone https://github.com/Kong/kubernetes-ingress-controller.git && cd kubernetes-ingress-controller
+   ```
+
+2. Check out the desired version
+
+   ```bash
+   export VERSION=v<x.y.z>
+   git checkout $VERSION
+   ```
+
+3. Run the conformance tests
+
+   ```bash
+   KONG_TEST_EXPRESSION_ROUTES=true make test.conformance
+   ```
+
+4. Check the produced report
+
+   ```bash
+   cat ./kong-kubernetes-ingress-controller.yaml
+   ```

--- a/conformance/reports/v1.1.0/kong-kubernetes-ingress-controller/experimental-v3.2.0-expressions-report.yaml
+++ b/conformance/reports/v1.1.0/kong-kubernetes-ingress-controller/experimental-v3.2.0-expressions-report.yaml
@@ -1,0 +1,57 @@
+apiVersion: gateway.networking.k8s.io/v1alpha1
+date: "2024-06-12T12:47:45Z"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.1.0
+implementation:
+  contact:
+    - github.com/kong/kubernetes-ingress-controller/issues/new/choose
+  organization: Kong
+  project: kubernetes-ingress-controller
+  url: github.com/kong/kubernetes-ingress-controller
+  version: v3.2.0
+kind: ConformanceReport
+mode: expressions
+profiles:
+  - core:
+      result: partial
+      skippedTests:
+        - GRPCRouteListenerHostnameMatching
+      statistics:
+        Failed: 0
+        Passed: 11
+        Skipped: 1
+    name: GATEWAY-GRPC
+    summary: Core tests partially succeeded with 1 test skips.
+  - core:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 33
+        Skipped: 0
+    extended:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 5
+        Skipped: 0
+      supportedFeatures:
+        - HTTPRouteHostRewrite
+        - HTTPRouteMethodMatching
+        - HTTPRoutePathRewrite
+        - HTTPRouteQueryParamMatching
+        - HTTPRouteResponseHeaderModification
+      unsupportedFeatures:
+        - GatewayHTTPListenerIsolation
+        - GatewayPort8080
+        - GatewayStaticAddresses
+        - HTTPRouteBackendRequestHeaderModification
+        - HTTPRouteBackendTimeout
+        - HTTPRouteParentRefPort
+        - HTTPRoutePathRedirect
+        - HTTPRoutePortRedirect
+        - HTTPRouteRequestMirror
+        - HTTPRouteRequestMultipleMirrors
+        - HTTPRouteRequestTimeout
+        - HTTPRouteSchemeRedirect
+    name: GATEWAY-HTTP
+    summary: Core tests succeeded. Extended tests succeeded.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
/area conformance

**What this PR does / why we need it**:

Adds a Gateway API v1.1.0 conformance report for Kong's Kubernetes Ingress Controller v3.2.0. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
