### PR TITLE
fix: change report API version

### DIFF
--- a/conformance/apis/v1/groupversion.go
+++ b/conformance/apis/v1/groupversion.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+const (
+	// Group is the API group for the Conformance Report API.
+	Group = "gateway.networking.k8s.io"
+
+	// Version is the API version for the Conformance Report API.
+	Version = "v1"
+)
+
+// GroupVersion is the API group and version for the Conformance Report API.
+var GroupVersion = schema.GroupVersion{Group: Group, Version: Version}

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -458,7 +458,7 @@ func (suite *ConformanceTestSuite) Report() (*confv1.ConformanceReport, error) {
 
 	return &confv1.ConformanceReport{
 		TypeMeta: v1.TypeMeta{
-			APIVersion: "gateway.networking.k8s.io/v1alpha1",
+			APIVersion: confv1.GroupVersion.String(),
 			Kind:       "ConformanceReport",
 		},
 		Date:              time.Now().Format(time.RFC3339),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind bug
/area conformance

**What this PR does / why we need it**:

With the graduation of the conformance test suite we bumped the `ConformanceReport` API to v1. However, we did not change the `APIVersion` of the reports created by the suite accordingly. The result was that we were creating v1 reports with v1alpha1 set as `APIVersion`. This PR fixes such a problem.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The generated conformance report API version is set to v1 instead of v1alpha1.
```
