### PR TITLE
Mark group field in LocalObjectReference as optional

### DIFF
--- a/apis/v1/object_reference_types.go
+++ b/apis/v1/object_reference_types.go
@@ -27,6 +27,7 @@ package v1
 type LocalObjectReference struct {
 	// Group is the group of the referent. For example, "gateway.networking.k8s.io".
 	// When unspecified or empty string, core API group is inferred.
+	// +optional
 	Group Group `json:"group"`
 
 	// Kind is kind of the referent. For example "HTTPRoute" or "Service".


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Marks group field in LocalObjectReference as optional

**Which issue(s) this PR fixes**:
Fixes #3322 

**Does this PR introduce a user-facing change?**:
```release
Mark group field in LocalObjectReference as optional 

```
