### PR TITLE
chore: fix cilium conformance report

### DIFF
--- a/conformance/reports/v1.1.0/cilium-cilium/README.md
+++ b/conformance/reports/v1.1.0/cilium-cilium/README.md
@@ -4,7 +4,7 @@
 
 | API channel  | Implementation version                                       | Mode    | Report                     |
 |--------------|--------------------------------------------------------------|---------|----------------------------|
-| experimental | [1.16](https://github.com/cilium/cilium/releases/tag/1.16.0) | default | [link](./1.16-report.yaml) |
+| experimental | [1.16](https://github.com/cilium/cilium/releases/tag/1.16.0-rc.0) | default | [link](./experimental-1.16-default-report.yaml) |
 
 ## Reproduce
 

--- a/conformance/reports/v1.1.0/cilium-cilium/experimental-1.16-default-report.yaml
+++ b/conformance/reports/v1.1.0/cilium-cilium/experimental-1.16-default-report.yaml
@@ -8,7 +8,7 @@ implementation:
   organization: cilium
   project: cilium
   url: github.com/cilium/cilium
-  version: main
+  version: v1.16.0
 kind: ConformanceReport
 mode: default
 profiles:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind documentation

**What this PR does / why we need it**:

https://github.com/kubernetes-sigs/gateway-api/pull/3137 added a new conformance report for Cilium. The report and the README were malformed in the following way:
- the link to the report in the README was broken
- the link to the cilium release was broken; Cilium v1.16.0 has not been released at the moment of writing yet, therefore I've set here the rc1 link.
- the version of the report was not set and instead was "main". Since the report was for Cilium version 1.16.0, I changed it to 1.16.0.

Once Cilium 1.16.0 gets released, we need to update this report again with the GH link to the new release.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
