### PR TITLE
Update GRPCRoute GEP to standard

### DIFF
--- a/geps/gep-1016/index.md
+++ b/geps/gep-1016/index.md
@@ -1,7 +1,7 @@
 # GEP-1016: GRPCRoute
 
 * Issue: [#1016](https://github.com/kubernetes-sigs/gateway-api/issues/1016)
-* Status: Experimental
+* Status: Standard
 
 > **Note**: This GEP is exempt from the [Probationary Period][expprob] rules of
 > our GEP overview as it existed before those rules did, and so it has been
@@ -74,10 +74,10 @@ The user experience would also degrade significantly if forced to route at the l
 
 - Encoding services and methods as URIs (an implementation detail of gRPC)
 - The [Transfer Encoding header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding) for trailers
-- Many features supported by HTTP/2 but not by gRPC, such as
-  - Query parameters
-  - Methods besides `POST`
-  - [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+- Many features supported by HTTP/2 but not by gRPC, such as:
+    - Query parameters
+    - Methods besides `POST`
+    - [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
 
 
 #### Proxyless Service Mesh

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,7 +126,6 @@ nav:
     - Implementable:
       - geps/gep-995/index.md
     - Experimental:
-      - geps/gep-1016/index.md
       - geps/gep-1619/index.md
       - geps/gep-1742/index.md
       - geps/gep-1748/index.md
@@ -144,6 +143,7 @@ nav:
       - geps/gep-820/index.md
       - geps/gep-851/index.md
       - geps/gep-957/index.md
+      - geps/gep-1016/index.md
       - geps/gep-1323/index.md
       - geps/gep-1364/index.md
       - geps/gep-1426/index.md


### PR DESCRIPTION
GEP-1016 (`GRPCRoute`) was still marked as Experimental, even though it's been moved to standard since v1.1 🤯 
**What type of PR is this?**

/kind bug
/kind cleanup
/kind documentation
/kind gep


**What this PR does / why we need it**:
Updates the GRPCRoute GEP to show it's standard 
Also fixed a spacing issue where the sub bullet points were not rendering on the site

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
