### PR TITLE
Remove extra newlines and format descriptions of items

### DIFF
--- a/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -238,7 +238,7 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               supportedFeatures:
-                description: |
+                description: |-
                   SupportedFeatures is the set of features the GatewayClass support.
                   It MUST be sorted in ascending alphabetical order by the Name key.
                 items:
@@ -482,7 +482,7 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               supportedFeatures:
-                description: |
+                description: |-
                   SupportedFeatures is the set of features the GatewayClass support.
                   It MUST be sorted in ascending alphabetical order by the Name key.
                 items:

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -61,7 +61,7 @@ spec:
             description: Spec defines the desired state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses requested for this Gateway. This is optional and behavior can
                   depend on the implementation. If a value is set in the spec and the
                   requested address is invalid or unavailable, the implementation MUST
@@ -82,7 +82,6 @@ spec:
                   GatewayStatus.Addresses.
 
                   Support: Extended
-
                 items:
                   description: GatewayAddress describes an address that can be bound
                     to a Gateway.
@@ -135,15 +134,14 @@ spec:
                   rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
                     a2.type == a1.type && a2.value == a1.value) : true )'
               backendTLS:
-                description: |+
+                description: |-
                   BackendTLS configures TLS settings for when this Gateway is connecting to
                   backends with TLS.
 
                   Support: Core
-
                 properties:
                   clientCertificateRef:
-                    description: |+
+                    description: |-
                       ClientCertificateRef is a reference to an object that contains a Client
                       Certificate and the associated private key.
 
@@ -159,7 +157,6 @@ spec:
                       This setting can be overridden on the service level by use of BackendTLSPolicy.
 
                       Support: Core
-
                     properties:
                       group:
                         default: ""
@@ -782,7 +779,7 @@ spec:
                           maxItems: 64
                           type: array
                         frontendValidation:
-                          description: |+
+                          description: |-
                             FrontendValidation holds configuration information for validating the frontend (client).
                             Setting this field will require clients to send a client certificate
                             required for validation during the TLS handshake. In browsers this may result in a dialog appearing
@@ -790,7 +787,6 @@ spec:
                             The maximum depth of a certificate chain accepted in verification is Implementation specific.
 
                             Support: Extended
-
                           properties:
                             caCertificateRefs:
                               description: |-
@@ -967,7 +963,7 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses lists the network addresses that have been bound to the
                   Gateway.
 
@@ -977,7 +973,6 @@ spec:
                     * no addresses are specified, all addresses are dynamically assigned
                     * a combination of specified and dynamic addresses are assigned
                     * a specified address was unusable (e.g. already in use)
-
                 items:
                   description: GatewayStatusAddress describes a network address that
                     is bound to a Gateway.
@@ -1295,7 +1290,7 @@ spec:
             description: Spec defines the desired state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses requested for this Gateway. This is optional and behavior can
                   depend on the implementation. If a value is set in the spec and the
                   requested address is invalid or unavailable, the implementation MUST
@@ -1316,7 +1311,6 @@ spec:
                   GatewayStatus.Addresses.
 
                   Support: Extended
-
                 items:
                   description: GatewayAddress describes an address that can be bound
                     to a Gateway.
@@ -1369,15 +1363,14 @@ spec:
                   rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
                     a2.type == a1.type && a2.value == a1.value) : true )'
               backendTLS:
-                description: |+
+                description: |-
                   BackendTLS configures TLS settings for when this Gateway is connecting to
                   backends with TLS.
 
                   Support: Core
-
                 properties:
                   clientCertificateRef:
-                    description: |+
+                    description: |-
                       ClientCertificateRef is a reference to an object that contains a Client
                       Certificate and the associated private key.
 
@@ -1393,7 +1386,6 @@ spec:
                       This setting can be overridden on the service level by use of BackendTLSPolicy.
 
                       Support: Core
-
                     properties:
                       group:
                         default: ""
@@ -2016,7 +2008,7 @@ spec:
                           maxItems: 64
                           type: array
                         frontendValidation:
-                          description: |+
+                          description: |-
                             FrontendValidation holds configuration information for validating the frontend (client).
                             Setting this field will require clients to send a client certificate
                             required for validation during the TLS handshake. In browsers this may result in a dialog appearing
@@ -2024,7 +2016,6 @@ spec:
                             The maximum depth of a certificate chain accepted in verification is Implementation specific.
 
                             Support: Extended
-
                           properties:
                             caCertificateRefs:
                               description: |-
@@ -2201,7 +2192,7 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses lists the network addresses that have been bound to the
                   Gateway.
 
@@ -2211,7 +2202,6 @@ spec:
                     * no addresses are specified, all addresses are dynamically assigned
                     * a combination of specified and dynamic addresses are assigned
                     * a specified address was unusable (e.g. already in use)
-
                 items:
                   description: GatewayStatusAddress describes a network address that
                     is bound to a Gateway.

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -152,7 +152,7 @@ spec:
                 maxItems: 16
                 type: array
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -214,11 +214,6 @@ spec:
                   connections originating from the same namespace as the Route, for which
                   the intended destination of the connections are a Service targeted as a
                   ParentRef of the Route.
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -392,9 +387,7 @@ spec:
                     || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
                     == p2.port))))
               rules:
-                description: |+
-                  Rules are a list of GRPC matchers, filters and actions.
-
+                description: Rules are a list of GRPC matchers, filters and actions.
                 items:
                   description: |-
                     GRPCRouteRule defines the semantics for matching a gRPC request based on
@@ -440,7 +433,6 @@ spec:
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
 
-                          <gateway:experimental:description>
 
                           When the BackendRef points to a Kubernetes Service, implementations SHOULD
                           honor the appProtocol field if it is set for the target Service Port.
@@ -455,8 +447,6 @@ spec:
                           If a Route is not able to send traffic to the backend using the specified
                           protocol then the backend is considered invalid. Implementations MUST set the
                           "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-                          </gateway:experimental:description>
                         properties:
                           filters:
                             description: |-
@@ -645,7 +635,7 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 requestMirror:
-                                  description: |+
+                                  description: |-
                                     RequestMirror defines a schema for a filter that mirrors requests.
                                     Requests are sent to the specified destination, but responses from
                                     that destination are ignored.
@@ -655,7 +645,6 @@ spec:
                                     backends.
 
                                     Support: Extended
-
                                   properties:
                                     backendRef:
                                       description: |-
@@ -751,13 +740,12 @@ spec:
                                         rule: '(size(self.group) == 0 && self.kind
                                           == ''Service'') ? has(self.port) : true'
                                     fraction:
-                                      description: |+
+                                      description: |-
                                         Fraction represents the fraction of requests that should be
                                         mirrored to BackendRef.
 
                                         Only one of Fraction or Percent may be specified. If neither field
                                         is specified, 100% of requests will be mirrored.
-
                                       properties:
                                         denominator:
                                           default: 100
@@ -776,14 +764,13 @@ spec:
                                           to denominator
                                         rule: self.numerator <= self.denominator
                                     percent:
-                                      description: |+
+                                      description: |-
                                         Percent represents the percentage of requests that should be
                                         mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
                                         requests) and its maximum value is 100 (indicating 100% of requests).
 
                                         Only one of Fraction or Percent may be specified. If neither field
                                         is specified, 100% of requests will be mirrored.
-
                                       format: int32
                                       maximum: 100
                                       minimum: 0
@@ -931,7 +918,7 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 type:
-                                  description: |+
+                                  description: |-
                                     Type identifies the type of filter to apply. As with other API fields,
                                     types are classified into three conformance levels:
 
@@ -956,7 +943,6 @@ spec:
                                     If a reference to a custom filter type cannot be resolved, the filter
                                     MUST NOT be skipped. Instead, requests that would have been processed by
                                     that filter MUST receive a HTTP error response.
-
                                   enum:
                                   - ResponseHeaderModifier
                                   - RequestHeaderModifier
@@ -1298,7 +1284,7 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           requestMirror:
-                            description: |+
+                            description: |-
                               RequestMirror defines a schema for a filter that mirrors requests.
                               Requests are sent to the specified destination, but responses from
                               that destination are ignored.
@@ -1308,7 +1294,6 @@ spec:
                               backends.
 
                               Support: Extended
-
                             properties:
                               backendRef:
                                 description: |-
@@ -1404,13 +1389,12 @@ spec:
                                   rule: '(size(self.group) == 0 && self.kind == ''Service'')
                                     ? has(self.port) : true'
                               fraction:
-                                description: |+
+                                description: |-
                                   Fraction represents the fraction of requests that should be
                                   mirrored to BackendRef.
 
                                   Only one of Fraction or Percent may be specified. If neither field
                                   is specified, 100% of requests will be mirrored.
-
                                 properties:
                                   denominator:
                                     default: 100
@@ -1429,14 +1413,13 @@ spec:
                                     denominator
                                   rule: self.numerator <= self.denominator
                               percent:
-                                description: |+
+                                description: |-
                                   Percent represents the percentage of requests that should be
                                   mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
                                   requests) and its maximum value is 100 (indicating 100% of requests).
 
                                   Only one of Fraction or Percent may be specified. If neither field
                                   is specified, 100% of requests will be mirrored.
-
                                 format: int32
                                 maximum: 100
                                 minimum: 0
@@ -1582,7 +1565,7 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           type:
-                            description: |+
+                            description: |-
                               Type identifies the type of filter to apply. As with other API fields,
                               types are classified into three conformance levels:
 
@@ -1607,7 +1590,6 @@ spec:
                               If a reference to a custom filter type cannot be resolved, the filter
                               MUST NOT be skipped. Instead, requests that would have been processed by
                               that filter MUST receive a HTTP error response.
-
                             enum:
                             - ResponseHeaderModifier
                             - RequestHeaderModifier
@@ -1826,7 +1808,7 @@ spec:
                       maxItems: 8
                       type: array
                     name:
-                      description: |
+                      description: |-
                         Name is the name of the route rule. This name MUST be unique within a Route if it is set.
 
                         Support: Extended
@@ -1835,12 +1817,11 @@ spec:
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     sessionPersistence:
-                      description: |+
+                      description: |-
                         SessionPersistence defines and configures session persistence
                         for the route rule.
 
                         Support: Extended
-
                       properties:
                         absoluteTimeout:
                           description: |-

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -132,7 +132,7 @@ spec:
                 maxItems: 16
                 type: array
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -194,11 +194,6 @@ spec:
                   connections originating from the same namespace as the Route, for which
                   the intended destination of the connections are a Service targeted as a
                   ParentRef of the Route.
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -377,9 +372,7 @@ spec:
                   - path:
                       type: PathPrefix
                       value: /
-                description: |+
-                  Rules are a list of HTTP matchers, filters and actions.
-
+                description: Rules are a list of HTTP matchers, filters and actions.
                 items:
                   description: |-
                     HTTPRouteRule defines semantics for matching an HTTP request based on
@@ -432,7 +425,6 @@ spec:
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
 
-                          <gateway:experimental:description>
 
                           When the BackendRef points to a Kubernetes Service, implementations SHOULD
                           honor the appProtocol field if it is set for the target Service Port.
@@ -447,8 +439,6 @@ spec:
                           If a Route is not able to send traffic to the backend using the specified
                           protocol then the backend is considered invalid. Implementations MUST set the
                           "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-                          </gateway:experimental:description>
                         properties:
                           filters:
                             description: |-
@@ -637,7 +627,7 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 requestMirror:
-                                  description: |+
+                                  description: |-
                                     RequestMirror defines a schema for a filter that mirrors requests.
                                     Requests are sent to the specified destination, but responses from
                                     that destination are ignored.
@@ -647,7 +637,6 @@ spec:
                                     backends.
 
                                     Support: Extended
-
                                   properties:
                                     backendRef:
                                       description: |-
@@ -743,13 +732,12 @@ spec:
                                         rule: '(size(self.group) == 0 && self.kind
                                           == ''Service'') ? has(self.port) : true'
                                     fraction:
-                                      description: |+
+                                      description: |-
                                         Fraction represents the fraction of requests that should be
                                         mirrored to BackendRef.
 
                                         Only one of Fraction or Percent may be specified. If neither field
                                         is specified, 100% of requests will be mirrored.
-
                                       properties:
                                         denominator:
                                           default: 100
@@ -768,14 +756,13 @@ spec:
                                           to denominator
                                         rule: self.numerator <= self.denominator
                                     percent:
-                                      description: |+
+                                      description: |-
                                         Percent represents the percentage of requests that should be
                                         mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
                                         requests) and its maximum value is 100 (indicating 100% of requests).
 
                                         Only one of Fraction or Percent may be specified. If neither field
                                         is specified, 100% of requests will be mirrored.
-
                                       format: int32
                                       maximum: 100
                                       minimum: 0
@@ -1576,7 +1563,7 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           requestMirror:
-                            description: |+
+                            description: |-
                               RequestMirror defines a schema for a filter that mirrors requests.
                               Requests are sent to the specified destination, but responses from
                               that destination are ignored.
@@ -1586,7 +1573,6 @@ spec:
                               backends.
 
                               Support: Extended
-
                             properties:
                               backendRef:
                                 description: |-
@@ -1682,13 +1668,12 @@ spec:
                                   rule: '(size(self.group) == 0 && self.kind == ''Service'')
                                     ? has(self.port) : true'
                               fraction:
-                                description: |+
+                                description: |-
                                   Fraction represents the fraction of requests that should be
                                   mirrored to BackendRef.
 
                                   Only one of Fraction or Percent may be specified. If neither field
                                   is specified, 100% of requests will be mirrored.
-
                                 properties:
                                   denominator:
                                     default: 100
@@ -1707,14 +1692,13 @@ spec:
                                     denominator
                                   rule: self.numerator <= self.denominator
                               percent:
-                                description: |+
+                                description: |-
                                   Percent represents the percentage of requests that should be
                                   mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
                                   requests) and its maximum value is 100 (indicating 100% of requests).
 
                                   Only one of Fraction or Percent may be specified. If neither field
                                   is specified, 100% of requests will be mirrored.
-
                                 format: int32
                                 maximum: 100
                                 minimum: 0
@@ -2496,7 +2480,7 @@ spec:
                       maxItems: 64
                       type: array
                     name:
-                      description: |
+                      description: |-
                         Name is the name of the route rule. This name MUST be unique within a Route if it is set.
 
                         Support: Extended
@@ -2505,11 +2489,10 @@ spec:
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     retry:
-                      description: |+
+                      description: |-
                         Retry defines the configuration for when to retry an HTTP request.
 
                         Support: Extended
-
                       properties:
                         attempts:
                           description: |-
@@ -2587,20 +2570,17 @@ spec:
 
                               Implementations MAY support specifying discrete values in the 400-499 range,
                               which are often inadvisable to retry.
-
-                              <gateway:experimental>
                             maximum: 599
                             minimum: 400
                             type: integer
                           type: array
                       type: object
                     sessionPersistence:
-                      description: |+
+                      description: |-
                         SessionPersistence defines and configures session persistence
                         for the route rule.
 
                         Support: Extended
-
                       properties:
                         absoluteTimeout:
                           description: |-
@@ -3200,7 +3180,7 @@ spec:
                 maxItems: 16
                 type: array
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -3262,11 +3242,6 @@ spec:
                   connections originating from the same namespace as the Route, for which
                   the intended destination of the connections are a Service targeted as a
                   ParentRef of the Route.
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -3445,9 +3420,7 @@ spec:
                   - path:
                       type: PathPrefix
                       value: /
-                description: |+
-                  Rules are a list of HTTP matchers, filters and actions.
-
+                description: Rules are a list of HTTP matchers, filters and actions.
                 items:
                   description: |-
                     HTTPRouteRule defines semantics for matching an HTTP request based on
@@ -3500,7 +3473,6 @@ spec:
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
 
-                          <gateway:experimental:description>
 
                           When the BackendRef points to a Kubernetes Service, implementations SHOULD
                           honor the appProtocol field if it is set for the target Service Port.
@@ -3515,8 +3487,6 @@ spec:
                           If a Route is not able to send traffic to the backend using the specified
                           protocol then the backend is considered invalid. Implementations MUST set the
                           "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-                          </gateway:experimental:description>
                         properties:
                           filters:
                             description: |-
@@ -3705,7 +3675,7 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 requestMirror:
-                                  description: |+
+                                  description: |-
                                     RequestMirror defines a schema for a filter that mirrors requests.
                                     Requests are sent to the specified destination, but responses from
                                     that destination are ignored.
@@ -3715,7 +3685,6 @@ spec:
                                     backends.
 
                                     Support: Extended
-
                                   properties:
                                     backendRef:
                                       description: |-
@@ -3811,13 +3780,12 @@ spec:
                                         rule: '(size(self.group) == 0 && self.kind
                                           == ''Service'') ? has(self.port) : true'
                                     fraction:
-                                      description: |+
+                                      description: |-
                                         Fraction represents the fraction of requests that should be
                                         mirrored to BackendRef.
 
                                         Only one of Fraction or Percent may be specified. If neither field
                                         is specified, 100% of requests will be mirrored.
-
                                       properties:
                                         denominator:
                                           default: 100
@@ -3836,14 +3804,13 @@ spec:
                                           to denominator
                                         rule: self.numerator <= self.denominator
                                     percent:
-                                      description: |+
+                                      description: |-
                                         Percent represents the percentage of requests that should be
                                         mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
                                         requests) and its maximum value is 100 (indicating 100% of requests).
 
                                         Only one of Fraction or Percent may be specified. If neither field
                                         is specified, 100% of requests will be mirrored.
-
                                       format: int32
                                       maximum: 100
                                       minimum: 0
@@ -4644,7 +4611,7 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           requestMirror:
-                            description: |+
+                            description: |-
                               RequestMirror defines a schema for a filter that mirrors requests.
                               Requests are sent to the specified destination, but responses from
                               that destination are ignored.
@@ -4654,7 +4621,6 @@ spec:
                               backends.
 
                               Support: Extended
-
                             properties:
                               backendRef:
                                 description: |-
@@ -4750,13 +4716,12 @@ spec:
                                   rule: '(size(self.group) == 0 && self.kind == ''Service'')
                                     ? has(self.port) : true'
                               fraction:
-                                description: |+
+                                description: |-
                                   Fraction represents the fraction of requests that should be
                                   mirrored to BackendRef.
 
                                   Only one of Fraction or Percent may be specified. If neither field
                                   is specified, 100% of requests will be mirrored.
-
                                 properties:
                                   denominator:
                                     default: 100
@@ -4775,14 +4740,13 @@ spec:
                                     denominator
                                   rule: self.numerator <= self.denominator
                               percent:
-                                description: |+
+                                description: |-
                                   Percent represents the percentage of requests that should be
                                   mirrored to BackendRef. Its minimum value is 0 (indicating 0% of
                                   requests) and its maximum value is 100 (indicating 100% of requests).
 
                                   Only one of Fraction or Percent may be specified. If neither field
                                   is specified, 100% of requests will be mirrored.
-
                                 format: int32
                                 maximum: 100
                                 minimum: 0
@@ -5564,7 +5528,7 @@ spec:
                       maxItems: 64
                       type: array
                     name:
-                      description: |
+                      description: |-
                         Name is the name of the route rule. This name MUST be unique within a Route if it is set.
 
                         Support: Extended
@@ -5573,11 +5537,10 @@ spec:
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     retry:
-                      description: |+
+                      description: |-
                         Retry defines the configuration for when to retry an HTTP request.
 
                         Support: Extended
-
                       properties:
                         attempts:
                           description: |-
@@ -5655,20 +5618,17 @@ spec:
 
                               Implementations MAY support specifying discrete values in the 400-499 range,
                               which are often inadvisable to retry.
-
-                              <gateway:experimental>
                             maximum: 599
                             minimum: 400
                             type: integer
                           type: array
                       type: object
                     sessionPersistence:
-                      description: |+
+                      description: |-
                         SessionPersistence defines and configures session persistence
                         for the route rule.
 
                         Support: Extended
-
                       properties:
                         absoluteTimeout:
                           description: |-

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -51,7 +51,7 @@ spec:
             description: Spec defines the desired state of TCPRoute.
             properties:
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -113,11 +113,6 @@ spec:
                   connections originating from the same namespace as the Route, for which
                   the intended destination of the connections are a Service targeted as a
                   ParentRef of the Route.
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -291,9 +286,7 @@ spec:
                     || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
                     == p2.port))))
               rules:
-                description: |+
-                  Rules are a list of TCP matchers and actions.
-
+                description: Rules are a list of TCP matchers and actions.
                 items:
                   description: TCPRouteRule is the configuration for a given rule.
                   properties:
@@ -323,7 +316,6 @@ spec:
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
 
-                          <gateway:experimental:description>
 
                           When the BackendRef points to a Kubernetes Service, implementations SHOULD
                           honor the appProtocol field if it is set for the target Service Port.
@@ -339,7 +331,6 @@ spec:
                           protocol then the backend is considered invalid. Implementations MUST set the
                           "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
 
-                          </gateway:experimental:description>
 
                           Note that when the BackendTLSPolicy object is enabled by the implementation,
                           there are some extra rules about validity to consider here. See the fields

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -111,7 +111,7 @@ spec:
                 maxItems: 16
                 type: array
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -173,11 +173,6 @@ spec:
                   connections originating from the same namespace as the Route, for which
                   the intended destination of the connections are a Service targeted as a
                   ParentRef of the Route.
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -351,9 +346,7 @@ spec:
                     || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
                     == p2.port))))
               rules:
-                description: |+
-                  Rules are a list of TLS matchers and actions.
-
+                description: Rules are a list of TLS matchers and actions.
                 items:
                   description: TLSRouteRule is the configuration for a given rule.
                   properties:
@@ -386,7 +379,6 @@ spec:
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
 
-                          <gateway:experimental:description>
 
                           When the BackendRef points to a Kubernetes Service, implementations SHOULD
                           honor the appProtocol field if it is set for the target Service Port.
@@ -402,7 +394,6 @@ spec:
                           protocol then the backend is considered invalid. Implementations MUST set the
                           "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
 
-                          </gateway:experimental:description>
 
                           Note that when the BackendTLSPolicy object is enabled by the implementation,
                           there are some extra rules about validity to consider here. See the fields

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -51,7 +51,7 @@ spec:
             description: Spec defines the desired state of UDPRoute.
             properties:
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -113,11 +113,6 @@ spec:
                   connections originating from the same namespace as the Route, for which
                   the intended destination of the connections are a Service targeted as a
                   ParentRef of the Route.
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -291,9 +286,7 @@ spec:
                     || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
                     == p2.port))))
               rules:
-                description: |+
-                  Rules are a list of UDP matchers and actions.
-
+                description: Rules are a list of UDP matchers and actions.
                 items:
                   description: UDPRouteRule is the configuration for a given rule.
                   properties:
@@ -323,7 +316,6 @@ spec:
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
 
-                          <gateway:experimental:description>
 
                           When the BackendRef points to a Kubernetes Service, implementations SHOULD
                           honor the appProtocol field if it is set for the target Service Port.
@@ -339,7 +331,6 @@ spec:
                           protocol then the backend is considered invalid. Implementations MUST set the
                           "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
 
-                          </gateway:experimental:description>
 
                           Note that when the BackendTLSPolicy object is enabled by the implementation,
                           there are some extra rules about validity to consider here. See the fields

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -61,7 +61,7 @@ spec:
             description: Spec defines the desired state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses requested for this Gateway. This is optional and behavior can
                   depend on the implementation. If a value is set in the spec and the
                   requested address is invalid or unavailable, the implementation MUST
@@ -82,7 +82,6 @@ spec:
                   GatewayStatus.Addresses.
 
                   Support: Extended
-
                 items:
                   description: GatewayAddress describes an address that can be bound
                     to a Gateway.
@@ -813,7 +812,7 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses lists the network addresses that have been bound to the
                   Gateway.
 
@@ -823,7 +822,6 @@ spec:
                     * no addresses are specified, all addresses are dynamically assigned
                     * a combination of specified and dynamic addresses are assigned
                     * a specified address was unusable (e.g. already in use)
-
                 items:
                   description: GatewayStatusAddress describes a network address that
                     is bound to a Gateway.
@@ -1141,7 +1139,7 @@ spec:
             description: Spec defines the desired state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses requested for this Gateway. This is optional and behavior can
                   depend on the implementation. If a value is set in the spec and the
                   requested address is invalid or unavailable, the implementation MUST
@@ -1162,7 +1160,6 @@ spec:
                   GatewayStatus.Addresses.
 
                   Support: Extended
-
                 items:
                   description: GatewayAddress describes an address that can be bound
                     to a Gateway.
@@ -1893,7 +1890,7 @@ spec:
             description: Status defines the current state of Gateway.
             properties:
               addresses:
-                description: |+
+                description: |-
                   Addresses lists the network addresses that have been bound to the
                   Gateway.
 
@@ -1903,7 +1900,6 @@ spec:
                     * no addresses are specified, all addresses are dynamically assigned
                     * a combination of specified and dynamic addresses are assigned
                     * a specified address was unusable (e.g. already in use)
-
                 items:
                   description: GatewayStatusAddress describes a network address that
                     is bound to a Gateway.

--- a/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
@@ -152,7 +152,7 @@ spec:
                 maxItems: 16
                 type: array
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -203,12 +203,6 @@ spec:
                   allowed by something in the namespace they are referring to. For example,
                   Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                   generic way to enable other kinds of cross-namespace reference.
-
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -270,8 +264,6 @@ spec:
                         Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
 
-
-
                         Support: Core
                       maxLength: 63
                       minLength: 1
@@ -289,8 +281,6 @@ spec:
                         as opposed to a listener(s) whose port(s) may be changed. When both Port
                         and SectionName are specified, the name and port of the selected listener
                         must match both specified values.
-
-
 
                         Implementations MAY choose to support other parent resources.
                         Implementations supporting other types of parent resources MUST clearly
@@ -365,9 +355,7 @@ spec:
                     == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
                     == p2.sectionName))))
               rules:
-                description: |+
-                  Rules are a list of GRPC matchers, filters and actions.
-
+                description: Rules are a list of GRPC matchers, filters and actions.
                 items:
                   description: |-
                     GRPCRouteRule defines the semantics for matching a gRPC request based on
@@ -412,24 +400,6 @@ spec:
                           ReferenceGrant object is required in the referent namespace to allow that
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
-
-                          <gateway:experimental:description>
-
-                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
-                          honor the appProtocol field if it is set for the target Service Port.
-
-                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
-                          Standard Application Protocols defined in KEP-3726.
-
-                          If a Service appProtocol isn't specified, an implementation MAY infer the
-                          backend protocol through its own means. Implementations MAY infer the
-                          protocol from the Route type referring to the backend Service.
-
-                          If a Route is not able to send traffic to the backend using the specified
-                          protocol then the backend is considered invalid. Implementations MUST set the
-                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-                          </gateway:experimental:description>
                         properties:
                           filters:
                             description: |-
@@ -618,7 +588,7 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 requestMirror:
-                                  description: |+
+                                  description: |-
                                     RequestMirror defines a schema for a filter that mirrors requests.
                                     Requests are sent to the specified destination, but responses from
                                     that destination are ignored.
@@ -628,7 +598,6 @@ spec:
                                     backends.
 
                                     Support: Extended
-
                                   properties:
                                     backendRef:
                                       description: |-
@@ -862,7 +831,7 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 type:
-                                  description: |+
+                                  description: |-
                                     Type identifies the type of filter to apply. As with other API fields,
                                     types are classified into three conformance levels:
 
@@ -887,7 +856,6 @@ spec:
                                     If a reference to a custom filter type cannot be resolved, the filter
                                     MUST NOT be skipped. Instead, requests that would have been processed by
                                     that filter MUST receive a HTTP error response.
-
                                   enum:
                                   - ResponseHeaderModifier
                                   - RequestHeaderModifier
@@ -1229,7 +1197,7 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           requestMirror:
-                            description: |+
+                            description: |-
                               RequestMirror defines a schema for a filter that mirrors requests.
                               Requests are sent to the specified destination, but responses from
                               that destination are ignored.
@@ -1239,7 +1207,6 @@ spec:
                               backends.
 
                               Support: Extended
-
                             properties:
                               backendRef:
                                 description: |-
@@ -1471,7 +1438,7 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           type:
-                            description: |+
+                            description: |-
                               Type identifies the type of filter to apply. As with other API fields,
                               types are classified into three conformance levels:
 
@@ -1496,7 +1463,6 @@ spec:
                               If a reference to a custom filter type cannot be resolved, the filter
                               MUST NOT be skipped. Instead, requests that would have been processed by
                               that filter MUST receive a HTTP error response.
-
                             enum:
                             - ResponseHeaderModifier
                             - RequestHeaderModifier
@@ -1915,8 +1881,6 @@ spec:
                             Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                             generic way to enable any other kind of cross-namespace reference.
 
-
-
                             Support: Core
                           maxLength: 63
                           minLength: 1
@@ -1934,8 +1898,6 @@ spec:
                             as opposed to a listener(s) whose port(s) may be changed. When both Port
                             and SectionName are specified, the name and port of the selected listener
                             must match both specified values.
-
-
 
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -132,7 +132,7 @@ spec:
                 maxItems: 16
                 type: array
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -183,12 +183,6 @@ spec:
                   allowed by something in the namespace they are referring to. For example,
                   Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                   generic way to enable other kinds of cross-namespace reference.
-
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -250,8 +244,6 @@ spec:
                         Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
 
-
-
                         Support: Core
                       maxLength: 63
                       minLength: 1
@@ -269,8 +261,6 @@ spec:
                         as opposed to a listener(s) whose port(s) may be changed. When both Port
                         and SectionName are specified, the name and port of the selected listener
                         must match both specified values.
-
-
 
                         Implementations MAY choose to support other parent resources.
                         Implementations supporting other types of parent resources MUST clearly
@@ -350,9 +340,7 @@ spec:
                   - path:
                       type: PathPrefix
                       value: /
-                description: |+
-                  Rules are a list of HTTP matchers, filters and actions.
-
+                description: Rules are a list of HTTP matchers, filters and actions.
                 items:
                   description: |-
                     HTTPRouteRule defines semantics for matching an HTTP request based on
@@ -404,24 +392,6 @@ spec:
                           ReferenceGrant object is required in the referent namespace to allow that
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
-
-                          <gateway:experimental:description>
-
-                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
-                          honor the appProtocol field if it is set for the target Service Port.
-
-                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
-                          Standard Application Protocols defined in KEP-3726.
-
-                          If a Service appProtocol isn't specified, an implementation MAY infer the
-                          backend protocol through its own means. Implementations MAY infer the
-                          protocol from the Route type referring to the backend Service.
-
-                          If a Route is not able to send traffic to the backend using the specified
-                          protocol then the backend is considered invalid. Implementations MUST set the
-                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-                          </gateway:experimental:description>
                         properties:
                           filters:
                             description: |-
@@ -610,7 +580,7 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 requestMirror:
-                                  description: |+
+                                  description: |-
                                     RequestMirror defines a schema for a filter that mirrors requests.
                                     Requests are sent to the specified destination, but responses from
                                     that destination are ignored.
@@ -620,7 +590,6 @@ spec:
                                     backends.
 
                                     Support: Extended
-
                                   properties:
                                     backendRef:
                                       description: |-
@@ -1507,7 +1476,7 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           requestMirror:
-                            description: |+
+                            description: |-
                               RequestMirror defines a schema for a filter that mirrors requests.
                               Requests are sent to the specified destination, but responses from
                               that destination are ignored.
@@ -1517,7 +1486,6 @@ spec:
                               backends.
 
                               Support: Extended
-
                             properties:
                               backendRef:
                                 description: |-
@@ -2681,8 +2649,6 @@ spec:
                             Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                             generic way to enable any other kind of cross-namespace reference.
 
-
-
                             Support: Core
                           maxLength: 63
                           minLength: 1
@@ -2700,8 +2666,6 @@ spec:
                             as opposed to a listener(s) whose port(s) may be changed. When both Port
                             and SectionName are specified, the name and port of the selected listener
                             must match both specified values.
-
-
 
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly
@@ -2883,7 +2847,7 @@ spec:
                 maxItems: 16
                 type: array
               parentRefs:
-                description: |+
+                description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
                   to be attached to. Note that the referenced parent resource needs to
                   allow this for the attachment to be complete. For Gateways, that means
@@ -2934,12 +2898,6 @@ spec:
                   allowed by something in the namespace they are referring to. For example,
                   Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                   generic way to enable other kinds of cross-namespace reference.
-
-
-
-
-
-
                 items:
                   description: |-
                     ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -3001,8 +2959,6 @@ spec:
                         Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
 
-
-
                         Support: Core
                       maxLength: 63
                       minLength: 1
@@ -3020,8 +2976,6 @@ spec:
                         as opposed to a listener(s) whose port(s) may be changed. When both Port
                         and SectionName are specified, the name and port of the selected listener
                         must match both specified values.
-
-
 
                         Implementations MAY choose to support other parent resources.
                         Implementations supporting other types of parent resources MUST clearly
@@ -3101,9 +3055,7 @@ spec:
                   - path:
                       type: PathPrefix
                       value: /
-                description: |+
-                  Rules are a list of HTTP matchers, filters and actions.
-
+                description: Rules are a list of HTTP matchers, filters and actions.
                 items:
                   description: |-
                     HTTPRouteRule defines semantics for matching an HTTP request based on
@@ -3155,24 +3107,6 @@ spec:
                           ReferenceGrant object is required in the referent namespace to allow that
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
-
-                          <gateway:experimental:description>
-
-                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
-                          honor the appProtocol field if it is set for the target Service Port.
-
-                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
-                          Standard Application Protocols defined in KEP-3726.
-
-                          If a Service appProtocol isn't specified, an implementation MAY infer the
-                          backend protocol through its own means. Implementations MAY infer the
-                          protocol from the Route type referring to the backend Service.
-
-                          If a Route is not able to send traffic to the backend using the specified
-                          protocol then the backend is considered invalid. Implementations MUST set the
-                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
-
-                          </gateway:experimental:description>
                         properties:
                           filters:
                             description: |-
@@ -3361,7 +3295,7 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 requestMirror:
-                                  description: |+
+                                  description: |-
                                     RequestMirror defines a schema for a filter that mirrors requests.
                                     Requests are sent to the specified destination, but responses from
                                     that destination are ignored.
@@ -3371,7 +3305,6 @@ spec:
                                     backends.
 
                                     Support: Extended
-
                                   properties:
                                     backendRef:
                                       description: |-
@@ -4258,7 +4191,7 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           requestMirror:
-                            description: |+
+                            description: |-
                               RequestMirror defines a schema for a filter that mirrors requests.
                               Requests are sent to the specified destination, but responses from
                               that destination are ignored.
@@ -4268,7 +4201,6 @@ spec:
                               backends.
 
                               Support: Extended
-
                             properties:
                               backendRef:
                                 description: |-
@@ -5432,8 +5364,6 @@ spec:
                             Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                             generic way to enable any other kind of cross-namespace reference.
 
-
-
                             Support: Core
                           maxLength: 63
                           minLength: 1
@@ -5451,8 +5381,6 @@ spec:
                             as opposed to a listener(s) whose port(s) may be changed. When both Port
                             and SectionName are specified, the name and port of the selected listener
                             must match both specified values.
-
-
 
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->
/kind cleanup

**What this PR does / why we need it**:
The standard CRD still contains <gateway:experimental:description> as the Custom Gateway API Tweaks in the descriptions of items are not processed. In addition, the descriptions contain many extra newlines, which cause them to fail the yaml-lint check (https://github.com/adrienverge/yamllint/blob/master/yamllint/rules/empty_lines.py).


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
