### PR TITLE
Remove experimental callout on GRPCRoute guide.

### DIFF
--- a/site-src/guides/grpc-routing.md
+++ b/site-src/guides/grpc-routing.md
@@ -1,11 +1,5 @@
 # gRPC routing
 
-!!! info "Experimental Channel"
-
-    The `GRPCRoute` resource described below is currently only included in the
-    "Experimental" channel of Gateway API. For more information on release
-    channels, refer to our [versioning guide](/concepts/versioning).
-
 The [GRPCRoute resource](/api-types/grpcroute) allows you to match on gRPC traffic and
 direct it to Kubernetes backends. This guide shows how the GRPCRoute matches
 traffic on host, header, and service, and method fields and forwards it to different

--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -52,7 +52,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/downloa
 
 The experimental release channel includes everything in the standard release
 channel plus some experimental resources and fields. This includes
-TCPRoute, TLSRoute, UDPRoute and GRPCRoute.
+TCPRoute, TLSRoute, and UDPRoute.
 
 Note that future releases of the API could include breaking changes to
 experimental resources and fields. For example, any experimental resource or


### PR DESCRIPTION
GRPCRoute is GA and has been included in the standard channel since v1.1.0.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Removes the experimental callout on GRPCRoute guide because is now GA and included in the standard channel as of 1.1.0.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
