### PR TITLE
Remove mkdocs-material-extensions from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ mkdocs==1.6.1
 mkdocs-awesome-pages-plugin==2.10.1
 mkdocs-macros-plugin==1.3.7
 mkdocs-material==9.6.7
-mkdocs-material-extensions==1.3.1
 mkdocs-redirects==1.2.2
 mkdocs-mermaid2-plugin==1.2.1
 pandas>=2.0.3


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The [mkdocs-material-extensions](https://github.com/facelessuser/mkdocs-material-extensions) package is now deprecated, and it's usage in mkdocs.yaml was removed in #3663. This fix also removes it from requirements.txt to prevent unnecessary installation.

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

CC: @blake 