### PR TITLE
Use GRPCHeaderMatchType in GRPCHeaderMatch structure

### DIFF
--- a/apis/applyconfiguration/apis/v1/grpcheadermatch.go
+++ b/apis/applyconfiguration/apis/v1/grpcheadermatch.go
@@ -25,9 +25,9 @@ import (
 // GRPCHeaderMatchApplyConfiguration represents an declarative configuration of the GRPCHeaderMatch type for use
 // with apply.
 type GRPCHeaderMatchApplyConfiguration struct {
-	Type  *v1.HeaderMatchType `json:"type,omitempty"`
-	Name  *v1.GRPCHeaderName  `json:"name,omitempty"`
-	Value *string             `json:"value,omitempty"`
+	Type  *v1.GRPCHeaderMatchType `json:"type,omitempty"`
+	Name  *v1.GRPCHeaderName      `json:"name,omitempty"`
+	Value *string                 `json:"value,omitempty"`
 }
 
 // GRPCHeaderMatchApplyConfiguration constructs an declarative configuration of the GRPCHeaderMatch type for use with
@@ -39,7 +39,7 @@ func GRPCHeaderMatch() *GRPCHeaderMatchApplyConfiguration {
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Type field is set to the value of the last call.
-func (b *GRPCHeaderMatchApplyConfiguration) WithType(value v1.HeaderMatchType) *GRPCHeaderMatchApplyConfiguration {
+func (b *GRPCHeaderMatchApplyConfiguration) WithType(value v1.GRPCHeaderMatchType) *GRPCHeaderMatchApplyConfiguration {
 	b.Type = &value
 	return b
 }

--- a/apis/v1/grpcroute_types.go
+++ b/apis/v1/grpcroute_types.go
@@ -388,7 +388,7 @@ type GRPCHeaderMatch struct {
 	//
 	// +optional
 	// +kubebuilder:default=Exact
-	Type *HeaderMatchType `json:"type,omitempty"`
+	Type *GRPCHeaderMatchType `json:"type,omitempty"`
 
 	// Name is the name of the gRPC Header to be matched.
 	//

--- a/apis/v1/zz_generated.deepcopy.go
+++ b/apis/v1/zz_generated.deepcopy.go
@@ -200,7 +200,7 @@ func (in *GRPCHeaderMatch) DeepCopyInto(out *GRPCHeaderMatch) {
 	*out = *in
 	if in.Type != nil {
 		in, out := &in.Type, &out.Type
-		*out = new(HeaderMatchType)
+		*out = new(GRPCHeaderMatchType)
 		**out = **in
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind bug

**What this PR does / why we need it**:

This pull request fixes the GRPC header match type used in the `GRPCHeaderMatch` struct to `GRPCHeaderMatchType` instead of using the `HeaderMatchType` from `HTTPRoute`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
