### PR TITLE
Make GRPCRoute v1alpha2's status a subresource

### DIFF
--- a/apis/v1alpha2/grpcroute_types.go
+++ b/apis/v1alpha2/grpcroute_types.go
@@ -24,6 +24,10 @@ import (
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=gateway-api
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Hostnames",type=string,JSONPath=`.spec.hostnames`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:deprecatedversion:warning="The v1alpha2 version of GRPCRoute has been deprecated and will be removed in a future release of the API. Please upgrade to v1."
 type GRPCRoute v1.GRPCRoute
 

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -2349,7 +2349,14 @@ spec:
     storage: true
     subresources:
       status: {}
-  - deprecated: true
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
     deprecationWarning: The v1alpha2 version of GRPCRoute has been deprecated and
       will be removed in a future release of the API. Please upgrade to v1.
     name: v1alpha2
@@ -4674,6 +4681,8 @@ spec:
         type: object
     served: true
     storage: false
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
@@ -2205,7 +2205,14 @@ spec:
     storage: true
     subresources:
       status: {}
-  - deprecated: true
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
     deprecationWarning: The v1alpha2 version of GRPCRoute has been deprecated and
       will be removed in a future release of the API. Please upgrade to v1.
     name: v1alpha2
@@ -4386,6 +4393,8 @@ spec:
         type: object
     served: false
     storage: false
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
/kind bug
/kind regression

Replace the kubebuilder flags for GRPCRoute v1alpha2 so that they're the same as v1. Also restore the additional printer columns.

Fixes #3411.

```release-note
Make GRPCRoute v1alpha2's status a subresource again, as it should be, and restore the previous additional printer columns.
```
