### PR TITLE
docs: fix project dashboard link

### DIFF
--- a/site-src/contributing/devguide.md
+++ b/site-src/contributing/devguide.md
@@ -25,7 +25,7 @@ command in PR and issue comments][issue-cmds]. For example,
 `/priority important-soon`.
 
 [gh-issues]: https://github.com/kubernetes-sigs/gateway-api/issues
-[gh-dashboard]: https://github.com/kubernetes-sigs/gateway-api/projects/1
+[gh-dashboard]: https://github.com/kubernetes-sigs/gateway-api/projects
 [gh-milestones]: https://github.com/kubernetes-sigs/gateway-api/milestones
 [semver]:https://semver.org/
 [prio-labels]:https://github.com/kubernetes-sigs/gateway-api/labels?q=priority


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**: This PR is just to fix a broken link

**Which issue(s) this PR fixes**:
Fixes #3451 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
