### PR TITLE
make update-codegen.sh runnable on Mac

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -193,15 +193,11 @@ PROTOC_URL=""
 PROTOC_CHECKSUM=""
 
 ARCH=$(uname -m)
-RAW_OS=$(uname -o)
+OS=$(uname)
 
-OS=""
-if echo "${RAW_OS}" | grep -i "Linux" >/dev/null; then
-  OS="Linux"
-elif echo "${RAW_OS}" | grep -i "Darwin" >/dev/null; then
-  OS="Mac"
-else
-  echo "Unsupported operating system"
+if [[ "${OS}" != "Linux" ]] && [[ "${OS}" != "Darwin" ]]; then
+  echo "Unsupported operating system ${OS}" >/dev/stderr
+  exit 1
 fi
 
 if [[ "${OS}" == "Linux" ]]; then
@@ -215,7 +211,7 @@ if [[ "${OS}" == "Linux" ]]; then
     echo "Architecture ${ARCH} is not supported on OS ${OS}." >/dev/stderr
     exit 1
   fi
-elif [[ "${OS}" == "Mac" ]]; then
+elif [[ "${OS}" == "Darwin" ]]; then
     PROTOC_URL="$PROTOC_MAC_UNIVERSAL_URL"
     PROTOC_CHECKSUM="$PROTOC_MAC_UNIVERSAL_CHECKSUM"
 fi


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind bug

**What this PR does / why we need it**:

`uname -o` isn't supported on Mac. Here is the output of `man uname`:

```
UNAME(1)                                                           General Commands Manual                                                          UNAME(1)

NAME
     uname – Print operating system name

SYNOPSIS
     uname [-amnprsv]

DESCRIPTION
     The uname utility writes symbols representing one or more system characteristics to the standard output.

     The following options are available:

     -a      Behave as though all of the options -mnrsv were specified.

     -m      print the machine hardware name.

     -n      print the nodename (the nodename may be a name that the system is known by to a communications network).

     -p      print the machine processor architecture name.

     -r      print the operating system release.

     -s      print the operating system name.

     -v      print the operating system version.

     If no options are specified, uname prints the operating system name as if the -s option had been specified.

SEE ALSO
     hostname(1), machine(1), sw_vers(1), uname(3)

STANDARDS
     The uname utility conforms to IEEE Std 1003.2-1992 (“POSIX.2”).  The -p option is an extension to the standard.

macOS 12.6
November 9, 1998
macOS 12.6
```

Also fix a passthrough bug when the script is running on Unsupported OS.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
