### PR TITLE
Add conformance tests for in-cluster Gateway infrastructure

### DIFF
--- a/conformance/tests/gateway-infrastructure.go
+++ b/conformance/tests/gateway-infrastructure.go
@@ -1,0 +1,79 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayInfrastructure)
+}
+
+var GatewayInfrastructure = suite.ConformanceTest{
+	ShortName:   "GatewayInfrastructure",
+	Description: "Propagation of metadata from Gateway infrastructure to generated components",
+	Features: []features.SupportedFeature{
+		features.SupportGateway,
+		features.SupportGatewayInfrastructurePropagation,
+	},
+	Manifests: []string{
+		"tests/gateway-infrastructure.yaml",
+	},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+
+		kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, []string{ns})
+
+		gwNN := types.NamespacedName{
+			Name:      "gateway-with-infrastructure-metadata",
+			Namespace: "gateway-conformance-infra",
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.DefaultTestTimeout)
+		defer cancel()
+
+		t.Logf("waiting for namespace %s and Gateway %s to be ready for testing", gwNN.Namespace, gwNN.Name)
+		kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
+
+		t.Logf("retrieving Gateway %s/%s", gwNN.Namespace, gwNN.Name)
+		currentGW := &v1.Gateway{}
+		err := s.Client.Get(ctx, gwNN, currentGW)
+		require.NoError(t, err, "error getting Gateway: %v", err)
+		t.Logf("verifying that the Gateway %s/%s is accepted with infrastructure declared", gwNN.Namespace, gwNN.Name)
+		kubernetes.GatewayMustHaveCondition(t, s.Client, s.TimeoutConfig, gwNN, metav1.Condition{
+			Type:   string(v1.GatewayConditionAccepted),
+			Status: metav1.ConditionTrue,
+		})
+
+		t.Logf("verifying that generated resources for Gateway %s/%s have the proper gateway name label", gwNN.Namespace, gwNN.Name)
+		// Don't check services because implementations may have special filtering logic (e.g. for LB annotations)
+		// Instead, check service accounts for the gateway-name label first and then
+		// fallback to Pod if that fails
+		annotations := currentGW.Spec.Infrastructure.Annotations
+		labels := currentGW.Spec.Infrastructure.Labels
+		saList := corev1.ServiceAccountList{}
+		s.Client.List(ctx, &saList, client.MatchingLabels{"gateway.networking.k8s.io/gateway-name": gwNN.Name}, client.InNamespace(ns))
+		if len(saList.Items) > 0 {
+			sa := saList.Items[0]
+			require.Subsetf(t, sa.Labels, labels, "expected Pod label set %v to contain all Gateway infrastructure labels %v", sa.Labels, labels)
+			require.Subsetf(t, sa.Annotations, annotations, "expected Pod annotation set %v to contain all Gateway infrastructure annotations %v", sa.Annotations, annotations)
+		} else {
+			// Fallback to pod
+			podList := corev1.PodList{}
+			s.Client.List(ctx, &podList, client.MatchingLabels{"gateway.networking.k8s.io/gateway-name": gwNN.Name}, client.InNamespace(ns))
+			require.Greater(t, len(podList.Items), 0, "expected at least one Pod or ServiceAccount with gateway-name label")
+			pod := podList.Items[0]
+			require.Subsetf(t, pod.Labels, labels, "expected Pod label set %v to contain all Gateway infrastructure labels %v", pod.Labels, labels)
+			require.Subsetf(t, pod.Annotations, annotations, "expected Pod annotation set %v to contain all Gateway infrastructure annotations %v", pod.Annotations, annotations)
+		}
+	},
+}

--- a/conformance/tests/gateway-infrastructure.go
+++ b/conformance/tests/gateway-infrastructure.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package tests
 
 import (

--- a/conformance/tests/gateway-infrastructure.go
+++ b/conformance/tests/gateway-infrastructure.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"

--- a/conformance/tests/gateway-infrastructure.go
+++ b/conformance/tests/gateway-infrastructure.go
@@ -104,7 +104,7 @@ var GatewayInfrastructure = suite.ConformanceTest{
 			require.Subsetf(t, pod.Labels, labels, "expected Pod label set %v to contain all Gateway infrastructure labels %v", pod.Labels, labels)
 			require.Subsetf(t, pod.Annotations, annotations, "expected Pod annotation set %v to contain all Gateway infrastructure annotations %v", pod.Annotations, annotations)
 		} else {
-			require.NotEmpty(t, serviceList.Items, 0, "expected at least one Pod, ServiceAccount, or Service with gateway-name label")
+			require.NotEmpty(t, serviceList.Items, "expected at least one Pod, ServiceAccount, or Service with gateway-name label")
 			service := serviceList.Items[0]
 			require.Subsetf(t, service.Labels, labels, "expected Pod label set %v to contain all Gateway infrastructure labels %v", service.Labels, labels)
 			require.Subsetf(t, service.Annotations, annotations, "expected Pod annotation set %v to contain all Gateway infrastructure annotations %v", service.Annotations, annotations)

--- a/conformance/tests/gateway-infrastructure.yaml
+++ b/conformance/tests/gateway-infrastructure.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-with-infrastructure-metadata
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  infrastructure:
+    annotations:
+      key1: value1
+    labels:
+      key2: value2
+  listeners:
+  - name: http
+    port: 8080
+    protocol: HTTP

--- a/geps/gep-1867/index.md
+++ b/geps/gep-1867/index.md
@@ -1,6 +1,6 @@
 # GEP-1867: Per-Gateway Infrastructure
 
-* Status: Experimental
+* Status: Standard
 * Issue: [#1867](https://github.com/kubernetes-sigs/gateway-api/issues/1867)
 
 ## Overview

--- a/geps/gep-1867/metadata.yaml
+++ b/geps/gep-1867/metadata.yaml
@@ -2,7 +2,7 @@ apiVersion: internal.gateway.networking.k8s.io/v1alpha1
 kind: GEPDetails
 number: 1867
 name: Per-Gateway Infrastructure
-status: Experimental
+status: Standard
 authors:
   - howardjohn
 relationships:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -58,6 +58,10 @@ const (
 	// SupportGatewayHTTPListenerIsolation option indicates support for the isolation
 	// of HTTP listeners.
 	SupportGatewayHTTPListenerIsolation SupportedFeature = "GatewayHTTPListenerIsolation"
+
+	// SupportGatewayInfrastructureAnnotations option indicates support for
+	// spec.infrastructure.annotations and spec.infrastrucutre.labels
+	SupportGatewayInfrastructurePropagation SupportedFeature = "GatewayInfrastructurePropagation"
 )
 
 // GatewayExtendedFeatures are extra generic features that implementations may
@@ -66,6 +70,7 @@ var GatewayExtendedFeatures = sets.New(
 	SupportGatewayPort8080,
 	SupportGatewayStaticAddresses,
 	SupportGatewayHTTPListenerIsolation,
+	SupportGatewayInfrastructurePropagation,
 )
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/area conformance
/kind test

**What this PR does / why we need it**:
Adds conformance tests to move in-cluster Gateway deployments GEP to standard

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Part of #1762

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
