### PR TITLE
GEP-1713: Move Website GEP Link to Experimental

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,7 +124,6 @@ nav:
     - Provisional:
       - geps/gep-1494/index.md
       - geps/gep-1651/index.md
-      - geps/gep-1713/index.md
       - geps/gep-1767/index.md
       - geps/gep-2648/index.md
     - Implementable:
@@ -134,6 +133,7 @@ nav:
     - Experimental:
       - geps/gep-995/index.md
       - geps/gep-1619/index.md
+      - geps/gep-1713/index.md
       - geps/gep-1731/index.md
       - geps/gep-1748/index.md
       - geps/gep-1897/index.md


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
GEP-1713 was previously listed under provisional in the website, but PR #3588 moved it to experimental.

**Which issue(s) this PR fixes**:
Related to #1713

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
