### PR TITLE
Add GKE Gateway v1.1 conformance report

### DIFF
--- a/conformance/reports/v1.1.0/gke-gateway/README.md
+++ b/conformance/reports/v1.1.0/gke-gateway/README.md
@@ -1,0 +1,47 @@
+# GKE (Google Kubernetes Engine) Gateway
+
+## Table of Contents
+
+|API channel|Implementation version|Mode|Report|
+|-----------|----------------------|----|------|
+|standard|1.30.3-gke.1211000|gke-l7-global-external-managed|[link](./standard-1.30.3-gxlb-report.yaml)|
+|standard|1.30.3-gke.1211000|gke-l7-regional-external-managed|[link](./standard-1.30.3-rxlb-report.yaml)|
+|standard|1.30.3-gke.1211000|gke-l7-rilb|[link](./standard-1.30.3-rilb-report.yaml)|
+
+## Reproduce
+
+GKE Gateway conformance report can be reproduced by the following steps.
+
+1. create a GKE cluster with Gateway API enabled
+
+```
+gcloud container clusters create "${cluster_name}" --gateway-api=standard --location="${location}"
+```
+
+2. create a proxy-only subnet if using a regional Gateway following [guide](https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#configure_a_proxy-only_subnet)
+
+3. run the following command from within the [GKE Gateway repo](https://github.com/GoogleCloudPlatform/gke-gateway-api)
+
+```
+go test ./conformance -run TestConformance -v -timeout=3h -args \
+    --gateway-class=gke-l7-global-external-managed \
+    --conformance-profiles=GATEWAY-HTTP \
+    --organization=GKE \
+    --project=gke-gateway \
+    --url=https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api \
+    --version=1.30.3-gke.1211000 \
+    --contact=gke-gateway-dev@google.com \
+    --report-output="/path/to/report"
+```
+
+or run a single conformance test case
+
+```
+go test ./conformance -run TestConformance -v -args \
+    --gateway-class=gke-l7-global-external-managed \
+    --run-test=HTTPRouteRequestMirror
+```
+
+Note: the repro result can be flaky in some cases because the conformance framework doesn't isolate test cases enough.
+See this [Issue](https://github.com/kubernetes-sigs/gateway-api/issues/3233) for more details.
+The flakiness will be eliminated after this [PR](https://github.com/kubernetes-sigs/gateway-api/pull/3243) is merged and appropriate test isolation timeout is configured.

--- a/conformance/reports/v1.1.0/gke-gateway/standard-1.30.3-gxlb-report.yaml
+++ b/conformance/reports/v1.1.0/gke-gateway/standard-1.30.3-gxlb-report.yaml
@@ -1,0 +1,52 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2024-08-03T05:08:25Z"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.1.0
+implementation:
+  contact:
+  - https://github.com/GoogleCloudPlatform/gke-gateway-api/discussions/new/choose
+  organization: GKE
+  project: gke-gateway
+  url: https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api
+  version: 1.30.3-gke.1211000
+kind: ConformanceReport
+mode: gke-l7-global-external-managed
+profiles:
+- core:
+    result: partial
+    skippedTests:
+    - HTTPRouteHostnameIntersection
+    statistics:
+      Failed: 0
+      Passed: 32
+      Skipped: 1
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 6
+      Skipped: 0
+    supportedFeatures:
+    - GatewayPort8080
+    - HTTPRouteHostRewrite
+    - HTTPRoutePathRedirect
+    - HTTPRouteRequestMirror
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    unsupportedFeatures:
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteMethodMatching
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestTimeout
+  name: GATEWAY-HTTP
+  summary: Core tests partially succeeded with 1 test skips. Extended tests succeeded.

--- a/conformance/reports/v1.1.0/gke-gateway/standard-1.30.3-rilb-report.yaml
+++ b/conformance/reports/v1.1.0/gke-gateway/standard-1.30.3-rilb-report.yaml
@@ -1,0 +1,52 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2024-08-02T22:45:22Z"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.1.0
+implementation:
+  contact:
+  - https://github.com/GoogleCloudPlatform/gke-gateway-api/discussions/new/choose
+  organization: GKE
+  project: gke-gateway
+  url: https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api
+  version: 1.30.3-gke.1211000
+kind: ConformanceReport
+mode: gke-l7-rilb
+profiles:
+- core:
+    result: partial
+    skippedTests:
+    - HTTPRouteHostnameIntersection
+    statistics:
+      Failed: 0
+      Passed: 32
+      Skipped: 1
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 6
+      Skipped: 0
+    supportedFeatures:
+    - GatewayPort8080
+    - HTTPRouteHostRewrite
+    - HTTPRoutePathRedirect
+    - HTTPRouteRequestMirror
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    unsupportedFeatures:
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteMethodMatching
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestTimeout
+  name: GATEWAY-HTTP
+  summary: Core tests partially succeeded with 1 test skips. Extended tests succeeded.

--- a/conformance/reports/v1.1.0/gke-gateway/standard-1.30.3-rxlb-report.yaml
+++ b/conformance/reports/v1.1.0/gke-gateway/standard-1.30.3-rxlb-report.yaml
@@ -1,0 +1,52 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2024-08-01T23:42:20Z"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.1.0
+implementation:
+  contact:
+  - https://github.com/GoogleCloudPlatform/gke-gateway-api/discussions/new/choose
+  organization: GKE
+  project: gke-gateway
+  url: https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api
+  version: 1.30.3-gke.1211000
+kind: ConformanceReport
+mode: gke-l7-regional-external-managed
+profiles:
+- core:
+    result: partial
+    skippedTests:
+    - HTTPRouteHostnameIntersection
+    statistics:
+      Failed: 0
+      Passed: 32
+      Skipped: 1
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 6
+      Skipped: 0
+    supportedFeatures:
+    - GatewayPort8080
+    - HTTPRouteHostRewrite
+    - HTTPRoutePathRedirect
+    - HTTPRouteRequestMirror
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    unsupportedFeatures:
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteMethodMatching
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestTimeout
+  name: GATEWAY-HTTP
+  summary: Core tests partially succeeded with 1 test skips. Extended tests succeeded.

--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -250,6 +250,8 @@ Gloo Gateway 2.0 brings the full power and community support of Gateway API to i
 
 ### Google Kubernetes Engine
 
+[![Conformance](https://img.shields.io/badge/Gateway_API_Partial_Conformance_v1.1.0-Google_Kubernetes_Engine-orange)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.1.0/gke-gateway)
+
 [Google Kubernetes Engine (GKE)][gke] is a managed Kubernetes platform offered
 by Google Cloud. GKE's implementation of the Gateway API is through the [GKE
 Gateway controller][gke-gateway] which provisions Google Cloud Load Balancers
@@ -259,6 +261,9 @@ The GKE Gateway controller supports weighted traffic splitting, mirroring,
 advanced routing, multi-cluster load balancing and more. See the docs to deploy
 [private or public Gateways][gke-gateway-deploy] and also [multi-cluster
 Gateways][gke-multi-cluster-gateway].
+
+The GKE Gateway controller passes all the core Gateway API conformance tests in the
+v1.1.0 release for the GATEWAY_HTTP conformance profile except `HTTPRouteHostnameIntersection`.
 
 [gke]:https://cloud.google.com/kubernetes-engine
 [gke-gateway]:https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/area conformance

**What this PR does / why we need it**:
Add conformance report for GKE Gateway v1.1

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
None
```
