### PR TITLE
Add conformance profile for NGINX Gateway Fabric

### DIFF
--- a/conformance/reports/v1.1.0/nginxinc-nginx-gateway-fabric/README.md
+++ b/conformance/reports/v1.1.0/nginxinc-nginx-gateway-fabric/README.md
@@ -4,7 +4,7 @@
 
 | API channel | Implementation version                                                         | Mode    | Report                                       |
 |-------------|--------------------------------------------------------------------------------|---------|----------------------------------------------|
-| standard    | [v1.3.0](https://github.com/nginxinc/nginx-gateway-fabric/releases/tag/v1.3.0) | default | [link](./standard-1.3.0-default-report.yaml) |
+| experimental    | [v1.4.0](https://github.com/nginxinc/nginx-gateway-fabric/releases/tag/v1.4.0) | default | [link](./experimental-1.4.0-default-report.yaml) |
 
 ## Reproduce
 

--- a/conformance/reports/v1.1.0/nginxinc-nginx-gateway-fabric/experimental-1.4.0-default-report.yaml
+++ b/conformance/reports/v1.1.0/nginxinc-nginx-gateway-fabric/experimental-1.4.0-default-report.yaml
@@ -1,0 +1,63 @@
+apiVersion: gateway.networking.k8s.io/v1alpha1
+date: "2024-08-20T18:43:28Z"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.1.0
+implementation:
+  contact:
+  - https://github.com/nginxinc/nginx-gateway-fabric/discussions/new/choose
+  organization: nginxinc
+  project: nginx-gateway-fabric
+  url: https://github.com/nginxinc/nginx-gateway-fabric
+  version: v1.4.0
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 12
+      Skipped: 0
+  name: GATEWAY-GRPC
+  summary: Core tests succeeded.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 33
+      Skipped: 0
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 9
+      Skipped: 0
+    supportedFeatures:
+    - GatewayPort8080
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    unsupportedFeatures:
+    - GatewayHTTPListenerIsolation
+    - GatewayStaticAddresses
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRedirect
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestTimeout
+  name: GATEWAY-HTTP
+  summary: Core tests succeeded. Extended tests succeeded.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 11
+      Skipped: 0
+  name: GATEWAY-TLS
+  summary: Core tests succeeded.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/area conformance
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:
Updates conformance profile for NGINX Gateway Fabric.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
