### PR TITLE
fix typo in BudgetDetails

### DIFF
--- a/apisx/v1alpha1/xbackendtrafficpolicy_types.go
+++ b/apisx/v1alpha1/xbackendtrafficpolicy_types.go
@@ -147,7 +147,7 @@ type RetryConstraint struct {
 // the percentage of requests in the budget, and the interval between
 // checks.
 type BudgetDetails struct {
-	// BudgetPercent defines the maximum percentage of active requests that may
+	// Percent defines the maximum percentage of active requests that may
 	// be made up of retries.
 	//
 	// Support: Extended
@@ -158,13 +158,13 @@ type BudgetDetails struct {
 	// +kubebuilder:validation:Maximum=100
 	Percent *int `json:"percent,omitempty"`
 
-	// BudgetInterval defines the duration in which requests will be considered
+	// Interval defines the duration in which requests will be considered
 	// for calculating the budget for retries.
 	//
 	// Support: Extended
 	//
 	// +optional
 	// +kubebuilder:default="10s"
-	// +kubebuilder:validation:XValidation:message="budgetInterval can not be greater than one hour or less than one second",rule="!(duration(self) < duration('1s') || duration(self) > duration('1h'))"
+	// +kubebuilder:validation:XValidation:message="interval can not be greater than one hour or less than one second",rule="!(duration(self) < duration('1s') || duration(self) > duration('1h'))"
 	Interval *Duration `json:"interval,omitempty"`
 }

--- a/config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
+++ b/config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
@@ -94,21 +94,21 @@ spec:
                       interval:
                         default: 10s
                         description: |-
-                          BudgetInterval defines the duration in which requests will be considered
+                          Interval defines the duration in which requests will be considered
                           for calculating the budget for retries.
 
                           Support: Extended
                         pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                         x-kubernetes-validations:
-                        - message: budgetInterval can not be greater than one hour
-                            or less than one second
+                        - message: interval can not be greater than one hour or less
+                            than one second
                           rule: '!(duration(self) < duration(''1s'') || duration(self)
                             > duration(''1h''))'
                       percent:
                         default: 20
                         description: |-
-                          BudgetPercent defines the maximum percentage of active requests that may
+                          Percent defines the maximum percentage of active requests that may
                           be made up of retries.
 
                           Support: Extended

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -7706,14 +7706,14 @@ func schema_sigsk8sio_gateway_api_apisx_v1alpha1_BudgetDetails(ref common.Refere
 				Properties: map[string]spec.Schema{
 					"percent": {
 						SchemaProps: spec.SchemaProps{
-							Description: "BudgetPercent defines the maximum percentage of active requests that may be made up of retries.\n\nSupport: Extended",
+							Description: "Percent defines the maximum percentage of active requests that may be made up of retries.\n\nSupport: Extended",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
 					},
 					"interval": {
 						SchemaProps: spec.SchemaProps{
-							Description: "BudgetInterval defines the duration in which requests will be considered for calculating the budget for retries.\n\nSupport: Extended",
+							Description: "Interval defines the duration in which requests will be considered for calculating the budget for retries.\n\nSupport: Extended",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/test/cel/backendtrafficpolicy_test.go
+++ b/pkg/test/cel/backendtrafficpolicy_test.go
@@ -105,7 +105,7 @@ func TestBackendTrafficPolicyConfig(t *testing.T) {
 					Interval: toDuration("10s"),
 				}),
 			},
-			wantErrors: []string{"budgetInterval can not be greater than one hour or less than one second"},
+			wantErrors: []string{"interval can not be greater than one hour or less than one second"},
 		},
 		{
 			name: "invalid BackendTrafficPolicyConfig budgetInterval too short",
@@ -124,7 +124,7 @@ func TestBackendTrafficPolicyConfig(t *testing.T) {
 					Interval: toDuration("10s"),
 				}),
 			},
-			wantErrors: []string{"budgetInterval can not be greater than one hour or less than one second"},
+			wantErrors: []string{"interval can not be greater than one hour or less than one second"},
 		},
 		{
 			name: "invalid BackendTrafficPolicyConfig minRetryRate interval",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind documentation

**What this PR does / why we need it**:

align comment with field name

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
