### PR TITLE
docs: Update GEPs in navbar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,16 +122,15 @@ nav:
   - Enhancements:
     - Overview: geps/overview.md
     - Provisional:
-      - geps/gep-91/index.md
       - geps/gep-1494/index.md
       - geps/gep-1651/index.md
       - geps/gep-1713/index.md
-      - geps/gep-1867/index.md
+      - geps/gep-1767/index.md
       - geps/gep-2648/index.md
-      - geps/gep-2649/index.md
-      - geps/gep-3388/index.md
     - Implementable:
-      - geps/gep-3155/index.md
+      - geps/gep-91/index.md
+      - geps/gep-3567/index.md
+      - geps/gep-3388/index.md
     - Experimental:
       - geps/gep-995/index.md
       - geps/gep-1619/index.md
@@ -139,6 +138,7 @@ nav:
       - geps/gep-1748/index.md
       - geps/gep-1897/index.md
       - geps/gep-2162/index.md
+      - geps/gep-2649/index.md
       - geps/gep-3155/index.md
       - geps/gep-3171/index.md
     - Standard:
@@ -158,6 +158,7 @@ nav:
       - geps/gep-1709/index.md
       - geps/gep-1742/index.md
       - geps/gep-1762/index.md
+      - geps/gep-1867/index.md
       - geps/gep-1911/index.md
       - geps/gep-2257/index.md
     - Memorandum:


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

This commit updates the list of GEPs displayed in the site's navigation sidebar to add missing GEPs, or move GEPs to accurately reflect their current state.

**Added**

* GEP-1767: Provisional
* GEP-3567: Implementable

**Moved**

* GEP-91: Provisional -> Implementable
* GEP-1867: Provisional -> Standard
* GEP-2649: Provisional -> Experimental
* GEP-3155: Implementable -> Experimental
* GEP-3388: Provisional -> Implementable


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
