### PR TITLE
Revert change to mirror threshold

### DIFF
--- a/conformance/tests/httproute-request-percentage-mirror.go
+++ b/conformance/tests/httproute-request-percentage-mirror.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	concurrentRequests    = 10
-	tolerancePercentage   = 5.0
+	tolerancePercentage   = 15.0
 	totalRequests         = 500.0
 	numDistributionChecks = 5
 )


### PR DESCRIPTION

**What type of PR is this?**

/area conformance-test

**What this PR does / why we need it**:
Reverts part of https://github.com/kubernetes-sigs/gateway-api/pull/3508. This was a new change in 1.3

See https://github.com/kubernetes-sigs/gateway-api/pull/3708; Envoy impl cannot meet this fine grain threshold.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
