### PR TITLE
GEP-1713: ListenerSets - Standard Mechanism to Merge Gateway Listeners (rev 2)

### DIFF
--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -36,7 +36,7 @@ The feature will be part of the experimental branches as an extended feature, wh
 
 This proposal introduces a new `ListenerSet` resource that has the ability to attach to a set of listeners to multiple parent `Gateways`.
 
-#### Go
+### Go
 
 ```go
 type GatewaySpec struct {
@@ -162,7 +162,7 @@ type ParentGatewayReference struct {
 }
 ```
 
-#### YAML
+### YAML
 
 The following example shows a `Gateway` with an HTTP listener and two child HTTPS `ListenerSets` with unique hostnames and certificates.
 
@@ -221,9 +221,9 @@ spec:
         group: ""
         name: second-workload-cert # Provisioned via HTTP01 challenge
 ```
-### Semantics
+## Semantics
 
-#### Gateway <> ListenerSet Handshake
+### Gateway <> ListenerSet Handshake
 
 By default a `Gateway` will allow `ListenerSets` in the same namespace to be attached. Users can prevent this behaviour by configuring their `Gateway` to disallow any listener attachment:
 
@@ -237,13 +237,14 @@ spec:
   - from: None
 ```
 
-#### GatewaySpec.Listeners MinItems
+### GatewaySpec.Listeners MinItems
 
 TBD: Do we want to make this change?
 
 Currently when creating a Gateway you must specify at least a single listener. With `ListenerSets` this opens the possibility of wanting to create a Gateway with no listeners.
 
-#### Route Attaching
+
+### Route Attaching
 
 Routes MUST be able to specify a `ListenerSet` as a `parentRef` and make use of the `sectionName` field in `ParentReference` to help target a specific listener. If no listener is targeted (`sectionName`/`port` are unset) then the Route references all the listeners on the `ListenerSet`. It `MUST NOT` attach to additional listeners on the parent `Gateway`.
 
@@ -273,7 +274,7 @@ spec:
     sectionName: foo
 ```
 
-#### Listener Validation
+### Listener Validation
 
 Implementations MUST treat the parent `Gateway`s as having the concatenated list of all listeners from itself and attached `ListenerSets`. See 'Listener Precedence' for more details on ordering.
 Validation of this list of listeners MUST behave the same as if the list were part of a single `Gateway`.
@@ -314,7 +315,7 @@ spec:
         name: second-workload-cert # Provisioned via HTTP01 challenge
 ```
 
-#### Listener Precedence
+### Listener Precedence
 
 Listeners should be merged using the following precedence:
 1. "parent" Gateway
@@ -352,7 +353,7 @@ For example, if I have a `Gateway` named `parent`, and two `ListenerSets` named 
 When reporting status of a child, an implementation SHOULD be cautious about what information from the parent or siblings are reported
 to avoid accidentally leaking sensitive information that the child would not otherwise have access to.
 
-#### Policy Attachment
+### Policy Attachment
 
 Policy attachment is [under discussion] in https://github.com/kubernetes-sigs/gateway-api/discussions/2927
 
@@ -362,28 +363,28 @@ If the implementation cannot apply the policy to only specific listeners, it sho
 
 ## Alternatives
 
-#### Re-using Gateway Resource
+### Re-using Gateway Resource
 
 The [first iteration of this GEP](https://github.com/kubernetes-sigs/gateway-api/pull/1863) proposed re-using the `Gateway` resource and introducing an `attachTo` property in the `infrastructure` stanza.
 
 The main downside of this approach is that users still require `Gateway` write access to create listeners. Secondly, it introduces complexity to future `Gateway` features as GEP authors would have now have to account for merging semantics.
 
-#### New 'GatewayGroup' Resource
+### New 'GatewayGroup' Resource
 
 This was proposed in the Gateway Hiearchy Brainstorming document (see references below). The idea is to introduce a central resource that will coalease Gateways together and offer forms of delegation.
 
 Issues with this is complexity with status propagation, cluster vs. namespace scoping etc. It also lacks a migration path for existing Gateways to help shard listeners.
 
-#### Use of Multiple Disjointed Gateways
+### Use of Multiple Disjointed Gateways
 
 An alternative would be to encourage users to not use overly large Gateways to minimize the blast radius of any issues. Use of disjoint Gateways could accomplish this but it has the disadvantage of consuming more resources and introducing complexity when it comes to operations work (eg. setting up DNS records etc.)
 
-#### Increase the Listener Limit
+### Increase the Listener Limit
 
 Increasing the limit may help in situations where you are creating many listeners such as adding certificates created using an ACME HTTP01 challenge. Unfortunately this still makes the Gateway a single point of contention. Unfortunately, there will always be an upper bound because of etcd limitations.
 For workloads like Knative we can have O(1000) Services on the cluster with unique subdomains.
 
-#### Expand Route Functionality
+### Expand Route Functionality
 
 For workloads with many certificates one option would be to introduce a `tls` stanza somewhere in the Route types. These Routes would then attach to a single Gateway. Then application operators can provide their own certificates. This probably would require some ability to have a handshake agreement with the Gateway.
 

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -616,6 +616,7 @@ Valid reasons for `Accepted` being `False` are:
 The `Programmed` condition MUST be set on every `ListenerSet` and have a similar meaning to the Gateway `Programmed` condition but only reflect the listeners in this `ListenerSet`.
 
 `Accepted` and `Programmed` conditions when surfacing details about listeners, MUST only summarize the `status.parents.listeners` conditions that are exclusive to the `ListenerSet`.
+An exception to this is when the parent `Gateway`'s `Accepted` or `Programmed` conditions transition to `False`
 
 `ListenerSets` MUST NOT have their parent `Gateway`'s' listeners in the associated `status.parents.listeners` conditions list.
 

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -619,9 +619,9 @@ The `Programmed` condition MUST be set on every `ListenerSet` and have a similar
 
 ### ListenerConditions within a ListenerSet
 
-An implementation MAY reject listeners by setting the `ListenerStatus` `Accepted` condition to `False` with the `Reason` `TooManyListeners`
+An implementation MAY reject listeners by setting the `ListenerEntryStatus` `Accepted` condition to `False` with the `Reason` `TooManyListeners`
 
-If a listener has a conflict, this should be reported in the `ListenerStatus` of the conflicted `ListenerSet` by setting the `Conflicted` condition to `True`.
+If a listener has a conflict, this should be reported in the `ListenerEntryStatus` of the conflicted `ListenerSet` by setting the `Conflicted` condition to `True`.
 
 Implementation SHOULD be cautious about what information from the parent or siblings are reported to avoid accidentally leaking sensitive information that the child would not otherwise have access to.
 

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -47,7 +47,7 @@ The feature will be part of the experimental channel, which implementations can 
 
 ## API
 
-This proposal introduces a new `ListenerSet` resource that has the ability to attach to a set of listeners to multiple parent `Gateways`.
+This proposal introduces a new `ListenerSet` resource that has the ability to attach a set of listeners to multiple parent `Gateways`.
 
 ### Go
 
@@ -60,6 +60,7 @@ type GatewaySpec struct {
 }
 
 type AllowedListeners struct {
+	// TODO - discuss changing this to Same in the future
 	// +kubebuilder:default={from: None}
 	Namespaces *ListenerNamespaces `json:"namespaces,omitempty"`
 }

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -82,15 +82,18 @@ type ListenerSet struct {
 type ListenerSetSpec struct {
 	// ParentRefs references the Gateway that the listeners are attached to.
 	//
-	// +kubebuilder:validation:MaxItems=32
+	// +kubebuilder:validation:MaxItems=2
 	ParentRefs []ParentGatewayReference `json:"parentRefs,omitempty"`
 
 	// Listeners associated with this ListenerSet. Listeners define
 	// logical endpoints that are bound on this referenced parent Gateway's addresses.
 	//
-	// At least one Listener MUST be specified.
 	//
 	// Note: this is the same Listener type in the GatewaySpec struct
+	// +listType=map
+	// +listMapKey=name
+	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:MaxItems=16
 	Listeners []Listener
 }
 
@@ -103,7 +106,7 @@ type ListenerSetStatus struct {
 	// first sees the route and should update the entry as appropriate when the
 	// route or gateway is modified.
 	//
-	// +kubebuilder:validation:MaxItems=32
+	// +kubebuilder:validation:MaxItems=2
 	Parents []ListenerSetParentStatus `json:"parents"`
 }
 
@@ -119,7 +122,7 @@ type ListenerSetParentStatus struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=64
+	// +kubebuilder:validation:MaxItems=16
 	//
 	// Note: this is the same ListenerStatus type in the GatewayStatus struct
 	Listeners []ListenerStatus `json:"listeners,omitempty"`

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -93,10 +93,8 @@ type ListenerSet struct {
 
 // ListenerSetSpec defines the desired state of a ListenerSet.
 type ListenerSetSpec struct {
-	// ParentRefs references the Gateway that the listeners are attached to.
-	//
-	// +kubebuilder:validation:MaxItems=2
-	ParentRefs []ParentGatewayReference `json:"parentRefs,omitempty"`
+	// ParentRef references the Gateway that the listeners are attached to.
+	ParentRef ParentGatewayReference `json:"parentRef,omitempty"`
 
 	// Listeners associated with this ListenerSet. Listeners define
 	// logical endpoints that are bound on this referenced parent Gateway's addresses.
@@ -114,7 +112,8 @@ type ListenerSetSpec struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64
-	Listeners []ListenerEntry
+	Listeners []ListenerEntry `json:"listeners"`
+
 }
 // ListenerEntry embodies the concept of a logical endpoint where a Gateway accepts
 // network connections.
@@ -219,24 +218,6 @@ type ListenerEntry struct {
 
 // ListenerSetStatus defines the observed state of a ListenerSet
 type ListenerSetStatus struct {
-	// Parents is a list of parent resources (usually Gateways) that are
-	// associated with the ListenerSet, and the status of the ListenerSet with respect to
-	// each parent. When this ListenerSet attaches to a parent, the controller that
-	// manages the parent must add an entry to this list when the controller
-	// first sees the ListenerSet and should update the entry as appropriate when the
-	// ListenerSet or gateway is modified.
-	//
-	// +kubebuilder:validation:MaxItems=2
-	Parents []ListenerSetParentStatus `json:"parents"`
-}
-
-// ListenerSetParentStatus defines the observed state of ListenerSet with
-// to an associated Parent.
-type ListenerSetParentStatus struct {
-	// ParentRef corresponds with a ParentRef in the spec that this
-	// RouteParentStatus struct describes the status of.
-	ParentRef ParentGatewayReference `json:"parentRef"`
-
 	// Listeners provide status for each unique listener port defined in the Spec.
 	//
 	// +optional
@@ -354,8 +335,8 @@ kind: ListenerSet
 metadata:
   name: first-workload-listeners
 spec:
-  parentRefs:
-  - name: parent-gateway
+  parentRef:
+    name: parent-gateway
     kind: Gateway
     group: gateway.networking.k8s.io
   listeners:
@@ -375,8 +356,8 @@ kind: ListenerSet
 metadata:
   name: second-workload-listeners
 spec:
-  parentRefs:
-  - name: parent-gateway
+  parentRef:
+    name: parent-gateway
     kind: Gateway
     group: gateway.networking.k8s.io
   listeners:
@@ -540,7 +521,7 @@ Parent `Gateways` MUST NOT have `ListenerSet` listeners in their `status.listene
 
 `ListenerSets` have a top-level `Accepted` and `Programmed` conditions.
 
-The `Accepted` condition MUST be set on every `ListenerSet`, and indicates that the `ListenerSet` is semantically valid and accepted by its `parentRefs`.
+The `Accepted` condition MUST be set on every `ListenerSet`, and indicates that the `ListenerSet` is semantically valid and accepted by its `parentRef`.
 
 Valid reasons for `Accepted` being `False` are:
 

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -158,8 +158,15 @@ type ListenerEntry struct {
 	// Port is the network port. Multiple listeners may use the
 	// same port, subject to the Listener compatibility rules.
 	//
+	// If the port is specified as zero, the implementation will assign
+	// a unique port. If the implementation does not support dynamic port
+	// assignment, it MUST set `Accepted` condition to `False` with the
+	// `UnsupportedPort` reason.
+	//
 	// Support: Core
-	Port PortNumber `json:"port"`
+	//
+	// +optional
+	Port *PortNumber `json:"port,omitempty"`
 
 	// Protocol specifies the network protocol this listener expects to receive.
 	//
@@ -261,6 +268,9 @@ type ListenerSetParentStatus struct {
 type ListenerEntryStatus struct {
 	// Name is the name of the Listener that this status corresponds to.
 	Name SectionName `json:"name"`
+
+	// Port is the network port that this listener is listening on.
+	Port PortNumber `json:"port"`
 
 	// SupportedKinds is the list indicating the Kinds supported by this
 	// listener. This MUST represent the kinds an implementation supports for

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -26,6 +26,12 @@ More broadly, large scale gateway users often expose `O(1000)` domains, but are 
 The spec currently has language to indicate implementations `MAY` merge `Gateways` resources but the mechanic isn't defined.
 https://github.com/kubernetes-sigs/gateway-api/blob/541e9fc2b3c2f62915cb58dc0ee5e43e4096b3e2/apis/v1beta1/gateway_types.go#L76-L78
 
+## Feature Details
+
+We define `ListenerSet` as the name of the feature outlined in this GEP.
+The feature will be part of the experimental branches as an extended feature, which implementations can choose to support. At that time, all the requirements in this document that use MUST apply to their implementation of the feature.
+
+
 ## API
 
 This proposal introduces a new `ListenerSet` resource that has the ability to attach to a set of listeners to a parent `Gateway`.

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -223,6 +223,13 @@ spec:
 ```
 ## Semantics
 
+### Gateway Changes
+
+When an implementation supports `ListenerSets` `Gateways` MUST allow the list of listeners to be empty. Thus the present `minItems=1` constraint on the listener list will be removed. This allows implementations to avoid security, cost etc. concerns with having dummy listeners. 
+When there are no listeners the `Gateway`'s `status.listeners` should be empty or unset. `status.listeners` is already an optional field.
+
+Implementations, when creating a `Gateway`, may provision underlying infrastructure when there are no listeners present. The status conditions `Accepted` and `Programmed` conditions should reflect state of this provisioning.
+
 ### Gateway <> ListenerSet Handshake
 
 By default a `Gateway` will allow `ListenerSets` in the same namespace to be attached. Users can prevent this behaviour by configuring their `Gateway` to disallow any listener attachment:
@@ -236,13 +243,6 @@ spec:
   allowedListeners:
   - from: None
 ```
-
-### GatewaySpec.Listeners MinItems
-
-TBD: Do we want to make this change?
-
-Currently when creating a Gateway you must specify at least a single listener. With `ListenerSets` this opens the possibility of wanting to create a Gateway with no listeners.
-
 
 ### Route Attaching
 

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -357,19 +357,26 @@ Parent `Gateways` MUST NOT have `ListenerSet` listeners in their `status.listene
 
 ### ListenerSet Conditions
 
-`ListenerSets` MUST NOT have their parent `Gateway`'s' listeners in the associated `status.parents.listeners` conditions list.  An implementation MAY reject listeners with `ListenerConditionAccepted=False` and Reason `TooManyListeners` `ListenerSets`, like a `Gateway`, also have two top-level conditions: `Accepted` and `Programmed`. These conditions, when surfacing details about listeners, MUST only summarize the `status.listener` conditions that are exclusive to the `ListenerSet`.
+`ListenerSets` have a top-level `Accepted` and `Programmed` conditions.
 
-These conditions MUST also surface top-level `Gateway` conditions that impact the `ListenerSet`. For example, if a `Gateway` requests an invalid address and it cannot be accepted/programmed then the `ListenerSet`'s' `Accepted` condition MUST be set to `False`.
+The `Accepted` condition MUST be set on every `ListenerSet`, and indicates that the `ListenerSet` is semantically valid and accepted by its `parentRefs`.
 
-For example, if I have a `Gateway` named `parent`, and two `ListenerSets` named `child-1`, and `child-2` then:
-* If `parent` is entirely invalid (for example, an invalid `address`) and `Accepted=False`, all two `ListenerSets` will reported `Accepted=False`.
-* If `child-1` has an invalid listener, `parent` and `child-1` will report `ListenersNotValid`, while `child-2` will not.
-* If `child-1` references a parent that doesn't allow merging then `child-1` will report `Accepted=False`
-* If `child-1` references another child (eg. `child-2`) then `child-1` will report `Accepted=False`
-* If `child-1` is valid, then when `child-2` is created if it conflicts with `child-1` then `child-2` will report `Accepted=False`. `child-1` status conditions will remain unchanged. `parent` will report `ListenersNotValid`
+Valid reasons for `Accepted` being `False` are:
+- `NotAllowed` - the `parentRef` doesn't allow attachment
+- `ParentNotAccepted` - the `parentRef` isn't accepted (eg. invalid address)
+- `UnsupportedValue` - a listener in the set is using an unsupported feature/value
 
-When reporting status of a child, an implementation SHOULD be cautious about what information from the parent or siblings are reported
-to avoid accidentally leaking sensitive information that the child would not otherwise have access to.
+The `Programmed` condition MUST be set on every `ListenerSet` and have a similar meaning to the Gateway `Programmed` condition but only reflect the listeners in this `ListenerSet`.
+
+`Accepted` and `Programmed` conditions when surfacing details about listeners, MUST only summarize the `status.parents.listeners` conditions that are exclusive to the `ListenerSet`.
+
+`ListenerSets` MUST NOT have their parent `Gateway`'s' listeners in the associated `status.parents.listeners` conditions list.
+
+### ListenerSetStatus.Parents.ListenerConditions
+
+An implementation MAY reject listeners by setting the ListenerStatus `Accepted` condition to `False` with the `Reason` `TooManyListeners`
+
+Implementation SHOULD be cautious about what information from the parent or siblings are reported to avoid accidentally leaking sensitive information that the child would not otherwise have access to.
 
 ### Policy Attachment
 

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -488,9 +488,10 @@ spec:
 
 ### Route Attaching
 
-Routes MUST be able to specify a `ListenerSet` as a `parentRef`. Routes can use `sectionName`/`port` fields in `ParentReference` to help target a specific listener. If no listener is targeted (`sectionName`/`port` are unset) then the Route attaches to all the listeners on the `ListenerSet` and it `MUST NOT` attach to any listeners in the `ListenerSet`'s parent `Gateways`.
+Routes MUST be able to specify a `ListenerSet` as a `parentRef`. Routes can use `sectionName`/`port` fields in `ParentReference` to help target a specific listener. If no listener is targeted (`sectionName`/`port` are unset) then the Route attaches to all the listeners in the `ListenerSet`.
 
-eg.
+Routes MUST be able to attach to a `ListenerSet` and it's parent `Gateway` by having multiple `parentRefs` eg:
+
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
@@ -517,7 +518,7 @@ spec:
     sectionName: foo
 ```
 
-To attach to listeners in both a `Gateway` and `ListenerSet` the route must have two `parentRefs`:
+To attach to listeners in both a `Gateway` and `ListenerSet` the route MUST have two `parentRefs`:
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -5,7 +5,7 @@
 
 (See status definitions [here](overview.md#status).)
 
-## tl;dr
+## Introduction
 
 The `Gateway` Resource is a point of contention since it is the only place to attach listeners with certificates. We propose a new resource called `ListenerSet` to allow a shared list of listeners to be attached to a single `Gateway`.
 
@@ -15,7 +15,7 @@ The `Gateway` Resource is a point of contention since it is the only place to at
 ## Future Goals (Beyond the GEP)
 - Attaching listeners to `Gateways` in different namespaces
 
-## Introduction
+## Use Cases & Motivation
 
 Knative generates on demand per-service certificates using HTTP-01 challenges.
 There can be O(1000) Knative `Services` in the cluster which means we have O(1000) distinct certificates.

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -226,7 +226,7 @@ spec:
 
 ### Gateway Changes
 
-When an implementation supports `ListenerSets` `Gateways` MUST allow the list of listeners to be empty. Thus the present `minItems=1` constraint on the listener list will be removed. This allows implementations to avoid security, cost etc. concerns with having dummy listeners. 
+When an implementation supports `ListenerSets` `Gateways` MUST allow the list of listeners to be empty. Thus the present `minItems=1` constraint on the listener list will be removed. This allows implementations to avoid security, cost etc. concerns with having dummy listeners.
 When there are no listeners the `Gateway`'s `status.listeners` should be empty or unset. `status.listeners` is already an optional field.
 
 Implementations, when creating a `Gateway`, may provision underlying infrastructure when there are no listeners present. The status conditions `Accepted` and `Programmed` conditions should reflect state of this provisioning.
@@ -327,14 +327,16 @@ If there are listener conflicts, this should be reported as `Conflicted=True` in
 
 ###  Gateway Conditions
 
-`Gateway` currently supports the following top-level condition types: `Accepted` and `Programmed`
+`Gateway`'s `Accepted` and `Programmed` top-level conditions remain unchanged and reflect the status of the local configuration.
 
-For a `Gateway`, `Accepted` should be set based on the entire set of merged listeners.
-For instance, if a `ListenerSet` listener is invalid, `ListenersNotValid` would be reported.
-`Programmed` is not expected, generally, to depend on the children resources, but if an implementation does depend on these
-they should consider child resources when reporting this status.
+Implementations MUST support a new condition type `AttachedListeners`.
 
-Parent gateways MUST NOT have `ListenerSet` listeners in their `status.listeners` conditions list.
+The condition's `Status` has the following values:
+- `True` when `AllowedListeners` is set and at least one child Listener arrives from a `ListenerSet`
+- `False` when `AllowedListeners` is set but has no valid listeners are attached
+- `Unknown` when no `AllowedListeners` config is present
+
+Parent `Gateways` MUST NOT have `ListenerSet` listeners in their `status.listeners` conditions list.
 
 It is up to the implementation whether an invalid listener affects other listeners in the Gateway.
 

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -275,7 +275,7 @@ spec:
 
 #### Listener Validation
 
-Implementations MUST treat the parent `Gateway`s as having the concatenated list of all listeners from itself and attached `ListenerSets`
+Implementations MUST treat the parent `Gateway`s as having the concatenated list of all listeners from itself and attached `ListenerSets`. See 'Listener Precedence' for more details on ordering.
 Validation of this list of listeners MUST behave the same as if the list were part of a single `Gateway`.
 
 From the earlier example the above resources would be equivalent to a single `Gateway` where the listeners are collapsed into a single list.

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -12,8 +12,20 @@ The `Gateway` Resource is a point of contention since it is the only place to at
 ## Goals
 - Define a mechanism to merge listeners into a single `Gateway`
 
-## Future Goals (Beyond the GEP)
+## Future Potential Goals (Beyond the GEP)
+
+From [Gateway Hiearchy Brainstorming](https://docs.google.com/document/d/1qj7Xog2t2fWRuzOeTsWkabUaVeOF7_2t_7appe8EXwA/edit#heading=h.w311n4l5qmwk):
+
 - Attaching listeners to `Gateways` in different namespaces
+- Standardize merging multiple lists of Listeners together ([\#1863](https://github.com/kubernetes-sigs/gateway-api/pull/1863))
+- Increase the number of Gateway Listeners that are supported ([\#2869](https://github.com/kubernetes-sigs/gateway-api/issues/2869))
+- Provide a mechanism for third party components to generate listeners and attach them to a Gateway ([\#1863](https://github.com/kubernetes-sigs/gateway-api/pull/1863))
+- Delegate TLS certificate management to App Owners and/or different namespaces ([\#102](https://github.com/kubernetes-sigs/gateway-api/issues/102), [\#103](https://github.com/kubernetes-sigs/gateway-api/issues/103))
+- Delegate domains to different namespaces, but allow those namespace to define TLS and routing configuration within those namespaces with Gateway-like resources ([\#102](https://github.com/kubernetes-sigs/gateway-api/issues/102), [\#103](https://github.com/kubernetes-sigs/gateway-api/issues/103))
+- Enable admins to delegate SNI-based routing for TLS passthrough to other teams and/or namespaces ([\#3177](https://github.com/kubernetes-sigs/gateway-api/discussions/3177)) (Remove TLSRoute)
+- Simplify L4 routing by removing at least one of the required layers (Gateway \-\> Route \-\> Service)
+- Delegate routing to namespaces based on path prefix (previously known as [Route delegation](https://github.com/kubernetes-sigs/gateway-api/issues/1058))
+- Static infrastructure attachment ([\#3103](https://github.com/kubernetes-sigs/gateway-api/discussions/3103\#discussioncomment-9678523))
 
 ## Use Cases & Motivation
 

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -504,7 +504,7 @@ spec:
     sectionName: second
 ```
 
-For instance, the following `HTTPRoute` attempts to attach to a listener defined in the parent `Gateway` using the sectionName `foo`. This is not valid and the route's status should reflect that.
+For instance, the following `HTTPRoute` attempts to attach to a listener defined in the parent `Gateway` using the sectionName `foo`. This is not valid and the route's status `Accepted` condition should be set to `False`
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1beta1

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -338,8 +338,6 @@ The condition's `Status` has the following values:
 
 Parent `Gateways` MUST NOT have `ListenerSet` listeners in their `status.listeners` conditions list.
 
-It is up to the implementation whether an invalid listener affects other listeners in the Gateway.
-
 ### ListenerSet Conditions
 
 `ListenerSets` MUST NOT have their parent `Gateway`'s' listeners in the associated `status.parents.listeners` conditions list.  An implementation MAY reject listeners with `ListenerConditionAccepted=False` and Reason `TooManyListeners` `ListenerSets`, like a `Gateway`, also have two top-level conditions: `Accepted` and `Programmed`. These conditions, when surfacing details about listeners, MUST only summarize the `status.listener` conditions that are exclusive to the `ListenerSet`.

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -36,13 +36,13 @@ Thus updating a single `Gateway` resource with this many certificates is a conte
 
 More broadly, large scale gateway users often expose `O(1000)` domains, but are currently limited by the maximum of 64 `listeners`.
 
-The spec currently has language to indicate implementations `MAY` merge `Gateways` resources but the mechanic isn't defined.
+The spec currently has language to indicate implementations `MAY` merge `Gateways` resources but does not define any specific requirements for how that should work.
 https://github.com/kubernetes-sigs/gateway-api/blob/541e9fc2b3c2f62915cb58dc0ee5e43e4096b3e2/apis/v1beta1/gateway_types.go#L76-L78
 
 ## Feature Details
 
 We define `ListenerSet` as the name of the feature outlined in this GEP.
-The feature will be part of the experimental branches as an extended feature, which implementations can choose to support. At that time, all the requirements in this document that use MUST apply to their implementation of the feature.
+The feature will be part of the experimental channel, which implementations can choose to support. All the `MUST` requirements in this document apply to implementations that choose to support this feature.
 
 
 ## API

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -577,6 +577,8 @@ spec:
 
 ### Listener Precedence
 
+Listeners in a `Gateway` and their attached `ListenerSets` are concatenated as a list when programming the underlying infrastructure
+
 Listeners should be merged using the following precedence:
 
 1. "parent" Gateway

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -1,0 +1,408 @@
+# GEP-1713: Standard Mechanism to Merge Multiple Gateways
+
+* Issue: [#1713](/kubernetes-sigs/gateway-api/issues/1713)
+* Status: Provisional
+
+(See status definitions [here](overview.md#status).)
+
+## tl;dr
+
+The `Gateway` Resource is a point of contention since it is the only place to attach listeners with certificates. We propose a new resource called `ListenerSet` to allow a shared list of listeners to be attached to a single `Gateway`.
+
+## Goals
+- Define a mechanism to merge listeners into a single `Gateway`
+
+## Future Goals (Beyond the GEP)
+- Attaching listeners to `Gateways` in different namespaces
+
+## Introduction
+
+Knative generates on demand per-service certificates using HTTP-01 challenges. 
+There can be O(1000) Knative `Services` in the cluster which means we have O(1000) distinct certificates. 
+Thus updating a single `Gateway` resource with this many certificates is a contention point and inhibits horizontal scaling of our controllers.
+
+More broadly, large scale gateway users often expose `O(1000)` domains, but are currently limited by the maximum of 64 `listeners`.
+
+The spec currently has language to indicate implementations `MAY` merge `Gateways` resources but the mechanic isn't defined.
+https://github.com/kubernetes-sigs/gateway-api/blob/541e9fc2b3c2f62915cb58dc0ee5e43e4096b3e2/apis/v1beta1/gateway_types.go#L76-L78
+
+## API
+
+This proposal has introduces a new resource `ListenerSet` that has the ability to attach to a set of listeners to a parent `Gateway`. 
+
+#### Go
+
+```go
+type GatewaySpec struct {
+  ...
+  AllowedListeners []*AllowedListeners `json:"allowedListeners"`
+  ...
+}
+
+type AllowedListeners struct {
+    // +kubebuilder:default={from: Same}
+    Namespaces *ListenerNamespaces `json:"namespaces,omitempty"`
+}
+
+// ListenerNamespaces indicate which namespaces ListenerSets should be selected from.
+type ListenerNamespaces struct {
+	// From indicates where ListenerSets can attach to this Gateway. Possible
+	// values are:
+	//
+	// * Same: Only ListenerSets in the same namespace may be attached to this Gateway.
+	// * None: Only listeners defined in the Gateway's spec are allowed
+	//
+	// +optional
+	// +kubebuilder:default=Same
+	From *FromNamespaces `json:"from,omitempty"`
+}
+
+// ListenerSet defines a set of additional listeners to attach to an existing Gateway. 
+type ListenerSet struct {
+    metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	
+	// Spec defines the desired state of ListenerSet.
+	Spec ListenerSetSpec `json:"spec"`
+
+	// Status defines the current state of ListenerSet.
+	Status ListenerSetStatus `json:"status,omitempty"`
+}
+
+// ListenerSetSpec defines the desired state of a ListenerSet.
+type ListenerSetSpec struct {
+    // ParentRef references the Gateway that the listeners are attached to.
+    ParentRef ParentGatewayReference `json:"parentRefs,omitempty"`
+    
+    // Listeners associated with this ListenerSet. Listeners define
+	// logical endpoints that are bound on this referenced parent Gateway's addresses.
+	//
+	// At least one Listener MUST be specified.
+	//
+	// Note: this is the same Listener type in the GatewaySpec struct
+    Listeners []Listener 
+}
+
+// ListenerSetStatus defines the observed state of ListenerSet.
+type ListenerSetStatus struct {
+    // Listeners provide status for each unique listener port defined in the Spec.
+	//
+	// +optional
+	// +listType=map
+	// +listMapKey=name
+	// +kubebuilder:validation:MaxItems=64
+	//
+	// Note: this is the same ListenerStatus type in the GatewayStatus struct
+	Listeners []ListenerStatus `json:"listeners,omitempty"`
+	
+	// Conditions describe the current conditions of the ListenerSet.
+	//
+	// Implementations should prefer to express ListenerSet conditions
+	// using the `GatewayConditionType` and `GatewayConditionReason`
+	// constants so that operators and tools can converge on a common
+	// vocabulary to describe Gateway state.
+	//
+	// Known condition types are:
+	//
+	// * "Accepted"
+	// * "Programmed"
+	//
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	// +kubebuilder:validation:MaxItems=8
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// ParentGatewayReference identifies an API object including its namespace,
+// defaulting to Gateway.
+type ParentGatewayReference struct {
+	// Group is the group of the referent.
+	//
+	// +optional
+	// +kubebuilder:default="gateway.networking.k8s.io"
+	Group *Group `json:"group"`
+
+	// Kind is kind of the referent. For example "Gateway".
+	//
+	// +optional
+	// +kubebuilder:default=Gateway
+	Kind *Kind `json:"kind"`
+
+	// Name is the name of the referent.
+	Name ObjectName `json:"name"`
+
+	// Namespace is the namespace of the referenced object. When unspecified, the local
+	// namespace is inferred.
+	//
+	// Support: Core
+	//
+	// +optional
+	Namespace *Namespace `json:"namespace,omitempty"`
+}
+```
+
+#### YAML
+
+The following example shows a `Gateway` with an HTTP listener and two child HTTPS `ListenerSets` with unique hostnames and certificates. 
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: parent-gateway
+spec:
+  gatewayClassName: example
+  listeners:
+  - name: foo
+    hostname: foo.com
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1alpha1
+kind: ListenerSet
+metadata:
+  name: first-workload-listeners
+  labels:
+    gateway.networking.k8s.io/gateway.name: parent-gateway
+spec:
+  parentRef:
+    name: parent-gateway
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+  - name: first
+    hostname: first.foo.com
+    protocol: HTTPS
+    port: 443
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        group: ""
+        name: first-workload-cert # Provisioned via HTTP01 challenge
+---
+apiVersion: gateway.networking.k8s.io/v1alpha1
+kind: ListenerSet
+metadata:
+  name: second-workload-listeners
+spec:
+  parentRef:
+    name: parent-gateway
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+  - name: second
+    hostname: second.foo.com
+    protocol: HTTPS
+    port: 443
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        group: ""
+        name: second-workload-cert # Provisioned via HTTP01 challenge
+```
+### Semantics
+
+#### Gateway <> ListenerSet Handshake
+
+By default a `Gateway` will allow `ListenerSets` in the same namespace to be attached. Users can prevent this behaviour by configuring their `Gateway` to disallow any listener attachment:
+
+```
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: parent-gateway
+spec:
+  allowedListeners:
+  - from: None
+```
+
+#### Listeners
+
+####  `ListenerSet.spec.parentRef` is immutable
+
+A `ListenerSet` `MUST` be created with a `parentRef` Updating the `parentRef` of a ListenerSet `MUST` be rejected by the API.
+
+#### `ListenerSet` Default Labels
+
+In order for clients of the API to easily discover `Gateways` and their `ListenerSets` we propose a set of labels to be defaulted when creating `ListenerSets`. This only applies if the `parentRef.kind` is a `Gateway`
+
+- `gateway.networking.k8s.io/gateway.name` is equal to `spec.parentRef.name`
+- `gateway.networking.k8s.io/gateway.namespace` is equal to `spec.parentRef.namespace`
+
+This allows clients to perform API [lookups](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#list-and-watch-filtering) using label selectors.
+
+TBD: Can conditional defaulting be done with CEL?
+
+#### GatewaySpec.Listeners MinItems
+
+TBD: Do we want to make this change?
+
+Currently when creating a Gateway you must specify at least a single listener. With `ListenerSets` this opens the possibility of wanting to create a Gateway with no listeners.
+
+#### Route Attaching
+
+Routes MUST be able to specify a `ListenerSet` as a `parentRef` and make use of the `sectionName` field in `ParentReference` to help target a specific listener. If no listener is targeted (`sectionName`/`port` are unset) then the Route references all the listeners on the `ListenerSet`. It `MUST NOT` attach to additional listeners on the parent `Gateway`.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: httproute-example
+spec:
+  parentRefs:
+  - name: second-workload-listeners
+    kind: ListenerSet
+    sectionName: second
+```
+
+For instance, the following `HTTPRoute` attemps to attach to a listener defined in the parent `Gateway`. This is not valid and the route's status should reflect that.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: httproute-example
+spec:
+  parentRefs:
+  - name: some-workload-listeners
+    kind: ListenerSet
+    sectionName: foo
+```
+
+#### Listener Validation
+
+Implementations MUST treat the parent `Gateway` as having the concatenated list of all listeners from itself and attached `ListenerSets`
+Validation of this list of listeners MUST behave the same as if the list were part of a single `Gateway`.
+
+From the earlier example the above resources would be equivalent to a single `Gateway` where the listeners are collapsed into a single list.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: parent-gateway
+spec:
+  gatewayClassName: example
+  listeners:
+  - name: foo
+    hostname: foo.com
+    protocol: HTTP
+    port: 80
+  - name: first
+    hostname: first.foo.com
+    protocol: HTTPS
+    port: 443
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        group: ""
+        name: first-workload-cert # Provisioned via HTTP01 challenge
+  - name: second
+    hostname: second.foo.com
+    protocol: HTTPS
+    port: 443
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        group: ""
+        name: second-workload-cert # Provisioned via HTTP01 challenge
+```
+
+#### Listener Precedence
+
+Listeners should be merged using the following precedence:
+1. "parent" Gateway
+2. ListenerSet ordered by creation time (oldest first)
+3. ListenerSet ordered alphabetically by “{namespace}/{name}”.
+
+If there are listener conflicts, this should be reported as `Conflicted=True` in the ListenerStatus as usual. See 'Conditions' section below for more details on object should report the conflict.
+
+###  Gateway Conditions
+
+`Gateway` currently supports the following top-level condition types: `Accepted` and `Programmed`
+
+For a `Gateway`, `Accepted` should be set based on the entire set of merged listeners.
+For instance, if a `ListenerSet` listener is invalid, `ListenersNotValid` would be reported. 
+`Programmed` is not expected, generally, to depend on the children resources, but if an implementation does depend on these
+they should consider child resources when reporting this status.
+
+Parent gateways MUST NOT have `ListenerSet` listeners in their `status.listeners` conditions list.
+
+It is up to the implementation whether an invalid listener affects other listeners in the Gateway.
+
+### ListenerSet Conditions
+
+`ListenerSets` MUST NOT have their parent `Gateway`'s' listeners in the `status.listeners` conditions list.  An implementation MAY reject listeners with `ListenerConditionAccepted=False` and Reason `TooManyListeners` `ListenerSets`, like a `Gateway`, also have two top-level conditions: `Accepted` and `Programmed`. These conditions, when surfacing details about listeners, MUST only summarize the `status.listener` conditions that are exclusive to the `ListenerSet`. 
+
+These conditions MUST also surface top-level `Gateway` conditions that impact the `ListenerSet`. For example, if a `Gateway` requests an invalid address and it cannot be accepted/programmed then the `ListenerSet`'s' `Accepted` condition MUST be set to `False`.
+
+For example, if I have a `Gateway` named `parent`, and two `ListenerSets` named `child-1`, and `child-2` then:
+* If `parent` is entirely invalid (for example, an invalid `address`) and `Accepted=False`, all two `ListenerSets` will reported `Accepted=False`.
+* If `child-1` has an invalid listener, `parent` and `child-1` will report `ListenersNotValid`, while `child-2` will not.
+* If `child-1` references a parent that doesn't allow merging then `child-1` will report `Accepted=False`
+* If `child-1` references another child (eg. `child-2`) then `child-1` will report `Accepted=False` 
+* If `child-1` is valid, then when `child-2` is created if it conflicts with `child-1` then `child-2` will report `Accepted=False`. `child-1` status conditions will remain unchanged. `parent` will report `ListenersNotValid`
+
+When reporting status of a child, an implementation SHOULD be cautious about what information from the parent or siblings are reported
+to avoid accidentally leaking sensitive information that the child would not otherwise have access to.
+
+TBD: The following situations aren't possible to handle since there's no 'gatewayClass' on the `ListenerSet`
+* If `child-1` references a parent that doesn't exist then `child-1` will report `Accepted=False`
+* If `child-1` references itself then `child-1` will report `Accepted=False`
+* If `child-1` and `parent` have different gatewayClassNames then `child-1` will report `Accepted=False`
+
+#### Policy Attachment
+
+Policies attached to a parent `Gateway` apply to both the parent and all `ListenerSet` listeners.
+
+Policies that attach to a `ListenerSet` apply to all listeners defined in that resource, but do not impact listeners in the parent `Gateway`
+If the implementation cannot apply the policy to only specific listeners, it should reject the policy.
+
+## Alternatives
+
+#### Re-using Gateway Resource
+
+The [first iteration of this GEP](https://github.com/kubernetes-sigs/gateway-api/pull/1863) proposed re-using the `Gateway` resource and introducing an `attachTo` property in the `infrastructure` stanza.
+
+The main downside of this approach is that users still require `Gateway` write access to create listeners. Secondly, it introduces complexity to future `Gateway` features as GEP authors would have now have to account for merging semantics.
+
+#### New 'GatewayGroup' Resource
+
+This was proposed in the Gateway Hiearchy Brainstorming document (see references below). The idea is to introduce a central resource that will coalease Gateways together and offer forms of delegation.
+
+Issues with this is complexity with status propagation, cluster vs. namespace scoping etc. It also lacks a migration path for existing Gateways to help shard listeners.
+
+#### Use of Multiple Disjointed Gateways
+
+An alternative would be to encourage users to not use overly large Gateways to minimize the blast radius of any issues. Use of disjoint Gateways could accomplish this but it has the disadvantage of consuming more resources and introducing complexity when it comes to operations work (eg. setting up DNS records etc.)
+
+#### Increase the Listener Limit
+
+Increasing the limit may help in situations where you are creating many listeners such as adding certificates created using an ACME HTTP01 challenge. Unfortunately this still makes the Gateway a single point of contention. Unfortunately, there will always be an upper bound because of etcd limitations.
+For workloads like Knative we can have O(1000) Services on the cluster with unique subdomains.
+
+#### Expand Route Functionality
+
+For workloads with many certificates one option would be to introduce a `tls` stanza somewhere in the Route types. These Routes would then attach to a single Gateway. Then application operators can provide their own certificates. This probably would require some ability to have a handshake agreement with the Gateway.
+
+Sorta related there was a Route Delegation GEP (https://github.com/kubernetes-sigs/gateway-api/issues/1058) that was abandoned
+
+## References
+
+First Revision of the GEP
+- https://github.com/kubernetes-sigs/gateway-api/pull/1863
+
+Mentioned in Prior GEPs:
+- https://github.com/kubernetes-sigs/gateway-api/pull/1757
+
+Prior Discussions:
+- https://github.com/kubernetes-sigs/gateway-api/discussions/1248
+- https://github.com/kubernetes-sigs/gateway-api/discussions/1246
+
+Gateway Hiearchy Brainstorming
+- https://docs.google.com/document/d/1qj7Xog2t2fWRuzOeTsWkabUaVeOF7_2t_7appe8EXwA/edit

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -1,4 +1,4 @@
-# GEP-1713: Standard Mechanism to Merge Multiple Gateways
+# GEP-1713: ListenerSets - Standard Mechanism to Merge Multiple Gateways
 
 * Issue: [#1713](/kubernetes-sigs/gateway-api/issues/1713)
 * Status: Provisional

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -340,7 +340,7 @@ Listeners should be merged using the following precedence:
 2. ListenerSet ordered by creation time (oldest first)
 3. ListenerSet ordered alphabetically by “{namespace}/{name}”.
 
-If there are listener conflicts, this should be reported as `Conflicted=True` in the `ListenerSetParentStatus` as usual. See 'Conditions' section below for more details on object should report the conflict.
+Conflicts are covered in the section 'ListenerConditions within a ListenerSet'
 
 ###  Gateway Conditions
 
@@ -372,9 +372,11 @@ The `Programmed` condition MUST be set on every `ListenerSet` and have a similar
 
 `ListenerSets` MUST NOT have their parent `Gateway`'s' listeners in the associated `status.parents.listeners` conditions list.
 
-### ListenerSetStatus.Parents.ListenerConditions
+### ListenerConditions within a ListenerSet
 
-An implementation MAY reject listeners by setting the ListenerStatus `Accepted` condition to `False` with the `Reason` `TooManyListeners`
+An implementation MAY reject listeners by setting the `ListenerStatus` `Accepted` condition to `False` with the `Reason` `TooManyListeners`
+
+If a listener has a conflict, this should be reported in the `ListenerStatus` of the conflicted `ListenerSet` by setting the `Conflicted` condition to `True`.
 
 Implementation SHOULD be cautious about what information from the parent or siblings are reported to avoid accidentally leaking sensitive information that the child would not otherwise have access to.
 

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -516,7 +516,7 @@ spec:
   - name: second-workload-listeners
     kind: ListenerSet
     sectionName: second
-	- name: parent-gateway
+  - name: parent-gateway
     kind: Gateway
     sectionName: foo
 ```
@@ -565,6 +565,7 @@ spec:
 ### Listener Precedence
 
 Listeners should be merged using the following precedence:
+
 1. "parent" Gateway
 2. ListenerSet ordered by creation time (oldest first)
 3. ListenerSet ordered alphabetically by “{namespace}/{name}”.
@@ -591,6 +592,7 @@ Parent `Gateways` MUST NOT have `ListenerSet` listeners in their `status.listene
 The `Accepted` condition MUST be set on every `ListenerSet`, and indicates that the `ListenerSet` is semantically valid and accepted by its `parentRefs`.
 
 Valid reasons for `Accepted` being `False` are:
+
 - `NotAllowed` - the `parentRef` doesn't allow attachment
 - `ParentNotAccepted` - the `parentRef` isn't accepted (eg. invalid address)
 - `UnsupportedValue` - a listener in the set is using an unsupported feature/value

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -34,7 +34,7 @@ The feature will be part of the experimental branches as an extended feature, wh
 
 ## API
 
-This proposal introduces a new `ListenerSet` resource that has the ability to attach to a set of listeners to a parent `Gateway`.
+This proposal introduces a new `ListenerSet` resource that has the ability to attach to a set of listeners to multiple parent `Gateways`.
 
 #### Go
 
@@ -67,7 +67,7 @@ type ListenerNamespaces struct {
 
 // ListenerSet defines a set of additional listeners to attach to an existing Gateway. 
 type ListenerSet struct {
-    metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	
 	// Spec defines the desired state of ListenerSet.
@@ -79,11 +79,11 @@ type ListenerSet struct {
 
 // ListenerSetSpec defines the desired state of a ListenerSet.
 type ListenerSetSpec struct {
-    // ParentRef references the Gateway that the listeners are attached to.
-    ParentRef ParentGatewayReference `json:"parentRefs,omitempty"`
+	// ParentRefs references the Gateway that the listeners are attached to.
+	ParentRefs []ParentGatewayReference `json:"parentRefs,omitempty"`
     
-    // Listeners associated with this ListenerSet. Listeners define
-    // logical endpoints that are bound on this referenced parent Gateway's addresses.
+	// Listeners associated with this ListenerSet. Listeners define
+	// logical endpoints that are bound on this referenced parent Gateway's addresses.
 	//
 	// At least one Listener MUST be specified.
 	//
@@ -93,7 +93,7 @@ type ListenerSetSpec struct {
 
 // ListenerSetStatus defines the observed state of ListenerSet.
 type ListenerSetStatus struct {
-    // Listeners provide status for each unique listener port defined in the Spec.
+	// Listeners provide status for each unique listener port defined in the Spec.
 	//
 	// +optional
 	// +listType=map
@@ -163,11 +163,9 @@ apiVersion: gateway.networking.k8s.io/v1alpha1
 kind: ListenerSet
 metadata:
   name: first-workload-listeners
-  labels:
-    gateway.networking.k8s.io/gateway.name: parent-gateway
 spec:
-  parentRef:
-    name: parent-gateway
+  parentRefs:
+  - name: parent-gateway
     kind: Gateway
     group: gateway.networking.k8s.io
   listeners:
@@ -186,11 +184,9 @@ apiVersion: gateway.networking.k8s.io/v1alpha1
 kind: ListenerSet
 metadata:
   name: second-workload-listeners
-  labels:
-    gateway.networking.k8s.io/gateway.name: parent-gateway
 spec:
-  parentRef:
-    name: parent-gateway
+  parentRefs:
+  - name: parent-gateway
     kind: Gateway
     group: gateway.networking.k8s.io
   listeners:
@@ -220,23 +216,6 @@ spec:
   allowedListeners:
   - from: None
 ```
-
-#### Listeners
-
-####  `ListenerSet.spec.parentRef` is immutable
-
-A `ListenerSet` `MUST` be created with a `parentRef` Updating the `parentRef` of a ListenerSet `MUST` be rejected by the API.
-
-#### `ListenerSet` Default Labels
-
-In order for clients of the API to easily discover `Gateways` and their `ListenerSets` we propose a set of labels to be defaulted when creating `ListenerSets`. This only applies if the `parentRef.kind` is a `Gateway`
-
-- `gateway.networking.k8s.io/gateway.name` is equal to `spec.parentRef.name`
-- `gateway.networking.k8s.io/gateway.namespace` is equal to `spec.parentRef.namespace`
-
-This allows clients to perform API [lookups](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#list-and-watch-filtering) using label selectors.
-
-TBD: Can conditional defaulting be done with CEL?
 
 #### GatewaySpec.Listeners MinItems
 

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -260,7 +260,7 @@ spec:
     sectionName: second
 ```
 
-For instance, the following `HTTPRoute` attemps to attach to a listener defined in the parent `Gateway`. This is not valid and the route's status should reflect that.
+For instance, the following `HTTPRoute` attemps to attach to a listener defined in the parent `Gateway` using the sectionName `foo`. This is not valid and the route's status should reflect that.
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1beta1

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -100,6 +100,14 @@ type ListenerSetSpec struct {
 	// Listeners associated with this ListenerSet. Listeners define
 	// logical endpoints that are bound on this referenced parent Gateway's addresses.
 	//
+	// Listeners in a `Gateway` and their attached `ListenerSets` are concatenated
+	// as a list when programming the underlying infrastructure.
+	//
+	// Listeners should be merged using the following precedence:
+	//
+	// 1. "parent" Gateway
+	// 2. ListenerSet ordered by creation time (oldest first)
+	// 3. ListenerSet ordered alphabetically by “{namespace}/{name}”.
 	//
 	// +listType=map
 	// +listMapKey=name

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -593,13 +593,13 @@ Conflicts are covered in the section 'ListenerConditions within a ListenerSet'
 
 `Gateway`'s `Accepted` and `Programmed` top-level conditions remain unchanged and reflect the status of the local configuration.
 
-Implementations MUST support a new condition type `AttachedListeners`.
+Implementations MUST support a new `Gateway` condition type `AttachedListenerSets`.
 
 The condition's `Status` has the following values:
 
-- `True` when `AllowedListeners` is set and at least one child Listener arrives from a `ListenerSet`
-- `False` when `AllowedListeners` is set but has no valid listeners are attached
-- `Unknown` when no `AllowedListeners` config is present
+- `True` when `Spec.AllowedListeners` is set and at least one child Listener arrives from a `ListenerSet`
+- `False` when `Spec.AllowedListeners` is set but has no valid listeners are attached
+- `Unknown` when no `Spec.AllowedListeners` config is present
 
 Parent `Gateways` MUST NOT have `ListenerSet` listeners in their `status.listeners` conditions list.
 

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -579,6 +579,7 @@ Conflicts are covered in the section 'ListenerConditions within a ListenerSet'
 Implementations MUST support a new condition type `AttachedListeners`.
 
 The condition's `Status` has the following values:
+
 - `True` when `AllowedListeners` is set and at least one child Listener arrives from a `ListenerSet`
 - `False` when `AllowedListeners` is set but has no valid listeners are attached
 - `Unknown` when no `AllowedListeners` config is present
@@ -651,14 +652,18 @@ Sorta related there was a Route Delegation GEP (https://github.com/kubernetes-si
 ## References
 
 First Revision of the GEP
+
 - https://github.com/kubernetes-sigs/gateway-api/pull/1863
 
 Mentioned in Prior GEPs:
+
 - https://github.com/kubernetes-sigs/gateway-api/pull/1757
 
 Prior Discussions:
+
 - https://github.com/kubernetes-sigs/gateway-api/discussions/1248
 - https://github.com/kubernetes-sigs/gateway-api/discussions/1246
 
-Gateway Hierarchy Brainstorming
+Gateway Hierarchy Brainstorming:
+
 - https://docs.google.com/document/d/1qj7Xog2t2fWRuzOeTsWkabUaVeOF7_2t_7appe8EXwA/edit

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -104,7 +104,7 @@ type ListenerSetSpec struct {
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	Listeners []ListenerEntry
 }
 // ListenerEntry embodies the concept of a logical endpoint where a Gateway accepts
@@ -305,7 +305,7 @@ type ListenerSetParentStatus struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	Listeners []ListenerEntryStatus `json:"listeners,omitempty"`
 
 	// Conditions describe the current conditions of the ListenerSet.

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -28,13 +28,14 @@ https://github.com/kubernetes-sigs/gateway-api/blob/541e9fc2b3c2f62915cb58dc0ee5
 
 ## API
 
-This proposal has introduces a new resource `ListenerSet` that has the ability to attach to a set of listeners to a parent `Gateway`. 
+This proposal introduces a new `ListenerSet` resource that has the ability to attach to a set of listeners to a parent `Gateway`.
 
 #### Go
 
 ```go
 type GatewaySpec struct {
   ...
+  // Note: this is a list to allow future potential features
   AllowedListeners []*AllowedListeners `json:"allowedListeners"`
   ...
 }
@@ -75,7 +76,7 @@ type ListenerSetSpec struct {
     ParentRef ParentGatewayReference `json:"parentRefs,omitempty"`
     
     // Listeners associated with this ListenerSet. Listeners define
-	// logical endpoints that are bound on this referenced parent Gateway's addresses.
+    // logical endpoints that are bound on this referenced parent Gateway's addresses.
 	//
 	// At least one Listener MUST be specified.
 	//
@@ -131,14 +132,6 @@ type ParentGatewayReference struct {
 
 	// Name is the name of the referent.
 	Name ObjectName `json:"name"`
-
-	// Namespace is the namespace of the referenced object. When unspecified, the local
-	// namespace is inferred.
-	//
-	// Support: Core
-	//
-	// +optional
-	Namespace *Namespace `json:"namespace,omitempty"`
 }
 ```
 
@@ -186,6 +179,8 @@ apiVersion: gateway.networking.k8s.io/v1alpha1
 kind: ListenerSet
 metadata:
   name: second-workload-listeners
+  labels:
+    gateway.networking.k8s.io/gateway.name: parent-gateway
 spec:
   parentRef:
     name: parent-gateway
@@ -404,5 +399,5 @@ Prior Discussions:
 - https://github.com/kubernetes-sigs/gateway-api/discussions/1248
 - https://github.com/kubernetes-sigs/gateway-api/discussions/1246
 
-Gateway Hiearchy Brainstorming
+Gateway Hierarchy Brainstorming
 - https://docs.google.com/document/d/1qj7Xog2t2fWRuzOeTsWkabUaVeOF7_2t_7appe8EXwA/edit

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -170,7 +170,7 @@ type ListenerEntry struct {
 	// Support: Core
 	//
 	// +optional
-	TLS *ListenerSetTLSConfig `json:"tls,omitempty"`
+	TLS *GatewayTLSConfig `json:"tls,omitempty"`
 
 	// AllowedRoutes defines the types of routes that MAY be attached to a
 	// Listener and the trusted namespaces where those Route resources MAY be
@@ -199,85 +199,6 @@ type ListenerEntry struct {
 	// +kubebuilder:default={namespaces:{from: Same}}
 	// +optional
 	AllowedRoutes *AllowedRoutes `json:"allowedRoutes,omitempty"`
-}
-
-// ListenerSetTLSConfig describes a TLS configuration.
-//
-// +kubebuilder:validation:XValidation:message="certificateRefs or options must be specified when mode is Terminate",rule="self.mode == 'Terminate' ? size(self.certificateRefs) > 0 || size(self.options) > 0 : true"
-type ListenerSetTLSConfig struct {
-	// Mode defines the TLS behavior for the TLS session initiated by the client.
-	// There are two possible modes:
-	//
-	// - Terminate: The TLS session between the downstream client and the
-	//   Gateway is terminated at the Gateway. This mode requires certificates
-	//   to be specified in some way, such as populating the certificateRefs
-	//   field.
-	// - Passthrough: The TLS session is NOT terminated by the Gateway. This
-	//   implies that the Gateway can't decipher the TLS stream except for
-	//   the ClientHello message of the TLS protocol. The certificateRefs field
-	//   is ignored in this mode.
-	//
-	// Support: Core
-	//
-	// +optional
-	// +kubebuilder:default=Terminate
-	Mode *TLSModeType `json:"mode,omitempty"`
-
-	// CertificateRefs contains a series of references to Kubernetes objects that
-	// contains TLS certificates and private keys. These certificates are used to
-	// establish a TLS handshake for requests that match the hostname of the
-	// associated listener.
-	//
-	// A single CertificateRef to a Kubernetes Secret has "Core" support.
-	// Implementations MAY choose to support attaching multiple certificates to
-	// a Listener, but this behavior is implementation-specific.
-	//
-	// References to a resource in different namespace are invalid UNLESS there
-	// is a ReferenceGrant in the target namespace that allows the certificate
-	// to be attached. If a ReferenceGrant does not allow this reference, the
-	// "ResolvedRefs" condition MUST be set to False for this listener with the
-	// "RefNotPermitted" reason.
-	//
-	// This field is required to have at least one element when the mode is set
-	// to "Terminate" (default) and is optional otherwise.
-	//
-	// CertificateRefs can reference to standard Kubernetes resources, i.e.
-	// Secret, or implementation-specific custom resources.
-	//
-	// Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
-	//
-	// Support: Implementation-specific (More than one reference or other resource types)
-	//
-	// +optional
-	// +kubebuilder:validation:MaxItems=64
-	CertificateRefs []SecretObjectReference `json:"certificateRefs,omitempty"`
-
-	// FrontendValidation holds configuration information for validating the frontend (client).
-	// Setting this field will require clients to send a client certificate
-	// required for validation during the TLS handshake. In browsers this may result in a dialog appearing
-	// that requests a user to specify the client certificate.
-	// The maximum depth of a certificate chain accepted in verification is Implementation specific.
-	//
-	// Support: Extended
-	//
-	// +optional
-	// <gateway:experimental>
-	FrontendValidation *FrontendTLSValidation `json:"frontendValidation,omitempty"`
-
-	// Options are a list of key/value pairs to enable extended TLS
-	// configuration for each implementation. For example, configuring the
-	// minimum TLS version or supported cipher suites.
-	//
-	// A set of common keys MAY be defined by the API in the future. To avoid
-	// any ambiguity, implementation-specific definitions MUST use
-	// domain-prefixed names, such as `example.com/my-custom-option`.
-	// Un-prefixed names are reserved for key names defined by Gateway API.
-	//
-	// Support: Implementation-specific
-	//
-	// +optional
-	// +kubebuilder:validation:MaxProperties=16
-	Options map[AnnotationKey]AnnotationValue `json:"options,omitempty"`
 }
 
 // ListenerSetStatus defines the observed state of a ListenerSet

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -399,7 +399,7 @@ Implementations, when creating a `Gateway`, may provision underlying infrastruct
 
 By default a `Gateway` MUST NOT allow `ListenerSets` to be attached. Users can enable this behaviour by configuring their `Gateway` to allow `ListenerSet` attachment:
 
-```
+```yaml
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -416,7 +416,7 @@ Routes MUST be able to specify a `ListenerSet` as a `parentRef`. Routes can use 
 Routes MUST be able to attach to a `ListenerSet` and it's parent `Gateway` by having multiple `parentRefs` eg:
 
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: httproute-example
@@ -430,7 +430,7 @@ spec:
 For instance, the following `HTTPRoute` attempts to attach to a listener defined in the parent `Gateway` using the sectionName `foo`. This is not valid and the route's status `Accepted` condition should be set to `False`
 
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: httproute-example
@@ -443,7 +443,7 @@ spec:
 
 To attach to listeners in both a `Gateway` and `ListenerSet` the route MUST have two `parentRefs`:
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: httproute-example

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -346,11 +346,6 @@ For example, if I have a `Gateway` named `parent`, and two `ListenerSets` named 
 When reporting status of a child, an implementation SHOULD be cautious about what information from the parent or siblings are reported
 to avoid accidentally leaking sensitive information that the child would not otherwise have access to.
 
-TBD: The following situations aren't possible to handle since there's no 'gatewayClass' on the `ListenerSet`
-* If `child-1` references a parent that doesn't exist then `child-1` will report `Accepted=False`
-* If `child-1` references itself then `child-1` will report `Accepted=False`
-* If `child-1` and `parent` have different gatewayClassNames then `child-1` will report `Accepted=False`
-
 #### Policy Attachment
 
 Policies attached to a parent `Gateway` apply to both the parent and all `ListenerSet` listeners.

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -339,7 +339,7 @@ spec:
     protocol: HTTP
     port: 80
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha1
+apiVersion: gateway.networking.x-k8s.io/v1alpha1
 kind: ListenerSet
 metadata:
   name: first-workload-listeners
@@ -360,7 +360,7 @@ spec:
         group: ""
         name: first-workload-cert # Provisioned via HTTP01 challenge
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha1
+apiVersion: gateway.networking.x-k8s.io/v1alpha1
 kind: ListenerSet
 metadata:
   name: second-workload-listeners

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -393,15 +393,8 @@ spec:
 ```
 ### ListenerEntry
 
-TBD: `ListenerEntry` is currently a copy of the `Listener` struct but we have the opportunity to make changes here.
-
-From robscott https://github.com/kubernetes-sigs/gateway-api/pull/3213#discussion_r1699248634:
-
-> Since this would be a new API, it could be worth exploring some potential regrets of Listeners:
->
-> 1. Should we have made it easier to leave port empty or do port ranges?
-> 2. Should we support multiple hostnames?
-> 3. Are there any validations that we wish we'd tightened up?
+`ListenerEntry` is currently a copy of the `Listener` struct with some changes
+1. `Port` is now a pointer to allow for dynamic port assignment.
 
 ## Semantics
 

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -48,7 +48,7 @@ type GatewaySpec struct {
 }
 
 type AllowedListeners struct {
-	// +kubebuilder:default={from: Same}
+	// +kubebuilder:default={from: None}
 	Namespaces *ListenerNamespaces `json:"namespaces,omitempty"`
 }
 
@@ -462,7 +462,7 @@ Implementations, when creating a `Gateway`, may provision underlying infrastruct
 
 ### Gateway <> ListenerSet Handshake
 
-By default a `Gateway` will allow `ListenerSets` in the same namespace to be attached. Users can prevent this behaviour by configuring their `Gateway` to disallow any listener attachment:
+By default a `Gateway` MUST NOT allow `ListenerSets` to be attached. Users can enable this behaviour by configuring their `Gateway` to allow `ListenerSet` attachment:
 
 ```
 apiVersion: gateway.networking.k8s.io/v1
@@ -471,7 +471,7 @@ metadata:
   name: parent-gateway
 spec:
   allowedListeners:
-  - from: None
+  - from: Same
 ```
 
 ### Route Attaching

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -204,11 +204,11 @@ type ListenerEntry struct {
 // ListenerSetStatus defines the observed state of a ListenerSet
 type ListenerSetStatus struct {
 	// Parents is a list of parent resources (usually Gateways) that are
-	// associated with the route, and the status of the route with respect to
-	// each parent. When this route attaches to a parent, the controller that
+	// associated with the ListenerSet, and the status of the ListenerSet with respect to
+	// each parent. When this ListenerSet attaches to a parent, the controller that
 	// manages the parent must add an entry to this list when the controller
-	// first sees the route and should update the entry as appropriate when the
-	// route or gateway is modified.
+	// first sees the ListenerSet and should update the entry as appropriate when the
+	// ListenerSet or gateway is modified.
 	//
 	// +kubebuilder:validation:MaxItems=2
 	Parents []ListenerSetParentStatus `json:"parents"`

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -55,6 +55,7 @@ type ListenerNamespaces struct {
 	//
 	// +optional
 	// +kubebuilder:default=Same
+	// +kubebuilder:validation:Enum=Same;None
 	From *FromNamespaces `json:"from,omitempty"`
 }
 

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -247,8 +247,9 @@ spec:
 
 ### Route Attaching
 
-Routes MUST be able to specify a `ListenerSet` as a `parentRef` and make use of the `sectionName` field in `ParentReference` to help target a specific listener. If no listener is targeted (`sectionName`/`port` are unset) then the Route references all the listeners on the `ListenerSet`. It `MUST NOT` attach to additional listeners on the parent `Gateway`.
+Routes MUST be able to specify a `ListenerSet` as a `parentRef`. Routes can use `sectionName`/`port` fields in `ParentReference` to help target a specific listener. If no listener is targeted (`sectionName`/`port` are unset) then the Route attaches to all the listeners on the `ListenerSet` and it `MUST NOT` attach to any listeners in the `ListenerSet`'s parent `Gateways`.
 
+eg.
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
@@ -261,7 +262,7 @@ spec:
     sectionName: second
 ```
 
-For instance, the following `HTTPRoute` attemps to attach to a listener defined in the parent `Gateway` using the sectionName `foo`. This is not valid and the route's status should reflect that.
+For instance, the following `HTTPRoute` attempts to attach to a listener defined in the parent `Gateway` using the sectionName `foo`. This is not valid and the route's status should reflect that.
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -272,6 +273,22 @@ spec:
   parentRefs:
   - name: some-workload-listeners
     kind: ListenerSet
+    sectionName: foo
+```
+
+To attach to listeners in both a `Gateway` and `ListenerSet` the route must have two `parentRefs`:
+```yaml
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: httproute-example
+spec:
+  parentRefs:
+  - name: second-workload-listeners
+    kind: ListenerSet
+    sectionName: second
+	- name: parent-gateway
+    kind: Gateway
     sectionName: foo
 ```
 

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -467,7 +467,9 @@ From robscott https://github.com/kubernetes-sigs/gateway-api/pull/3213#discussio
 
 ### Gateway Changes
 
-When an implementation supports `ListenerSets` `Gateways` MUST allow the list of listeners to be empty. Thus the present `minItems=1` constraint on the listener list will be removed. This allows implementations to avoid security, cost etc. concerns with having dummy listeners.
+An initial experimental release of `ListenerSets` _will have no modifications_ to listener list on the `Gateway` resource. Using `ListenerSets` will  require a dummy listener to be configured.
+
+In a future (potential) release when an implementation supports `ListenerSets`, `Gateways` MUST allow the list of listeners to be empty. Thus the present `minItems=1` constraint on the listener list will be removed. This allows implementations to avoid security, cost etc. concerns with having dummy listeners.
 When there are no listeners the `Gateway`'s `status.listeners` should be empty or unset. `status.listeners` is already an optional field.
 
 Implementations, when creating a `Gateway`, may provision underlying infrastructure when there are no listeners present. The status conditions `Accepted` and `Programmed` conditions should reflect state of this provisioning.

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -277,7 +277,7 @@ spec:
 
 ### Listener Validation
 
-Implementations MUST treat the parent `Gateway`s as having the concatenated list of all listeners from itself and attached `ListenerSets`. See 'Listener Precedence' for more details on ordering.
+Implementations MUST treat the parent `Gateway`s as having the merged list of all listeners from itself and attached `ListenerSets`. See 'Listener Precedence' for more details on ordering.
 Validation of this list of listeners MUST behave the same as if the list were part of a single `Gateway`.
 
 From the earlier example the above resources would be equivalent to a single `Gateway` where the listeners are collapsed into a single list.

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -626,7 +626,7 @@ An implementation MAY reject listeners by setting the `ListenerEntryStatus` `Acc
 
 If a listener has a conflict, this should be reported in the `ListenerEntryStatus` of the conflicted `ListenerSet` by setting the `Conflicted` condition to `True`.
 
-Implementation SHOULD be cautious about what information from the parent or siblings are reported to avoid accidentally leaking sensitive information that the child would not otherwise have access to.
+Implementations SHOULD be cautious about what information from the parent or siblings are reported to avoid accidentally leaking sensitive information that the child would not otherwise have access to. This can include contents of secrets etc.
 
 ### Policy Attachment
 

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -20,6 +20,7 @@ The `Gateway` Resource is a point of contention since it is the only place to at
 Knative generates on demand per-service certificates using HTTP-01 challenges.
 There can be O(1000) Knative `Services` in the cluster which means we have O(1000) distinct certificates.
 Thus updating a single `Gateway` resource with this many certificates is a contention point and inhibits horizontal scaling of our controllers.
+[Istio Ambient](https://istio.io/v1.15/blog/2022/introducing-ambient-mesh/), similarly, creates a listener per Kubernetes service.
 
 More broadly, large scale gateway users often expose `O(1000)` domains, but are currently limited by the maximum of 64 `listeners`.
 

--- a/geps/gep-1713/metadata.yaml
+++ b/geps/gep-1713/metadata.yaml
@@ -1,0 +1,7 @@
+apiVersion: internal.gateway.networking.k8s.io/v1alpha1
+kind: GEPDetails
+number: 1713
+name: Gateway Merging - ListenerSet
+status: Provisional
+authors:
+  - dprotaso


### PR DESCRIPTION
This replaces https://github.com/kubernetes-sigs/gateway-api/pull/1863 
**What type of PR is this?**

/kind gep

**What this PR does / why we need it**:

Outlines a mechanism to merge Gateway Listeners

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/1713

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
