### PR TITLE
feat(conformance): validate implementation flags

### DIFF
--- a/conformance/conformance.go
+++ b/conformance/conformance.go
@@ -72,13 +72,14 @@ func DefaultOptions(t *testing.T) suite.ConformanceOptions {
 	namespaceAnnotations := suite.ParseKeyValuePairs(*flags.NamespaceAnnotations)
 	conformanceProfiles := suite.ParseConformanceProfiles(*flags.ConformanceProfiles)
 
-	implementation := suite.ParseImplementation(
+	implementation, err := suite.ParseImplementation(
 		*flags.ImplementationOrganization,
 		*flags.ImplementationProject,
 		*flags.ImplementationURL,
 		*flags.ImplementationVersion,
 		*flags.ImplementationContact,
 	)
+	require.NoError(t, err, "error parsing implementation details")
 
 	return suite.ConformanceOptions{
 		AllowCRDsMismatch:          *flags.AllowCRDsMismatch,
@@ -92,7 +93,7 @@ func DefaultOptions(t *testing.T) suite.ConformanceOptions {
 		ExemptFeatures:             exemptFeatures,
 		ManifestFS:                 []fs.FS{&Manifests},
 		GatewayClassName:           *flags.GatewayClassName,
-		Implementation:             implementation,
+		Implementation:             *implementation,
 		Mode:                       *flags.Mode,
 		NamespaceAnnotations:       namespaceAnnotations,
 		NamespaceLabels:            namespaceLabels,

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	neturl "net/url"
 	"slices"
 	"sort"
 	"strings"
@@ -558,14 +559,33 @@ func (suite *ConformanceTestSuite) Report() (*confv1.ConformanceReport, error) {
 
 // ParseImplementation parses implementation-specific flag arguments and
 // creates a *confv1a1.Implementation.
-func ParseImplementation(org, project, url, version, contact string) confv1.Implementation {
-	return confv1.Implementation{
+func ParseImplementation(org, project, url, version, contact string) (*confv1.Implementation, error) {
+	if org == "" {
+		return nil, errors.New("organization must be set")
+	}
+	if project == "" {
+		return nil, errors.New("project must be set")
+	}
+	if url == "" {
+		return nil, errors.New("url must be set")
+	}
+	if version == "" {
+		return nil, errors.New("version must be set")
+	}
+	if contact == "" {
+		return nil, errors.New("contact must be set")
+	}
+	if _, err := neturl.ParseRequestURI(url); err != nil {
+		return nil, errors.New("url is malformed")
+	}
+
+	return &confv1.Implementation{
 		Organization: org,
 		Project:      project,
 		URL:          url,
 		Version:      version,
 		Contact:      strings.Split(contact, ","),
-	}
+	}, nil
 }
 
 // ParseConformanceProfiles parses flag arguments and converts the string to

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -538,3 +538,89 @@ func namesToFeatureSet(names []string) FeaturesSet {
 	}
 	return featureSet
 }
+
+func TestParseImplementation(t *testing.T) {
+	testCases := []struct {
+		name        string
+		org         string
+		project     string
+		url         string
+		version     string
+		contact     string
+		expected    *confv1.Implementation
+		expectedErr error
+	}{
+		{
+			name:        "missing organization",
+			project:     "test-project",
+			url:         "https://example.com",
+			version:     "v1.0.0",
+			contact:     "test@example.com",
+			expectedErr: errors.New("organization must be set"),
+		},
+		{
+			name:        "missing project",
+			org:         "test-org",
+			url:         "https://example.com",
+			version:     "v1.0.0",
+			contact:     "test@example.com",
+			expectedErr: errors.New("project must be set"),
+		},
+		{
+			name:        "missing url",
+			org:         "test-org",
+			project:     "test-project",
+			version:     "v1.0.0",
+			contact:     "test@example.com",
+			expectedErr: errors.New("url must be set"),
+		},
+		{
+			name:        "missing version",
+			org:         "test-org",
+			project:     "test-project",
+			url:         "https://example.com",
+			contact:     "test@example.com",
+			expectedErr: errors.New("version must be set"),
+		},
+		{
+			name:        "missing contact",
+			org:         "test-org",
+			project:     "test-project",
+			url:         "https://example.com",
+			version:     "v1.0.0",
+			expectedErr: errors.New("contact must be set"),
+		},
+		{
+			name:        "malformed url",
+			org:         "test-org",
+			project:     "test-project",
+			url:         "invalid-url",
+			version:     "v1.0.0",
+			contact:     "test@example.com",
+			expectedErr: errors.New("url is malformed"),
+		},
+		{
+			name:    "valid input",
+			org:     "test-org",
+			project: "test-project",
+			url:     "https://example.com",
+			version: "v1.0.0",
+			contact: "test@example.com,test2@example.com",
+			expected: &confv1.Implementation{
+				Organization: "test-org",
+				Project:      "test-project",
+				URL:          "https://example.com",
+				Version:      "v1.0.0",
+				Contact:      []string{"test@example.com", "test2@example.com"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ParseImplementation(tc.org, tc.project, tc.url, tc.version, tc.contact)
+			assert.Equal(t, tc.expected, result)
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
+}

--- a/pkg/test/cel/grpcroute_test.go
+++ b/pkg/test/cel/grpcroute_test.go
@@ -341,7 +341,8 @@ func TestGRPCRouteRule(t *testing.T) {
 				}
 				return rules
 			}(),
-		}}
+		},
+	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

/area conformance-machinery

**What this PR does / why we need it**:

The conformance suite implementation-related flags are properly validated.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2178 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The conformance suite implementation-related flags are properly validated.
```
