### PR TITLE
Signal test stability

### DIFF
--- a/conformance/apis/v1/conformancereport.go
+++ b/conformance/apis/v1/conformancereport.go
@@ -47,9 +47,9 @@ type ConformanceReport struct {
 	// profile that was enabled for a test run.
 	ProfileReports []ProfileReport `json:"profiles"`
 
-	// SucceededTrialTests is a list of the names of the trial tests that
+	// SucceededProvisionalTests is a list of the names of the provisional tests that
 	// have been successfully run.
-	SucceededTrialTests []string `json:"succeededTrialTests,omitempty"`
+	SucceededProvisionalTests []string `json:"succeededProvisionalTests,omitempty"`
 }
 
 // Implementation provides metadata information on the downstream

--- a/conformance/apis/v1/conformancereport.go
+++ b/conformance/apis/v1/conformancereport.go
@@ -46,6 +46,10 @@ type ConformanceReport struct {
 	// ProfileReports is a list of the individual reports for each conformance
 	// profile that was enabled for a test run.
 	ProfileReports []ProfileReport `json:"profiles"`
+
+	// SucceededTrialTests is a list of the names of the trial tests that
+	// have been successfully run.
+	SucceededTrialTests []string `json:"succeededTrialTests,omitempty"`
 }
 
 // Implementation provides metadata information on the downstream

--- a/conformance/conformance.go
+++ b/conformance/conformance.go
@@ -96,6 +96,7 @@ func DefaultOptions(t *testing.T) suite.ConformanceOptions {
 		SkipTests:                  skipTests,
 		SupportedFeatures:          supportedFeatures,
 		TimeoutConfig:              conformanceconfig.DefaultTimeoutConfig(),
+		SkipTrialTests:             *flags.SkipTrialTests,
 	}
 }
 

--- a/conformance/conformance.go
+++ b/conformance/conformance.go
@@ -96,7 +96,7 @@ func DefaultOptions(t *testing.T) suite.ConformanceOptions {
 		SkipTests:                  skipTests,
 		SupportedFeatures:          supportedFeatures,
 		TimeoutConfig:              conformanceconfig.DefaultTimeoutConfig(),
-		SkipTrialTests:             *flags.SkipTrialTests,
+		SkipProvisionalTests:       *flags.SkipProvisionalTests,
 	}
 }
 

--- a/conformance/tests/udproute-simple.go
+++ b/conformance/tests/udproute-simple.go
@@ -42,7 +42,7 @@ var UDPRouteTest = suite.ConformanceTest{
 		features.SupportUDPRoute,
 		features.SupportGateway,
 	},
-	Trial: true,
+	Provisional: true,
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		t.Run("Simple UDP request matching UDPRoute should reach coredns backend", func(t *testing.T) {
 			namespace := "gateway-conformance-infra"

--- a/conformance/tests/udproute-simple.go
+++ b/conformance/tests/udproute-simple.go
@@ -42,6 +42,7 @@ var UDPRouteTest = suite.ConformanceTest{
 		features.SupportUDPRoute,
 		features.SupportGateway,
 	},
+	Trial: true,
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		t.Run("Simple UDP request matching UDPRoute should reach coredns backend", func(t *testing.T) {
 			namespace := "gateway-conformance-infra"

--- a/conformance/utils/flags/flags.go
+++ b/conformance/utils/flags/flags.go
@@ -48,5 +48,5 @@ var (
 	AllowCRDsMismatch          = flag.Bool("allow-crds-mismatch", false, "Flag to allow the suite not to fail in case there is a mismatch between CRDs versions and channels.")
 	ConformanceProfiles        = flag.String("conformance-profiles", "", "Comma-separated list of the conformance profiles to run")
 	ReportOutput               = flag.String("report-output", "", "The file where to write the conformance report")
-	SkipTrialTests             = flag.Bool("skip-trial-tests", false, "Whether to skip trial tests")
+	SkipProvisionalTests       = flag.Bool("skip-provisional-tests", false, "Whether to skip provisional tests")
 )

--- a/conformance/utils/flags/flags.go
+++ b/conformance/utils/flags/flags.go
@@ -48,4 +48,5 @@ var (
 	AllowCRDsMismatch          = flag.Bool("allow-crds-mismatch", false, "Flag to allow the suite not to fail in case there is a mismatch between CRDs versions and channels.")
 	ConformanceProfiles        = flag.String("conformance-profiles", "", "Comma-separated list of the conformance profiles to run")
 	ReportOutput               = flag.String("report-output", "", "The file where to write the conformance report")
+	SkipTrialTests             = flag.Bool("skip-trial-tests", false, "Whether to skip trial tests")
 )

--- a/conformance/utils/suite/conformance.go
+++ b/conformance/utils/suite/conformance.go
@@ -36,6 +36,7 @@ type ConformanceTest struct {
 	Slow        bool
 	Parallel    bool
 	Test        func(*testing.T, *ConformanceTestSuite)
+	Trial       bool
 }
 
 // Run runs an individual tests, applying and cleaning up the required manifests

--- a/conformance/utils/suite/conformance.go
+++ b/conformance/utils/suite/conformance.go
@@ -36,7 +36,7 @@ type ConformanceTest struct {
 	Slow        bool
 	Parallel    bool
 	Test        func(*testing.T, *ConformanceTestSuite)
-	Trial       bool
+	Provisional bool
 }
 
 // Run runs an individual tests, applying and cleaning up the required manifests

--- a/conformance/utils/suite/reports.go
+++ b/conformance/utils/suite/reports.go
@@ -18,7 +18,6 @@ package suite
 
 import (
 	"fmt"
-	"sort"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -137,10 +136,7 @@ func (p profileReportsMap) compileResults(supportedFeaturesMap map[ConformancePr
 		supportedFeatures := supportedFeaturesMap[ConformanceProfileName(report.Name)]
 		if report.Extended != nil {
 			if supportedFeatures != nil {
-				supportedFeatures := supportedFeatures.UnsortedList()
-				sort.Slice(supportedFeatures, func(i, j int) bool {
-					return supportedFeatures[i] < supportedFeatures[j]
-				})
+				supportedFeatures := sets.List(supportedFeatures)
 				for _, f := range supportedFeatures {
 					report.Extended.SupportedFeatures = append(report.Extended.SupportedFeatures, string(f))
 				}
@@ -150,10 +146,7 @@ func (p profileReportsMap) compileResults(supportedFeaturesMap map[ConformancePr
 		unsupportedFeatures := unsupportedFeaturesMap[ConformanceProfileName(report.Name)]
 		if report.Extended != nil {
 			if unsupportedFeatures != nil {
-				unsupportedFeatures := unsupportedFeatures.UnsortedList()
-				sort.Slice(unsupportedFeatures, func(i, j int) bool {
-					return unsupportedFeatures[i] < unsupportedFeatures[j]
-				})
+				unsupportedFeatures := sets.List(unsupportedFeatures)
 				for _, f := range unsupportedFeatures {
 					report.Extended.UnsupportedFeatures = append(report.Extended.UnsupportedFeatures, string(f))
 				}

--- a/conformance/utils/suite/reports.go
+++ b/conformance/utils/suite/reports.go
@@ -37,11 +37,11 @@ type testResult struct {
 type resultType string
 
 var (
-	testSucceeded    resultType = "SUCCEEDED"
-	testFailed       resultType = "FAILED"
-	testSkipped      resultType = "SKIPPED"
-	testNotSupported resultType = "NOT_SUPPORTED"
-	testTrialSkipped resultType = "TRIAL_SKIPPED"
+	testSucceeded          resultType = "SUCCEEDED"
+	testFailed             resultType = "FAILED"
+	testSkipped            resultType = "SKIPPED"
+	testNotSupported       resultType = "NOT_SUPPORTED"
+	testProvisionalSkipped resultType = "PROVISIONAL_SKIPPED"
 )
 
 type profileReportsMap map[ConformanceProfileName]confv1.ProfileReport

--- a/conformance/utils/suite/reports.go
+++ b/conformance/utils/suite/reports.go
@@ -42,6 +42,7 @@ var (
 	testFailed       resultType = "FAILED"
 	testSkipped      resultType = "SKIPPED"
 	testNotSupported resultType = "NOT_SUPPORTED"
+	testTrialSkipped resultType = "TRIAL_SKIPPED"
 )
 
 type profileReportsMap map[ConformanceProfileName]confv1.ProfileReport

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -495,19 +495,19 @@ func (suite *ConformanceTestSuite) Report() (*confv1.ConformanceReport, error) {
 	profileReports := newReports()
 	succeededTrialTestSet := sets.Set[string]{}
 	for _, tN := range testNames {
-		testResult := suite.results[tN]
-		if testResult.result == testTrialSkipped {
+		tr := suite.results[tN]
+		if tr.result == testTrialSkipped {
 			continue
 		}
-		if testResult.result == testSucceeded && testResult.test.Trial {
+		if tr.result == testSucceeded && tr.test.Trial {
 			succeededTrialTestSet.Insert(tN)
 		}
-		conformanceProfiles := getConformanceProfilesForTest(testResult.test, suite.conformanceProfiles).UnsortedList()
+		conformanceProfiles := getConformanceProfilesForTest(tr.test, suite.conformanceProfiles).UnsortedList()
 		sort.Slice(conformanceProfiles, func(i, j int) bool {
 			return conformanceProfiles[i].Name < conformanceProfiles[j].Name
 		})
 		for _, profile := range conformanceProfiles {
-			profileReports.addTestResults(*profile, testResult)
+			profileReports.addTestResults(*profile, tr)
 		}
 	}
 	var succeededTrialTests []string

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -512,7 +512,7 @@ func (suite *ConformanceTestSuite) Report() (*confv1.ConformanceReport, error) {
 	}
 	var succeededTrialTests []string
 	if len(succeededTrialTestSet) > 0 {
-		succeededTrialTests = succeededTrialTestSet.UnsortedList()
+		succeededTrialTests = sets.List(succeededTrialTestSet)
 	}
 
 	profileReports.compileResults(suite.extendedSupportedFeatures, suite.extendedUnsupportedFeatures)

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -202,15 +202,15 @@ var (
 		ShortName: "extendedTest",
 		Features:  []features.FeatureName{extendedFeature},
 	}
-	coreTrialTest = ConformanceTest{
-		ShortName: "coreTrialTest",
-		Features:  []features.FeatureName{coreFeature},
-		Trial:     true,
+	coreProvisionalTest = ConformanceTest{
+		ShortName:   "coreProvisionalTest",
+		Features:    []features.FeatureName{coreFeature},
+		Provisional: true,
 	}
-	extendedTrialTest = ConformanceTest{
-		ShortName: "extendedTrialTest",
-		Features:  []features.FeatureName{extendedFeature},
-		Trial:     true,
+	extendedProvisionalTest = ConformanceTest{
+		ShortName:   "extendedProvisionalTest",
+		Features:    []features.FeatureName{extendedFeature},
+		Provisional: true,
 	}
 )
 
@@ -220,7 +220,7 @@ func TestSuiteReport(t *testing.T) {
 		features                  sets.Set[features.FeatureName]
 		extendedSupportedFeatures map[ConformanceProfileName]sets.Set[features.FeatureName]
 		profiles                  sets.Set[ConformanceProfileName]
-		skipTrialTests            bool
+		skipProvisionalTests      bool
 		results                   map[string]testResult
 		expectedReport            confv1.ConformanceReport
 		expectedError             error
@@ -241,13 +241,13 @@ func TestSuiteReport(t *testing.T) {
 					result: testSucceeded,
 					test:   extendedTest,
 				},
-				coreTrialTest.ShortName: {
+				coreProvisionalTest.ShortName: {
 					result: testSucceeded,
-					test:   coreTrialTest,
+					test:   coreProvisionalTest,
 				},
-				extendedTrialTest.ShortName: {
+				extendedProvisionalTest.ShortName: {
 					result: testSucceeded,
-					test:   extendedTrialTest,
+					test:   extendedProvisionalTest,
 				},
 			},
 			expectedReport: confv1.ConformanceReport{
@@ -272,9 +272,9 @@ func TestSuiteReport(t *testing.T) {
 						},
 					},
 				},
-				SucceededTrialTests: []string{
-					coreTrialTest.ShortName,
-					extendedTrialTest.ShortName,
+				SucceededProvisionalTests: []string{
+					coreProvisionalTest.ShortName,
+					extendedProvisionalTest.ShortName,
 				},
 			},
 		},
@@ -294,13 +294,13 @@ func TestSuiteReport(t *testing.T) {
 					result: testSkipped,
 					test:   extendedTest,
 				},
-				coreTrialTest.ShortName: {
+				coreProvisionalTest.ShortName: {
 					result: testSucceeded,
-					test:   coreTrialTest,
+					test:   coreProvisionalTest,
 				},
-				extendedTrialTest.ShortName: {
-					result: testTrialSkipped,
-					test:   extendedTrialTest,
+				extendedProvisionalTest.ShortName: {
+					result: testProvisionalSkipped,
+					test:   extendedProvisionalTest,
 				},
 			},
 			expectedReport: confv1.ConformanceReport{
@@ -332,19 +332,19 @@ func TestSuiteReport(t *testing.T) {
 						},
 					},
 				},
-				SucceededTrialTests: []string{
-					coreTrialTest.ShortName,
+				SucceededProvisionalTests: []string{
+					coreProvisionalTest.ShortName,
 				},
 			},
 		},
 		{
-			name:     "skip trial tests",
+			name:     "skip provisional tests",
 			features: sets.New(coreFeature, extendedFeature),
 			extendedSupportedFeatures: map[ConformanceProfileName]sets.Set[features.FeatureName]{
 				testProfileName: sets.New(extendedFeature),
 			},
-			profiles:       sets.New(testProfileName),
-			skipTrialTests: true,
+			profiles:             sets.New(testProfileName),
+			skipProvisionalTests: true,
 			results: map[string]testResult{
 				coreTest.ShortName: {
 					result: testSucceeded,
@@ -354,13 +354,13 @@ func TestSuiteReport(t *testing.T) {
 					result: testSucceeded,
 					test:   extendedTest,
 				},
-				coreTrialTest.ShortName: {
-					result: testTrialSkipped,
-					test:   coreTrialTest,
+				coreProvisionalTest.ShortName: {
+					result: testProvisionalSkipped,
+					test:   coreProvisionalTest,
 				},
-				extendedTrialTest.ShortName: {
-					result: testTrialSkipped,
-					test:   extendedTrialTest,
+				extendedProvisionalTest.ShortName: {
+					result: testProvisionalSkipped,
+					test:   extendedProvisionalTest,
 				},
 			},
 			expectedReport: confv1.ConformanceReport{
@@ -398,11 +398,11 @@ func TestSuiteReport(t *testing.T) {
 				SupportedFeatures:         tc.features,
 				extendedSupportedFeatures: tc.extendedSupportedFeatures,
 				results:                   tc.results,
-				SkipTrialTests:            tc.skipTrialTests,
+				SkipProvisionalTests:      tc.skipProvisionalTests,
 			}
 			report, err := suite.Report()
 			assert.Equal(t, tc.expectedReport.ProfileReports, report.ProfileReports)
-			assert.Equal(t, tc.expectedReport.SucceededTrialTests, report.SucceededTrialTests)
+			assert.Equal(t, tc.expectedReport.SucceededProvisionalTests, report.SucceededProvisionalTests)
 			assert.Equal(t, tc.expectedError, err)
 		})
 	}

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -24,6 +24,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+
 	confv1 "sigs.k8s.io/gateway-api/conformance/apis/v1"
 	"sigs.k8s.io/gateway-api/pkg/consts"
 	"sigs.k8s.io/gateway-api/pkg/features"
@@ -186,13 +187,11 @@ const (
 	testProfileName ConformanceProfileName = "testProfile"
 )
 
-var (
-	testProfile = ConformanceProfile{
-		Name:             "testProfile",
-		CoreFeatures:     sets.New(coreFeature),
-		ExtendedFeatures: sets.New(extendedFeature),
-	}
-)
+var testProfile = ConformanceProfile{
+	Name:             "testProfile",
+	CoreFeatures:     sets.New(coreFeature),
+	ExtendedFeatures: sets.New(extendedFeature),
+}
 
 var (
 	coreTest = ConformanceTest{
@@ -216,7 +215,7 @@ var (
 )
 
 func TestSuiteReport(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name                      string
 		features                  sets.Set[features.FeatureName]
 		extendedSupportedFeatures map[ConformanceProfileName]sets.Set[features.FeatureName]
@@ -391,7 +390,6 @@ func TestSuiteReport(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			conformanceProfileMap[testProfileName] = testProfile
 

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -23,8 +23,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
+	"k8s.io/apimachinery/pkg/util/sets"
+	confv1 "sigs.k8s.io/gateway-api/conformance/apis/v1"
 	"sigs.k8s.io/gateway-api/pkg/consts"
+	"sigs.k8s.io/gateway-api/pkg/features"
 )
 
 func TestGetAPIVersionAndChannel(t *testing.T) {
@@ -173,6 +175,237 @@ func TestGetAPIVersionAndChannel(t *testing.T) {
 			assert.Equal(t, tc.expectedVersion, version)
 			assert.Equal(t, tc.expectedChannel, channel)
 			assert.Equal(t, tc.err, err)
+		})
+	}
+}
+
+const (
+	coreFeature     features.FeatureName = "coreFature"
+	extendedFeature features.FeatureName = "extendedFeature"
+
+	testProfileName ConformanceProfileName = "testProfile"
+)
+
+var (
+	testProfile = ConformanceProfile{
+		Name:             "testProfile",
+		CoreFeatures:     sets.New(coreFeature),
+		ExtendedFeatures: sets.New(extendedFeature),
+	}
+)
+
+var (
+	coreTest = ConformanceTest{
+		ShortName: "coreTest",
+		Features:  []features.FeatureName{coreFeature},
+	}
+	extendedTest = ConformanceTest{
+		ShortName: "extendedTest",
+		Features:  []features.FeatureName{extendedFeature},
+	}
+	coreTrialTest = ConformanceTest{
+		ShortName: "coreTrialTest",
+		Features:  []features.FeatureName{coreFeature},
+		Trial:     true,
+	}
+	extendedTrialTest = ConformanceTest{
+		ShortName: "extendedTrialTest",
+		Features:  []features.FeatureName{extendedFeature},
+		Trial:     true,
+	}
+)
+
+func TestSuiteReport(t *testing.T) {
+	var testCases = []struct {
+		name                      string
+		features                  sets.Set[features.FeatureName]
+		extendedSupportedFeatures map[ConformanceProfileName]sets.Set[features.FeatureName]
+		profiles                  sets.Set[ConformanceProfileName]
+		skipTrialTests            bool
+		results                   map[string]testResult
+		expectedReport            confv1.ConformanceReport
+		expectedError             error
+	}{
+		{
+			name:     "all tests succeeded",
+			features: sets.New(coreFeature, extendedFeature),
+			extendedSupportedFeatures: map[ConformanceProfileName]sets.Set[features.FeatureName]{
+				testProfileName: sets.New(extendedFeature),
+			},
+			profiles: sets.New(testProfileName),
+			results: map[string]testResult{
+				coreTest.ShortName: {
+					result: testSucceeded,
+					test:   coreTest,
+				},
+				extendedTest.ShortName: {
+					result: testSucceeded,
+					test:   extendedTest,
+				},
+				coreTrialTest.ShortName: {
+					result: testSucceeded,
+					test:   coreTrialTest,
+				},
+				extendedTrialTest.ShortName: {
+					result: testSucceeded,
+					test:   extendedTrialTest,
+				},
+			},
+			expectedReport: confv1.ConformanceReport{
+				ProfileReports: []confv1.ProfileReport{
+					{
+						Name:    string(testProfileName),
+						Summary: "Core tests succeeded. Extended tests succeeded.",
+						Core: confv1.Status{
+							Result: confv1.Success,
+							Statistics: confv1.Statistics{
+								Passed: 2,
+							},
+						},
+						Extended: &confv1.ExtendedStatus{
+							Status: confv1.Status{
+								Result: confv1.Success,
+								Statistics: confv1.Statistics{
+									Passed: 2,
+								},
+							},
+							SupportedFeatures: []string{string(extendedFeature)},
+						},
+					},
+				},
+				SucceededTrialTests: []string{
+					coreTrialTest.ShortName,
+					extendedTrialTest.ShortName,
+				},
+			},
+		},
+		{
+			name:     "mixed results",
+			features: sets.New(coreFeature, extendedFeature),
+			extendedSupportedFeatures: map[ConformanceProfileName]sets.Set[features.FeatureName]{
+				testProfileName: sets.New(extendedFeature),
+			},
+			profiles: sets.New(testProfileName),
+			results: map[string]testResult{
+				coreTest.ShortName: {
+					result: testFailed,
+					test:   coreTest,
+				},
+				extendedTest.ShortName: {
+					result: testSkipped,
+					test:   extendedTest,
+				},
+				coreTrialTest.ShortName: {
+					result: testSucceeded,
+					test:   coreTrialTest,
+				},
+				extendedTrialTest.ShortName: {
+					result: testTrialSkipped,
+					test:   extendedTrialTest,
+				},
+			},
+			expectedReport: confv1.ConformanceReport{
+				ProfileReports: []confv1.ProfileReport{
+					{
+						Name:    string(testProfileName),
+						Summary: "Core tests failed with 1 test failures. Extended tests partially succeeded with 1 test skips.",
+						Core: confv1.Status{
+							Result: confv1.Failure,
+							Statistics: confv1.Statistics{
+								Passed: 1,
+								Failed: 1,
+							},
+							FailedTests: []string{
+								coreTest.ShortName,
+							},
+						},
+						Extended: &confv1.ExtendedStatus{
+							Status: confv1.Status{
+								Result: confv1.Partial,
+								Statistics: confv1.Statistics{
+									Skipped: 1,
+								},
+								SkippedTests: []string{
+									extendedTest.ShortName,
+								},
+							},
+							SupportedFeatures: []string{string(extendedFeature)},
+						},
+					},
+				},
+				SucceededTrialTests: []string{
+					coreTrialTest.ShortName,
+				},
+			},
+		},
+		{
+			name:     "skip trial tests",
+			features: sets.New(coreFeature, extendedFeature),
+			extendedSupportedFeatures: map[ConformanceProfileName]sets.Set[features.FeatureName]{
+				testProfileName: sets.New(extendedFeature),
+			},
+			profiles:       sets.New(testProfileName),
+			skipTrialTests: true,
+			results: map[string]testResult{
+				coreTest.ShortName: {
+					result: testSucceeded,
+					test:   coreTest,
+				},
+				extendedTest.ShortName: {
+					result: testSucceeded,
+					test:   extendedTest,
+				},
+				coreTrialTest.ShortName: {
+					result: testTrialSkipped,
+					test:   coreTrialTest,
+				},
+				extendedTrialTest.ShortName: {
+					result: testTrialSkipped,
+					test:   extendedTrialTest,
+				},
+			},
+			expectedReport: confv1.ConformanceReport{
+				ProfileReports: []confv1.ProfileReport{
+					{
+						Name:    string(testProfileName),
+						Summary: "Core tests succeeded. Extended tests succeeded.",
+						Core: confv1.Status{
+							Result: confv1.Success,
+							Statistics: confv1.Statistics{
+								Passed: 1,
+							},
+						},
+						Extended: &confv1.ExtendedStatus{
+							Status: confv1.Status{
+								Result: confv1.Success,
+								Statistics: confv1.Statistics{
+									Passed: 1,
+								},
+							},
+							SupportedFeatures: []string{string(extendedFeature)},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			conformanceProfileMap[testProfileName] = testProfile
+
+			suite := ConformanceTestSuite{
+				conformanceProfiles:       tc.profiles,
+				SupportedFeatures:         tc.features,
+				extendedSupportedFeatures: tc.extendedSupportedFeatures,
+				results:                   tc.results,
+				SkipTrialTests:            tc.skipTrialTests,
+			}
+			report, err := suite.Report()
+			assert.Equal(t, tc.expectedReport.ProfileReports, report.ProfileReports)
+			assert.Equal(t, tc.expectedReport.SucceededTrialTests, report.SucceededTrialTests)
+			assert.Equal(t, tc.expectedError, err)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind feature
/area conformance

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3009 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Conformance tests include a new Provisional field that signals the specific test's stability level. The conformance report has been updated to include which provisional tests have been successfully executed by the implementation. 
```
