### PR TITLE
chore: Changelog for 1.1.1

### DIFF
--- a/CHANGELOG/1.1-CHANGELOG.md
+++ b/CHANGELOG/1.1-CHANGELOG.md
@@ -28,7 +28,7 @@ follow.
 
 ### Conformance suite improvements
 
-- Expose the grpc client interface as a conformance suite option (#3095, @snehachhabria)
+- Expose the gRPC client interface as a conformance suite option (#3095, @snehachhabria)
 
 # v1.1.0
 On behalf of Kubernetes SIG Network, we are pleased to announce the v1.1 release!

--- a/CHANGELOG/1.1-CHANGELOG.md
+++ b/CHANGELOG/1.1-CHANGELOG.md
@@ -2,9 +2,33 @@
 
 ## Table of Contents
 
+- [v1.1.1](#v111)
 - [v1.1.0](#v110)
 - [v1.1.0-rc2](#v110-rc2)
 - [v1.1.0-rc1](#v110-rc1)
+
+# v1.1.1
+This is a patch release that fixes some issues with GRPCRoute v1alpha2 and session
+persistence, and backports some improvements on CI and the conformance suite. Details
+follow.
+
+## Changes by Kind
+
+### Bug Fixes
+
+- Make GRPCRoute v1alpha2's status a subresource, and restore the previous additional
+  printer columns (#3412, @kflynn)
+- Allow the header based session persistence not to have AbsoluteTimeout, by relaxing
+  CEL validation (#3215, @sanposhiho)
+
+### CI improvements
+
+- Perform CEL validation tests for multiple Kubernetes versions (#3417, @mlavacca,
+  @robscott)
+
+### Conformance suite improvements
+
+- Expose the grpc client interface as a conformance suite option (#3095, @snehachhabria)
 
 # v1.1.0
 On behalf of Kubernetes SIG Network, we are pleased to announce the v1.1 release!


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
