### PR TITLE
test: improve GatewayWithAttachedRoutes conformance test

### DIFF
--- a/conformance/tests/gateway-with-attached-routes.go
+++ b/conformance/tests/gateway-with-attached-routes.go
@@ -127,6 +127,34 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 
 			kubernetes.HTTPRouteMustHaveCondition(t, s.Client, s.TimeoutConfig, hrouteNN, gwNN, unresolved)
 		})
+
+		t.Run("Gateway listener should not have attached route by not specifying the sectionName", func(t *testing.T) {
+			gwNN := types.NamespacedName{Name: "gateway-with-one-listener-and-no-attached-route", Namespace: "gateway-conformance-infra"}
+			listeners := []v1.ListenerStatus{
+				{
+					Name: v1.SectionName("http-unattached"),
+					SupportedKinds: []v1.RouteGroupKind{{
+						Group: (*v1.Group)(&v1.GroupVersion.Group),
+						Kind:  v1.Kind("HTTPRoute"),
+					}},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1.ListenerConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+						{
+							Type:   string(v1.ListenerConditionResolvedRefs),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+					},
+					AttachedRoutes: 0,
+				},
+			}
+
+			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
+		})
 	},
 }
 

--- a/conformance/tests/gateway-with-attached-routes.yaml
+++ b/conformance/tests/gateway-with-attached-routes.yaml
@@ -130,3 +130,36 @@ spec:
   - backendRefs:
     - name: does-not-exist
       port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-with-one-listener-and-no-attached-route
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: http-unattached
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      kinds:
+      - kind: HTTPRoute
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-route-5
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - kind: Gateway
+    name: gateway-with-one-listener-and-no-attached-route
+    namespace: gateway-conformance-infra
+    sectionName: http
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind test
/area conformance

**What this PR does / why we need it**:

The GatewayWithAttachedRoutes conformance test has been improved such that when a route references a non-existing listener in a Gateway through the `SectionName`, the number of `AttachedRoutes` does not get incremented.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
