### PR TITLE
conformance: Add conformance reports for Airlock Microgateway 4.5.0

### DIFF
--- a/conformance/reports/v1.1.0/airlock-microgateway/standard-4.5.0-default-report.yaml
+++ b/conformance/reports/v1.1.0/airlock-microgateway/standard-4.5.0-default-report.yaml
@@ -1,0 +1,47 @@
+apiVersion: gateway.networking.k8s.io/v1alpha1
+date: "2025-02-03T15:50:39Z"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.1.0
+implementation:
+  contact:
+    - https://www.airlock.com/en/contact
+  organization: airlock
+  project: microgateway
+  url: https://github.com/airlock/microgateway
+  version: 4.5.0
+kind: ConformanceReport
+mode: default
+profiles:
+  - core:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 33
+        Skipped: 0
+    extended:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 10
+        Skipped: 0
+      supportedFeatures:
+        - GatewayPort8080
+        - HTTPRouteHostRewrite
+        - HTTPRouteMethodMatching
+        - HTTPRouteParentRefPort
+        - HTTPRoutePathRewrite
+        - HTTPRoutePortRedirect
+        - HTTPRouteQueryParamMatching
+        - HTTPRouteSchemeRedirect
+      unsupportedFeatures:
+        - GatewayHTTPListenerIsolation
+        - GatewayStaticAddresses
+        - HTTPRouteBackendRequestHeaderModification
+        - HTTPRouteBackendTimeout
+        - HTTPRoutePathRedirect
+        - HTTPRouteRequestMirror
+        - HTTPRouteRequestMultipleMirrors
+        - HTTPRouteRequestTimeout
+        - HTTPRouteResponseHeaderModification
+    name: GATEWAY-HTTP
+    summary: Core tests succeeded. Extended tests succeeded.

--- a/conformance/reports/v1.1.1/airlock-microgateway/README.md
+++ b/conformance/reports/v1.1.1/airlock-microgateway/README.md
@@ -2,10 +2,9 @@
 
 ## Table of contents
 
-| API channel  | Implementation version                                               | Mode    | Report                                           |
-|--------------|----------------------------------------------------------------------|---------|--------------------------------------------------|
-| experimental | [v4.4.0](https://github.com/airlock/microgateway/releases/tag/4.4.0) | default | [link](./experimental-4.4.0-default-report.yaml) |
-| standard     | [v4.5.0](https://github.com/airlock/microgateway/releases/tag/4.5.0) | default | [link](./standard-4.5.0-default-report.yaml)     |
+| API channel | Implementation version                                               | Mode    | Report                                       |
+|-------------|----------------------------------------------------------------------|---------|----------------------------------------------|
+| standard    | [v4.5.0](https://github.com/airlock/microgateway/releases/tag/4.5.0) | default | [link](./standard-4.5.0-default-report.yaml) |
 
 ## Reproduce
 

--- a/conformance/reports/v1.1.1/airlock-microgateway/standard-4.5.0-default-report.yaml
+++ b/conformance/reports/v1.1.1/airlock-microgateway/standard-4.5.0-default-report.yaml
@@ -1,0 +1,47 @@
+apiVersion: gateway.networking.k8s.io/v1alpha1
+date: "2025-02-03T15:50:18Z"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.1.1
+implementation:
+  contact:
+    - https://www.airlock.com/en/contact
+  organization: airlock
+  project: microgateway
+  url: https://github.com/airlock/microgateway
+  version: 4.5.0
+kind: ConformanceReport
+mode: default
+profiles:
+  - core:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 33
+        Skipped: 0
+    extended:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 10
+        Skipped: 0
+      supportedFeatures:
+        - GatewayPort8080
+        - HTTPRouteHostRewrite
+        - HTTPRouteMethodMatching
+        - HTTPRouteParentRefPort
+        - HTTPRoutePathRewrite
+        - HTTPRoutePortRedirect
+        - HTTPRouteQueryParamMatching
+        - HTTPRouteSchemeRedirect
+      unsupportedFeatures:
+        - GatewayHTTPListenerIsolation
+        - GatewayStaticAddresses
+        - HTTPRouteBackendRequestHeaderModification
+        - HTTPRouteBackendTimeout
+        - HTTPRoutePathRedirect
+        - HTTPRouteRequestMirror
+        - HTTPRouteRequestMultipleMirrors
+        - HTTPRouteRequestTimeout
+        - HTTPRouteResponseHeaderModification
+    name: GATEWAY-HTTP
+    summary: Core tests succeeded. Extended tests succeeded.

--- a/conformance/reports/v1.2.0/airlock-microgateway/README.md
+++ b/conformance/reports/v1.2.0/airlock-microgateway/README.md
@@ -2,10 +2,9 @@
 
 ## Table of contents
 
-| API channel  | Implementation version                                               | Mode    | Report                                           |
-|--------------|----------------------------------------------------------------------|---------|--------------------------------------------------|
-| experimental | [v4.4.0](https://github.com/airlock/microgateway/releases/tag/4.4.0) | default | [link](./experimental-4.4.0-default-report.yaml) |
-| standard     | [v4.5.0](https://github.com/airlock/microgateway/releases/tag/4.5.0) | default | [link](./standard-4.5.0-default-report.yaml)     |
+| API channel | Implementation version                                               | Mode    | Report                                       |
+|-------------|----------------------------------------------------------------------|---------|----------------------------------------------|
+| standard    | [v4.5.0](https://github.com/airlock/microgateway/releases/tag/4.5.0) | default | [link](./standard-4.5.0-default-report.yaml) |
 
 ## Reproduce
 

--- a/conformance/reports/v1.2.0/airlock-microgateway/standard-4.5.0-default-report.yaml
+++ b/conformance/reports/v1.2.0/airlock-microgateway/standard-4.5.0-default-report.yaml
@@ -1,0 +1,53 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2025-02-03T15:51:50Z"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.2.0
+implementation:
+  contact:
+    - https://www.airlock.com/en/contact
+  organization: airlock
+  project: microgateway
+  url: https://github.com/airlock/microgateway
+  version: 4.5.0
+kind: ConformanceReport
+mode: default
+profiles:
+  - core:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 33
+        Skipped: 0
+    extended:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 16
+        Skipped: 0
+      supportedFeatures:
+        - GatewayInfrastructurePropagation
+        - GatewayPort8080
+        - HTTPRouteBackendProtocolH2C
+        - HTTPRouteBackendProtocolWebSocket
+        - HTTPRouteBackendTimeout
+        - HTTPRouteDestinationPortMatching
+        - HTTPRouteHostRewrite
+        - HTTPRouteMethodMatching
+        - HTTPRouteParentRefPort
+        - HTTPRoutePathRewrite
+        - HTTPRoutePortRedirect
+        - HTTPRouteQueryParamMatching
+        - HTTPRouteRequestTimeout
+        - HTTPRouteSchemeRedirect
+      unsupportedFeatures:
+        - GatewayHTTPListenerIsolation
+        - GatewayStaticAddresses
+        - HTTPRouteBackendRequestHeaderModification
+        - HTTPRoutePathRedirect
+        - HTTPRouteRequestMirror
+        - HTTPRouteRequestMultipleMirrors
+        - HTTPRouteResponseHeaderModification
+    name: GATEWAY-HTTP
+    summary: Core tests succeeded. Extended tests succeeded.
+succeededProvisionalTests:
+  - GatewayInfrastructure

--- a/conformance/reports/v1.2.1/airlock-microgateway/README.md
+++ b/conformance/reports/v1.2.1/airlock-microgateway/README.md
@@ -4,8 +4,7 @@
 
 | API channel  | Implementation version                                               | Mode    | Report                                           |
 |--------------|----------------------------------------------------------------------|---------|--------------------------------------------------|
-| experimental | [v4.4.0](https://github.com/airlock/microgateway/releases/tag/4.4.0) | default | [link](./experimental-4.4.0-default-report.yaml) |
-| standard     | [v4.5.0](https://github.com/airlock/microgateway/releases/tag/4.5.0) | default | [link](./standard-4.5.0-default-report.yaml)     |
+| experimental | [v4.5.0](https://github.com/airlock/microgateway/releases/tag/4.5.0) | default | [link](./experimental-4.5.0-default-report.yaml) |
 
 ## Reproduce
 

--- a/conformance/reports/v1.2.1/airlock-microgateway/experimental-4.5.0-default-report.yaml
+++ b/conformance/reports/v1.2.1/airlock-microgateway/experimental-4.5.0-default-report.yaml
@@ -1,0 +1,53 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2025-02-03T15:48:50Z"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.2.1
+implementation:
+  contact:
+    - https://www.airlock.com/en/contact
+  organization: airlock
+  project: microgateway
+  url: https://github.com/airlock/microgateway
+  version: 4.5.0
+kind: ConformanceReport
+mode: default
+profiles:
+  - core:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 33
+        Skipped: 0
+    extended:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 16
+        Skipped: 0
+      supportedFeatures:
+        - GatewayInfrastructurePropagation
+        - GatewayPort8080
+        - HTTPRouteBackendProtocolH2C
+        - HTTPRouteBackendProtocolWebSocket
+        - HTTPRouteBackendTimeout
+        - HTTPRouteDestinationPortMatching
+        - HTTPRouteHostRewrite
+        - HTTPRouteMethodMatching
+        - HTTPRouteParentRefPort
+        - HTTPRoutePathRewrite
+        - HTTPRoutePortRedirect
+        - HTTPRouteQueryParamMatching
+        - HTTPRouteRequestTimeout
+        - HTTPRouteSchemeRedirect
+      unsupportedFeatures:
+        - GatewayHTTPListenerIsolation
+        - GatewayStaticAddresses
+        - HTTPRouteBackendRequestHeaderModification
+        - HTTPRoutePathRedirect
+        - HTTPRouteRequestMirror
+        - HTTPRouteRequestMultipleMirrors
+        - HTTPRouteResponseHeaderModification
+    name: GATEWAY-HTTP
+    summary: Core tests succeeded. Extended tests succeeded.
+succeededProvisionalTests:
+  - GatewayInfrastructure

--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -113,13 +113,13 @@ In this section you will find specific links to blog posts, documentation and ot
 [epicsource]:https://github.com/epic-gateway
 
 ### Airlock Microgateway
-[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.1.0-Airlock%20Microgateway-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.1.0/airlock-microgateway)
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.2.1-Airlock%20Microgateway-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.2.1/airlock-microgateway)
 
 [Airlock Microgateway][airlock-microgateway] is a Kubernetes native WAAP (Web Application and API Protection) solution to protect microservices.
 Modern application security is embedded in the development workflow and follows DevSecOps paradigms.
 Airlock Microgateway protects your applications and microservices with the tried-and-tested Airlock security features against attacks, while also providing a high degree of scalability.
 
-With [Airlock Microgateway 4.4][airlock-microgateway-v4.4], Airlock Microgateway introduces a sidecarless data plane mode
+With [Airlock Microgateway 4.4][airlock-microgateway-gwapi-arch], Airlock Microgateway introduces a sidecarless data plane mode
 based on Gateway API to avoid the operational complexity of sidecars.
 
 #### Features
@@ -135,9 +135,9 @@ based on Gateway API to avoid the operational complexity of sidecars.
 - Check our [Airlock community forum][airlock-microgateway-community-support] and [support process][airlock-microgateway-premium-support] for support.
 
 [airlock-microgateway]:https://www.airlock.com/en/secure-access-hub/components/microgateway
-[airlock-microgateway-v4.4]:https://docs.airlock.com/microgateway/4.4/#data/1725073468781.html
+[airlock-microgateway-gwapi-arch]:https://docs.airlock.com/microgateway/latest/?topic=MGW-00000141
 [airlock-microgateway-documentation]:https://docs.airlock.com/microgateway/latest
-[airlock-microgateway-guide]:https://docs.airlock.com/microgateway/4.4/#data/1726159368351.html
+[airlock-microgateway-guide]:https://docs.airlock.com/microgateway/latest/?topic=MGW-00000142
 [airlock-microgateway-community-support]:https://forum.airlock.com/
 [airlock-microgateway-premium-support]:https://techzone.ergon.ch/support-process
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/area conformance


**What this PR does / why we need it**:
Adds conformance reports for various Gateway API versions and updates implementation page for Airlock Microgateway 4.5.0


**Which issue(s) this PR fixes**:
Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
