### PR TITLE
Gep 2907 update - TLS mode and allowed routes

### DIFF
--- a/geps/gep-2907/index.md
+++ b/geps/gep-2907/index.md
@@ -267,3 +267,9 @@ The following is a summary of all the Routes and the TLS termination mode they s
 | `TLSRoute` | yes | yes |
 | `TCPRoute` | no | no |
 | `UDPRoute` | no | no |
+
+> [!NOTE]
+> When the traffic is routed to the backend via `TCPRoute`, the packets
+> are left untouched by the gateway. In order to terminate the TLS connection to
+> the gateway and forward the traffic unencrypted to the backend, a `TLSRoute` configured
+> with `Terminate` as TLS mode has to be used.

--- a/geps/gep-2907/index.md
+++ b/geps/gep-2907/index.md
@@ -258,18 +258,20 @@ a Gateway with no Listener matching the protocol needed by the Route, the Route
 
 ### What Routes are allowed by Listeners with TLS
 
-The following is a summary of all the Routes and the TLS termination mode they support.
+The following is a summary of all the Routes and the TLS termination mode they support, along
+with the compatible protocol.
 
-| Route | TLS with Terminate | TLS with Passthrough |
-|-|-|-|
-| `HTTPRoute` | yes | no |
-| `GRPCRoute` | yes | no |
-| `TLSRoute` | yes | yes |
-| `TCPRoute` | no | no |
-| `UDPRoute` | no | no |
+| Protocol  |  Routes | TLS Terminate | TLS Passthough |
+|-----------|---------|---------------|----------------|
+| HTTP  | `HTTPRoute` | no  | no  |
+| HTTPS | `HTTPRoute` | yes | no  |
+| GRPC  | `GRPCRoute` | yes | no  |
+| TLS   | `TLSRoute`  | yes | yes | 
+| TCP   | `TCPRoute`  | yes | no  |
+| UDP   | `UDPRoute`  | no  | no  |
 
 > [!NOTE]
-> When the traffic is routed to the backend via `TCPRoute`, the packets
-> are left untouched by the gateway. In order to terminate the TLS connection to
-> the gateway and forward the traffic unencrypted to the backend, a `TLSRoute` configured
-> with `Terminate` as TLS mode must be used.
+> When the traffic is routed to the backend via a listener configured with TLS `Passthrough`
+> and a compatible route, the packets are left untouched by the gateway. In order to
+> terminate the TLS connection to the gateway and forward the traffic unencrypted to the backend,
+> a listener configured with TLS `Terminate` and a compatible route must be used.

--- a/geps/gep-2907/index.md
+++ b/geps/gep-2907/index.md
@@ -82,7 +82,7 @@ TLS can be configured with two distinct modes:
  unless a new TLS connection between the two entities is configured via BackendTLSPolicy.
 * **Passthrough**: the TLS connection is instantiated between the frontend and the
   backend. The traffic flows through the Gateway encrypted, and the Gateway is not
-  able to decrypt or inspect the TLS stream.
+  able to decrypt or inspect the encrypted portions of the TLS stream.
 
 ## Proposed Segments
 Note that this does not represent any form of commitment that any of these
@@ -272,4 +272,4 @@ The following is a summary of all the Routes and the TLS termination mode they s
 > When the traffic is routed to the backend via `TCPRoute`, the packets
 > are left untouched by the gateway. In order to terminate the TLS connection to
 > the gateway and forward the traffic unencrypted to the backend, a `TLSRoute` configured
-> with `Terminate` as TLS mode has to be used.
+> with `Terminate` as TLS mode must be used.

--- a/geps/gep-2907/index.md
+++ b/geps/gep-2907/index.md
@@ -263,12 +263,11 @@ with the compatible protocol.
 
 | Protocol  |  Routes | TLS Terminate | TLS Passthough |
 |-----------|---------|---------------|----------------|
-| HTTP  | `HTTPRoute` | no  | no  |
-| HTTPS | `HTTPRoute` | yes | no  |
-| GRPC  | `GRPCRoute` | yes | no  |
-| TLS   | `TLSRoute`  | yes | yes | 
-| TCP   | `TCPRoute`  | yes | no  |
-| UDP   | `UDPRoute`  | no  | no  |
+| HTTP      | `HTTPRoute`/`GRPCRoute` | no  | no  |
+| HTTPS     | `HTTPRoute`/`GRPCRoute` | yes | no  |
+| TLS       | `TLSRoute`  | yes | yes | 
+| TCP       | `TCPRoute`  | yes | no  |
+| UDP       | `UDPRoute`  | no  | no  |
 
 > [!NOTE]
 > When the traffic is routed to the backend via a listener configured with TLS `Passthrough`

--- a/geps/gep-2907/index.md
+++ b/geps/gep-2907/index.md
@@ -21,14 +21,12 @@ and [Client Certificate Verification](../gep-91/index.md).
   is merely to provide space for future configuration, not a commitment that we
   will add it to the API.)
 
-## Out of Initial Scope
+## Out of Scope
 There are a variety of related TLS concepts in Gateway API that are not currently
 in scope for this GEP. In the future, this GEP may be expanded to include:
 
 1. Automatic mTLS (often associated with Service mesh)
-1. TLS Passthrough
-1. TLSRoute
-
+2. TLSRoute
 
 ## Introduction
 
@@ -74,6 +72,17 @@ flowchart LR
 ```
 
 The above diagram depicts these four segments as edges in a graph.
+
+### TLS mode
+
+TLS can be configured with two distinct modes:
+
+* **Terminate**: the TLS connection is instantiated between the frontend and the
+  Gateway. The connection between the Gateway and the backend is left unencrypted
+ unless a new TLS connection between the two entities is configured via BackendTLSPolicy.
+* **Passthrough**: the TLS connection is instantiated between the frontend and the
+  backend. The traffic flows through the Gateway encrypted, and the Gateway is not
+  able to decrypt or inspect the TLS stream.
 
 ## Proposed Segments
 Note that this does not represent any form of commitment that any of these
@@ -125,7 +134,6 @@ for a Gateway is not sufficiently different than the persona that would be
 responsible for frontend TLS, so the current proposal is likely the best option
 available to us.
 
-
 ### 2. Configure TLS Termination, including Server Certificate
 
 | Proposed Placement | Name | Status |
@@ -136,7 +144,6 @@ available to us.
 This is already finalized in the API and so we're stuck with this name. In
 hindsight a name that was more clearly tied to frontend TLS would have been
 ideal here.
-
 
 ### 3. Configure Client Certificate that Gateway should use to connect to Backend
 
@@ -159,7 +166,6 @@ connection). On the other hand, when determining the identity a Gateway should
 use when connecting to a backend, it should likely either be tied directly to
 the Gateway or Backend, but the Listener is not particularly relevant in this
 context.
-
 
 ### 4. Validate Server Certificate that is provided by Backend
 | Proposed Placement | Name | Status |
@@ -207,3 +213,57 @@ would be to introduce a Listener like resource for BackendTLS, resulting in a
 more consistent naming scheme within Gateway TLS configuration. Although it's
 not yet clear if we need this additional layer, we should reconsider it as we're
 further developing Backend TLS.
+
+### 5. Configure TLS mode
+
+| Proposed Placement | Name | Status |
+|-|-|-|
+| Gateway Listener | `Listener.TLS.Mode` | GA |
+
+#### Rationale
+
+Similarly to the broader [TLS termination](#2-configure-tls-termination-including-server-certificate)
+segment, this field is already finalized in the API. In hindsight, along with a
+different naming of `Listener.TLS`, we could have moved this field out of the broader
+frontend TLS configuration, as it is not bound to it.
+
+#### How the TLS configuration is affected
+
+The TLS mode affects how the frontend TLS should be configured. In case `Terminate`
+is set, the `Listener.TLS.CertificateRefs` field has to be populated, as the connection
+is intended to be terminated at the Gateway level, while for `Passthrough`, the Certificate
+does not need to be provided, as the TLS termination is handled by the backend.
+
+## Routes and TLS
+
+Multiple routes can be attached to listeners specifying TLS configuration. This section
+intends to clearly state how and when Routes can attach to listeners with TLS configuration.
+
+### Context
+
+The `*Route` objects refer the Gateway (or a specific Listener of the Gateway) they
+want to be attached to. A successful attachment can be granted by one of the two
+following conditions:
+
+* the `Listener.AllowedRoutes` field allows that specific Route `GroupKind` to be
+  attached to it, or
+* the `Listener.Protocol` field allows that specific Route to be attached to the
+  Listener. This applies only in case the Gateway's AllowedRoutes field is not set.
+
+In case the First condition is not satisfied (the Route references a Gateway that
+does not explicitly allow such an attachment), the Route `Accepted` condition
+is set to False with reason `NotAllowedByListeners`. In case the Route references
+a Gateway with no Listener matching the protocol needed by the Route, the Route
+`ResolvedRefs` condition is set to False with reason `UnsupportedProtocol`.
+
+### What Routes are allowed by Listeners with TLS
+
+The following is a summary of all the Routes and the TLS termination mode they support.
+
+| Route | TLS with Terminate | TLS with Passthrough |
+|-|-|-|
+| `HTTPRoute` | yes | no |
+| `GRPCRoute` | yes | no |
+| `TLSRoute` | yes | yes |
+| `TCPRoute` | no | no |
+| `UDPRoute` | no | no |


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind gep

**What this PR does / why we need it**:

This PR supersedes #3190.

This PR updates GEP-2907 with two different aspects:

- definition of TLS mode (Terminate and Passthrough)
- what routes can be attached to Listeners that specify TLS configuration.

A key takeaway and most discussed point of this PR is allowing TLS termination for TLSRoute. A lot of context can be found in https://github.com/kubernetes-sigs/gateway-api/issues/2111 and https://github.com/kubernetes-sigs/gateway-api/pull/3458#discussion_r1935423388. The needs of this feature boils down to "I want to route L4 and L7 traffic on the same listener, and I want to route L4 traffic based on hostname."

This PR intends to reach an agreement that will make https://github.com/kubernetes-sigs/gateway-api/issues/2111 and https://github.com/kubernetes-sigs/gateway-api/issues/1474 addressable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
