### PR TITLE
docs: Fix missing v1beta1, v1alpha3 API versions

### DIFF
--- a/hack/api-docs/pkg.tpl
+++ b/hack/api-docs/pkg.tpl
@@ -41,12 +41,16 @@ Resource Types:
 
 <p>Packages:</p>
 <ul>
-    {{ template "link" index .packages 1 }}
     {{ template "link" index .packages 0 }}
+    {{ template "link" index .packages 3 }}
+    {{ template "link" index .packages 2 }}
+    {{ template "link" index .packages 1 }}
 </ul>
 
-{{ template "package" index .packages 1 }}
 {{ template "package" index .packages 0 }}
+{{ template "package" index .packages 3 }}
+{{ template "package" index .packages 2 }}
+{{ template "package" index .packages 1 }}
 
 <p><em>
     Generated with <code>gen-crd-api-reference-docs</code>.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind documentation
-->

**What this PR does / why we need it**:
PR #1345 assumed there would be two versions of the API for the "[API Specification](https://gateway-api.sigs.k8s.io/reference/spec/)" doc page. Now we have 4 versions, and 2 are left out (v1beta1 and v1alpha3). This is a quick fix, but this will break every API version release. We should pursue a more sustainable solution.

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
