### PR TITLE
Fix conformance coredns deployment

### DIFF
--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -706,6 +706,13 @@ spec:
         - /root/Corefile
         image: coredns/coredns
         name: coredns
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /root
           name: conf


### PR DESCRIPTION

/kind bug

**What this PR does / why we need it**:

This PR fixes conformance test when running on certain kubernetes distributions with stricter policies. The coredns deployment required by some tests would fail to start due to missing `NET_BIND_SERVICE` capability

-->
```release-note
NONE
```
