### PR TITLE
chore(docs): GRPC and HTTP docs versions cleanup

### DIFF
--- a/examples/standard/basic-grpc.yaml
+++ b/examples/standard/basic-grpc.yaml
@@ -27,7 +27,7 @@ spec:
         group: ""
         name: example-com-cert
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:
   name: grpc-app-1

--- a/examples/standard/grpc-filter.yaml
+++ b/examples/standard/grpc-filter.yaml
@@ -1,6 +1,6 @@
 #$ Used in:
 #$ - site-src/api-types/grpcroute.md
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:
   name: grpc-filter-1

--- a/site-src/api-types/grpcroute.md
+++ b/site-src/api-types/grpcroute.md
@@ -81,7 +81,7 @@ here for implementations to support other types of parent resources.
 The following example shows how a Route would attach to the `acme-lb` Gateway:
 
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:
   name: grpcroute-example
@@ -109,8 +109,9 @@ evaluated. If no hostname is specified, traffic is routed based on GRPCRoute
 rules and filters (optional).
 
 The following example defines hostname "my.example.com":
+
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:
   name: grpcroute-example
@@ -131,8 +132,9 @@ Matches define conditions used for matching an gRPC requests. Each match is
 independent, i.e. this rule will be matched if any single match is satisfied.
 
 Take the following matches configuration as an example:
+
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 ...
 matches:
@@ -168,7 +170,7 @@ header "my.filter.com". Note that GRPCRoute uses HTTPRoute filters for features
 with functionality identical to HTTPRoute, such as this.
 
 ```yaml
-{% include 'experimental/grpc-filter.yaml' %}
+{% include 'standard/grpc-filter.yaml' %}
 ```
 
 API conformance is defined based on the filter type. The effects of ordering
@@ -196,18 +198,18 @@ unspecified, the rule performs no forwarding. If unspecified and no filters
 are specified that would result in a response being sent, an `UNIMPLEMENTED` error code
 is returned.
 
-
-
 The following example forwards gRPC requests for the method `User.Login` to service
 "my-service1" on port `50051` and gRPC requests for the method `Things.DoThing` with
 header `magic: foo` to service "my-service2" on port `50051`:
+
 ```yaml
-{% include 'experimental/basic-grpc.yaml' %}
+{% include 'standard/basic-grpc.yaml' %}
 ```
 
 The following example uses the `weight` field to forward 90% of gRPC requests to
 `foo.example.com` to the "foo-v1" Service and the other 10% to the "foo-v2"
 Service:
+
 ```yaml
 {% include 'experimental/traffic-splitting/grpc-traffic-split-2.yaml' %}
 ```
@@ -236,8 +238,9 @@ appropriate when the route is modified.
 
 The following example indicates GRPCRoute "grpc-example" has been accepted by
 Gateway "gw-example" in namespace "gw-example-ns":
+
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:
   name: grpc-example
@@ -257,13 +260,11 @@ Multiple GRPCRoutes can be attached to a single Gateway resource. Importantly,
 only one Route rule may match each request. For more information on how conflict
 resolution applies to merging, refer to the [API specification][grpcrouterule].
 
-
-[grpcroute]: /reference/spec/#gateway.networking.k8s.io/v1alpha2.GRPCPRoute
-[grpcrouterule]: /reference/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRouteRule
+[grpcroute]: /reference/spec/#gateway.networking.k8s.io/v1.GRPCPRoute
+[grpcrouterule]: /reference/spec/#gateway.networking.k8s.io/v1.GRPCRouteRule
 [hostname]: /reference/spec/#gateway.networking.k8s.io/v1.Hostname
 [rfc-3986]: https://tools.ietf.org/html/rfc3986
-[matches]: /reference/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRouteMatch
-[filters]: /reference/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRouteFilter
-[backendRef]: /reference/spec/#gateway.networking.k8s.io/v1alpha2.GRPCBackendRef
+[matches]: /reference/spec/#gateway.networking.k8s.io/v1.GRPCRouteMatch
+[filters]: /reference/spec/#gateway.networking.k8s.io/v1.GRPCRouteFilter
+[backendRef]: /reference/spec/#gateway.networking.k8s.io/v1.GRPCBackendRef
 [parentRef]: /reference/spec/#gateway.networking.k8s.io/v1.ParentRef
-

--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -32,8 +32,9 @@ to. In most cases, that's going to be Gateways, but there is some flexibility
 here for implementations to support other types of parent resources.
 
 The following example shows how a Route would attach to the `acme-lb` Gateway:
+
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: httproute-example
@@ -119,8 +120,9 @@ evaluated. If no hostname is specified, traffic is routed based on HTTPRoute
 rules and filters (optional).
 
 The following example defines hostname "my.example.com":
+
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: httproute-example
@@ -141,8 +143,9 @@ Matches define conditions used for matching an HTTP request. Each match is
 independent, i.e. this rule will be matched if any single match is satisfied.
 
 Take the following matches configuration as an example:
+
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 ...
 spec:
@@ -246,6 +249,7 @@ Because the `request` timeout encompasses the `backendRequest` timeout, the valu
 Timeouts are optional, and their fields are of type [Duration](/geps/gep-2257/). A zero-valued timeout ("0s") MUST be interpreted as disabling the timeout. A valid non-zero-valued timeout MUST be >= 1ms.
 
 The following example uses the `request` field which will cause a timeout if a client request is taking longer than 10 seconds to complete. The example also defines a 2s `backendRequest` which specifies a timeout for an individual request from the gateway to a backend service `timeout-svc`:
+
 ```yaml
 {% include 'experimental/http-route-timeouts/timeout-example.yaml' %}
 ```
@@ -286,7 +290,7 @@ appropriate when the route is modified.
 The following example indicates HTTPRoute "http-example" has been accepted by
 Gateway "gw-example" in namespace "gw-example-ns":
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: http-example


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind cleanup
/kind documentation

**What this PR does / why we need it**:

Docs clean up:

- bump `GRPC` to `v1` in several doc mentions
- bump `HTTPRoute` to `v1` in several places
- move some related manifests from `experimental` to `standard`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
