### PR TITLE
GEP2257 Duration parsing

### DIFF
--- a/pkg/utils/duration.go
+++ b/pkg/utils/duration.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+)
+
+var re = regexp.MustCompile(`^([0-9]{1,5}(h|m|s|ms)){1,4}$`)
+
+func ParseDuration(s string) (*time.Duration, error) {
+	/*
+		parseDuration parses a GEP-2257 Duration format to a time object
+		Valid date units in time.Duration are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+		Valid date units according to GEP-2257 are "h", "m", "s", "ms"
+
+		input: string
+
+		output: time.Duration
+
+		See https://gateway-api.sigs.k8s.io/geps/gep-2257/ for more details.
+	*/
+	if matched := re.MatchString(s); matched == false {
+		return nil, errors.New("Invalid duration format")
+	}
+	parsedTime, err := time.ParseDuration(s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &parsedTime, nil
+
+}
+
+var reSplit = regexp.MustCompile(`[0-9]{1,5}(h|ms|s|m)`)
+
+func FormatDuration(duration time.Duration) (string, error) {
+	/*
+		formatDuration formats a time object to GEP-2257 Duration format to a GEP-2257 Duration Format
+		The time format from GEP-2257 must match the regex
+		"^([1-9]{1,5}(h|m|s|ms)){1,4}$"
+
+		A time.Duration allows for negative time, floating points, and allow for zero units
+		For example, -4h, 4.5h, and 4h0m0s are all valid in the golang time package
+
+		See https://gateway-api.sigs.k8s.io/geps/gep-2257/ for more details.
+
+		Input: time.Duration
+
+		Returns: string or error if duration cannot be expressed as a GEP-2257 Duration format.
+	*/
+	m, _ := time.ParseDuration("0s")
+	if duration == m {
+		return "0s", nil
+	}
+	// time.Duration allows for floating point ms, which is not allowed in GEP-2257
+	durationMicroseconds := duration.Microseconds()
+
+	if durationMicroseconds%1000 != 0 {
+		return "", errors.New("Cannot express sub-milliseconds precision in GEP-2257")
+	}
+
+	//Golang's time.Duration allows for floating point seconds instead of converting to ms
+	durationMilliseconds := duration.Milliseconds()
+
+	var ms int64
+	if durationMilliseconds%1000 != 0 {
+		ms = durationMilliseconds % 1000
+		durationMilliseconds -= ms
+		duration = time.Millisecond * time.Duration(durationMilliseconds)
+	}
+
+	durationString := duration.String()
+	if ms > 0 {
+		durationString += fmt.Sprintf("%dms", ms)
+	}
+
+	// check if a negative value
+	if duration < 0 {
+		return "", errors.New("Invalid duration format. Cannot have negative durations")
+	}
+
+	// trim the 0 values from the string (for example, 30m0s should result in 30m)
+	// going to have a regexp that finds the index of the time units with 0, then appropriately trim those away
+	temp := reSplit.FindAll([]byte(durationString), -1)
+	res := ""
+	for _, t := range temp {
+		if t[0] != '0' {
+			res += string(t)
+		} else {
+			continue
+		}
+	}
+
+	// check if there are floating number points
+	if matched := re.MatchString(res); matched == false {
+		return "", errors.New("Invalid duration format")
+	}
+
+	return res, nil
+}

--- a/pkg/utils/duration.go
+++ b/pkg/utils/duration.go
@@ -48,8 +48,6 @@ func ParseDuration(s string) (*time.Duration, error) {
 	return &parsedTime, nil
 }
 
-var reSplit = regexp.MustCompile(`[0-9]{1,5}(h|ms|s|m)`)
-
 const maxDuration = 99999*time.Hour + 59*time.Minute + 59*time.Second + 999*time.Millisecond
 
 func FormatDuration(duration time.Duration) (string, error) {
@@ -91,7 +89,7 @@ func FormatDuration(duration time.Duration) (string, error) {
 	seconds := int(duration.Seconds())
 
 	// calculating the hours
-	hours := int(seconds / 3600)
+	hours := seconds / 3600
 
 	if hours > 0 {
 		output += fmt.Sprintf("%dh", hours)
@@ -99,18 +97,19 @@ func FormatDuration(duration time.Duration) (string, error) {
 	}
 
 	// calculating the minutes
-	minutes := int(seconds / 60)
+	minutes := seconds / 60
 
 	if minutes > 0 {
 		output += fmt.Sprintf("%dm", minutes)
 		seconds -= minutes * 60
 	}
 
+	// calculating the seconds
 	if seconds > 0 {
 		output += fmt.Sprintf("%ds", seconds)
 	}
 
-	// Golang's time.Duration allows for floating point seconds instead of converting to ms
+	// calculating the milliseconds
 	durationMilliseconds := durationMicroseconds / 1000
 
 	ms := durationMilliseconds % 1000

--- a/pkg/utils/duration_test.go
+++ b/pkg/utils/duration_test.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func makeDuration(h, m, s, ms int) time.Duration {
+	duration := h*int(time.Hour) + m*int(time.Minute) + s*int(time.Second) + ms*int(time.Millisecond)
+	return time.Duration(duration)
+}
+
+func TestParseDuration(t *testing.T) {
+	// valid durations
+	validTestCases := []struct {
+		name     string
+		args     string
+		expected time.Duration
+	}{
+		{
+			name:     "0h to timeDuration of 0s",
+			args:     "0h",
+			expected: makeDuration(0, 0, 0, 0),
+		},
+		{
+			name:     "0s should be 0s",
+			args:     "0s",
+			expected: makeDuration(0, 0, 0, 0),
+		},
+		{
+			name:     "0h0m0s should be 0s",
+			args:     "0h0m0s",
+			expected: makeDuration(0, 0, 0, 0),
+		},
+		{
+			name:     "1h should be 1h",
+			args:     "1h",
+			expected: makeDuration(1, 0, 0, 0),
+		},
+		{
+			name:     "30m should be 30m",
+			args:     "30m",
+			expected: makeDuration(0, 30, 0, 0),
+		},
+		{
+			name:     "10s should be 10s",
+			args:     "10s",
+			expected: makeDuration(0, 0, 10, 0),
+		},
+		{
+			name:     "500ms should be 500ms",
+			args:     "500ms",
+			expected: makeDuration(0, 0, 0, 500),
+		},
+		{
+			name:     "2h30m should be 2h30m",
+			args:     "2h30m",
+			expected: makeDuration(2, 30, 0, 0),
+		},
+		{
+			name:     "150m should be 2h30m",
+			args:     "150m",
+			expected: makeDuration(0, 150, 0, 0),
+		},
+		{
+			name:     "7320s should be 2h30m",
+			args:     "7320s",
+			expected: makeDuration(0, 0, 7320, 0),
+		},
+		{
+			name:     "1h30m10s shoulw be 1h30m10s",
+			args:     "1h30m10s",
+			expected: makeDuration(1, 30, 10, 0),
+		},
+		{
+			name:     "10s30m1h should be 1h30m10s",
+			args:     "10s30m1h",
+			expected: makeDuration(1, 30, 10, 0),
+		},
+		{
+			name:     "100ms200ms300ms should be 600ms",
+			args:     "100ms200ms300ms",
+			expected: makeDuration(0, 0, 0, 600),
+		},
+	}
+
+	invalidTestCases := []struct {
+		name string
+		args string
+	}{
+		{
+			name: "Missing unit",
+			args: "1",
+		},
+		{
+			name: "Missing unit in 1h1",
+			args: "1h1",
+		},
+		{
+			name: "Too many units/components",
+			args: "1h30m10s20ms50h",
+		},
+		{
+			name: "Too many digits",
+			args: "999999h",
+		},
+		{
+			name: "No floating points allowed",
+			args: "1.5h",
+		},
+		{
+			name: "No floating points for seconds allowed",
+			args: "0.5s",
+		},
+		{
+			name: "Negative numbers not allowed",
+			args: "-15m",
+		},
+	}
+
+	// Running valid test cases
+	for _, tc := range validTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			arg, _ := ParseDuration(tc.args)
+			assert.Equal(t, tc.expected, *arg)
+		})
+	}
+
+	// Running invalid test cases
+	for _, tc := range invalidTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, errArg := ParseDuration(tc.args)
+			assert.Error(t, errArg)
+		})
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	validTestCases := []struct {
+		name     string
+		args     string
+		expected string
+	}{
+		{
+			name:     "0 should be 0s",
+			args:     "0",
+			expected: "0s",
+		},
+		{
+			name:     "1h should be 1h",
+			args:     "1h",
+			expected: "1h",
+		},
+		{
+			name:     "30m should be 30m",
+			args:     "30m",
+			expected: "30m",
+		},
+		{
+			name:     "10s should be 10s",
+			args:     "10s",
+			expected: "10s",
+		},
+		{
+			name:     "500ms should be 500ms",
+			args:     "500ms",
+			expected: "500ms",
+		},
+		{
+			name:     "2h30m should be 2h30m",
+			args:     "2h30m",
+			expected: "2h30m",
+		},
+		{
+			name:     "1h30m10s should be 1h30m10s",
+			args:     "1h30m10s",
+			expected: "1h30m10s",
+		},
+		{
+			name:     "600ms should be 600ms",
+			args:     "600ms",
+			expected: "600ms",
+		},
+		{
+			name:     "2h600ms should be 2h600ms",
+			args:     "2h600ms",
+			expected: "2h600ms",
+		},
+		{
+			name:     "2h30m600ms should be 2h30m600ms",
+			args:     "2h30m600ms",
+			expected: "2h30m600ms",
+		},
+		{
+			name:     "2h30m10s600ms should be 2h30m10s600ms",
+			args:     "2h30m10s600ms",
+			expected: "2h30m10s600ms",
+		},
+		{
+			name:     "0.5m should be 30s",
+			args:     "0.5m",
+			expected: "30s",
+		},
+		{
+			name:     "0.5s should be 500ms",
+			args:     "0.5s",
+			expected: "500ms",
+		},
+	}
+
+	// invalid test cases
+	invalidTestCases := []struct {
+		name string
+		args string
+	}{
+		{
+			name: "Sub-milliseconds not allowed (100us)",
+			args: "100us",
+		},
+		{
+			name: "Sub-milliseconds not allowed (0.5ms)",
+			args: "0.5ms",
+		},
+		{
+			name: "Out of range (greater than 99999 hours)",
+			args: "100000h",
+		},
+		{
+			name: "Negative duration not supported",
+			args: "-10h",
+		},
+	}
+	// Valid test cases
+
+	for _, tc := range validTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, _ := time.ParseDuration(tc.args)
+			arg, _ := FormatDuration(a)
+			assert.Equal(t, tc.expected, arg)
+		})
+	}
+
+	// Invalid test cases
+	for _, tc := range invalidTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, errArg := ParseDuration(tc.args)
+			assert.Error(t, errArg)
+		})
+	}
+}

--- a/pkg/utils/duration_test.go
+++ b/pkg/utils/duration_test.go
@@ -1,13 +1,30 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func makeDuration(h, m, s, ms int) time.Duration {
-	duration := h*int(time.Hour) + m*int(time.Minute) + s*int(time.Second) + ms*int(time.Millisecond)
+func makeDuration(h, m, s, ms float64) time.Duration {
+	duration := h*float64(time.Hour) + m*float64(time.Minute) + s*float64(time.Second) + ms*float64(time.Millisecond)
 	return time.Duration(duration)
 }
 
@@ -21,12 +38,12 @@ func TestParseDuration(t *testing.T) {
 		{
 			name:     "0h to timeDuration of 0s",
 			args:     "0h",
-			expected: makeDuration(0, 0, 0, 0),
+			expected: time.Hour * 0,
 		},
 		{
 			name:     "0s should be 0s",
 			args:     "0s",
-			expected: makeDuration(0, 0, 0, 0),
+			expected: time.Second * 0,
 		},
 		{
 			name:     "0h0m0s should be 0s",
@@ -69,7 +86,7 @@ func TestParseDuration(t *testing.T) {
 			expected: makeDuration(0, 0, 7320, 0),
 		},
 		{
-			name:     "1h30m10s shoulw be 1h30m10s",
+			name:     "1h30m10s should be 1h30m10s",
 			args:     "1h30m10s",
 			expected: makeDuration(1, 30, 10, 0),
 		},
@@ -139,104 +156,106 @@ func TestParseDuration(t *testing.T) {
 func TestFormatDuration(t *testing.T) {
 	validTestCases := []struct {
 		name     string
-		args     string
+		args     time.Duration
 		expected string
 	}{
 		{
 			name:     "0 should be 0s",
-			args:     "0",
+			args:     makeDuration(0, 0, 0, 0),
 			expected: "0s",
 		},
 		{
 			name:     "1h should be 1h",
-			args:     "1h",
+			args:     makeDuration(1, 0, 0, 0),
 			expected: "1h",
 		},
 		{
 			name:     "30m should be 30m",
-			args:     "30m",
+			args:     makeDuration(0, 30, 0, 0),
 			expected: "30m",
 		},
 		{
 			name:     "10s should be 10s",
-			args:     "10s",
+			args:     makeDuration(0, 0, 10, 0),
 			expected: "10s",
 		},
 		{
 			name:     "500ms should be 500ms",
-			args:     "500ms",
+			args:     makeDuration(0, 0, 0, 500),
 			expected: "500ms",
 		},
 		{
 			name:     "2h30m should be 2h30m",
-			args:     "2h30m",
+			args:     makeDuration(2, 30, 0, 0),
 			expected: "2h30m",
 		},
 		{
 			name:     "1h30m10s should be 1h30m10s",
-			args:     "1h30m10s",
+			args:     makeDuration(1, 30, 10, 0),
 			expected: "1h30m10s",
 		},
 		{
 			name:     "600ms should be 600ms",
-			args:     "600ms",
+			args:     makeDuration(0, 0, 0, 600),
 			expected: "600ms",
 		},
 		{
 			name:     "2h600ms should be 2h600ms",
-			args:     "2h600ms",
+			args:     makeDuration(2, 0, 0, 600),
 			expected: "2h600ms",
 		},
 		{
 			name:     "2h30m600ms should be 2h30m600ms",
-			args:     "2h30m600ms",
+			args:     makeDuration(2, 30, 0, 600),
 			expected: "2h30m600ms",
 		},
 		{
 			name:     "2h30m10s600ms should be 2h30m10s600ms",
-			args:     "2h30m10s600ms",
+			args:     makeDuration(2, 30, 10, 600),
 			expected: "2h30m10s600ms",
 		},
 		{
 			name:     "0.5m should be 30s",
-			args:     "0.5m",
+			args:     makeDuration(0, 0.5, 0, 0),
 			expected: "30s",
 		},
 		{
 			name:     "0.5s should be 500ms",
-			args:     "0.5s",
+			args:     makeDuration(0, 0, 0.5, 0),
 			expected: "500ms",
 		},
 	}
-
 	// invalid test cases
 	invalidTestCases := []struct {
 		name string
-		args string
+		args time.Duration
 	}{
 		{
 			name: "Sub-milliseconds not allowed (100us)",
-			args: "100us",
+			args: 100 * time.Microsecond,
 		},
 		{
 			name: "Sub-milliseconds not allowed (0.5ms)",
-			args: "0.5ms",
+			args: makeDuration(0, 0, 0, 0.5),
 		},
 		{
 			name: "Out of range (greater than 99999 hours)",
-			args: "100000h",
+			args: makeDuration(100000, 0, 0, 0),
 		},
 		{
 			name: "Negative duration not supported",
-			args: "-10h",
+			args: -15 * time.Hour,
+		},
+		{
+			name: "Max duration represented in GEP",
+			args: makeDuration(99999, 59, 59, 999) + makeDuration(0, 0, 0, 1),
 		},
 	}
 	// Valid test cases
 
 	for _, tc := range validTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			a, _ := time.ParseDuration(tc.args)
-			arg, _ := FormatDuration(a)
+			arg, _ := FormatDuration(tc.args)
 			assert.Equal(t, tc.expected, arg)
 		})
 	}
@@ -244,7 +263,7 @@ func TestFormatDuration(t *testing.T) {
 	// Invalid test cases
 	for _, tc := range invalidTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, errArg := ParseDuration(tc.args)
+			_, errArg := FormatDuration(tc.args)
 			assert.Error(t, errArg)
 		})
 	}


### PR DESCRIPTION
Per GEP 2257, adding duration utils for [implementing GEP2257 duration format ](https://gateway-api.sigs.k8s.io/geps/gep-2257/)

**What type of PR is this?**
/kind feature 
(not sure if this is the right kind for this 😅 )
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:
Per GEP 2257 Duration formatting's [next step to graduation](https://gateway-api.sigs.k8s.io/geps/gep-2257/#graduation-criteria) is implementing parsers. Helping out with this push to standard channel 👍 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
Related PRs: 
- https://github.com/kube-rs/gateway-api-rs/pull/45
- https://github.com/kubernetes-client/python/pull/2261

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
cc: @kflynn 