### PR TITLE
conformance: initial draft for CORS filter tests

### DIFF
--- a/conformance/tests/httproute-cors.go
+++ b/conformance/tests/httproute-cors.go
@@ -1,0 +1,118 @@
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteCORS)
+}
+
+var HTTPRouteCORS = suite.ConformanceTest{
+	ShortName:   "HTTPRouteCORS",
+	Description: "An HTTPRoute with cors filter",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteCORS,
+	},
+	Manifests: []string{"tests/httproute-cors.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Name: "cors", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		testCases := []http.ExpectedResponse{{
+			TestCaseName: "GET request",
+			Request: http.Request{
+				Path: "/one",
+				Headers: map[string]string{
+					"Origin": "http://example.com",
+				},
+			},
+			Response: http.Response{
+				StatusCode: 200,
+				Headers: map[string]string{
+					"Access-Control-Allow-Origin": "http://example.com",
+				},
+			},
+			Backend:   "infra-backend-v1",
+			Namespace: ns,
+		}, {
+			TestCaseName: "CORS preflight request with request method and headers",
+			Request: http.Request{
+				Method: "OPTIONS",
+				Path:   "/one",
+				Headers: map[string]string{
+					"Origin":                         "http://one.example.com",
+					"Access-Control-Request-Method":  "POST",
+					"Access-Control-Request-Headers": "Accept,Content-Type",
+				},
+			},
+			ExpectedRequest: &http.ExpectedRequest{
+				Request: http.Request{
+					Method: "OPTIONS",
+				},
+			},
+			Response: http.Response{
+				StatusCode: 200,
+				Headers: map[string]string{
+					"Access-Control-Allow-Origin":  "http://one.example.com",
+					"Access-Control-Allow-Methods": "GET,HEAD,POST",
+					"Access-Control-Allow-Headers": "Accept,Accept-Language,Content-Language,Content-Type,Range",
+					"Access-Control-Max-Age":       "5",
+				},
+				AbsentHeaders: []string{
+					"Access-Control-Allow-Credentials",
+					"Access-Control-Expose-Headers",
+				},
+			},
+		}, {
+			TestCaseName: "CORS preflight request with request method",
+			Request: http.Request{
+				Method: "OPTIONS",
+				Path:   "/two",
+				Headers: map[string]string{
+					"Origin":                        "http://two.example.com",
+					"Access-Control-Request-Method": "DELETE",
+				},
+			},
+			ExpectedRequest: &http.ExpectedRequest{
+				Request: http.Request{
+					Method: "OPTIONS",
+				},
+			},
+			Response: http.Response{
+				StatusCode: 200,
+				Headers: map[string]string{
+					"Access-Control-Allow-Origin":      "http://two.example.com",
+					"Access-Control-Allow-Methods":     "GET,HEAD,POST,DELETE",
+					"Access-Control-Max-Age":           "1728000",
+					"Access-Control-Allow-Credentials": "true",
+					"Access-Control-Expose-Headers":    "Content-Security-Policy",
+				},
+				AbsentHeaders: []string{
+					"Access-Control-Allow-Headers",
+				},
+			},
+		}}
+
+		for i := range testCases {
+			// Declare tc here to avoid loop variable
+			// reuse issues across parallel tests.
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-cors.yaml
+++ b/conformance/tests/httproute-cors.yaml
@@ -1,0 +1,55 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: cors
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /one
+      filters:
+        - type: CORS
+          cors:
+            allowOrigins:
+              - http://one.example.com
+              - http://example.com
+              - https://example.com
+            allowMethods:
+              - GET
+              - HEAD
+              - POST
+            allowHeaders:
+              - Accept
+              - Accept-Language
+              - Content-Language
+              - Content-Type
+              - Range
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /two
+      filters:
+        - type: CORS
+          cors:
+            allowOrigins:
+              - http://two.example.com
+              - http://example.com
+            allowMethods:
+              - GET
+              - HEAD
+              - POST
+              - DELETE
+            allowCredentials: true
+            exposeHeaders:
+              - Content-Security-Policy
+            maxAge: 1728000
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080

--- a/pkg/features/httproute.go
+++ b/pkg/features/httproute.go
@@ -97,6 +97,9 @@ const (
 
 	// This option indicates support for HTTPRoute with a backendref with an appProtocol 'kubernetes.io/ws' (extended conformance)
 	SupportHTTPRouteBackendProtocolWebSocket FeatureName = "HTTPRouteBackendProtocolWebSocket"
+
+	// This option indicates support for HTTPRoute CORS filter (extended conformance).
+	SupportHTTPRouteCORS FeatureName = "HTTPRouteCORS"
 )
 
 var (
@@ -190,6 +193,11 @@ var (
 		Name:    SupportHTTPRouteBackendProtocolWebSocket,
 		Channel: FeatureChannelStandard,
 	}
+	// HTTPRouteCORSFeature contains metadata for the HTTPRouteCORS feature.
+	HTTPRouteCORSFeature = Feature{
+		Name:    SupportHTTPRouteCORS,
+		Channel: FeatureChannelExperimental,
+	}
 )
 
 // HTTPRouteExtendedFeatures includes all extended features for HTTPRoute
@@ -214,4 +222,5 @@ var HTTPRouteExtendedFeatures = sets.New(
 	HTTPRouteParentRefPortFeature,
 	HTTPRouteBackendProtocolH2CFeature,
 	HTTPRouteBackendProtocolWebSocketFeature,
+	HTTPRouteCORSFeature,
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind test
/area conformance-test

**What this PR does / why we need it**:
During the implementation of the new CORS HTTPRoute filter, I created additional tests that can serve as a foundation for developing conformance tests for the CORS feature (#1767).

The proposed tests focus on:
- CORS preflight requests
- GET requests with `Origin` header set

**Open Points**
- [ ] Test case with  `*` as an allowed origin (currently not possible due to #3648)
- [ ] Handling multiple valid status codes in the response (currently, only status code 200 is considered valid in this tests).

 Feedback is welcome to enhance the tests and address the open items effectively.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
TODO
```
