### PR TITLE
increase timeout of MaxTimeToConsistency

### DIFF
--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -120,7 +120,7 @@ func DefaultTimeoutConfig() TimeoutConfig {
 		TLSRouteMustHaveCondition:          60 * time.Second,
 		RouteMustHaveParents:               60 * time.Second,
 		ManifestFetchTimeout:               10 * time.Second,
-		MaxTimeToConsistency:               30 * time.Second,
+		MaxTimeToConsistency:               90 * time.Second,
 		NamespacesMustBeReady:              300 * time.Second,
 		RequestTimeout:                     10 * time.Second,
 		LatestObservedGenerationSet:        60 * time.Second,


### PR DESCRIPTION
**What type of PR is this?**

/area conformance


**What this PR does / why we need it**:

When executing conformance test on AWS platform we found the AWS ELB needs about 60s for DNS propagation, some tests failed due to timeout and the logs look like:
```
    http.go:235: 2025-01-10T19:26:43.485792184+08:00: Request failed, not ready yet: Get "http://a07f90a89d57542ea85a21d458419cb7-1697596113.us-east-2.elb.amazonaws.com/s3": dial tcp: lookup a07f90a89d57542ea85a21d458419cb7-1697596113.us-east-2.elb.amazonaws.com: no such host (after 29.084124971s)
    http.go:221: 2025-01-10T19:26:44.400442594+08:00: timeout while waiting after 30 attempts, 0/3 successes
```
After increase the timeout of `MaxTimeToConsistency` to 90s, the tests passed and the logs look like:
```
    http.go:233: Request failed, not ready yet: Get "http://a8e79a0f084034f56a07a703284ceb75-207388715.us-east-2.elb.amazonaws.com/non-matching-prefix": dial tcp: lookup a8e79a0f084034f56a07a703284ceb75-207388715.us-east-2.elb.amazonaws.com: no such host (after 59.079967411s)
    http.go:244: Request passed
``` 
And from this log, we learned that the AWS ELB DNS propagation needs ~60s.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
