### PR TITLE
fix: deduplicate Declined status

### DIFF
--- a/geps/overview.md
+++ b/geps/overview.md
@@ -41,11 +41,10 @@ Each GEP has a state, which tracks where it is in the GEP process.
 
 GEPs can move to some states from any other state:
 
-  * **Declined**: The GEP has been declined and further work will not occur.
   * **Deferred:** We do not currently have bandwidth to handle this GEP, it
     may be revisited in the future.
   * **Declined:** This proposal was considered by the community but ultimately
-  rejected.
+  rejected and further work will not occur.
   * **Withdrawn:** This proposal was considered by the community but ultimately
   withdrawn by the author.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**

/kind cleanup
/kind documentation


**What this PR does / why we need it**:
declined status is listed twice so I'm combining them into one


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
