### PR TITLE
BackendTLSPolicy SANs field marked as extended

### DIFF
--- a/apis/openapi/zz_generated.openapi.go
+++ b/apis/openapi/zz_generated.openapi.go
@@ -7038,7 +7038,7 @@ func schema_sigsk8sio_gateway_api_apis_v1alpha3_BackendTLSPolicyValidation(ref c
 					},
 					"hostname": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Hostname is used for two purposes in the connection between Gateways and backends:\n\n1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066). 2. If SubjectAltNames is not specified or unsupported, Hostname MUST be used for\n   authentication and MUST match the certificate served by the matching\n   backend.\n\nSupport: Core",
+							Description: "Hostname is used for two purposes in the connection between Gateways and backends:\n\n1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066). 2. Hostname MUST be used for authentication and MUST match the certificate served by the matching backend, unless SubjectAltNames is specified.\n   authentication and MUST match the certificate served by the matching\n   backend.\n\nSupport: Core",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -7046,7 +7046,7 @@ func schema_sigsk8sio_gateway_api_apis_v1alpha3_BackendTLSPolicyValidation(ref c
 					},
 					"subjectAltNames": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SubjectAltNames contains one or more Subject Alternative Names. When specified, if supported, the certificate served from the backend MUST have at least one Subject Alternate Name matching one of the specified SubjectAltNames.\n\nSupport: Extended",
+							Description: "SubjectAltNames contains one or more Subject Alternative Names. When specified the certificate served from the backend MUST have at least one Subject Alternate Name matching one of the specified SubjectAltNames.\n\nSupport: Extended",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/apis/openapi/zz_generated.openapi.go
+++ b/apis/openapi/zz_generated.openapi.go
@@ -7038,7 +7038,7 @@ func schema_sigsk8sio_gateway_api_apis_v1alpha3_BackendTLSPolicyValidation(ref c
 					},
 					"hostname": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Hostname is used for two purposes in the connection between Gateways and backends:\n\n1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066). 2. If SubjectAltNames is not specified, Hostname MUST be used for\n   authentication and MUST match the certificate served by the matching\n   backend.\n\nSupport: Core",
+							Description: "Hostname is used for two purposes in the connection between Gateways and backends:\n\n1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066). 2. If SubjectAltNames is not specified or unsupported, Hostname MUST be used for\n   authentication and MUST match the certificate served by the matching\n   backend.\n\nSupport: Core",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -7046,7 +7046,7 @@ func schema_sigsk8sio_gateway_api_apis_v1alpha3_BackendTLSPolicyValidation(ref c
 					},
 					"subjectAltNames": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SubjectAltNames contains one or more Subject Alternative Names. When specified, the certificate served from the backend MUST have at least one Subject Alternate Name matching one of the specified SubjectAltNames.\n\nSupport: Core",
+							Description: "SubjectAltNames contains one or more Subject Alternative Names. When specified, if supported, the certificate served from the backend MUST have at least one Subject Alternate Name matching one of the specified SubjectAltNames.\n\nSupport: Extended",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/apis/v1alpha3/backendtlspolicy_types.go
+++ b/apis/v1alpha3/backendtlspolicy_types.go
@@ -151,7 +151,7 @@ type BackendTLSPolicyValidation struct {
 	// backends:
 	//
 	// 1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066).
-	// 2. If SubjectAltNames is not specified, Hostname MUST be used for
+	// 2. If SubjectAltNames is not specified or unsupported, Hostname MUST be used for
 	//    authentication and MUST match the certificate served by the matching
 	//    backend.
 	//
@@ -159,10 +159,10 @@ type BackendTLSPolicyValidation struct {
 	Hostname v1.PreciseHostname `json:"hostname"`
 
 	// SubjectAltNames contains one or more Subject Alternative Names.
-	// When specified, the certificate served from the backend MUST have at least one
-	// Subject Alternate Name matching one of the specified SubjectAltNames.
+	// When specified, if supported, the certificate served from the backend MUST
+	// have at least one Subject Alternate Name matching one of the specified SubjectAltNames.
 	//
-	// Support: Core
+	// Support: Extended
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=5

--- a/apis/v1alpha3/backendtlspolicy_types.go
+++ b/apis/v1alpha3/backendtlspolicy_types.go
@@ -151,7 +151,7 @@ type BackendTLSPolicyValidation struct {
 	// backends:
 	//
 	// 1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066).
-	// 2. If SubjectAltNames is not specified or unsupported, Hostname MUST be used for
+	// 2. Hostname MUST be used for authentication and MUST match the certificate served by the matching backend, unless SubjectAltNames is specified.
 	//    authentication and MUST match the certificate served by the matching
 	//    backend.
 	//
@@ -159,7 +159,7 @@ type BackendTLSPolicyValidation struct {
 	Hostname v1.PreciseHostname `json:"hostname"`
 
 	// SubjectAltNames contains one or more Subject Alternative Names.
-	// When specified, if supported, the certificate served from the backend MUST
+	// When specified the certificate served from the backend MUST
 	// have at least one Subject Alternate Name matching one of the specified SubjectAltNames.
 	//
 	// Support: Extended

--- a/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -232,7 +232,7 @@ spec:
                       backends:
 
                       1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066).
-                      2. If SubjectAltNames is not specified or unsupported, Hostname MUST be used for
+                      2. Hostname MUST be used for authentication and MUST match the certificate served by the matching backend, unless SubjectAltNames is specified.
                          authentication and MUST match the certificate served by the matching
                          backend.
 
@@ -244,7 +244,7 @@ spec:
                   subjectAltNames:
                     description: |-
                       SubjectAltNames contains one or more Subject Alternative Names.
-                      When specified, if supported, the certificate served from the backend MUST
+                      When specified the certificate served from the backend MUST
                       have at least one Subject Alternate Name matching one of the specified SubjectAltNames.
 
                       Support: Extended

--- a/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -232,7 +232,7 @@ spec:
                       backends:
 
                       1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066).
-                      2. If SubjectAltNames is not specified, Hostname MUST be used for
+                      2. If SubjectAltNames is not specified or unsupported, Hostname MUST be used for
                          authentication and MUST match the certificate served by the matching
                          backend.
 
@@ -244,10 +244,10 @@ spec:
                   subjectAltNames:
                     description: |-
                       SubjectAltNames contains one or more Subject Alternative Names.
-                      When specified, the certificate served from the backend MUST have at least one
-                      Subject Alternate Name matching one of the specified SubjectAltNames.
+                      When specified, if supported, the certificate served from the backend MUST
+                      have at least one Subject Alternate Name matching one of the specified SubjectAltNames.
 
-                      Support: Core
+                      Support: Extended
                     items:
                       description: SubjectAltName represents Subject Alternative Name.
                       properties:

--- a/geps/gep-3155/metadata.yaml
+++ b/geps/gep-3155/metadata.yaml
@@ -6,6 +6,8 @@ status: Experimental
 authors:
   - mkosieradzki
   - robscott
+featureNames:
+  - BackendTLSPolicySANs
 relationships:
   seeAlso:
     - number: 2907


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

Given the not triviality of supporting this feature for nginx-based implementations (such as Kong) and the fact that this feature is not mandatory to ensure core functionality in the proxy->backend encrypted communication, we can set the `SANs` field of the `BackendTLSPolicy` API as an extended feature.

/cc @robscott @shaneutt @youngnick @LiorLieberman @candita 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The SANs field of `backendTLSPolicy` has been marked as an extended feature.
```