### PR TITLE
feat: Exclude comments from CRD generation but not from go struct definition

### DIFF
--- a/apis/v1/shared_types.go
+++ b/apis/v1/shared_types.go
@@ -542,7 +542,7 @@ type PreciseHostname string
 // scheme (e.g., "http" or "spiffe") and a scheme-specific-part.  URIs that
 // include an authority MUST include a fully qualified domain name or
 // IP address as the host.
-
+// <gateway:util:excludeFromCRD> The below regex is taken from the regex section in RFC 3986 with a slight modification to enforce a full URI and not relative. </gateway:util:excludeFromCRD>
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=253
 // +kubebuilder:validation:Pattern=`^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?`

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -222,6 +222,19 @@ func gatewayTweaks(channel string, props map[string]apiext.JSONSchemaProps) map[
 			jsonProps.Description = strings.ReplaceAll(jsonProps.Description, endTag, "")
 		}
 
+		startTag = "<gateway:util:excludeFromCRD>"
+		endTag = "</gateway:util:excludeFromCRD>"
+		regexPattern = `(?:\r?\n)*` + regexp.QuoteMeta(startTag) + `(?s:(.*?))` + regexp.QuoteMeta(endTag) + `(?:\r?\n)*`
+		if strings.Contains(jsonProps.Description, "<gateway:util:excludeFromCRD>") {
+			re := regexp.MustCompile(regexPattern)
+			match := re.FindStringSubmatch(jsonProps.Description)
+			if len(match) != 2 {
+				log.Fatalf("Invalid <gateway:util:excludeFromCRD> tag for %s", name)
+			}
+			modifiedDescription := re.ReplaceAllString(jsonProps.Description, "\n\n")
+			jsonProps.Description = modifiedDescription
+		}
+
 		if numValid < numExpressions {
 			fmt.Printf("Description: %s\n", jsonProps.Description)
 			log.Fatalf("Found %d Gateway validation expressions, but only %d were valid", numExpressions, numValid)

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -222,6 +222,8 @@ func gatewayTweaks(channel string, props map[string]apiext.JSONSchemaProps) map[
 			jsonProps.Description = strings.ReplaceAll(jsonProps.Description, endTag, "")
 		}
 
+		// Comments within "gateway:util:excludeFromCRD" tag is not included in the generated CRD and all trailing \n operators before
+		// and after the tags are removed and replaced with three \n operators.
 		startTag = "<gateway:util:excludeFromCRD>"
 		endTag = "</gateway:util:excludeFromCRD>"
 		regexPattern = `\n*` + regexp.QuoteMeta(startTag) + `(?s:(.*?))` + regexp.QuoteMeta(endTag) + `\n*`

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -224,14 +224,14 @@ func gatewayTweaks(channel string, props map[string]apiext.JSONSchemaProps) map[
 
 		startTag = "<gateway:util:excludeFromCRD>"
 		endTag = "</gateway:util:excludeFromCRD>"
-		regexPattern = `(?:\r?\n)*` + regexp.QuoteMeta(startTag) + `(?s:(.*?))` + regexp.QuoteMeta(endTag) + `(?:\r?\n)*`
+		regexPattern = `\n*` + regexp.QuoteMeta(startTag) + `(?s:(.*?))` + regexp.QuoteMeta(endTag) + `\n*`
 		if strings.Contains(jsonProps.Description, "<gateway:util:excludeFromCRD>") {
 			re := regexp.MustCompile(regexPattern)
 			match := re.FindStringSubmatch(jsonProps.Description)
 			if len(match) != 2 {
 				log.Fatalf("Invalid <gateway:util:excludeFromCRD> tag for %s", name)
 			}
-			modifiedDescription := re.ReplaceAllString(jsonProps.Description, "\n\n")
+			modifiedDescription := re.ReplaceAllString(jsonProps.Description, "\n\n\n")
 			jsonProps.Description = modifiedDescription
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind documentation
/kind feature

**What this PR does / why we need it**:
This PR adds a new tag `gateway:util:excludeFromCRD` in CRD description which allows to exclude comments in the go struct from being included in the generated CRD, preventing unnecessary clutter in the CRD specification.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3306 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```

/cc @LiorLieberman @robscott 