### PR TITLE
override unmarshalJSON for supportedfeature to ensure comptability

### DIFF
--- a/apis/v1/gatewayclass_types_overrides.go
+++ b/apis/v1/gatewayclass_types_overrides.go
@@ -26,7 +26,8 @@ import (
 // We are overriding the UnmarshalJSON function to be able to handle cases where
 // users had the old version of the GatewayClass CRD applied with SupportedFeatures
 // as a list of strings and not list of objects.
-// See https://github.com/istio/istio/issues/53846 for more information.
+// See https://github.com/kubernetes-sigs/gateway-api/issues/3464
+// for more information.
 
 func (s *SupportedFeature) UnmarshalJSON(data []byte) error {
 	var oldSupportedFeature oldSupportedFeature

--- a/apis/v1/gatewayclass_types_overrides.go
+++ b/apis/v1/gatewayclass_types_overrides.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// Below code handles the experimental field breaking change introduced in
+// https://github.com/kubernetes-sigs/gateway-api/pull/3200/.
+// We are overriding the UnmarshalJSON function to be able to handle cases where
+// users had the old version of the GatewayClass CRD applied with SupportedFeatures
+// as a list of strings and not list of objects.
+// See https://github.com/istio/istio/issues/53846 for more information.
+
+func (s *SupportedFeature) UnmarshalJSON(data []byte) error {
+	var oldSupportedFeature oldSupportedFeature
+	var unmarshalTypeErr *json.UnmarshalTypeError
+	if err := json.Unmarshal(data, &oldSupportedFeature); err == nil {
+		s.Name = FeatureName(oldSupportedFeature)
+		return nil
+	} else if !errors.As(err, &unmarshalTypeErr) {
+		// If the error is not a type error, return it
+		return err
+	}
+
+	var si supportedFeatureInternal
+	if err := json.Unmarshal(data, &si); err != nil {
+		return err
+	}
+	s.Name = si.Name
+	return nil
+}
+
+// This is solely for the purpose of ensuring backward compatibility and
+// SHOULD NOT be used elsewhere.
+type supportedFeatureInternal struct {
+	Name FeatureName `json:"name"`
+}
+
+// This is solely for the purpose of ensuring backward compatibility and
+// SHOULD NOT be used elsewhere.
+type oldSupportedFeature string

--- a/apis/v1/gatewayclass_types_test.go
+++ b/apis/v1/gatewayclass_types_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSupportedFeature_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    SupportedFeature
+		expectError bool
+	}{
+		{
+			name:     "old struct input",
+			input:    `"featureA"`,
+			expected: SupportedFeature{Name: "featureA"},
+		},
+		{
+			name:     "new struct input",
+			input:    `{"name": "featureB"}`,
+			expected: SupportedFeature{Name: "featureB"},
+		},
+		{
+			name:        "expected error",
+			input:       `["featureA", "featureB"]`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result SupportedFeature
+			err := json.Unmarshal([]byte(tt.input), &result)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected an error, but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if result != tt.expected {
+					t.Errorf("Expected %+v, got %+v", tt.expected, result)
+				}
+			}
+		})
+	}
+}

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -145,6 +145,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"sigs.k8s.io/gateway-api/apis/v1.SecretObjectReference":                           schema_sigsk8sio_gateway_api_apis_v1_SecretObjectReference(ref),
 		"sigs.k8s.io/gateway-api/apis/v1.SessionPersistence":                              schema_sigsk8sio_gateway_api_apis_v1_SessionPersistence(ref),
 		"sigs.k8s.io/gateway-api/apis/v1.SupportedFeature":                                schema_sigsk8sio_gateway_api_apis_v1_SupportedFeature(ref),
+		"sigs.k8s.io/gateway-api/apis/v1.supportedFeatureInternal":                        schema_sigsk8sio_gateway_api_apis_v1_supportedFeatureInternal(ref),
 		"sigs.k8s.io/gateway-api/apis/v1alpha2.BackendLBPolicy":                           schema_sigsk8sio_gateway_api_apis_v1alpha2_BackendLBPolicy(ref),
 		"sigs.k8s.io/gateway-api/apis/v1alpha2.BackendLBPolicyList":                       schema_sigsk8sio_gateway_api_apis_v1alpha2_BackendLBPolicyList(ref),
 		"sigs.k8s.io/gateway-api/apis/v1alpha2.BackendLBPolicySpec":                       schema_sigsk8sio_gateway_api_apis_v1alpha2_BackendLBPolicySpec(ref),
@@ -3797,8 +3798,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_GatewayClassStatus(ref common.Referenc
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("sigs.k8s.io/gateway-api/apis/v1.SupportedFeature"),
+										Ref: ref("sigs.k8s.io/gateway-api/apis/v1.SupportedFeature"),
 									},
 								},
 							},
@@ -5635,6 +5635,27 @@ func schema_sigsk8sio_gateway_api_apis_v1_SupportedFeature(ref common.ReferenceC
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+				},
+				Required: []string{"name"},
+			},
+		},
+	}
+}
+
+func schema_sigsk8sio_gateway_api_apis_v1_supportedFeatureInternal(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "This is solely for the purpose of ensuring backward compatibility and SHOULD NOT be used elsewhere.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{


### PR DESCRIPTION
I messed up the branch name so disregard it.

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

This change is following an issue with the breaking change we introduced in https://github.com/kubernetes-sigs/gateway-api/pull/3200/. 
Issue link - https://github.com/istio/istio/issues/53846

I added unitests which hopefully provide enough coverage but happy to add more tests if you have ideas.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3464 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add backward compatibility for the older version of SupportedFeature
```

/cc @howardjohn @youngnick @mikemorris @robscott 
