### PR TITLE
chore: bump Kind and test k8s 1.28->1.32

### DIFF
--- a/hack/test-crds-validation.sh
+++ b/hack/test-crds-validation.sh
@@ -42,16 +42,16 @@ cleanup() {
 trap cleanup INT TERM EXIT
 
 # TODO(mlavacca): find a good way to keep this dependency up to date.
-KIND_VERSION="v0.24.0"
+KIND_VERSION="v0.26.0"
 
-# list of kind images taken from https://github.com/kubernetes-sigs/kind/releases/tag/v0.24.0.
+# list of kind images taken from https://github.com/kubernetes-sigs/kind/releases/tag/v0.26.0.
 # they need to be updated when kind is updated.
 KIND_IMAGES=(
-  "kindest/node:v1.27.17@sha256:3fd82731af34efe19cd54ea5c25e882985bafa2c9baefe14f8deab1737d9fabe"
-  "kindest/node:v1.28.13@sha256:45d319897776e11167e4698f6b14938eb4d52eb381d9e3d7a9086c16c69a8110"
-  "kindest/node:v1.29.8@sha256:d46b7aa29567e93b27f7531d258c372e829d7224b25e3fc6ffdefed12476d3aa"
-  "kindest/node:v1.30.4@sha256:976ea815844d5fa93be213437e3ff5754cd599b040946b5cca43ca45c2047114"
-  "kindest/node:v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865"
+  "kindest/node:v1.28.15@sha256:a7c05c7ae043a0b8c818f5a06188bc2c4098f6cb59ca7d1856df00375d839251"
+  "kindest/node:v1.29.12@sha256:62c0672ba99a4afd7396512848d6fc382906b8f33349ae68fb1dbfe549f70dec"
+  "kindest/node:v1.30.8@sha256:17cd608b3971338d9180b00776cb766c50d0a0b6b904ab4ff52fd3fc5c6369bf"
+  "kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30"
+  "kindest/node:v1.32.0@sha256:2458b423d635d7b01637cac2d6de7e1c1dca1148a2ba2e90975e214ca849e7cb"
 )
 
 if [ "$#" -gt 1 ]; then

--- a/pkg/test/cel/main_test.go
+++ b/pkg/test/cel/main_test.go
@@ -65,9 +65,14 @@ func celErrorStringMatches(got, want string) bool {
 	gotL := strings.ToLower(got)
 	wantL := strings.ToLower(want)
 
+	// Starting in k8s v1.32, some CEL error messages changed to use "more" instead of "longer"
+	alternativeWantL := strings.ReplaceAll(wantL, "longer", "more")
+
 	// Starting in k8s v1.28, CEL error messages stopped adding spec and status prefixes to path names
 	wantLAdjusted := strings.ReplaceAll(wantL, "spec.", "")
 	wantLAdjusted = strings.ReplaceAll(wantLAdjusted, "status.", "")
+	alternativeWantL = strings.ReplaceAll(alternativeWantL, "spec.", "")
+	alternativeWantL = strings.ReplaceAll(alternativeWantL, "status.", "")
 
 	// Enum validation messages changed in k8s v1.28:
 	// Before: must be one of ['Exact', 'PathPrefix', 'RegularExpression']
@@ -81,5 +86,5 @@ func celErrorStringMatches(got, want string) bool {
 		)
 		wantLAdjusted = r.Replace(wantLAdjusted)
 	}
-	return strings.Contains(gotL, wantL) || strings.Contains(gotL, wantLAdjusted)
+	return strings.Contains(gotL, wantL) || strings.Contains(gotL, wantLAdjusted) || strings.Contains(gotL, alternativeWantL)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind test

**What this PR does / why we need it**:

Kind is bumped to 0.26 and the tested kubernetes versions now are:
- 1.32.0
- 1.31.4
- 1.30.8
- 1.29.12
- 1.28.15

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
