### PR TITLE
docs: Fix 'mkdocs serve' endless build loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,3 @@ go.work.sum
 /cache
 .venv/
 release/
-site-src/geps

--- a/hack/mkdocs-generate-conformance.py
+++ b/hack/mkdocs-generate-conformance.py
@@ -30,6 +30,7 @@ def on_files(files, config, **kwargs):
     log.info("generating conformance")
 
     vers = getConformancePaths()
+    # Iterate over the list of versions. Exclude the pre 1.0 versions.
     for v in vers[3:]:
 
         confYamls = getYaml(v)
@@ -176,7 +177,7 @@ def getConformancePaths():
         allVersions.add(vers)
         reportedImplementationsPath.add(v+"**")
 
-    return list(reportedImplementationsPath)
+    return sorted(list(reportedImplementationsPath))
 
 
 def getYaml(conf_path):

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
     command = "make docs"
     publish = "site"
 [build.environment]
-    PYTHON_VERSION = "3.9"
+    PYTHON_VERSION = "3.12"
     GO_VERSION = "1.22.8"
 
 # Standard Netlify redirects


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

When developing and previewing docs using `mkdocs serve`, the site gets stuck into an endless build loop when any content is changed. This is caused by two hooks that copy content into the site-src/ directory on site build, `mkdocs-copy-geps.py` and `mkdocs-generate-conformance.py`, triggering another build due to the changed content.

The solution is to use MkDocs Files API to programmatically add the files into the site instead of copying them into the site directory.

See mkdocs/mkdocs#2544 for more information.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
