### PR TITLE
Clarify why the older policy wins in GEP 713

### DIFF
--- a/geps/gep-713/index.md
+++ b/geps/gep-713/index.md
@@ -246,9 +246,12 @@ ties:
   only come up in exceptional circumstances.
 * Inside Inherited Policies, the same setting in `overrides` beats the one in
   `defaults`.
-* The oldest Policy based on creation timestamp beats a newer one. For example,
-  a Policy with a creation timestamp of "2021-07-15 01:02:03" MUST be given
-  precedence over a Policy with a creation timestamp of "2021-07-15 01:02:04".
+* The older Policy based on creation timestamp beats a newer one. For example,
+  a Policy with a creation timestamp of "2021-07-15 01:02:03" MUST be given
+  precedence over a Policy with a creation timestamp of "2021-07-15 01:02:04".
+  The goal is to ensure that introducing new, unused policies doesn’t disrupt
+  existing ones, since changing active rules can cause outages while altering
+  unused policies poses no risk.
 * The Policy appearing first in alphabetical order by `{namespace}/{name}`. For
   example, foo/bar is given precedence over foo/baz.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind documentation

**What this PR does / why we need it**:

Clarify why the older policy wins in GEP 713

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3434

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
