### PR TITLE
fix: turn `allowCredentials` to boolean

### DIFF
--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -1371,7 +1371,7 @@ type HTTPCORSFilter struct {
 	// Support: Extended
 	//
 	// +optional
-	AllowCredentials *LowercaseTrue `json:"allowCredentials,omitempty"`
+	AllowCredentials TrueField `json:"allowCredentials,omitempty"`
 
 	// AllowMethods indicates which HTTP methods are supported for accessing the
 	// requested resource.

--- a/apis/v1/shared_types.go
+++ b/apis/v1/shared_types.go
@@ -764,7 +764,7 @@ type HeaderName string
 // +kubebuilder:validation:Pattern=`^([0-9]{1,5}(h|m|s|ms)){1,4}$`
 type Duration string
 
-// TrueField is a boolean value that can only be set to true 
+// TrueField is a boolean value that can only be set to true
 //
 // +kubebuilder:validation:Enum=true
 type TrueField bool

--- a/apis/v1/shared_types.go
+++ b/apis/v1/shared_types.go
@@ -764,11 +764,10 @@ type HeaderName string
 // +kubebuilder:validation:Pattern=`^([0-9]{1,5}(h|m|s|ms)){1,4}$`
 type Duration string
 
-// LowercaseTrue is a string value that can only be set to "true" (case
-// sensitive).
+// TrueField is a boolean value that can only be set to true 
 //
 // +kubebuilder:validation:Enum=true
-type LowercaseTrue string
+type TrueField bool
 
 const (
 	// A textual representation of a numeric IP address. IPv4

--- a/apis/v1/zz_generated.deepcopy.go
+++ b/apis/v1/zz_generated.deepcopy.go
@@ -910,11 +910,6 @@ func (in *HTTPCORSFilter) DeepCopyInto(out *HTTPCORSFilter) {
 		*out = make([]AbsoluteURI, len(*in))
 		copy(*out, *in)
 	}
-	if in.AllowCredentials != nil {
-		in, out := &in.AllowCredentials, &out.AllowCredentials
-		*out = new(LowercaseTrue)
-		**out = **in
-	}
 	if in.AllowMethods != nil {
 		in, out := &in.AllowMethods, &out.AllowMethods
 		*out = make([]HTTPMethodWithWildcard, len(*in))

--- a/applyconfiguration/apis/v1/httpcorsfilter.go
+++ b/applyconfiguration/apis/v1/httpcorsfilter.go
@@ -26,7 +26,7 @@ import (
 // with apply.
 type HTTPCORSFilterApplyConfiguration struct {
 	AllowOrigins     []v1.AbsoluteURI            `json:"allowOrigins,omitempty"`
-	AllowCredentials *v1.LowercaseTrue           `json:"allowCredentials,omitempty"`
+	AllowCredentials *v1.TrueField               `json:"allowCredentials,omitempty"`
 	AllowMethods     []v1.HTTPMethodWithWildcard `json:"allowMethods,omitempty"`
 	AllowHeaders     []v1.HTTPHeaderName         `json:"allowHeaders,omitempty"`
 	ExposeHeaders    []v1.HTTPHeaderName         `json:"exposeHeaders,omitempty"`
@@ -52,7 +52,7 @@ func (b *HTTPCORSFilterApplyConfiguration) WithAllowOrigins(values ...v1.Absolut
 // WithAllowCredentials sets the AllowCredentials field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the AllowCredentials field is set to the value of the last call.
-func (b *HTTPCORSFilterApplyConfiguration) WithAllowCredentials(value v1.LowercaseTrue) *HTTPCORSFilterApplyConfiguration {
+func (b *HTTPCORSFilterApplyConfiguration) WithAllowCredentials(value v1.TrueField) *HTTPCORSFilterApplyConfiguration {
 	b.AllowCredentials = &value
 	return b
 }

--- a/applyconfiguration/internal/internal.go
+++ b/applyconfiguration/internal/internal.go
@@ -696,7 +696,7 @@ var schemaYAML = typed.YAMLObject(`types:
     fields:
     - name: allowCredentials
       type:
-        scalar: string
+        scalar: boolean
     - name: allowHeaders
       type:
         list:

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -478,7 +478,7 @@ spec:
                                         Support: Extended
                                       enum:
                                       - true
-                                      type: string
+                                      type: boolean
                                     allowHeaders:
                                       description: |-
                                         AllowHeaders indicates which HTTP request headers are supported for
@@ -1700,7 +1700,7 @@ spec:
                                   Support: Extended
                                 enum:
                                 - true
-                                type: string
+                                type: boolean
                               allowHeaders:
                                 description: |-
                                   AllowHeaders indicates which HTTP request headers are supported for
@@ -4094,7 +4094,7 @@ spec:
                                         Support: Extended
                                       enum:
                                       - true
-                                      type: string
+                                      type: boolean
                                     allowHeaders:
                                       description: |-
                                         AllowHeaders indicates which HTTP request headers are supported for
@@ -5316,7 +5316,7 @@ spec:
                                   Support: Extended
                                 enum:
                                 - true
-                                type: string
+                                type: boolean
                               allowHeaders:
                                 description: |-
                                   AllowHeaders indicates which HTTP request headers are supported for

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -4284,7 +4284,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_HTTPCORSFilter(ref common.ReferenceCal
 					"allowCredentials": {
 						SchemaProps: spec.SchemaProps{
 							Description: "AllowCredentials indicates whether the actual cross-origin request allows to include credentials.\n\nThe only valid value for the `Access-Control-Allow-Credentials` response header is true (case-sensitive).\n\nIf the credentials are not allowed in cross-origin requests, the gateway will omit the header `Access-Control-Allow-Credentials` entirely rather than setting its value to false.\n\nSupport: Extended",
-							Type:        []string{"string"},
+							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},


### PR DESCRIPTION

/kind bug

Fixes #3650

**Does this PR introduce a user-facing change?**:

```release-note
change `HTTPRouteFilter.CORS.AllowCredentials` to expect a boolean and not a string
```
