### PR TITLE
docs: Fix several MkDocs info and warning messages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,8 +52,8 @@ markdown_extensions:
   - admonition
   - meta
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.details
   - pymdownx.highlight
   - pymdownx.inlinehilite

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -181,3 +181,6 @@ nav:
     - Enhancement Requests: contributing/enhancement-requests.md
     - Release Cycle: contributing/release-cycle.md
     - Contributor Ladder: contributing/contributor-ladder.md
+not_in_nav: |
+  /blog/*
+  /geps/gep-696/*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,17 +70,17 @@ nav:
   - Overview:
     - Introduction: index.md
     - Concepts:
-        API Overview: concepts/api-overview.md
-        Conformance: concepts/conformance.md
-        Roles and Personas: concepts/roles-and-personas.md
-        Security Model: concepts/security-model.md
-        Tools: concepts/tooling.md
-        Use Cases: concepts/use-cases.md
-        Versioning: concepts/versioning.md
+      - API Overview: concepts/api-overview.md
+      - Conformance: concepts/conformance.md
+      - Roles and Personas: concepts/roles-and-personas.md
+      - Security Model: concepts/security-model.md
+      - Tools: concepts/tooling.md
+      - Use Cases: concepts/use-cases.md
+      - Versioning: concepts/versioning.md
     - Service Mesh:
-        Overview: mesh/index.md
-        GAMMA Initiative: mesh/gamma.md
-        Service Facets: mesh/service-facets.md
+      - Overview: mesh/index.md
+      - GAMMA Initiative: mesh/gamma.md
+      - Service Facets: mesh/service-facets.md
     - Implementations:
         - List: implementations.md
         - Comparisons:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,8 @@ repo_url: https://github.com/kubernetes-sigs/gateway-api
 repo_name: kubernetes-sigs/gateway-api
 site_dir: site
 docs_dir: site-src
-trademark: https://www.linuxfoundation.org/legal/trademark-usage
+extra:
+  trademark: https://www.linuxfoundation.org/legal/trademark-usage
 extra_css:
   - stylesheets/extra.css
 extra_javascript:

--- a/site-src/overrides/partials/copyright.html
+++ b/site-src/overrides/partials/copyright.html
@@ -22,10 +22,10 @@
 
 <!-- Copyright and theme information -->
 <div class="md-copyright">
-  {% if config.trademark %}
+  {% if config.extra.trademark %}
   <p>
     The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation,
-    please see our <a href="{{ config.trademark }}">Trademark Usage page</a>.
+    please see our <a href="{{ config.extra.trademark }}">Trademark Usage page</a>.
   </p>
   {% endif %}
   {% if not config.extra.generator == false %}


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

This PR contains several commits that resolve info and warning messages that are currently being logged by MkDocs when building the site.

* Ignore certain files from nav config
* Fix warning for invalid 'trademark' config
* Update pymdownx.emoji extensions
* Fix nav error in mkdocs.yml

More information about these changes can be found in the commit message for each commit.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
