### PR TITLE
Removing "None" as option for Route Namespaces

### DIFF
--- a/apis/v1/gateway_types.go
+++ b/apis/v1/gateway_types.go
@@ -315,6 +315,7 @@ type ListenerNamespaces struct {
 	//
 	// +optional
 	// +kubebuilder:default=None
+	// +kubebuilder:validation:Enum=All;Selector;Same;None
 	From *FromNamespaces `json:"from,omitempty"`
 
 	// Selector must be specified when From is set to "Selector". In that case,
@@ -669,8 +670,6 @@ type AllowedRoutes struct {
 
 // FromNamespaces specifies namespace from which Routes/ListenerSets may be attached to a
 // Gateway.
-//
-// +kubebuilder:validation:Enum=All;Selector;Same;None
 type FromNamespaces string
 
 const (
@@ -700,6 +699,7 @@ type RouteNamespaces struct {
 	//
 	// +optional
 	// +kubebuilder:default=Same
+	// +kubebuilder:validation:Enum=All;Selector;Same
 	From *FromNamespaces `json:"from,omitempty"`
 
 	// Selector must be specified when From is set to "Selector". In that case,

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -658,7 +658,6 @@ spec:
                               - All
                               - Selector
                               - Same
-                              - None
                               type: string
                             selector:
                               description: |-
@@ -1997,7 +1996,6 @@ spec:
                               - All
                               - Selector
                               - Same
-                              - None
                               type: string
                             selector:
                               description: |-

--- a/config/crd/experimental/gateway.networking.x-k8s.io_xlistenersets.yaml
+++ b/config/crd/experimental/gateway.networking.x-k8s.io_xlistenersets.yaml
@@ -174,7 +174,6 @@ spec:
                               - All
                               - Selector
                               - Same
-                              - None
                               type: string
                             selector:
                               description: |-

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -513,7 +513,6 @@ spec:
                               - All
                               - Selector
                               - Same
-                              - None
                               type: string
                             selector:
                               description: |-
@@ -1620,7 +1619,6 @@ spec:
                               - All
                               - Selector
                               - Same
-                              - None
                               type: string
                             selector:
                               description: |-


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`None` was accidentally added as an option for Route Namespaces as part of the ListenerSet work. This fixes that.

**Which issue(s) this PR fixes**:
Fixes #3743

**Does this PR introduce a user-facing change?**:
```release-note
`None` has been removed as option for Route Namespaces.
```

/cc @howardjohn @dprotaso 