### PR TITLE
Requiring Port number on ListenerSet Listener

### DIFF
--- a/apisx/v1alpha1/xlistenerset_types.go
+++ b/apisx/v1alpha1/xlistenerset_types.go
@@ -127,9 +127,7 @@ type ListenerEntry struct {
 
 	// Port is the network port. Multiple listeners may use the
 	// same port, subject to the Listener compatibility rules.
-	//
-	// +optional
-	Port PortNumber `json:"port,omitempty"`
+	Port PortNumber `json:"port"`
 
 	// Protocol specifies the network protocol this listener expects to receive.
 	Protocol ProtocolType `json:"protocol"`

--- a/applyconfiguration/internal/internal.go
+++ b/applyconfiguration/internal/internal.go
@@ -1753,6 +1753,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: port
       type:
         scalar: numeric
+      default: 0
     - name: protocol
       type:
         scalar: string

--- a/config/crd/experimental/gateway.networking.x-k8s.io_xlistenersets.yaml
+++ b/config/crd/experimental/gateway.networking.x-k8s.io_xlistenersets.yaml
@@ -514,6 +514,7 @@ spec:
                           > 0 || size(self.options) > 0 : true'
                   required:
                   - name
+                  - port
                   - protocol
                   type: object
                 maxItems: 64

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -7748,6 +7748,7 @@ func schema_sigsk8sio_gateway_api_apisx_v1alpha1_ListenerEntry(ref common.Refere
 					"port": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -7773,7 +7774,7 @@ func schema_sigsk8sio_gateway_api_apisx_v1alpha1_ListenerEntry(ref common.Refere
 						},
 					},
 				},
-				Required: []string{"name", "protocol"},
+				Required: []string{"name", "port", "protocol"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We missed this when reviewing the ListenerSet GEP. Although an optional port that would require implementations to assign a port could be legitimately useful, I think we haven't fully processed this concept. Moving this back to required allows us to make it optional in the future, where starting with optional would make it much more painful to transition to required.

Some potential concerns of an optional port on ListenerSet:

* Automatic port allocation could become a bit complicated for Gateway implementations to maintain
* Spec.Listeners.Port would no longer be a reliable source for understanding which Port a Listener was listening on
* Each Listener with an optional Port would _require_ a status entry (not currently the case)
* If ListenerSet ever supported multiple parents, the same Listener might have different Ports assigned

With all that said, I think this is potentially a very useful idea, I just don't think we spent enough time on this while reviewing ListenerSet and would prefer to take the safest possible path forward towards RC2. This is not "never",  just "not yet".

**Does this PR introduce a user-facing change?**:
```release-note
XListenerSet Port is required. (It was already effectively required due to 0 being an invalid value, but had been marked optional).
```

/cc @dprotaso @youngnick 