### PR TITLE
Move GEP-995 to Implementable

### DIFF
--- a/geps/gep-995/index.md
+++ b/geps/gep-995/index.md
@@ -1,7 +1,7 @@
 # GEP-995: Named route rules
 
 * Issue: [#995](https://github.com/kubernetes-sigs/gateway-api/issues/995)
-* Status: Provisional
+* Status: Implementable
 
 ## TLDR
 

--- a/geps/gep-995/metadata.yaml
+++ b/geps/gep-995/metadata.yaml
@@ -2,7 +2,7 @@ apiVersion: internal.gateway.networking.k8s.io/v1alpha1
 kind: GEPDetails
 number: 995
 name: Named route rules
-status: Provisional
+status: Implementable
 authors:
   - guicassolato
 changelog:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,13 +117,12 @@ nav:
     - Overview: geps/overview.md
     - Provisional:
       - geps/gep-91/index.md
-      - geps/gep-995/index.md
       - geps/gep-1651/index.md
       - geps/gep-1867/index.md
       - geps/gep-2648/index.md
       - geps/gep-2649/index.md
-    # - Implementable:
-    #   -
+    - Implementable:
+      - geps/gep-995/index.md
     - Experimental:
       - geps/gep-1016/index.md
       - geps/gep-1619/index.md


### PR DESCRIPTION
**What type of PR is this?**
/kind gep

**What this PR does / why we need it**:
Changes the state of GEP-995 to `Implementable`, given it's in the [scope for v1.2](https://github.com/kubernetes-sigs/gateway-api/discussions/3103#discussioncomment-9505850).

I'll leave the next step of flagging the GEP at `Experimental` to/post #2985.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```