### PR TITLE
mark the GatewayInfrastructure test as Provisional

### DIFF
--- a/conformance/tests/gateway-infrastructure.go
+++ b/conformance/tests/gateway-infrastructure.go
@@ -43,6 +43,7 @@ var GatewayInfrastructure = suite.ConformanceTest{
 		features.SupportGateway,
 		features.SupportGatewayInfrastructurePropagation,
 	},
+	Provisional: true,
 	Manifests: []string{
 		"tests/gateway-infrastructure.yaml",
 	},


### PR DESCRIPTION


**What type of PR is this?**
/kind test
/area conformance
-->

**What this PR does / why we need it**:

The test expects generated Gateway resources to
have the `gateway.networking.k8s.io/gateway` label set. Mark the test as provisional until these statements have moved into the API docs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Relates to https://github.com/kubernetes-sigs/gateway-api/issues/3366#issuecomment-2384566059

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
