### PR TITLE
conformance: Update Conformance report

### DIFF
--- a/conformance/reports/v1.1.0/cilium-cilium/experimental-1.16-default-report.yaml
+++ b/conformance/reports/v1.1.0/cilium-cilium/experimental-1.16-default-report.yaml
@@ -1,5 +1,5 @@
-apiVersion: gateway.networking.k8s.io/v1alpha1
-date: "2024-06-07T06:33:39Z"
+apiVersion: gateway.networking.k8s.io/v1
+date: "2024-08-02T12:50:00Z"
 gatewayAPIChannel: experimental
 gatewayAPIVersion: v1.1.0
 implementation:
@@ -16,56 +16,19 @@ profiles:
       result: success
       statistics:
         Failed: 0
-        Passed: 33
-        Skipped: 0
-    extended:
-      result: success
-      statistics:
-        Failed: 0
-        Passed: 16
-        Skipped: 0
-      supportedFeatures:
-        - GatewayHTTPListenerIsolation
-        - GatewayPort8080
-        - HTTPRouteBackendRequestHeaderModification
-        - HTTPRouteBackendTimeout
-        - HTTPRouteHostRewrite
-        - HTTPRouteMethodMatching
-        - HTTPRoutePathRedirect
-        - HTTPRoutePathRewrite
-        - HTTPRoutePortRedirect
-        - HTTPRouteQueryParamMatching
-        - HTTPRouteRequestMirror
-        - HTTPRouteRequestMultipleMirrors
-        - HTTPRouteRequestTimeout
-        - HTTPRouteResponseHeaderModification
-        - HTTPRouteSchemeRedirect
-      unsupportedFeatures:
-        - GatewayStaticAddresses
-        - HTTPRouteParentRefPort
-    name: GATEWAY-HTTP
-    summary: Core tests succeeded. Extended tests succeeded.
-  - core:
-      result: success
-      statistics:
-        Failed: 0
-        Passed: 11
-        Skipped: 0
-    name: GATEWAY-TLS
-    summary: Core tests succeeded.
-  - core:
-      result: success
-      statistics:
-        Failed: 0
         Passed: 3
         Skipped: 0
     extended:
-      result: success
+      result: partial
+      skippedTests:
+        - MeshConsumerRoute
       statistics:
         Failed: 0
-        Passed: 2
-        Skipped: 0
+        Passed: 3
+        Skipped: 1
       supportedFeatures:
+        - HTTPRouteBackendProtocolH2C
+        - HTTPRouteBackendProtocolWebSocket
         - HTTPRouteBackendRequestHeaderModification
         - HTTPRouteBackendTimeout
         - HTTPRouteHostRewrite
@@ -80,16 +43,83 @@ profiles:
         - HTTPRouteResponseHeaderModification
         - HTTPRouteSchemeRedirect
         - MeshClusterIPMatching
-      unsupportedFeatures:
-        - HTTPRouteParentRefPort
         - MeshConsumerRoute
     name: MESH-HTTP
-    summary: Core tests succeeded. Extended tests succeeded.
+    summary: Core tests succeeded. Extended tests partially succeeded with 1 test skips.
   - core:
       result: success
       statistics:
         Failed: 0
         Passed: 12
         Skipped: 0
+    extended:
+      result: partial
+      skippedTests:
+        - GatewayStaticAddresses
+      statistics:
+        Failed: 0
+        Passed: 0
+        Skipped: 1
+      supportedFeatures:
+        - GatewayHTTPListenerIsolation
+        - GatewayPort8080
+        - GatewayStaticAddresses
     name: GATEWAY-GRPC
-    summary: Core tests succeeded.
+    summary: Core tests succeeded. Extended tests partially succeeded with 1 test skips.
+  - core:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 33
+        Skipped: 0
+    extended:
+      result: partial
+      skippedTests:
+        - GatewayStaticAddresses
+        - HTTPRouteListenerPortMatching
+      statistics:
+        Failed: 0
+        Passed: 19
+        Skipped: 2
+      supportedFeatures:
+        - GatewayHTTPListenerIsolation
+        - GatewayPort8080
+        - GatewayStaticAddresses
+        - HTTPRouteBackendProtocolH2C
+        - HTTPRouteBackendProtocolWebSocket
+        - HTTPRouteBackendRequestHeaderModification
+        - HTTPRouteBackendTimeout
+        - HTTPRouteHostRewrite
+        - HTTPRouteMethodMatching
+        - HTTPRouteParentRefPort
+        - HTTPRoutePathRedirect
+        - HTTPRoutePathRewrite
+        - HTTPRoutePortRedirect
+        - HTTPRouteQueryParamMatching
+        - HTTPRouteRequestMirror
+        - HTTPRouteRequestMultipleMirrors
+        - HTTPRouteRequestTimeout
+        - HTTPRouteResponseHeaderModification
+        - HTTPRouteSchemeRedirect
+    name: GATEWAY-HTTP
+    summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
+  - core:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 11
+        Skipped: 0
+    extended:
+      result: partial
+      skippedTests:
+        - GatewayStaticAddresses
+      statistics:
+        Failed: 0
+        Passed: 0
+        Skipped: 1
+      supportedFeatures:
+        - GatewayHTTPListenerIsolation
+        - GatewayPort8080
+        - GatewayStaticAddresses
+    name: GATEWAY-TLS
+    summary: Core tests succeeded. Extended tests partially succeeded with 1 test skips.


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind documentation
/area conformance

**What this PR does / why we need it**:

The previous version didn't show extended features properly for few conformance profiles (e.g. GATEWAY-TLS, GATEWAY-GRPC, etc). It seems like if extempt-features flag is used, none of extended features will show up in the report, hence I just use skip-test instead.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
