### PR TITLE
Remove mkdocs-material-extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ mkdocs==1.6.1
 mkdocs-awesome-pages-plugin==2.10.1
 mkdocs-macros-plugin==1.3.7
 mkdocs-material==9.6.7
-mkdocs-material-extensions==1.3.1
 mkdocs-redirects==1.2.2
 mkdocs-mermaid2-plugin==1.2.1
 pandas>=2.0.3


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The [mkdocs-material-extensions](https://github.com/facelessuser/mkdocs-material-extensions) package is now deprecated, and it is now integrated into the mkdocs-material package version 9.4.

This PR cleans up a warning on `make docs`:
```
INFO    -  DeprecationWarning: 'materialx.emoji.twemoji' is deprecated.
           Material emoji logic has been officially moved into mkdocs-material
           version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
           instead of 'materialx.emoji.twemoji' in your 'mkdocs.yml' file.

           ```
           markdown_extensions:
             - pymdownx.emoji:
                 emoji_index: !!python/name:material.extensions.emoji.twemoji
                 emoji_generator: !!python/name:material.extensions.emoji.to_svg
           ```

           'mkdocs_material_extensions' is deprecated and will no longer be
           supported moving forward. This is the last release.
```

See https://github.com/squidfunk/mkdocs-material/releases/tag/9.4.0 for more info.

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
