### PR TITLE
Contour 1.29.1, 1.28.5, 1.27.4 patch release reports

### DIFF
--- a/conformance/reports/v0.8.1/projectcontour-contour/README.md
+++ b/conformance/reports/v0.8.1/projectcontour-contour/README.md
@@ -8,7 +8,7 @@
 |experimental|[v1.27.1](https://github.com/projectcontour/contour/releases/tag/v1.27.1)|x|[link](./v1.27.1-report.yaml)|
 |experimental|[v1.27.2](https://github.com/projectcontour/contour/releases/tag/v1.27.2)|x|[link](./v1.27.2-report.yaml)|
 |experimental|[v1.27.3](https://github.com/projectcontour/contour/releases/tag/v1.27.3)|x|[link](./v1.27.3-report.yaml)|
-|experimental|[v1.27.4](https://github.com/projectcontour/contour/releases/tag/v1.27.4)|x|[link](./experimental-v1.27.3-default-report.yaml)|
+|experimental|[v1.27.4](https://github.com/projectcontour/contour/releases/tag/v1.27.4)|x|[link](./experimental-v1.27.4-default-report.yaml)|
 
 ## Reproduce
 

--- a/conformance/reports/v0.8.1/projectcontour-contour/README.md
+++ b/conformance/reports/v0.8.1/projectcontour-contour/README.md
@@ -8,6 +8,7 @@
 |experimental|[v1.27.1](https://github.com/projectcontour/contour/releases/tag/v1.27.1)|x|[link](./v1.27.1-report.yaml)|
 |experimental|[v1.27.2](https://github.com/projectcontour/contour/releases/tag/v1.27.2)|x|[link](./v1.27.2-report.yaml)|
 |experimental|[v1.27.3](https://github.com/projectcontour/contour/releases/tag/v1.27.3)|x|[link](./v1.27.3-report.yaml)|
+|experimental|[v1.27.4](https://github.com/projectcontour/contour/releases/tag/v1.27.4)|x|[link](./experimental-v1.27.3-default-report.yaml)|
 
 ## Reproduce
 

--- a/conformance/reports/v0.8.1/projectcontour-contour/experimental-v1.27.4-default-report.yaml
+++ b/conformance/reports/v0.8.1/projectcontour-contour/experimental-v1.27.4-default-report.yaml
@@ -1,0 +1,46 @@
+apiVersion: gateway.networking.k8s.io/v1alpha1
+date: "2024-06-12T19:23:58Z"
+gatewayAPIVersion: v0.8.1
+implementation:
+  contact:
+  - '@projectcontour/maintainers'
+  organization: projectcontour
+  project: contour
+  url: https://projectcontour.io/
+  version: v1.27.4
+kind: ConformanceReport
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 29
+      Skipped: 0
+    summary: ""
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 10
+      Skipped: 0
+    summary: ""
+    supportedFeatures:
+    - HTTPRouteMethodMatching
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRoutePathRedirect
+    - HTTPRouteHostRewrite
+    - HTTPRoutePathRewrite
+    - HTTPRouteQueryParamMatching
+    - HTTPResponseHeaderModification
+    - HTTPRoutePortRedirect
+    - HTTPRouteSchemeRedirect
+    - HTTPRouteRequestMirror
+  name: HTTP
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 11
+      Skipped: 0
+    summary: ""
+  name: TLS

--- a/conformance/reports/v1.0.0/projectcontour-contour/README.md
+++ b/conformance/reports/v1.0.0/projectcontour-contour/README.md
@@ -8,6 +8,7 @@
 |experimental|[v1.28.2](https://github.com/projectcontour/contour/releases/tag/v1.28.2)|x|[link](./v1.28.2-report.yaml)|
 |experimental|[v1.28.3](https://github.com/projectcontour/contour/releases/tag/v1.28.3)|x|[link](./v1.28.3-report.yaml)|
 |experimental|[v1.28.4](https://github.com/projectcontour/contour/releases/tag/v1.28.4)|x|[link](./v1.28.4-report.yaml)|
+|experimental|[v1.28.5](https://github.com/projectcontour/contour/releases/tag/v1.28.5)|x|[link](./experimental-v1.28.5-default-report.yaml)|
 |experimental|[v1.29.0](https://github.com/projectcontour/contour/releases/tag/v1.29.0)|x|[link](./v1.29.0-report.yaml)|
 
 ## Reproduce

--- a/conformance/reports/v1.0.0/projectcontour-contour/README.md
+++ b/conformance/reports/v1.0.0/projectcontour-contour/README.md
@@ -10,6 +10,7 @@
 |experimental|[v1.28.4](https://github.com/projectcontour/contour/releases/tag/v1.28.4)|x|[link](./v1.28.4-report.yaml)|
 |experimental|[v1.28.5](https://github.com/projectcontour/contour/releases/tag/v1.28.5)|x|[link](./experimental-v1.28.5-default-report.yaml)|
 |experimental|[v1.29.0](https://github.com/projectcontour/contour/releases/tag/v1.29.0)|x|[link](./v1.29.0-report.yaml)|
+|experimental|[v1.29.1](https://github.com/projectcontour/contour/releases/tag/v1.29.1)|x|[link](./experimental-v1.29.1-default-report.yaml)|
 
 ## Reproduce
 

--- a/conformance/reports/v1.0.0/projectcontour-contour/experimental-v1.28.5-default-report.yaml
+++ b/conformance/reports/v1.0.0/projectcontour-contour/experimental-v1.28.5-default-report.yaml
@@ -1,0 +1,50 @@
+apiVersion: gateway.networking.k8s.io/v1alpha1
+date: "2024-06-12T19:26:43Z"
+gatewayAPIVersion: v1.0.0
+implementation:
+  contact:
+  - '@projectcontour/maintainers'
+  organization: projectcontour
+  project: contour
+  url: https://projectcontour.io/
+  version: v1.28.5
+kind: ConformanceReport
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 10
+      Skipped: 0
+    summary: ""
+  name: TLS
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 29
+      Skipped: 0
+    summary: ""
+  extended:
+    result: partial
+    skippedTests:
+    - HTTPRouteTimeoutBackendRequest
+    statistics:
+      Failed: 0
+      Passed: 11
+      Skipped: 1
+    summary: ""
+    supportedFeatures:
+    - HTTPRoutePathRewrite
+    - HTTPRouteSchemeRedirect
+    - HTTPRouteBackendTimeout
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteMethodMatching
+    - HTTPRouteRequestMirror
+    - HTTPRouteHostRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestTimeout
+    - HTTPRoutePathRedirect
+  name: HTTP

--- a/conformance/reports/v1.0.0/projectcontour-contour/experimental-v1.29.1-default-report.yaml
+++ b/conformance/reports/v1.0.0/projectcontour-contour/experimental-v1.29.1-default-report.yaml
@@ -1,0 +1,48 @@
+apiVersion: gateway.networking.k8s.io/v1alpha1
+date: "2024-06-12T19:30:34Z"
+gatewayAPIVersion: v1.0.0
+implementation:
+  contact:
+  - '@projectcontour/maintainers'
+  organization: projectcontour
+  project: contour
+  url: https://projectcontour.io/
+  version: v1.29.1
+kind: ConformanceReport
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 29
+      Skipped: 0
+    summary: ""
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 12
+      Skipped: 0
+    summary: ""
+    supportedFeatures:
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestTimeout
+    - HTTPRoutePortRedirect
+    - HTTPRouteSchemeRedirect
+    - HTTPRouteHostRewrite
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteMethodMatching
+    - HTTPRoutePathRewrite
+    - HTTPRouteBackendTimeout
+    - HTTPRouteRequestMirror
+    - HTTPRouteResponseHeaderModification
+    - HTTPRoutePathRedirect
+  name: HTTP
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 10
+      Skipped: 0
+    summary: ""
+  name: TLS

--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -175,7 +175,7 @@ effort, check out the #development channel or join our [weekly developer meeting
 
 [Contour][contour] is a CNCF open source Envoy-based ingress controller for Kubernetes.
 
-Contour [v1.29.0][contour-release] implements Gateway API v1.0.0.
+Contour [v1.29.1][contour-release] implements Gateway API v1.0.0.
 All [Standard channel][contour-standard] v1 API group resources (GatewayClass, Gateway, HTTPRoute, ReferenceGrant), plus most v1alpha2 API group resources (TLSRoute, TCPRoute, GRPCRoute, ReferenceGrant, and BackendTLSPolicy) are supported.
 Contour's implementation passes all core and most extended Gateway API conformance tests included in the v1.0.0 release.
 
@@ -184,7 +184,7 @@ See the [Contour Gateway API Guide][contour-guide] for information on how to dep
 For help and support with Contour's implementation, [create an issue][contour-issue-new] or ask for help in the [#contour channel on Kubernetes slack][contour-slack].
 
 [contour]:https://projectcontour.io
-[contour-release]:https://github.com/projectcontour/contour/releases/tag/v1.29.0
+[contour-release]:https://github.com/projectcontour/contour/releases/tag/v1.29.1
 [contour-standard]:https://gateway-api.sigs.k8s.io/concepts/versioning/#release-channels-eg-experimental-standard
 [contour-guide]:https://projectcontour.io/docs/1.29/guides/gateway-api/
 [contour-issue-new]:https://github.com/projectcontour/contour/issues/new/choose


### PR DESCRIPTION
**What type of PR is this?**

/area conformance

**What this PR does / why we need it**:

Adds conformance reports for latest Contour patch releases

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
