### PR TITLE
Clarify HTTPRouteMatch rules

### DIFF
--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -213,7 +213,7 @@ is returned.
 
 The following example forwards HTTP requests for prefix `/bar` to service
 "my-service1" on port `8080` and HTTP requests for prefix `/some/thing` with
-header `magic: foo` to service "my-service2" on port `8080`:
+header `magic: foo` **AND** query param `great: example` to service "my-service2" on port `8080`:
 ```yaml
 {% include 'standard/basic-http.yaml' %}
 ```

--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -211,9 +211,16 @@ unspecified, the rule performs no forwarding. If unspecified and no filters
 are specified that would result in a response being sent, a 404 error code
 is returned.
 
-The following example forwards HTTP requests for prefix `/bar` to service
-"my-service1" on port `8080` and HTTP requests for prefix `/some/thing` with
-header `magic: foo` **AND** query param `great: example` to service "my-service2" on port `8080`:
+The following example forwards HTTP requests for path prefix `/bar` to service
+"my-service1" on port `8080`, and HTTP requests fulfilling _all_ four of the 
+following criteria
+
+- header `magic: foo` 
+- query param `great: example`
+- path prefix `/some/thing`
+- method `GET`
+
+to service "my-service2" on port `8080`:
 ```yaml
 {% include 'standard/basic-http.yaml' %}
 ```


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Documentation clarification of the `HTTPRouteMatch` rules.

The documentation links to the following example `HTTPRoute`

https://github.com/kubernetes-sigs/gateway-api/blob/3222422bb2124d8cdd072d710ffd2474d99431e1/examples/standard/basic-http.yaml#L25-L57

with a `rules.matches` entry with three elements: `headers`, `queryParams` and `path`.

From the current wording it is unclear if you need to match the `queryParams` criterion or not.
My understand from reading the [**Matches** section](https://gateway-api.sigs.k8s.io/api-types/httproute/#matches) and [**HTTPRouteMatch** documentation](https://gateway-api.sigs.k8s.io/reference/spec/#httproutematch) is that you need to match all criteria (`headers`, `queryParams`, and `path`) in order to be forwarded to the "my-service2" backend on port 8080.

Alternatively the `basic-http.yaml` example can be modified to remove to `queryParams` rule.

If my understanding is wrong I'd be happy to update the documentation with the correct logic.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
