### PR TITLE
Add v1.1.0 conformance report for envoy gateway v1.1.0

### DIFF
--- a/conformance/reports/v1.1.0/envoy-gateway/README.md
+++ b/conformance/reports/v1.1.0/envoy-gateway/README.md
@@ -1,0 +1,34 @@
+# Envoy Gateway
+
+## Table of Contents
+
+|API channel|Implementation version|Mode|Report|
+|-----------|----------------------|----|------|
+| experimental |[v1.1.0](https://github.com/envoyproxy/gateway/releases/tag/v1.1.0)| default |[link](./experimental-v1.1.0-default-report.yaml)|
+
+## Reproduce
+
+1. Clone the Envoy Gateway GitHub repository
+
+   ```bash
+   git clone https://github.com/envoyproxy/gateway.git && cd gateway
+   ```
+
+2. Check out the desired version
+
+   ```bash
+   export VERSION=v<x.y.z>
+   git checkout $VERSION
+   ```
+
+3. Run the conformance tests
+
+   ```bash
+   CONFORMANCE_REPORT_PATH=conformance-report-k8s.yaml make experimental-conformance
+   ```
+
+4. Check the produced report
+
+   ```bash
+   cat ./conformance-report-k8s.yaml
+   ```

--- a/conformance/reports/v1.1.0/envoy-gateway/experimental-v1.1.0-default-report.yaml
+++ b/conformance/reports/v1.1.0/envoy-gateway/experimental-v1.1.0-default-report.yaml
@@ -1,0 +1,69 @@
+apiVersion: gateway.networking.k8s.io/v1alpha1
+date: "2024-07-23T01:46:12Z"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.1.0
+implementation:
+  contact:
+  - https://github.com/envoyproxy/gateway/blob/main/GOVERNANCE.md
+  organization: envoyproxy
+  project: envoy-gateway
+  url: https://github.com/envoyproxy/gateway
+  version: v1.1.0
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 33
+      Skipped: 0
+  extended:
+    result: partial
+    skippedTests:
+    - GatewayHTTPListenerIsolation
+    - GatewayStaticAddresses
+    statistics:
+      Failed: 0
+      Passed: 17
+      Skipped: 2
+    supportedFeatures:
+    - GatewayHTTPListenerIsolation
+    - GatewayPort8080
+    - GatewayStaticAddresses
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRedirect
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestTimeout
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+  name: GATEWAY-HTTP
+  summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 11
+      Skipped: 0
+  extended:
+    result: partial
+    skippedTests:
+    - GatewayStaticAddresses
+    statistics:
+      Failed: 0
+      Passed: 0
+      Skipped: 1
+    supportedFeatures:
+    - GatewayHTTPListenerIsolation
+    - GatewayPort8080
+    - GatewayStaticAddresses
+  name: GATEWAY-TLS
+  summary: Core tests succeeded. Extended tests partially succeeded with 1 test skips.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Add v1.1.0 conformance report for envoy gateway v1.1.0

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
