### PR TITLE
chore: add conformance suite client options

### DIFF
--- a/conformance/conformance.go
+++ b/conformance/conformance.go
@@ -45,7 +45,8 @@ import (
 func DefaultOptions(t *testing.T) suite.ConformanceOptions {
 	cfg, err := config.GetConfig()
 	require.NoError(t, err, "error loading Kubernetes config")
-	client, err := client.New(cfg, client.Options{})
+	clientOptions := client.Options{}
+	client, err := client.New(cfg, clientOptions)
 	require.NoError(t, err, "error initializing Kubernetes client")
 
 	// This clientset is needed in addition to the client only because
@@ -79,6 +80,7 @@ func DefaultOptions(t *testing.T) suite.ConformanceOptions {
 		AllowCRDsMismatch:          *flags.AllowCRDsMismatch,
 		CleanupBaseResources:       *flags.CleanupBaseResources,
 		Client:                     client,
+		ClientOptions:              clientOptions,
 		Clientset:                  clientset,
 		ConformanceProfiles:        conformanceProfiles,
 		Debug:                      *flags.ShowDebug,

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -56,6 +56,7 @@ import (
 // conformance tests.
 type ConformanceTestSuite struct {
 	Client                   client.Client
+	ClientOptions            client.Options
 	Clientset                clientset.Interface
 	RESTClient               *rest.RESTClient
 	RestConfig               *rest.Config
@@ -123,6 +124,7 @@ type ConformanceTestSuite struct {
 // Options can be used to initialize a ConformanceTestSuite.
 type ConformanceOptions struct {
 	Client               client.Client
+	ClientOptions        client.Options
 	Clientset            clientset.Interface
 	RestConfig           *rest.Config
 	GatewayClassName     string
@@ -234,6 +236,7 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 
 	suite := &ConformanceTestSuite{
 		Client:           options.Client,
+		ClientOptions:    options.ClientOptions,
 		Clientset:        options.Clientset,
 		RestConfig:       options.RestConfig,
 		RoundTripper:     roundTripper,
@@ -398,7 +401,7 @@ func (suite *ConformanceTestSuite) setClientsetForTest(test ConformanceTest) err
 			strings.Join(featureNames, ","),
 		},
 		"::")
-	client, err := client.New(suite.RestConfig, client.Options{})
+	client, err := client.New(suite.RestConfig, suite.ClientOptions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind test
/kind bug
/kind cleanup
/area conformance

**What this PR does / why we need it**:

pass options to the Kubernetes client to allow for things like schema and mapper.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3342

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
