### PR TITLE
geps: Add the missing trailing backtick to gep-3155

### DIFF
--- a/geps/gep-3155/index.md
+++ b/geps/gep-3155/index.md
@@ -35,7 +35,7 @@ it will also enable higher level automation to simplify this process for users.
 ### Client Certs on Gateways
 
 A key requirement of mutual TLS is that the Gateway can provide a client cert to the
-backend. This adds that configuration to both Gateway and Service (via 
+backend. This adds that configuration to both Gateway and Service (via
 BackendTLSPolicy).
 
 #### Gateway-level (Core support)
@@ -49,7 +49,7 @@ subject for consideration as the future work.
 type GatewaySpec struct {
   // BackendTLS configures TLS settings for when this Gateway is connecting to
   // backends with TLS.
-  BackendTLS GatewayBackendTLS `json:"backendTLS,omitempty"'
+  BackendTLS GatewayBackendTLS `json:"backendTLS,omitempty"'`
 }
 type GatewayBackendTLS struct {
   // ClientCertificateRef is a reference to an object that contains a Client
@@ -73,10 +73,10 @@ type GatewayBackendTLS struct {
 
 This change enables the backend certificate to have a different identity than the SNI
 (both are currently tied to the hostname field). This is particularly useful
-when using SPIFFE, which relies on URI Subject Names which are not valid SNIs 
+when using SPIFFE, which relies on URI Subject Names which are not valid SNIs
 as per https://www.rfc-editor.org/rfc/rfc6066.html#section-3.
 
-In such case either connection properties or an arbitrary SNI, like cluster-local 
+In such case either connection properties or an arbitrary SNI, like cluster-local
 service name could be used for certificate selection, while the identity validation
 will be done based on SubjectAltNames field.
 
@@ -134,7 +134,7 @@ Before:
 
 After:
 ```go
-  // 2. Only if SubjectAltNames is not specified, Hostname MUST be used for 
+  // 2. Only if SubjectAltNames is not specified, Hostname MUST be used for
   //    authentication and MUST match the certificate served by the matching
   //    backend.
 ```


### PR DESCRIPTION
This commit adds the missing backtick to the gep-3155 index.md to fix markdown rendering.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind cleanup

**What this PR does / why we need it**:

This is a quick cleanup PR that adds the missing backtick to json field tag in the gep-3155's index.md. This fixes markdown rendering of this GEP when viewed in the UI or an IDE that supports markdown previewing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
