### PR TITLE
Fix CEL tests for v1.28+

### DIFF
--- a/pkg/test/cel/backendlbpolicy_test.go
+++ b/pkg/test/cel/backendlbpolicy_test.go
@@ -22,7 +22,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -122,7 +121,7 @@ func validateBackendLBPolicy(t *testing.T, lbPolicy *gatewayv1a2.BackendLBPolicy
 
 	var missingErrorStrings []string
 	for _, wantError := range wantErrors {
-		if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(wantError)) {
+		if !celErrorStringMatches(err.Error(), wantError) {
 			missingErrorStrings = append(missingErrorStrings, wantError)
 		}
 	}

--- a/pkg/test/cel/backendtlspolicy_test.go
+++ b/pkg/test/cel/backendtlspolicy_test.go
@@ -22,7 +22,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -305,7 +304,7 @@ func validateBackendTLSPolicy(t *testing.T, route *gatewayv1a3.BackendTLSPolicy,
 
 	var missingErrorStrings []string
 	for _, wantError := range wantErrors {
-		if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(wantError)) {
+		if !celErrorStringMatches(err.Error(), wantError) {
 			missingErrorStrings = append(missingErrorStrings, wantError)
 		}
 	}

--- a/pkg/test/cel/gateway_experimental_test.go
+++ b/pkg/test/cel/gateway_experimental_test.go
@@ -123,7 +123,7 @@ func TestGatewayInfrastructureLabels(t *testing.T) {
 
 			var missingErrorStrings []string
 			for _, wantError := range tc.wantErrors {
-				if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(wantError)) {
+				if !celErrorStringMatches(err.Error(), wantError) {
 					missingErrorStrings = append(missingErrorStrings, wantError)
 				}
 			}

--- a/pkg/test/cel/gateway_test.go
+++ b/pkg/test/cel/gateway_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -608,7 +607,7 @@ func TestValidateGateway(t *testing.T) {
 
 			var missingErrorStrings []string
 			for _, wantError := range tc.wantErrors {
-				if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(wantError)) {
+				if !celErrorStringMatches(err.Error(), wantError) {
 					missingErrorStrings = append(missingErrorStrings, wantError)
 				}
 			}

--- a/pkg/test/cel/gatewayclass_test.go
+++ b/pkg/test/cel/gatewayclass_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -72,7 +71,7 @@ func TestValidateGatewayClassUpdate(t *testing.T) {
 			if (tc.wantError != "") != (err != nil) {
 				t.Fatalf("Unexpected error while updating GatewayClass; got err=\n%v\n;want error=%v", err, tc.wantError != "")
 			}
-			if tc.wantError != "" && !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(tc.wantError)) {
+			if tc.wantError != "" && !celErrorStringMatches(err.Error(), tc.wantError) {
 				t.Fatalf("Unexpected error while updating GatewayClass; got err=\n%v\n;want substring within error=%q", err, tc.wantError)
 			}
 		})

--- a/pkg/test/cel/grpcroute_test.go
+++ b/pkg/test/cel/grpcroute_test.go
@@ -22,7 +22,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -424,7 +423,7 @@ func validateGRPCRoute(t *testing.T, route *gatewayv1.GRPCRoute, wantErrors []st
 
 	var missingErrorStrings []string
 	for _, wantError := range wantErrors {
-		if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(wantError)) {
+		if !celErrorStringMatches(err.Error(), wantError) {
 			missingErrorStrings = append(missingErrorStrings, wantError)
 		}
 	}

--- a/pkg/test/cel/httproute_test.go
+++ b/pkg/test/cel/httproute_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -75,7 +74,7 @@ func TestHTTPPathMatch(t *testing.T) {
 		},
 		{
 			name:       "invalid type",
-			wantErrors: []string{"type must be one of ['Exact', 'PathPrefix', 'RegularExpression']"},
+			wantErrors: []string{"must be one of ['Exact', 'PathPrefix', 'RegularExpression']"},
 			path: &gatewayv1.HTTPPathMatch{
 				Type:  ptrTo(gatewayv1.PathMatchType("FooBar")),
 				Value: ptrTo("/path"),
@@ -740,13 +739,13 @@ func TestHTTPRouteRule(t *testing.T) {
 			}},
 		},
 		{
-			name:       "invalid URLRewrite filter because too many path matches",
+			name:       "invalid URLRewrite filter because wrong path match type",
 			wantErrors: []string{"When using URLRewrite filter with path.replacePrefixMatch, exactly one PathPrefix match must be specified"},
 			rules: []gatewayv1.HTTPRouteRule{{
 				Matches: []gatewayv1.HTTPRouteMatch{
 					{
 						Path: &gatewayv1.HTTPPathMatch{
-							Type:  ptrTo(gatewayv1.PathMatchType(gatewayv1.FullPathHTTPPathModifier)), // Incorrect Patch match Type for URLRewrite filter with ReplacePrefixMatch.
+							Type:  ptrTo(gatewayv1.PathMatchRegularExpression), // Incorrect Path match Type for URLRewrite filter with ReplacePrefixMatch.
 							Value: ptrTo("/foo"),
 						},
 					},
@@ -814,13 +813,13 @@ func TestHTTPRouteRule(t *testing.T) {
 			}},
 		},
 		{
-			name:       "invalid RequestRedirect filter because path match has type ReplaceFullPath",
+			name:       "invalid RequestRedirect filter because path match has type RegularExpression",
 			wantErrors: []string{"When using RequestRedirect filter with path.replacePrefixMatch, exactly one PathPrefix match must be specified"},
 			rules: []gatewayv1.HTTPRouteRule{{
 				Matches: []gatewayv1.HTTPRouteMatch{
 					{
 						Path: &gatewayv1.HTTPPathMatch{
-							Type:  ptrTo(gatewayv1.PathMatchType(gatewayv1.FullPathHTTPPathModifier)), // Incorrect Patch match Type for RequestRedirect filter with ReplacePrefixMatch.
+							Type:  ptrTo(gatewayv1.PathMatchRegularExpression), // Incorrect Path match Type for RequestRedirect filter with ReplacePrefixMatch.
 							Value: ptrTo("/foo"),
 						},
 					},
@@ -908,13 +907,13 @@ func TestHTTPRouteRule(t *testing.T) {
 			}},
 		},
 		{
-			name:       "invalid URLRewrite filter (within backendRefs) because path match has type ReplaceFullPath",
+			name:       "invalid URLRewrite filter (within backendRefs) because path match has type RegularExpression",
 			wantErrors: []string{"Within backendRefs, When using URLRewrite filter with path.replacePrefixMatch, exactly one PathPrefix match must be specified"},
 			rules: []gatewayv1.HTTPRouteRule{{
 				Matches: []gatewayv1.HTTPRouteMatch{
 					{
 						Path: &gatewayv1.HTTPPathMatch{
-							Type:  ptrTo(gatewayv1.PathMatchType(gatewayv1.FullPathHTTPPathModifier)), // Incorrect Patch match Type for URLRewrite filter with ReplacePrefixMatch.
+							Type:  ptrTo(gatewayv1.PathMatchRegularExpression), // Incorrect Path match Type for URLRewrite filter with ReplacePrefixMatch.
 							Value: ptrTo("/foo"),
 						},
 					},
@@ -1012,13 +1011,13 @@ func TestHTTPRouteRule(t *testing.T) {
 			}},
 		},
 		{
-			name:       "invalid RequestRedirect filter (within backendRefs) because path match has type ReplaceFullPath",
+			name:       "invalid RequestRedirect filter (within backendRefs) because path match has type RegularExpression",
 			wantErrors: []string{"Within backendRefs, when using RequestRedirect filter with path.replacePrefixMatch, exactly one PathPrefix match must be specified"},
 			rules: []gatewayv1.HTTPRouteRule{{
 				Matches: []gatewayv1.HTTPRouteMatch{
 					{
 						Path: &gatewayv1.HTTPPathMatch{
-							Type:  ptrTo(gatewayv1.PathMatchType(gatewayv1.FullPathHTTPPathModifier)), // Incorrect Patch match Type for RequestRedirect filter with ReplacePrefixMatch.
+							Type:  ptrTo(gatewayv1.PathMatchRegularExpression), // Incorrect Path match Type for RequestRedirect filter with ReplacePrefixMatch.
 							Value: ptrTo("/foo"),
 						},
 					},
@@ -1361,6 +1360,7 @@ func TestHTTPPathModifier(t *testing.T) {
 			name:       "type must be 'ReplaceFullPath' when replaceFullPath is set",
 			wantErrors: []string{"type must be 'ReplaceFullPath' when replaceFullPath is set"},
 			pathModifier: gatewayv1.HTTPPathModifier{
+				Type:            gatewayv1.PrefixMatchHTTPPathModifier,
 				ReplaceFullPath: ptrTo("foo"),
 			},
 		},
@@ -1382,6 +1382,7 @@ func TestHTTPPathModifier(t *testing.T) {
 			name:       "type must be 'ReplacePrefixMatch' when replacePrefixMatch is set",
 			wantErrors: []string{"type must be 'ReplacePrefixMatch' when replacePrefixMatch is set"},
 			pathModifier: gatewayv1.HTTPPathModifier{
+				Type:               gatewayv1.FullPathHTTPPathModifier,
 				ReplacePrefixMatch: ptrTo("/foo"),
 			},
 		},
@@ -1427,7 +1428,7 @@ func validateHTTPRoute(t *testing.T, route *gatewayv1.HTTPRoute, wantErrors []st
 
 	var missingErrorStrings []string
 	for _, wantError := range wantErrors {
-		if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(wantError)) {
+		if !celErrorStringMatches(err.Error(), wantError) {
 			missingErrorStrings = append(missingErrorStrings, wantError)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind failing-test

**What this PR does / why we need it**:
As @mlavacca discovered in #3316, our CEL tests were failing in v1.28+. Fortunately it was just a variety of changes to how error messages are presented to users. I've also tested these changes against v1.27 and v1.29.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @gauravkghildiyal @jpbetz 