### PR TITLE
Fix link in Mesh page

### DIFF
--- a/site-src/mesh/index.md
+++ b/site-src/mesh/index.md
@@ -38,6 +38,8 @@ Service.
 [service-mesh]:/concepts/glossary#service-mesh
 [service-facets]:/concepts/service-facets
 
+## Connecting routes and services <a name="gateway-api-for-mesh">
+
 GAMMA specifies that individual Route resources attach directly to a Service,
 representing configuration meant to be applied to _any traffic directed to the
 Service_.


### PR DESCRIPTION
I've always been confused as to where the dangling link on this page went to, so [I've found out](https://github.com/kubernetes-sigs/gateway-api/blob/7b9876e1f1a513304bdb92e93125eb345b7b9c40/site-src/concepts/gamma.md?plain=1#L99) and recreated the heading.

I considered removing the link instead, but it makes more sense in terms of the table of contents to break this section up from the "request flow" section below and the summary above.

/kind documentation

```release-note
NONE
```
