### PR TITLE
docs: add Mattia Lavacca as Gateway API maintainer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,6 +10,7 @@ aliases:
 
   # Reference: https://github.com/kubernetes/org/blob/main/config/kubernetes-sigs/sig-network/teams.yaml
   gateway-api-maintainers:
+    - mlavacca
     - robscott
     - shaneutt
     - youngnick
@@ -32,20 +33,17 @@ aliases:
     - arkodg
     - LiorLieberman
     - michaelbeaumont
-    - mlavacca
     - sunjayBhatia
     - xunzhuo
 
   gateway-api-conformance-approvers:
     - arkodg
-    - mlavacca
     - sunjayBhatia
 
   gateway-api-gep-reviewers:
     - candita
     - gcs278
     - LiorLieberman
-    - mlavacca
 
   gwctl-approvers:
     - gauravkghildiyal


### PR DESCRIPTION
As per the [mailing list discussion](https://groups.google.com/g/kubernetes-sig-network/c/nFN64I33zUo), this adds @mlavacca as a Gateway API maintainer.

**What type of PR is this?**

/kind documentation