### PR TITLE
fix(docs): grpcroute name is not set

### DIFF
--- a/site-src/api-types/grpcroute.md
+++ b/site-src/api-types/grpcroute.md
@@ -280,3 +280,4 @@ resolution applies to merging, refer to the [API specification][grpcrouterule].
 [filters]: /reference/spec/#gateway.networking.k8s.io/v1.GRPCRouteFilter
 [backendRef]: /reference/spec/#gateway.networking.k8s.io/v1.GRPCBackendRef
 [parentRef]: /reference/spec/#gateway.networking.k8s.io/v1.ParentRef
+[name]: /reference/spec/#gateway.networking.k8s.io/v1.SectionName


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/kind documentation

**What this PR does / why we need it**:

fix(docs): grpcroute name is not set

<img width="839" alt="Clipboard_Screenshot_1740651471" src="https://github.com/user-attachments/assets/1e42e0cc-f493-484d-a15c-90c42b36b22b" />

source: https://gateway-api.sigs.k8s.io/api-types/grpcroute/#spec

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
