### PR TITLE
gep: add GEP-3388 HTTP Retry Budget

### DIFF
--- a/geps/gep-1731/metadata.yaml
+++ b/geps/gep-1731/metadata.yaml
@@ -17,7 +17,9 @@ relationships:
   # or additional implementation. The extended GEP MUST have its extendedBy
   # field set back to this GEP.
   extends: {}
-  extendedBy: {}
+  extendedBy:
+    - number: 3388
+      name: HTTPRoute Retry Budget
   # seeAlso indicates other GEPs that are relevant in some way without being
   # covered by an existing relationship.
   seeAlso:

--- a/geps/gep-1731/metadata.yaml
+++ b/geps/gep-1731/metadata.yaml
@@ -19,7 +19,7 @@ relationships:
   extends: {}
   extendedBy:
     - number: 3388
-      name: HTTPRoute Retry Budget
+      name: Retry Budgets
   # seeAlso indicates other GEPs that are relevant in some way without being
   # covered by an existing relationship.
   seeAlso:

--- a/geps/gep-3388/index.md
+++ b/geps/gep-3388/index.md
@@ -7,83 +7,38 @@
 
 ## TLDR
 
-To allow configuration of a "retry budget" in HTTPRoute, to limit the rate of
-client-side retries based on a percentage of the active request load across all
-endpoints of a destination service.
+To allow configuration of a "retry budget" in HTTPRoute, to limit the rate of client-side retries based on a percentage of the active request load across all endpoints of a destination service.
 
 ## Goals
 
-* To allow specification of a retry
-  ["budget"](https://finagle.github.io/blog/2016/02/08/retry-budgets/) to
-  determine whether a request should be retried, and any shared configuration
-  or interaction with configuration of a static retry limit within HTTPRoute.
-* To allow specification of a percentage of active requests, or recently active
-  requests, that should be able
-  to be retried concurrently.
-* To allow specification of a *minimum* number of retries that should be
-  allowed per second or concurrently, such that the budget for retries never
-  goes below this minimum value.
-* To define a standard for retry budgets that reconciles the known
-  differences in current retry budget functionality between Gateway API data
-  plane implementations.
+* To allow specification of a retry ["budget"](https://finagle.github.io/blog/2016/02/08/retry-budgets/) to determine whether a request should be retried, and any shared configuration or interaction with configuration of a static retry limit within HTTPRoute.
+* To allow specification of a percentage of active requests, or recently active requests, that should be able to be retried concurrently.
+* To allow specification of a *minimum* number of retries that should be allowed per second or concurrently, such that the budget for retries never goes below this minimum value.
+* To define a standard for retry budgets that reconciles the known differences in current retry budget functionality between Gateway API data plane implementations.
 
 ## Non-Goals
 
 * To allow specifying a default retry budget policy across a namespace or attached to a specific gateway.
-* To allow configuration of a backoff strategy or timeout window within the retry budget spec.
+* To allow configuration of a back-off strategy or timeout window within the retry budget spec.
 * To allow specifying inclusion of specific HTTP status codes and responses within the retry budget spec.
-* To allow specification of more than one retry budget for a
-  givne service, for specific subsets of its traffic.
+* To allow specification of more than one retry budget for a given service, for specific subsets of its traffic.
 
 
 ## Introduction
 
-Multiple data plane proxies offer optional configuration for budgeted retries,
-in order to create a dynamic limit on the amount of a service's active request that is being retried across its clients. In the case of Linkerd, retry budgets
-are the default retry policy configuration for HTTP retries within the [ServiceProfile CRD](https://linkerd.io/2.12/reference/service-profiles/), with static max
-retries being a [fairly recent addition](https://linkerd.io/2024/08/13/announcing-linkerd-2.16/).
+Multiple data plane proxies offer optional configuration for budgeted retries, in order to create a dynamic limit on the amount of a service's active request that is being retried across its clients. In the case of Linkerd, retry budgets are the default retry policy configuration for HTTP retries within the [ServiceProfile CRD](https://linkerd.io/2.12/reference/service-profiles/), with static max retries being a [fairly recent addition](https://linkerd.io/2024/08/13/announcing-linkerd-2.16/).
 
-Configuring a limit for client retries is an important factor in building a
-resilient system, allowing requests to be successfully retried during periods
-of intermittent failure. But too many client-side retries can also exacerbate consistent
-failures and slow down recovery, quickly overwhelming a failing
-system and leading to cascading failures such as retry
-storms. Configuring a sane
-limit for max client-side retries is often challenging in complex
-systems. Allowing an application developer (Ana) to configure a dynamic
-"retry budget", reducing the risk of a high number of retries across clients,
-allows a service to perform as expected in both times of high & low request
-load, as well
-as both during periods of intermittent & consistent failures.
+Configuring a limit for client retries is an important factor in building a resilient system, allowing requests to be successfully retried during periods of intermittent failure. But too many client-side retries can also exacerbate consistent failures and slow down recovery, quickly overwhelming a failing system and leading to cascading failures such as retry storms. Configuring a sane limit for max client-side retries is often challenging in complex systems. Allowing an application developer (Ana) to configure a dynamic "retry budget", reducing the risk of a high number of retries across clients, allows a service to perform as expected in both times of high & low request load, as well as both during periods of intermittent & consistent failures.
 
-While HTTPRoute retry budget configuration has been a frequently discussed
-feature within the community, differences in semantics between different data
-plane proxies
-creates a challenge for a consensus on the correct location for the
-configuration.
+While HTTPRoute retry budget configuration has been a frequently discussed feature within the community, differences in semantics between different data plane proxies creates a challenge for a consensus on the correct location for the configuration.
 
-Envoy, for example, offers retry budgets as a configurable circuit breaker threshold
-for concurrent retries to an upstream cluster, in favor of configuring a static
-active retry threshold. In Istio, Envoy circuit breaker
-thresholds are typically configured [within the DestinationRule
-CRD](https://istio.io/latest/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings-HTTPSettings),
-which
-applies rules to clients of a service after routing has already occurred.
-The linkerd implementation of
-retry budgets is configured alongside service route configuration, within the [ServiceProfile CRD](https://linkerd.io/2.12/reference/service-profiles/), limiting the number
-of total retries for a service as a percentage of the number of recent requests.
-This proposal aims to determine where retry budget's should be defined within the
-Gateway API,
-and whether data plane proxies may need to be altered to accommodate the
-specification.
+Envoy, for example, offers retry budgets as a configurable circuit breaker threshold for concurrent retries to an upstream cluster, in favor of configuring a static active retry threshold. In Istio, Envoy circuit breaker thresholds are typically configured [within the DestinationRule CRD](https://istio.io/latest/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings-HTTPSettings), which applies rules to clients of a service after routing has already occurred. The linkerd implementation of retry budgets is configured alongside service route configuration, within the [ServiceProfile CRD](https://linkerd.io/2.12/reference/service-profiles/), limiting the number of total retries for a service as a percentage of the number of recent requests. This proposal aims to determine where retry budget's should be defined within the Gateway API, and whether data plane proxies may need to be altered to accommodate the specification.
 
 ### Background on implementations
 
 #### Envoy
 
-Supports configuring a
-[RetryBudget](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-msg-config-cluster-v3-circuitbreakers-thresholds-retrybudget)
-CircuitBreaker threshold across a group of upstream endpoints, with the following parameters.
+Supports configuring a [RetryBudget](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-msg-config-cluster-v3-circuitbreakers-thresholds-retrybudget) CircuitBreaker threshold across a group of upstream endpoints, with the following parameters.
 
 * `budget_percent` Specifies the limit on concurrent retries as a percentage of the sum of active requests and active pending requests. For example, if there are 100 active requests and the budget_percent is set to 25, there may be 25 active retries. This parameter is optional. Defaults to 20%.
 
@@ -93,12 +48,7 @@ CircuitBreaker threshold across a group of upstream endpoints, with the followin
 
 Linkerd supports [budgeted retries](https://linkerd.io/2.15/features/retries-and-timeouts/), the default way to specify retries to a service, and - as of [edge-24.7.5](https://github.com/linkerd/linkerd2/releases/tag/edge-24.7.5) - counted retries. In all cases, retries are implemented by the `linkerd2-proxy` making the request on behalf on an application workload.
 
-Linkerd's budgeted retries allow retrying an indefinite number of times, as
-long as the fraction of retries remains within the budget. Budgeted retries are
-supported only using Linkerd's native ServiceProfile CRD, which allows enabling
-retries, setting the retry budget (by default, 20% plus 10 "extra" retries per
-second), and configuring the window over which the fraction of retries to
-non-retries is calculated.
+Linkerd's budgeted retries allow retrying an indefinite number of times, as long as the fraction of retries remains within the budget. Budgeted retries are supported only using Linkerd's native ServiceProfile CRD, which allows enabling retries, setting the retry budget (by default, 20% plus 10 "extra" retries per second), and configuring the window over which the fraction of retries to non-retries is calculated.
 
 ## API
 

--- a/geps/gep-3388/index.md
+++ b/geps/gep-3388/index.md
@@ -104,17 +104,25 @@ non-retries is calculated.
 
 ### Go
 
+TODO
 
 ### YAML
 
+TODO
+
 ## Conformance Details
 
+TODO
 
 ## Alternatives
 
 ### Policy Attachment
 
+TODO
+
 ## Other considerations
+
+TODO
 
 ### What accommodations are needed for retry budget support?
 

--- a/geps/gep-3388/index.md
+++ b/geps/gep-3388/index.md
@@ -1,0 +1,134 @@
+# GEP-3388: HTTPRoute Retry Budget
+
+* Issue: [#3388](https://github.com/kubernetes-sigs/gateway-api/issues/3388)
+* Status: Provisional
+
+(See status definitions [here](/geps/overview/#gep-states).)
+
+## TLDR
+
+To allow budgeted retry configuration of a Gateway, in order to retry unsuccessful requests based on a percentage of it's
+active request load, as opposed to a static max retry value.
+
+## Goals
+
+* To allow specification of a retry
+  ["budget"](https://finagle.github.io/blog/2016/02/08/retry-budgets/) to
+  determine whether a request should be retried, and any shared configuration
+  or interaction with max count retry configuration.
+* To allow specification of the percentage of active requests that should be able to be retried at the same time.
+* To allow specification of the minimum number of retries that should be
+  allowed per second or concurrently, such that the budget for retries never
+  goes below this minimum value.
+* To define a standard for retry budgets that reconciles the known
+  differences in retry budget functionality between Gateway API implementations.
+
+## Future Goals
+
+## Non-Goals
+
+## Introduction
+
+Multiple data plane proxies offer optional configuration for budgeted retries,
+either as a circuit breaker threshold for concurrent retries or as an
+alternative for configuring a
+static retry limit for client retries. In the case of Linkerd, retry budgets
+are the default retry policy configuration for HTTP retries, with static max
+retries being a fairly recent addition.
+
+Configuring a limit for client retries is an important factor in building a
+resilient system in order to
+allow for requests to be successfully retried during periods of intermittent
+failure. But too many client-side retries can also exacerbate consistent
+failures and slow down recovery, quickly overwhelming a failing
+system and leading to retry
+storms. Configuring a sane
+limit for max client-side retries is often challenging in complex
+systems. Allowing an application developer (Ana) to instead configure a dynamic
+"retry budget" prevents them from needing to decide on a static max retry value
+that will perform as expected in both times of high & low request load, as well
+as periods of intermittent or consistent failures.
+
+While HTTPRoute retry budget configuration has been a frequently discussed
+feature within the community, differences in semantics between different data
+plane proxies
+creates a challenge for a consensus on the correct location for the
+configuration.
+
+Envoy, for example, offers retry budgets as a configurable circuit breaker threshold
+for concurrent retries to an upstream cluster. In Istio, Envoy circuit breaker
+thresholds are typically configured [within the DestinationRule
+CRD](https://istio.io/latest/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings-HTTPSettings),
+which
+applies rules to clients of a service after routing has already occurred.
+The linkerd implementation of
+retry budgets is configured on specific routes, and instead limits the number
+of total retry attempts as a percentage of original requests. This creates a
+challenge for
+defining where retry budget's should be configured within the Gateway API,
+and how data plane proxies may need to be altered to accommodate the correct
+path forward. If Istio were to implement Envoy's retry budget threshold also
+at the per-route level in their API, retry budget
+configuration would need to be introduced within [the VirtualService
+CRD](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRetry).
+Envoy's retry budget threshold does not address overall retry attempts on the
+client-side, though. A potential solution would be for Envoy to additionally
+allow a budget for retry *attempts* as well as a concurrent retry threshold.
+
+When configuring a retry budget on the route, you
+subsequently need to define this value for each one. Defining a single
+retry budget threshold for a destination is a simpler approach.
+
+### Background on implementations
+
+
+#### Envoy
+
+Supports configuring a [RetryBudget](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-msg-config-cluster-v3-circuitbreakers-thresholds-retrybudget) with a following parameters in cluster CircuitBreaker thresholds.
+
+* `budget_percent` Specifies the limit on concurrent retries as a percentage of the sum of active requests and active pending requests. For example, if there are 100 active requests and the budget_percent is set to 25, there may be 25 active retries. This parameter is optional. Defaults to 20%.
+
+* `min_retry_concurrency` Specifies the minimum retry concurrency allowed for the retry budget. The limit on the number of active retries may never go below this number. This parameter is optional. Defaults to 3.
+
+#### NGINX
+
+
+#### HAProxy
+
+
+#### Traefik
+
+Supports configuration of a [Circuit Breaker](https://doc.traefik.io/traefik/middlewares/http/circuitbreaker/) which could possibly be used to implement budgeted retries. Each router gets its own instance of a given circuit breaker. One circuit breaker instance can be open while the other remains closed: their state is not shared. This is the expected behavior, we want you to be able to define what makes a service healthy without having to declare a circuit breaker for each route.
+
+#### linkerd2-proxy
+
+Linkerd supports [budgeted retries](https://linkerd.io/2.15/features/retries-and-timeouts/) and - as of [edge-24.7.5](https://github.com/linkerd/linkerd2/releases/tag/edge-24.7.5) - counted retries. In all cases, retries are implemented by the `linkerd2-proxy` making the request on behalf on an application workload.
+
+Linkerd's budgeted retries allow retrying an indefinite number of times, as long as the fraction of retries remains within the budget. Budgeted retries are supported only using Linkerd's native ServiceProfile CRD, which allows enabling retries, setting the retry budget (by default, 20% plus 10 "extra" retries per second), and configuring the window over which the fraction of retries to non-retries is calculated.
+
+## API
+
+### Go
+
+
+### YAML
+
+## Conformance Details
+
+
+## Alternatives
+
+### Policy Attachment
+
+## Other considerations
+
+### What accommodations are needed for retry budget support?
+
+Changing the retry stanza to a Kubernetes "tagged union" pattern with something like `mode: "budget"` to support mutually-exclusive distinct sibling fields is possible as a non-breaking change if omitting the `mode` field defaults to the currently proposed behavior (which could retroactively become something like `mode: count`).
+
+## References
+
+* <https://gateway-api.sigs.k8s.io/geps/gep-1731/>
+* <https://linkerd.io/2019/02/22/how-we-designed-retries-in-linkerd-2-2/>
+* <https://linkerd.io/2.11/tasks/configuring-retries/>
+* <https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#config-cluster-v3-circuitbreakers-thresholds-retrybudget>

--- a/geps/gep-3388/index.md
+++ b/geps/gep-3388/index.md
@@ -7,7 +7,7 @@
 
 ## TLDR
 
-To allow configuration of a "retry budget" in HTTPRoute, to limit the rate of client-side retries based on a percentage of the active request load across all endpoints of a destination service.
+To allow configuration of a "retry budget" in HTTPRoute, to determine when to prevent additional client-side retries, by limiting the percentage of the active request load that may consist of retries, across all endpoints of a destination service.
 
 ## Goals
 
@@ -32,7 +32,7 @@ Configuring a limit for client retries is an important factor in building a resi
 
 While HTTPRoute retry budget configuration has been a frequently discussed feature within the community, differences in semantics between different data plane proxies creates a challenge for a consensus on the correct location for the configuration.
 
-Envoy, for example, offers retry budgets as a configurable circuit breaker threshold for concurrent retries to an upstream cluster, in favor of configuring a static active retry threshold. In Istio, Envoy circuit breaker thresholds are typically configured [within the DestinationRule CRD](https://istio.io/latest/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings-HTTPSettings), which applies rules to clients of a service after routing has already occurred. The linkerd implementation of retry budgets is configured alongside service route configuration, within the [ServiceProfile CRD](https://linkerd.io/2.12/reference/service-profiles/), limiting the number of total retries for a service as a percentage of the number of recent requests. This proposal aims to determine where retry budget's should be defined within the Gateway API, and whether data plane proxies may need to be altered to accommodate the specification.
+Envoy, for example, offers retry budgets as a configurable circuit breaker threshold for concurrent retries to an upstream cluster, in favor of configuring a static active retry threshold. In Istio, Envoy circuit breaker thresholds are typically configured [within the DestinationRule CRD](https://istio.io/latest/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings-HTTPSettings), which applies rules to clients of a service after routing has already occurred. The Linkerd implementation of retry budgets is configured alongside service route configuration, within the [ServiceProfile CRD](https://linkerd.io/2.12/reference/service-profiles/), limiting the number of total retries for a service as a percentage of the number of recent requests. This proposal aims to determine where retry budget's should be defined within the Gateway API, and whether data plane proxies may need to be altered to accommodate the specification.
 
 ### Background on implementations
 

--- a/geps/gep-3388/index.md
+++ b/geps/gep-3388/index.md
@@ -7,48 +7,53 @@
 
 ## TLDR
 
-To allow configuration of a "retry budget" in HTTPRoute, to make total
-client-side retries a percentage of a destination service's active request
-load, in place of configuring a static max count retry value.
+To allow configuration of a "retry budget" in HTTPRoute, to limit the rate of
+client-side retries based on a percentage of the active request load across all
+endpoints of a destination service.
 
 ## Goals
 
 * To allow specification of a retry
   ["budget"](https://finagle.github.io/blog/2016/02/08/retry-budgets/) to
   determine whether a request should be retried, and any shared configuration
-  or interaction with max count retry configuration.
-* To allow specification of a percentage of active requests that should be able
+  or interaction with configuration of a static retry limit within HTTPRoute.
+* To allow specification of a percentage of active requests, or recently active
+  requests, that should be able
   to be retried concurrently.
 * To allow specification of a *minimum* number of retries that should be
   allowed per second or concurrently, such that the budget for retries never
   goes below this minimum value.
 * To define a standard for retry budgets that reconciles the known
-  differences in retry budget functionality between Gateway API data plane
-  implementations.
-
-## Future Goals
+  differences in current retry budget functionality between Gateway API data
+  plane implementations.
 
 ## Non-Goals
+
+* To allow specifying a default retry budget policy across a namespace or attached to a specific gateway.
+* To allow configuration of a backoff strategy or timeout window within the retry budget spec.
+* To allow specifying inclusion of specific HTTP status codes and responses within the retry budget spec.
+* To allow specification of more than one retry budget for a
+  givne service, for specific subsets of its traffic.
+
 
 ## Introduction
 
 Multiple data plane proxies offer optional configuration for budgeted retries,
-either as a circuit breaker threshold for concurrent retries, or as an
-alternative for configuring a
-static retry limit for client retries. In the case of Linkerd, retry budgets
-are the default retry policy configuration for HTTP retries, with static max
+in order to create a dynamic limit on the amount of a service's active request that is being retried across its clients. In the case of Linkerd, retry budgets
+are the default retry policy configuration for HTTP retries within the [ServiceProfile CRD](https://linkerd.io/2.12/reference/service-profiles/), with static max
 retries being a [fairly recent addition](https://linkerd.io/2024/08/13/announcing-linkerd-2.16/).
 
 Configuring a limit for client retries is an important factor in building a
 resilient system, allowing requests to be successfully retried during periods
 of intermittent failure. But too many client-side retries can also exacerbate consistent
 failures and slow down recovery, quickly overwhelming a failing
-system and leading to retry
+system and leading to cascading failures such as retry
 storms. Configuring a sane
 limit for max client-side retries is often challenging in complex
-systems. Allowing an application developer (Ana) to instead configure a dynamic
-"retry budget", prevents them from needing to decide on a static max retry value
-that will perform as expected in both times of high & low request load, as well
+systems. Allowing an application developer (Ana) to configure a dynamic
+"retry budget", reducing the risk of a high number of retries across clients,
+allows a service to perform as expected in both times of high & low request
+load, as well
 as both during periods of intermittent & consistent failures.
 
 While HTTPRoute retry budget configuration has been a frequently discussed
@@ -58,49 +63,42 @@ creates a challenge for a consensus on the correct location for the
 configuration.
 
 Envoy, for example, offers retry budgets as a configurable circuit breaker threshold
-for concurrent retries to an upstream cluster. In Istio, Envoy circuit breaker
+for concurrent retries to an upstream cluster, in favor of configuring a static
+active retry threshold. In Istio, Envoy circuit breaker
 thresholds are typically configured [within the DestinationRule
 CRD](https://istio.io/latest/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings-HTTPSettings),
 which
 applies rules to clients of a service after routing has already occurred.
 The linkerd implementation of
-retry budgets is configured within the ServiceProfile CRD, limiting the number
-of total retry attempts across routes as a percentage of original requests.
-This creates a question of where retry budget's should be defined within the
+retry budgets is configured alongside service route configuration, within the [ServiceProfile CRD](https://linkerd.io/2.12/reference/service-profiles/), limiting the number
+of total retries for a service as a percentage of the number of recent requests.
+This proposal aims to determine where retry budget's should be defined within the
 Gateway API,
-and whether data plane proxies may need to be altered to accommodate the correct
-path forward. If Istio were to implement Envoy's retry budget
-threshold where
-routing occurs in their API, retry budget
-configuration would need to be introduced within [the VirtualService
-CRD](https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRetry).
+and whether data plane proxies may need to be altered to accommodate the
+specification.
 
 ### Background on implementations
 
-
 #### Envoy
 
-Supports configuring a [RetryBudget](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-msg-config-cluster-v3-circuitbreakers-thresholds-retrybudget) with a following parameters in cluster CircuitBreaker thresholds.
+Supports configuring a
+[RetryBudget](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-msg-config-cluster-v3-circuitbreakers-thresholds-retrybudget)
+CircuitBreaker threshold across a group of upstream endpoints, with the following parameters.
 
 * `budget_percent` Specifies the limit on concurrent retries as a percentage of the sum of active requests and active pending requests. For example, if there are 100 active requests and the budget_percent is set to 25, there may be 25 active retries. This parameter is optional. Defaults to 20%.
 
 * `min_retry_concurrency` Specifies the minimum retry concurrency allowed for the retry budget. The limit on the number of active retries may never go below this number. This parameter is optional. Defaults to 3.
 
-#### NGINX
-
-
-#### HAProxy
-
-
-#### Traefik
-
-Supports configuration of a [Circuit Breaker](https://doc.traefik.io/traefik/middlewares/http/circuitbreaker/) which could possibly be used to implement budgeted retries. Each router gets its own instance of a given circuit breaker. One circuit breaker instance can be open while the other remains closed: their state is not shared. This is the expected behavior, we want you to be able to define what makes a service healthy without having to declare a circuit breaker for each route.
-
 #### linkerd2-proxy
 
-Linkerd supports [budgeted retries](https://linkerd.io/2.15/features/retries-and-timeouts/) and - as of [edge-24.7.5](https://github.com/linkerd/linkerd2/releases/tag/edge-24.7.5) - counted retries. In all cases, retries are implemented by the `linkerd2-proxy` making the request on behalf on an application workload.
+Linkerd supports [budgeted retries](https://linkerd.io/2.15/features/retries-and-timeouts/), the default way to specify retries to a service, and - as of [edge-24.7.5](https://github.com/linkerd/linkerd2/releases/tag/edge-24.7.5) - counted retries. In all cases, retries are implemented by the `linkerd2-proxy` making the request on behalf on an application workload.
 
-Linkerd's budgeted retries allow retrying an indefinite number of times, as long as the fraction of retries remains within the budget. Budgeted retries are supported only using Linkerd's native ServiceProfile CRD, which allows enabling retries, setting the retry budget (by default, 20% plus 10 "extra" retries per second), and configuring the window over which the fraction of retries to non-retries is calculated.
+Linkerd's budgeted retries allow retrying an indefinite number of times, as
+long as the fraction of retries remains within the budget. Budgeted retries are
+supported only using Linkerd's native ServiceProfile CRD, which allows enabling
+retries, setting the retry budget (by default, 20% plus 10 "extra" retries per
+second), and configuring the window over which the fraction of retries to
+non-retries is calculated.
 
 ## API
 

--- a/geps/gep-3388/index.md
+++ b/geps/gep-3388/index.md
@@ -101,7 +101,6 @@ TODO
 
 ## Other considerations
 
-* Is it worth allowing the budget to be expressed as a `Fraction` similar to `HTTPRequestMirrorFilter` as described in [GEP-3171](https://gateway-api.sigs.k8s.io/geps/gep-3171/), or is a percentage sufficient for this use case? (Expressing a sub-1% budget for retries seems less necessary than for mirroring or redirecting traffic at significant scale.)
 * As there isn't anything inherently specific to HTTP requests in either known implementation, a retry budget policy on a target Service could likely be applicable to GRPCRoute as well as HTTPRoute requests.
 * While retry budgets are commonly associated with service mesh uses cases to handle many distributed clients, a retry budget policy may also be desirable for north/south implementations of Gateway API to prioritize new inbound requests and minimize tail latency during periods of service instability.
 

--- a/geps/gep-3388/metadata.yaml
+++ b/geps/gep-3388/metadata.yaml
@@ -1,0 +1,45 @@
+apiVersion: internal.gateway.networking.k8s.io/v1alpha1
+kind: GEPDetails
+number: 1731
+name: HTTPRoute Retries
+status: Experimental
+# Any authors who contribute to the GEP in any way should be listed here using
+# their Github handle.
+authors:
+  - mikemorris
+relationships:
+  # obsoletes indicates that a GEP makes the linked GEP obsolete, and completely
+  # replaces that GEP. The obsoleted GEP MUST have its obsoletedBy field
+  # set back to this GEP, and MUST be moved to Declined.
+  obsoletes: {}
+  obsoletedBy: {}
+  # extends indicates that a GEP extends the linkned GEP, adding more detail
+  # or additional implementation. The extended GEP MUST have its extendedBy
+  # field set back to this GEP.
+  extends: {}
+  extendedBy: {}
+  # seeAlso indicates other GEPs that are relevant in some way without being
+  # covered by an existing relationship.
+  seeAlso:
+    - number: 2257
+      name: Gateway API Duration Format
+      description: Uses duration format introduced in this GEP.
+    - number: 1742
+      name: HTTPRoute Timeouts
+      description: Covers some overlapping considerations around when requests should be retried.
+# references is a list of hyperlinks to relevant external references.
+# It's intended to be used for storing Github discussions, Google docs, etc.
+references:
+  - https://www.rfc-editor.org/rfc/rfc9110
+  - https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+# featureNames is a list of the feature names introduced by the GEP, if there
+# are any. This will allow us to track which feature was introduced by which GEP.
+featureNames:
+  - SupportHTTPRouteRetry
+  - SupportHTTPRouteRetryBackendTimeout
+  - SupportHTTPRouteRetryBackoff
+  - SupportHTTPRouteRetryCodes
+  - SupportHTTPRouteRetryConnectionError
+# changelog is a list of hyperlinks to PRs that make changes to the GEP, in
+# ascending date order.
+changelog: {}

--- a/geps/gep-3388/metadata.yaml
+++ b/geps/gep-3388/metadata.yaml
@@ -1,7 +1,7 @@
 apiVersion: internal.gateway.networking.k8s.io/v1alpha1
 kind: GEPDetails
 number: 3388
-name: HTTPRoute Retry Budget
+name: HTTP Retry Budget
 status: Provisional
 # Any authors who contribute to the GEP in any way should be listed here using
 # their Github handle.

--- a/geps/gep-3388/metadata.yaml
+++ b/geps/gep-3388/metadata.yaml
@@ -1,11 +1,12 @@
 apiVersion: internal.gateway.networking.k8s.io/v1alpha1
 kind: GEPDetails
-number: 1731
-name: HTTPRoute Retries
-status: Experimental
+number: 3388
+name: HTTPRoute Retry Budget
+status: Provisional
 # Any authors who contribute to the GEP in any way should be listed here using
 # their Github handle.
 authors:
+  - ericdbishop
   - mikemorris
 relationships:
   # obsoletes indicates that a GEP makes the linked GEP obsolete, and completely
@@ -16,30 +17,19 @@ relationships:
   # extends indicates that a GEP extends the linkned GEP, adding more detail
   # or additional implementation. The extended GEP MUST have its extendedBy
   # field set back to this GEP.
-  extends: {}
+  extends:
+    - number: 1731
+      name: HTTPRoute Retries
   extendedBy: {}
   # seeAlso indicates other GEPs that are relevant in some way without being
   # covered by an existing relationship.
-  seeAlso:
-    - number: 2257
-      name: Gateway API Duration Format
-      description: Uses duration format introduced in this GEP.
-    - number: 1742
-      name: HTTPRoute Timeouts
-      description: Covers some overlapping considerations around when requests should be retried.
+  seeAlso: {}
 # references is a list of hyperlinks to relevant external references.
 # It's intended to be used for storing Github discussions, Google docs, etc.
-references:
-  - https://www.rfc-editor.org/rfc/rfc9110
-  - https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+references: {}
 # featureNames is a list of the feature names introduced by the GEP, if there
 # are any. This will allow us to track which feature was introduced by which GEP.
-featureNames:
-  - SupportHTTPRouteRetry
-  - SupportHTTPRouteRetryBackendTimeout
-  - SupportHTTPRouteRetryBackoff
-  - SupportHTTPRouteRetryCodes
-  - SupportHTTPRouteRetryConnectionError
+featureNames: {}
 # changelog is a list of hyperlinks to PRs that make changes to the GEP, in
 # ascending date order.
 changelog: {}

--- a/geps/gep-3388/metadata.yaml
+++ b/geps/gep-3388/metadata.yaml
@@ -1,7 +1,7 @@
 apiVersion: internal.gateway.networking.k8s.io/v1alpha1
 kind: GEPDetails
 number: 3388
-name: HTTP Retry Budget
+name: Retry Budgets
 status: Provisional
 # Any authors who contribute to the GEP in any way should be listed here using
 # their Github handle.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - geps/gep-1867/index.md
       - geps/gep-2648/index.md
       - geps/gep-2649/index.md
+      - geps/gep-3388/index.md
     - Implementable:
       - geps/gep-3155/index.md
     - Experimental:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind gep

**What this PR does / why we need it**:

To seek consensus on the ideal configuration of a "retry budget" in HTTPRoute, allowing application developers to dynamically limit the rate of client-side retries to their service based on a percentage of the active request volume.

Extends #1731

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3388

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
