### PR TITLE
Graduate GEP-2257 and GEP-1742 to standard

### DIFF
--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -286,7 +286,6 @@ type HTTPRouteRule struct {
 	// Support: Extended
 	//
 	// +optional
-	// <gateway:experimental>
 	Timeouts *HTTPRouteTimeouts `json:"timeouts,omitempty"`
 
 	// SessionPersistence defines and configures session persistence

--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -321,7 +321,8 @@ type HTTPRouteTimeouts struct {
 	// request stream has been received instead of immediately after the transaction is
 	// initiated by the client.
 	//
-	// When this field is unspecified, request timeout behavior is implementation-specific.
+	// The value of Request is a Gateway API Duration string as defined by GEP-2257. When this
+	// field is unspecified, request timeout behavior is implementation-specific.
 	//
 	// Support: Extended
 	//
@@ -341,8 +342,10 @@ type HTTPRouteTimeouts struct {
 	// may result in more than one call from the gateway to the destination backend,
 	// for example, if automatic retries are supported.
 	//
-	// Because the Request timeout encompasses the BackendRequest timeout, the value of
-	// BackendRequest must be <= the value of Request timeout.
+	// The value of BackendRequest must be a Gateway API Duration string as defined by
+	// GEP-2257.  When this field is unspecified, its behavior is implementation-specific;
+	// when specified, the value of BackendRequest must be no more than the value of the
+	// Request timeout (since the Request timeout encompasses the BackendRequest timeout).
 	//
 	// Support: Extended
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -2815,13 +2815,11 @@ spec:
                         rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
                           || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
                     timeouts:
-                      description: |+
+                      description: |-
                         Timeouts defines the timeouts that can be configured for an HTTP request.
 
 
                         Support: Extended
-
-
                       properties:
                         backendRequest:
                           description: |-
@@ -2841,8 +2839,10 @@ spec:
                             for example, if automatic retries are supported.
 
 
-                            Because the Request timeout encompasses the BackendRequest timeout, the value of
-                            BackendRequest must be <= the value of Request timeout.
+                            The value of BackendRequest must be a Gateway API Duration string as defined by
+                            GEP-2257.  When this field is unspecified, its behavior is implementation-specific;
+                            when specified, the value of BackendRequest must be no more than the value of the
+                            Request timeout (since the Request timeout encompasses the BackendRequest timeout).
 
 
                             Support: Extended
@@ -2872,7 +2872,8 @@ spec:
                             initiated by the client.
 
 
-                            When this field is unspecified, request timeout behavior is implementation-specific.
+                            The value of Request is a Gateway API Duration string as defined by GEP-2257. When this
+                            field is unspecified, request timeout behavior is implementation-specific.
 
 
                             Support: Extended
@@ -6061,13 +6062,11 @@ spec:
                         rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
                           || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
                     timeouts:
-                      description: |+
+                      description: |-
                         Timeouts defines the timeouts that can be configured for an HTTP request.
 
 
                         Support: Extended
-
-
                       properties:
                         backendRequest:
                           description: |-
@@ -6087,8 +6086,10 @@ spec:
                             for example, if automatic retries are supported.
 
 
-                            Because the Request timeout encompasses the BackendRequest timeout, the value of
-                            BackendRequest must be <= the value of Request timeout.
+                            The value of BackendRequest must be a Gateway API Duration string as defined by
+                            GEP-2257.  When this field is unspecified, its behavior is implementation-specific;
+                            when specified, the value of BackendRequest must be no more than the value of the
+                            Request timeout (since the Request timeout encompasses the BackendRequest timeout).
 
 
                             Support: Extended
@@ -6118,7 +6119,8 @@ spec:
                             initiated by the client.
 
 
-                            When this field is unspecified, request timeout behavior is implementation-specific.
+                            The value of Request is a Gateway API Duration string as defined by GEP-2257. When this
+                            field is unspecified, request timeout behavior is implementation-specific.
 
 
                             Support: Extended

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -2685,6 +2685,78 @@ spec:
                         type: object
                       maxItems: 64
                       type: array
+                    timeouts:
+                      description: |-
+                        Timeouts defines the timeouts that can be configured for an HTTP request.
+
+
+                        Support: Extended
+                      properties:
+                        backendRequest:
+                          description: |-
+                            BackendRequest specifies a timeout for an individual request from the gateway
+                            to a backend. This covers the time from when the request first starts being
+                            sent from the gateway to when the full response has been received from the backend.
+
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
+
+
+                            An entire client HTTP transaction with a gateway, covered by the Request timeout,
+                            may result in more than one call from the gateway to the destination backend,
+                            for example, if automatic retries are supported.
+
+
+                            The value of BackendRequest must be a Gateway API Duration string as defined by
+                            GEP-2257.  When this field is unspecified, its behavior is implementation-specific;
+                            when specified, the value of BackendRequest must be no more than the value of the
+                            Request timeout (since the Request timeout encompasses the BackendRequest timeout).
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        request:
+                          description: |-
+                            Request specifies the maximum duration for a gateway to respond to an HTTP request.
+                            If the gateway has not been able to respond before this deadline is met, the gateway
+                            MUST return a timeout error.
+
+
+                            For example, setting the `rules.timeouts.request` field to the value `10s` in an
+                            `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds
+                            to complete.
+
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
+
+
+                            This timeout is intended to cover as close to the whole request-response transaction
+                            as possible although an implementation MAY choose to start the timeout after the entire
+                            request stream has been received instead of immediately after the transaction is
+                            initiated by the client.
+
+
+                            The value of Request is a Gateway API Duration string as defined by GEP-2257. When this
+                            field is unspecified, request timeout behavior is implementation-specific.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: backendRequest timeout cannot be longer than request
+                          timeout
+                        rule: '!(has(self.request) && has(self.backendRequest) &&
+                          duration(self.request) != duration(''0s'') && duration(self.backendRequest)
+                          > duration(self.request))'
                   type: object
                   x-kubernetes-validations:
                   - message: RequestRedirect filter must not be used together with
@@ -5716,6 +5788,78 @@ spec:
                         type: object
                       maxItems: 64
                       type: array
+                    timeouts:
+                      description: |-
+                        Timeouts defines the timeouts that can be configured for an HTTP request.
+
+
+                        Support: Extended
+                      properties:
+                        backendRequest:
+                          description: |-
+                            BackendRequest specifies a timeout for an individual request from the gateway
+                            to a backend. This covers the time from when the request first starts being
+                            sent from the gateway to when the full response has been received from the backend.
+
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
+
+
+                            An entire client HTTP transaction with a gateway, covered by the Request timeout,
+                            may result in more than one call from the gateway to the destination backend,
+                            for example, if automatic retries are supported.
+
+
+                            The value of BackendRequest must be a Gateway API Duration string as defined by
+                            GEP-2257.  When this field is unspecified, its behavior is implementation-specific;
+                            when specified, the value of BackendRequest must be no more than the value of the
+                            Request timeout (since the Request timeout encompasses the BackendRequest timeout).
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        request:
+                          description: |-
+                            Request specifies the maximum duration for a gateway to respond to an HTTP request.
+                            If the gateway has not been able to respond before this deadline is met, the gateway
+                            MUST return a timeout error.
+
+
+                            For example, setting the `rules.timeouts.request` field to the value `10s` in an
+                            `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds
+                            to complete.
+
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
+                            completely. Implementations that cannot completely disable the timeout MUST
+                            instead interpret the zero duration as the longest possible value to which
+                            the timeout can be set.
+
+
+                            This timeout is intended to cover as close to the whole request-response transaction
+                            as possible although an implementation MAY choose to start the timeout after the entire
+                            request stream has been received instead of immediately after the transaction is
+                            initiated by the client.
+
+
+                            The value of Request is a Gateway API Duration string as defined by GEP-2257. When this
+                            field is unspecified, request timeout behavior is implementation-specific.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: backendRequest timeout cannot be longer than request
+                          timeout
+                        rule: '!(has(self.request) && has(self.backendRequest) &&
+                          duration(self.request) != duration(''0s'') && duration(self.backendRequest)
+                          > duration(self.request))'
                   type: object
                   x-kubernetes-validations:
                   - message: RequestRedirect filter must not be used together with

--- a/geps/gep-1742/index.md
+++ b/geps/gep-1742/index.md
@@ -1,7 +1,7 @@
 # GEP-1742: HTTPRoute Timeouts
 
 * Issue: [#1742](https://github.com/kubernetes-sigs/gateway-api/issues/1742)
-* Status: Experimental
+* Status: Standard
 
 (See status definitions [here](overview.md#status).)
 
@@ -383,7 +383,7 @@ type HTTPRouteRule struct {
 	// Support: Extended
 	//
 	// +optional
-	// <gateway:experimental>
+	// <gateway:standard>
 	Timeouts *HTTPRouteTimeouts `json:"timeouts,omitempty"`
 
 	// ...
@@ -503,5 +503,4 @@ previous section, is likely a better way to handle timeout configuration above t
 
 ## References
 
-(Add any additional document links. Again, we should try to avoid
-too much content not in version control to avoid broken links)
+[GEP-2257]:/geps/gep-2257/

--- a/geps/gep-1742/index.md
+++ b/geps/gep-1742/index.md
@@ -408,7 +408,8 @@ type HTTPRouteTimeouts struct {
 	// request stream has been received instead of immediately after the transaction is
 	// initiated by the client.
 	//
-	// When this field is unspecified, request timeout behavior is implementation-specific.
+	// The value of Request is a Gateway API Duration string as defined by GEP-2257. When this
+	// field is unspecified, request timeout behavior is implementation-specific.
 	//
 	// Support: Extended
 	//
@@ -423,8 +424,10 @@ type HTTPRouteTimeouts struct {
 	// may result in more than one call from the gateway to the destination backend,
 	// for example, if automatic retries are supported.
 	//
-	// Because the Request timeout encompasses the BackendRequest timeout, the value of
-	// BackendRequest must be <= the value of Request timeout.
+	// The value of BackendRequest must be a Gateway API Duration string as defined by
+	// GEP-2257.  When this field is unspecified, its behavior is implementation-specific;
+	// when specified, the value of BackendRequest must be no more than the value of the
+	// Request timeout (since the Request timeout encompasses the BackendRequest timeout).
 	//
 	// Support: Extended
 	//

--- a/geps/gep-1742/index.md
+++ b/geps/gep-1742/index.md
@@ -432,7 +432,7 @@ type HTTPRouteTimeouts struct {
 	BackendRequest *Duration `json:"backendRequest,omitempty"`
 }
 
-// Duration is a string value representing a duration in time. The foramat is as specified
+// Duration is a string value representing a duration in time. The format is as specified
 // in GEP-2257, a strict subset of the syntax parsed by Golang time.ParseDuration.
 //
 // +kubebuilder:validation:Pattern=`^([0-9]{1,5}(h|m|s|ms)){1,4}$`
@@ -474,7 +474,7 @@ Timeouts could be configured using policy attachments or in objects other than `
 Instead of configuring timeouts directly on an API object, they could be configured using policy
 attachments. The advantage to this approach would be that timeout policies can be not only
 configured for an `HTTPRouteRule`, but can also be added/overriden at a more fine
-(e.g., `HTTPBackendRef`) or course (e.g. `HTTPRoute`) level of granularity.
+(e.g., `HTTPBackendRef`) or coarse (e.g. `HTTPRoute`) level of granularity.
 
 The downside, however, is complexity introduced for the most common use case, adding a simple
 timeout for an HTTP request. Setting a single field in the route rule, instead of needing to

--- a/geps/gep-1742/metadata.yaml
+++ b/geps/gep-1742/metadata.yaml
@@ -2,7 +2,7 @@ apiVersion: internal.gateway.networking.k8s.io/v1alpha1
 kind: GEPDetails
 number: 1742
 name: HTTPRoute Timeouts
-status: Experimental
+status: Standard
 authors:
   - youngnick
   - spacewander
@@ -12,7 +12,13 @@ authors:
   - robscott
   - sjberman
 relationships:
-  extendedBy:
+  seeAlso:
     - number: 2257
       name: Gateway API Duration Format
-      description: Adds a duration format for us in timeouts.
+      description: Defines the duration format used by HTTPRoute timeouts.
+references:
+  - https://datatracker.ietf.org/doc/html/rfc8174
+  - https://datatracker.ietf.org/doc/html/rfc2119
+changelog:
+  - https://github.com/kubernetes-sigs/gateway-api/pull/3210
+

--- a/geps/gep-2257/index.md
+++ b/geps/gep-2257/index.md
@@ -48,10 +48,9 @@ Durations are a subset of what `time.ParseDuration` supports:
   `1h500ms` is supported (although probably not terribly useful).
 
 - Units MAY be repeated, although users SHOULD NOT rely on this support since
-  this GEP is Experimental, and future revisions may remove support for
-  repeated units. If units are repeated, the total duration remains the sum of
-  all components: a GEP-2257 duration of `1h2h20m10m` is a duration of 3 hours
-  30 minutes.
+  future revisions of this GEP may remove support for repeated units. If units
+  are repeated, the total duration remains the sum of all components: a
+  GEP-2257 duration of `1h2h20m10m` is a duration of 3 hours 30 minutes.
 
 - Since the value and the unit are both required within a component, `0` is
   not a valid GEP-2257 duration string (though `0s` is). Likewise the empty

--- a/geps/gep-2257/index.md
+++ b/geps/gep-2257/index.md
@@ -1,7 +1,7 @@
 # GEP-2257: Gateway API Duration Format
 
 * Issue: [#2257](https://github.com/kubernetes-sigs/gateway-api/issues/2257)
-* Status: Experimental
+* Status: Standard
 
 ## TL;DR
 
@@ -107,6 +107,82 @@ There is (a lot) more discussion in [PR 2155].
 
 [PR 2155]:https://github.com/kubernetes-sigs/gateway-api/pull/2155
 
+## Test Vectors
+
+### Parsing
+
+Valid GEP-2257 Duration strings, their canonical forms, and the components of
+the resulting durations:
+
+| Input | Canonical Form | Hours | Minutes | Seconds | Milliseconds |
+|-------|-----------------|-------|---------|---------|--------------|
+| `0h` | `0s` | 0 | 0 | 0 | 0 |
+| `0s` | `0s` | 0 | 0 | 0 | 0 |
+| `0h0m0s` | `0s` | 0 | 0 | 0 | 0 |
+| `1h` | `1h` | 1 | 0 | 0 | 0 |
+| `30m` | `30m` | 0 | 30 | 0 | 0 |
+| `10s` | `10s` | 0 | 0 | 10 | 0 |
+| `500ms` | `500ms` | 0 | 0 | 0 | 500 |
+| `2h30m` | `2h30m` | 2 | 30 | 0 | 0 |
+| `150m` | `2h30m` | 2 | 30 | 0 | 0 |
+| `7230s` | `2h30s` | 2 | 0 | 30 | 0 |
+| `1h30m10s` | `1h30m10s` | 1 | 30 | 10 | 0 |
+| `10s30m1h` | `1h30m10s` | 1 | 30 | 10 | 0 |
+| `100ms200ms300ms` | `600ms` | 0 | 0 | 0 | 600 |
+
+Invalid GEP-2257 Duration strings:
+
+| Input | Reason |
+|-------|--------|
+| `1` | Missing unit |
+| `1m1` | Missing unit |
+| `1d` | Days are not supported |
+| `1h30m10s20ms50h` | Too many components |
+| `999999h` | Too many digits |
+| `1.5h` | Floating point is not supported |
+| `-15m` | Negative durations are not supported |
+
+### Formatting
+
+Valid durations and their canonical GEP-2257 forms:
+
+| Hours | Minutes | Seconds | Milliseconds | Canonical Form |
+|-------|---------|---------|--------------|----------------|
+| 0 | 0 | 0 | 0 | `0s` |
+| 1 | 0 | 0 | 0 | `1h` |
+| 0 | 30 | 0 | 0 | `30m` |
+| 0 | 0 | 10 | 0 | `10s` |
+| 0 | 0 | 0 | 500 | `500ms` |
+| 2 | 30 | 0 | 0 | `2h30m` |
+| 1 | 30 | 10 | 0 | `1h30m10s` |
+| 0 | 0 | 0 | 600 | `600ms` |
+| 2 | 0 | 0 | 600 | `2h600ms` |
+| 2 | 30 | 0 | 600 | `2h30m600ms` |
+| 2 | 30 | 10 | 600 | `2h30m10s600ms` |
+| 0 | 0.5 | 0 | 0 | `30s` |
+| 0 | 0 | 0.5 | 0 | `500ms` |
+| 10 days | 0 | 0 | 0 | `240h` |
+
+Note the last three durations: while `0.5m`, for example, is not a valid
+GEP-2257 Duration, it is possible to express a half-minute duration using
+GEP-2257. Implementations that support formatting durations SHOULD support
+these cases and, if they do, MUST always format them as valid GEP-2257
+Durations.
+
+Note also that, as stated above, implementations MUST NOT modify resources
+supplied by a user. The formatting vectors above describe correctness when an
+implementation needs to format a duration for output; no requirement to
+normalize user input is implied.
+
+Invalid durations:
+
+| Duration | Reason |
+|----------|--------|
+| 100 microseconds | Sub-millisecond precision is not supported |
+| 0.5 milliseconds | Sub-millisecond precision is not supported |
+| 10000 days | Out of range (more than 99999 hours) |
+| -15 minutes | Negative durations are not supported |
+
 ## Graduation Criteria
 
 To graduate GEP-2257 to Standard channel, we need to meet the following
@@ -119,4 +195,7 @@ criteria:
 
 - Have a custom CEL validator for GEP-2257 Duration fields.
 
-- Have support for GEP-2257 Durations in standard Kubernetes libraries.
+The previous graduation criterion of "Have support for GEP-2257 Durations in
+standard Kubernetes libraries" has been removed. Work is in progress to add
+such parsers to `kube-rs`, `client-go`, and `client-python`, but it is not
+necessary to gate the graduation of GEP-2257 on this work.

--- a/geps/gep-2257/metadata.yaml
+++ b/geps/gep-2257/metadata.yaml
@@ -2,11 +2,17 @@ apiVersion: internal.gateway.networking.k8s.io/v1alpha1
 kind: GEPDetails
 number: 2257
 name: Gateway API Duration Format
-status: Experimental
+status: Standard
 authors:
   - kflynn
 relationships:
-  extends:
+  seeAlso:
     - number: 1742
       name: HTTPRoute Timeouts
-      description: Adds a duration format for us in timeouts.
+      description: HTTPRoute Timeouts use the format specified in this GEP.
+references:
+  - https://datatracker.ietf.org/doc/html/rfc8174
+  - https://datatracker.ietf.org/doc/html/rfc2119
+  - https://github.com/kubernetes-sigs/gateway-api/pull/2155
+changelog:
+  - https://github.com/kubernetes-sigs/gateway-api/pull/3210

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,13 +127,11 @@ nav:
       - geps/gep-995/index.md
     - Experimental:
       - geps/gep-1619/index.md
-      - geps/gep-1742/index.md
       - geps/gep-1748/index.md
       - geps/gep-1762/index.md
       - geps/gep-1897/index.md
       - geps/gep-1911/index.md
       - geps/gep-2162/index.md
-      - geps/gep-2257/index.md
     - Standard:
       - geps/gep-709/index.md
       - geps/gep-718/index.md
@@ -149,6 +147,8 @@ nav:
       - geps/gep-1426/index.md
       - geps/gep-1686/index.md
       - geps/gep-1709/index.md
+      - geps/gep-1742/index.md
+      - geps/gep-2257/index.md
     - Memorandum:
       - geps/gep-713/index.md
       - geps/gep-917/index.md

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -4704,7 +4704,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_HTTPRouteRule(ref common.ReferenceCall
 					},
 					"timeouts": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Timeouts defines the timeouts that can be configured for an HTTP request.\n\nSupport: Extended\n\n<gateway:experimental>",
+							Description: "Timeouts defines the timeouts that can be configured for an HTTP request.\n\nSupport: Extended",
 							Ref:         ref("sigs.k8s.io/gateway-api/apis/v1.HTTPRouteTimeouts"),
 						},
 					},
@@ -4819,14 +4819,14 @@ func schema_sigsk8sio_gateway_api_apis_v1_HTTPRouteTimeouts(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"request": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Request specifies the maximum duration for a gateway to respond to an HTTP request. If the gateway has not been able to respond before this deadline is met, the gateway MUST return a timeout error.\n\nFor example, setting the `rules.timeouts.request` field to the value `10s` in an `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds to complete.\n\nSetting a timeout to the zero duration (e.g. \"0s\") SHOULD disable the timeout completely. Implementations that cannot completely disable the timeout MUST instead interpret the zero duration as the longest possible value to which the timeout can be set.\n\nThis timeout is intended to cover as close to the whole request-response transaction as possible although an implementation MAY choose to start the timeout after the entire request stream has been received instead of immediately after the transaction is initiated by the client.\n\nWhen this field is unspecified, request timeout behavior is implementation-specific.\n\nSupport: Extended",
+							Description: "Request specifies the maximum duration for a gateway to respond to an HTTP request. If the gateway has not been able to respond before this deadline is met, the gateway MUST return a timeout error.\n\nFor example, setting the `rules.timeouts.request` field to the value `10s` in an `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds to complete.\n\nSetting a timeout to the zero duration (e.g. \"0s\") SHOULD disable the timeout completely. Implementations that cannot completely disable the timeout MUST instead interpret the zero duration as the longest possible value to which the timeout can be set.\n\nThis timeout is intended to cover as close to the whole request-response transaction as possible although an implementation MAY choose to start the timeout after the entire request stream has been received instead of immediately after the transaction is initiated by the client.\n\nThe value of Request is a Gateway API Duration string as defined by GEP-2257. When this field is unspecified, request timeout behavior is implementation-specific.\n\nSupport: Extended",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"backendRequest": {
 						SchemaProps: spec.SchemaProps{
-							Description: "BackendRequest specifies a timeout for an individual request from the gateway to a backend. This covers the time from when the request first starts being sent from the gateway to when the full response has been received from the backend.\n\nSetting a timeout to the zero duration (e.g. \"0s\") SHOULD disable the timeout completely. Implementations that cannot completely disable the timeout MUST instead interpret the zero duration as the longest possible value to which the timeout can be set.\n\nAn entire client HTTP transaction with a gateway, covered by the Request timeout, may result in more than one call from the gateway to the destination backend, for example, if automatic retries are supported.\n\nBecause the Request timeout encompasses the BackendRequest timeout, the value of BackendRequest must be <= the value of Request timeout.\n\nSupport: Extended",
+							Description: "BackendRequest specifies a timeout for an individual request from the gateway to a backend. This covers the time from when the request first starts being sent from the gateway to when the full response has been received from the backend.\n\nSetting a timeout to the zero duration (e.g. \"0s\") SHOULD disable the timeout completely. Implementations that cannot completely disable the timeout MUST instead interpret the zero duration as the longest possible value to which the timeout can be set.\n\nAn entire client HTTP transaction with a gateway, covered by the Request timeout, may result in more than one call from the gateway to the destination backend, for example, if automatic retries are supported.\n\nThe value of BackendRequest must be a Gateway API Duration string as defined by GEP-2257.  When this field is unspecified, its behavior is implementation-specific; when specified, the value of BackendRequest must be no more than the value of the Request timeout (since the Request timeout encompasses the BackendRequest timeout).\n\nSupport: Extended",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
**What type of PR is this?**
/kind gep

**REVIEWERS**: this PR has been rebased to be best reviewed commit by commit:

- 905d8060: Actually move from experimental to standard
- 767798b0: Fix a couple of old typos in GEP-1742
- 30d9acbd: Clean up language in GEP-2257 around repeated units
- dcc24383: Mention GEP-2257 in the CRD docstrings (I ran into this today for unrelated reasons) and clarify that if the backend request timeout isn't specified, behavior is implementation-specific.
- fc64635e: Run `make generate`

**What this PR does / why we need it**:
This PR moves GEPs 2257 and 1742 to Standard rather than Experimental. Conformant implementations of `HTTPRouteRequestTimeout` and `HTTPRouteBackendTimeout` as of Gateway API v1.0.0:

- Cilium v1.15.0-pre.3
- Contour v1.29.0
- Envoy Gateway v0.6.0
- Istio 1.2

(All of these implementations support both timeout fields. I'm referencing 1.0.0 because we don't have many 1.1.0 conformance reports yet. 😐)

**Does this PR introduce a user-facing change?**:
```release-note
GEP-2257 Durations and HTTPRoute Timeouts are now standard.
```
