### PR TITLE
align API Gateway definition with CNCF Glossary

### DIFF
--- a/site-src/faq.md
+++ b/site-src/faq.md
@@ -66,23 +66,22 @@ Guide](/guides/tls) for more details about passthrough and other TLS
 configurations.
 
 #### What's the difference between Gateway API and an API Gateway?
-An API Gateway is a general concept that describes anything that exposes
-capabilities of a backend service, while providing extra capabilities for
-traffic routing and manipulation, such as load balancing, request and response
-transformation, and sometimes more advanced features like authentication and
-authorization, rate limiting, and circuit breaking.
+An [API gateway](https://glossary.cncf.io/api-gateway/) is a tool that
+aggregates unique application APIs, making them all available in one place.
+It allows organizations to move key functions, such as authentication and
+authorization or limiting the number of requests between applications, to a
+centrally managed location. An API gateway functions as a common interface to (often external) API consumers.
 
-Gateway API is an interface, or set of resources, that model service networking
-in Kubernetes. One of the main resources is a `Gateway`, which declares the
-Gateway type (or class) to instantiate and its configuration. As a Gateway
-Provider, you can implement Gateway API to model Kubernetes service networking
-in an expressive, extensible, and role-oriented way.
+Gateway API is an interface, defined as a set of Kubernetes resources, that 
+models service networking in Kubernetes. One of the main resources is a `Gateway`,
+which declares the Gateway type (or class) to instantiate and its configuration.
+As a Gateway provider, you can implement Gateway API to model Kubernetes service
+networking in an expressive, extensible, and role-oriented way.
 
-Most Gateway API implementations are API Gateways to some extent, but not all
-API Gateways are Gateway API implementations.
+Some API gateways can be programmed using the Gateway API.
 
 #### Is Gateway API a standard for API Management?
 No. API Management is a much broader concept than what Gateway API aims to be,
 or what an API Gateway is intended to provide. An API Gateway can be an
 essential part of an API Management solution. Gateway API can be seen as a way
-to standardize on that aspect of API Management.
+to standardize provisioning of API Gateways.

--- a/site-src/index.md
+++ b/site-src/index.md
@@ -181,7 +181,7 @@ it must fit the uses to which each of Ana, Chihiro, and Ian will put it.
 
 [use-cases]:/concepts/use-cases
 
-#### What's the difference between Gateway API and an API Gateway?
+## What's the difference between Gateway API and an API Gateway?
 
 An [API gateway](https://glossary.cncf.io/api-gateway/) is a tool that
 aggregates unique application APIs, making them all available in one place.

--- a/site-src/index.md
+++ b/site-src/index.md
@@ -181,22 +181,21 @@ it must fit the uses to which each of Ana, Chihiro, and Ian will put it.
 
 [use-cases]:/concepts/use-cases
 
-## What's the difference between Gateway API and an API Gateway?
+#### What's the difference between Gateway API and an API Gateway?
 
-An API Gateway is a general concept that describes anything that exposes
-capabilities of a backend service, while providing extra capabilities for
-traffic routing and manipulation, such as load balancing, request and response
-transformation, and sometimes more advanced features like authentication and
-authorization, rate limiting, and circuit breaking.
+An [API gateway](https://glossary.cncf.io/api-gateway/) is a tool that
+aggregates unique application APIs, making them all available in one place.
+It allows organizations to move key functions, such as authentication and
+authorization or limiting the number of requests between applications, to a
+centrally managed location. An API gateway functions as a common interface to (often external) API consumers.
 
-Gateway API is an interface, or set of resources, that model service
-networking in Kubernetes. One of the main resources is a `Gateway`, which
-declares the Gateway type (or class) to instantiate and its configuration. As
-a Gateway Provider, you can implement Gateway API to model Kubernetes
-service networking in an expressive, extensible, and role-oriented way.
+Gateway API is an interface, defined as a set of Kubernetes resources, that 
+models service networking in Kubernetes. One of the main resources is a `Gateway`,
+which declares the Gateway type (or class) to instantiate and its configuration.
+As a Gateway provider, you can implement Gateway API to model Kubernetes service
+networking in an expressive, extensible, and role-oriented way.
 
-Most Gateway API implementations are API Gateways to some extent, but not all
-API Gateways are Gateway API implementations.
+Some API gateways can be programmed using the Gateway API.
 
 ## Who is working on Gateway API?
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This site offers a comparison of an API Gateway with the Gateway API, with a very broad definition, which defines almost any ingress system or edge router as an API gateway, regardless of whether the traffic passing through it is user- or machine-facing.

The industry tends towards a more narrow definition, which is well-captured by the CNCF Glossary.  I've copied that language into the index and FAQ pages and added a link to the glossary.

**Does this PR introduce a user-facing change?**:
```release-note
Updates comparison of Gateway API and API Gateway to use the CNCF's definition of the latter.
```
