### PR TITLE
[Conformance]: Adds GatewayClass SupportedVersion Test

### DIFF
--- a/conformance/tests/gatewayclass-supported-version-condition.go
+++ b/conformance/tests/gatewayclass-supported-version-condition.go
@@ -40,9 +40,8 @@ var GatewayClassSupportedVersionCondition = suite.ConformanceTest{
 		features.SupportGateway,
 	},
 	Description: "A GatewayClass should set the SupportedVersion condition based on the presence and version of Gateway API CRDs in the cluster",
-	Manifests:   []string{"tests/gatewayclass-supported-version-condition.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
-		gwc := types.NamespacedName{Name: "gatewayclass-supported-version-condition"}
+		gwc := types.NamespacedName{Name: s.GatewayClassName}
 
 		t.Run("SupportedVersion condition should be set correctly", func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.DefaultTestTimeout)

--- a/conformance/tests/gatewayclass-supported-version-condition.go
+++ b/conformance/tests/gatewayclass-supported-version-condition.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/consts"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayClassSupportedVersionCondition)
+}
+
+var GatewayClassSupportedVersionCondition = suite.ConformanceTest{
+	ShortName: "GatewayClassSupportedVersionCondition",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+	},
+	Description: "A GatewayClass should set the SupportedVersion condition based on the presence and version of Gateway API CRDs in the cluster",
+	Manifests:   []string{"tests/gatewayclass-supported-version-condition.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		gwc := types.NamespacedName{Name: "gatewayclass-supported-version-condition"}
+
+		t.Run("SupportedVersion condition should be set correctly", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.DefaultTestTimeout)
+			defer cancel()
+
+			// Ensure GatewayClass conditions are as expected before proceeding
+			kubernetes.GWCMustHaveAcceptedConditionTrue(t, s.Client, s.TimeoutConfig, gwc.Name)
+			kubernetes.GWCMustHaveSupportedVersionConditionAny(t, s.Client, s.TimeoutConfig, gwc.Name)
+
+			// Retrieve the GatewayClass CRD
+			crd := &apiextv1.CustomResourceDefinition{}
+			crdName := types.NamespacedName{Name: "gatewayclasses.gateway.networking.k8s.io"}
+			err := s.Client.Get(ctx, crdName, crd)
+			require.NoErrorf(t, err, "error getting GatewayClass CRD: %v", err)
+
+			if crd.Annotations != nil {
+				// Remove the bundle version annotation if it exists
+				if _, exists := crd.Annotations[consts.BundleVersionAnnotation]; !exists {
+					t.Fatalf("Annotation %q does not exist on CRD %s", consts.BundleVersionAnnotation, crdName)
+				}
+				delete(crd.Annotations, consts.BundleVersionAnnotation)
+				if err := s.Client.Update(ctx, crd); err != nil {
+					t.Fatalf("Failed to update CRD %s: %v", crdName, err)
+				}
+			}
+
+			// Ensure the SupportedVersion status condition is false
+			kubernetes.GWCMustHaveSupportedVersionConditionFalse(t, s.Client, s.TimeoutConfig, gwc.Name)
+
+			// Add the bundle version annotation
+			crd.Annotations[consts.BundleVersionAnnotation] = consts.BundleVersion
+			if err := s.Client.Update(ctx, crd); err != nil {
+				t.Fatalf("Failed to update CRD %s: %v", crdName, err)
+			}
+
+			// Ensure the SupportedVersion status condition is true
+			kubernetes.GWCMustHaveSupportedVersionConditionTrue(t, s.Client, s.TimeoutConfig, gwc.Name)
+
+			// Set the bundle version annotation to an unsupported version
+			crd.Annotations[consts.BundleVersionAnnotation] = "v0.0.0"
+			if err := s.Client.Update(ctx, crd); err != nil {
+				t.Fatalf("Failed to update CRD %s: %v", crdName, err)
+			}
+
+			// Ensure the SupportedVersion is false
+			kubernetes.GWCMustHaveSupportedVersionConditionFalse(t, s.Client, s.TimeoutConfig, gwc.Name)
+
+			// Add the bundle version annotation back
+			crd.Annotations[consts.BundleVersionAnnotation] = consts.BundleVersion
+			if err := s.Client.Update(ctx, crd); err != nil {
+				t.Fatalf("Failed to update CRD %s: %v", crdName, err)
+			}
+
+			// Ensure the SupportedVersion is true
+			kubernetes.GWCMustHaveSupportedVersionConditionTrue(t, s.Client, s.TimeoutConfig, gwc.Name)
+		})
+	},
+}

--- a/conformance/tests/gatewayclass-supported-version-condition.yaml
+++ b/conformance/tests/gatewayclass-supported-version-condition.yaml
@@ -1,6 +1,0 @@
-apiVersion: gateway.networking.k8s.io/v1
-kind: GatewayClass
-metadata:
-  name: gatewayclass-supported-version-condition
-spec:
-  controllerName: "{GATEWAY_CONTROLLER_NAME}"

--- a/conformance/tests/gatewayclass-supported-version-condition.yaml
+++ b/conformance/tests/gatewayclass-supported-version-condition.yaml
@@ -1,0 +1,6 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: gatewayclass-supported-version-condition
+spec:
+  controllerName: "{GATEWAY_CONTROLLER_NAME}"

--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -56,6 +56,10 @@ type TimeoutConfig struct {
 	// Max value for conformant implementation: None
 	GWCMustBeAccepted time.Duration
 
+	// GWCMustBeSupportedVersion represents the maximum time for a GatewayClass to have a SupportedVersion condition set to true.
+	// Max value for conformant implementation: None
+	GWCMustBeSupportedVersion time.Duration
+
 	// HTTPRouteMustNotHaveParents represents the maximum time for an HTTPRoute to have either no parents or a single parent that is not accepted.
 	// Max value for conformant implementation: None
 	HTTPRouteMustNotHaveParents time.Duration
@@ -115,6 +119,7 @@ func DefaultTimeoutConfig() TimeoutConfig {
 		GatewayStatusMustHaveListeners:     60 * time.Second,
 		GatewayListenersMustHaveConditions: 60 * time.Second,
 		GWCMustBeAccepted:                  180 * time.Second,
+		GWCMustBeSupportedVersion:          180 * time.Second,
 		HTTPRouteMustNotHaveParents:        60 * time.Second,
 		HTTPRouteMustHaveCondition:         60 * time.Second,
 		TLSRouteMustHaveCondition:          60 * time.Second,
@@ -154,6 +159,9 @@ func SetupTimeoutConfig(timeoutConfig *TimeoutConfig) {
 	}
 	if timeoutConfig.GWCMustBeAccepted == 0 {
 		timeoutConfig.GWCMustBeAccepted = defaultTimeoutConfig.GWCMustBeAccepted
+	}
+	if timeoutConfig.GWCMustBeSupportedVersion == 0 {
+		timeoutConfig.GWCMustBeSupportedVersion = defaultTimeoutConfig.GWCMustBeSupportedVersion
 	}
 	if timeoutConfig.HTTPRouteMustNotHaveParents == 0 {
 		timeoutConfig.HTTPRouteMustNotHaveParents = defaultTimeoutConfig.HTTPRouteMustNotHaveParents


### PR DESCRIPTION
**What type of PR is this?**
/kind test
/area conformance

**What this PR does / why we need it**:
Adds a test to ensure implementations conform to the GatewayClass SupportedVersion status condition.

**Which issue(s) this PR fixes**:
Fixes #3367

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
