### PR TITLE
Add conformance report for NGINX Gateway Fabric v1.5.0

### DIFF
--- a/conformance/reports/v1.2.0/nginxinc-nginx-gateway-fabric/README.md
+++ b/conformance/reports/v1.2.0/nginxinc-nginx-gateway-fabric/README.md
@@ -1,0 +1,23 @@
+# Nginxinc NGINX Gateway Fabric
+
+## Table of Contents
+
+| API channel  | Implementation version                                                         | Mode    | Report                                       |
+|--------------|--------------------------------------------------------------------------------|---------|----------------------------------------------|
+| experimental | [v1.5.0](https://github.com/nginxinc/nginx-gateway-fabric/releases/tag/v1.5.0) | default | [link](./experimental-1.5.0-default-report.yaml) |
+
+## Reproduce
+
+To reproduce results, clone the NGF repository:
+
+```shell
+git clone https://github.com/nginxinc/nginx-gateway-fabric.git && cd nginx-gateway-fabric/tests
+```
+
+Follow the steps in the [NGINX Gateway Fabric Testing](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/tests/README.md) document to run the conformance tests. If you are running tests on the `edge` version, then you don't need to build any images. Otherwise, you'll need to check out the specific release tag that you want to test, and then build and load the images onto your cluster, per the steps in the README.
+
+After running, see the conformance report:
+
+```shell
+cat conformance-profile.yaml
+```

--- a/conformance/reports/v1.2.0/nginxinc-nginx-gateway-fabric/experimental-1.5.0-default-report.yaml
+++ b/conformance/reports/v1.2.0/nginxinc-nginx-gateway-fabric/experimental-1.5.0-default-report.yaml
@@ -1,0 +1,67 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2024-11-20T21:04:59Z"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.2.0
+implementation:
+  contact:
+  - https://github.com/nginxinc/nginx-gateway-fabric/discussions/new/choose
+  organization: nginxinc
+  project: nginx-gateway-fabric
+  url: https://github.com/nginxinc/nginx-gateway-fabric
+  version: v1.5.0
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 12
+      Skipped: 0
+  name: GATEWAY-GRPC
+  summary: Core tests succeeded.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 33
+      Skipped: 0
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 9
+      Skipped: 0
+    supportedFeatures:
+    - GatewayPort8080
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    unsupportedFeatures:
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRedirect
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestTimeout
+  name: GATEWAY-HTTP
+  summary: Core tests succeeded. Extended tests succeeded.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 11
+      Skipped: 0
+  name: GATEWAY-TLS
+  summary: Core tests succeeded.


### PR DESCRIPTION
**What type of PR is this?**
/area conformance

**What this PR does / why we need it**:
Updates conformance report for NGINX Gateway Fabric v1.5.0

**Does this PR introduce a user-facing change?**:
NO

```release-note
NONE
```
