### PR TITLE
Add mesh conformance tests for httproute path host and status redirect

### DIFF
--- a/conformance/tests/mesh/httproute-redirect-host-and-status.go
+++ b/conformance/tests/mesh/httproute-redirect-host-and-status.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meshtests
+
+import (
+	"testing"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/echo"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	MeshConformanceTests = append(MeshConformanceTests, MeshHTTPRouteRedirectHostAndStatus)
+}
+
+var MeshHTTPRouteRedirectHostAndStatus = suite.ConformanceTest{
+	ShortName:   "MeshHTTPRouteRedirectHostAndStatus",
+	Description: "An HTTPRoute with hostname and statusCode redirect filters",
+	Features: []features.FeatureName{
+		features.SupportMesh,
+		features.SupportHTTPRoute,
+	},
+	Manifests: []string{"tests/mesh/httproute-redirect-host-and-status.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-mesh"
+		client := echo.ConnectToApp(t, s, echo.MeshAppEchoV1)
+
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/hostname-redirect",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Host: "example.org",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/host-and-status",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 301,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Host: "example.org",
+				},
+				Namespace: ns,
+			},
+		}
+		for i := range testCases {
+			// Declare tc here to avoid loop variable
+			// reuse issues across parallel tests.
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				client.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
+			})
+		}
+	},
+}

--- a/conformance/tests/mesh/httproute-redirect-host-and-status.yaml
+++ b/conformance/tests/mesh/httproute-redirect-host-and-status.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mesh-redirect-host-and-status
+  namespace: gateway-conformance-mesh
+spec:
+  parentRefs:
+  - group: ""
+    kind: Service
+    name: echo
+    port: 80
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /hostname-redirect
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: example.org
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /host-and-status
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        statusCode: 301
+        hostname: example.org
+

--- a/conformance/tests/mesh/httproute-redirect-path.go
+++ b/conformance/tests/mesh/httproute-redirect-path.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meshtests
+
+import (
+	"testing"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/echo"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	MeshConformanceTests = append(MeshConformanceTests, MeshHTTPRouteRedirectPath)
+}
+
+var MeshHTTPRouteRedirectPath = suite.ConformanceTest{
+	ShortName:   "MeshHTTPRouteRedirectPath",
+	Description: "An HTTPRoute with scheme redirect filter",
+	Manifests:   []string{"tests/mesh/httproute-redirect-path.yaml"},
+	Features: []features.FeatureName{
+		features.SupportMesh,
+		features.SupportHTTPRoute,
+		features.SupportMeshHTTPRouteRedirectPath,
+	},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-mesh"
+		client := echo.ConnectToApp(t, s, echo.MeshAppEchoV1)
+
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/original-prefix/lemon",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Path: "/replacement-prefix/lemon",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/full/path/original",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Path: "/full-path-replacement",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/path-and-host",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Host: "example.org",
+					Path: "/replacement-prefix",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/path-and-status",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 301,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Path: "/replacement-prefix",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/full-path-and-host",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Host: "example.org",
+					Path: "/replacement-full",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/full-path-and-status",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 301,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Path: "/replacement-full",
+				},
+				Namespace: ns,
+			},
+		}
+		for i := range testCases {
+			// Declare tc here to avoid loop variable
+			// reuse issues across parallel tests.
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				client.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
+			})
+		}
+	},
+}

--- a/conformance/tests/mesh/httproute-redirect-path.yaml
+++ b/conformance/tests/mesh/httproute-redirect-path.yaml
@@ -1,0 +1,76 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mesh-redirect-path
+  namespace: gateway-conformance-mesh
+spec:
+  parentRefs:
+  - group: ""
+    kind: Service
+    name: echo
+    port: 80
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /original-prefix
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: /replacement-prefix
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /full
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /full-path-replacement
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /path-and-host
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: example.org
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: /replacement-prefix
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /path-and-status
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: /replacement-prefix
+        statusCode: 301
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /full-path-and-host
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: example.org
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /replacement-full
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /full-path-and-status
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /replacement-full
+        statusCode: 301

--- a/conformance/tests/mesh/httproute-redirect-port.go
+++ b/conformance/tests/mesh/httproute-redirect-port.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meshtests
+
+import (
+	"testing"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/echo"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	MeshConformanceTests = append(MeshConformanceTests, MeshHTTPRouteRedirectPort)
+}
+
+var MeshHTTPRouteRedirectPort = suite.ConformanceTest{
+	ShortName:   "MeshHTTPRouteRedirectPort",
+	Description: "An HTTPRoute with a port redirect filter",
+	Manifests:   []string{"tests/mesh/httproute-redirect-port.yaml"},
+	Features: []features.FeatureName{
+		features.SupportMesh,
+		features.SupportHTTPRoute,
+		features.SupportMeshHTTPRouteRedirectPort,
+	},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-mesh"
+		client := echo.ConnectToApp(t, s, echo.MeshAppEchoV1)
+
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/port",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Port: "8083",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/port-and-host",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Host: "example.org",
+					Port: "8083",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/port-and-status",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 301,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Port: "8083",
+				},
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/port-and-host-and-status",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Port: "8083",
+					Host: "example.org",
+				},
+				Namespace: ns,
+			},
+		}
+		for i := range testCases {
+			// Declare tc here to avoid loop variable
+			// reuse issues across parallel tests.
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				client.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
+			})
+		}
+	},
+}

--- a/conformance/tests/mesh/httproute-redirect-port.yaml
+++ b/conformance/tests/mesh/httproute-redirect-port.yaml
@@ -1,0 +1,48 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mesh-redirect-port
+  namespace: gateway-conformance-mesh
+spec:
+  parentRefs:
+  - group: ""
+    kind: Service
+    name: echo
+    port: 80
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /port
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        port: 8083
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /port-and-host
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: example.org
+        port: 8083
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /port-and-status
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        port: 8083
+        statusCode: 301
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /port-and-host-and-status
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        port: 8083
+        hostname: example.org
+        statusCode: 302

--- a/conformance/tests/mesh/httproute-redirect-scheme.go
+++ b/conformance/tests/mesh/httproute-redirect-scheme.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meshtests
+
+import (
+	"testing"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/echo"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	MeshConformanceTests = append(MeshConformanceTests, MeshHTTPRouteSchemeRedirect)
+}
+
+var MeshHTTPRouteSchemeRedirect = suite.ConformanceTest{
+	ShortName:   "MeshHTTPRouteSchemeRedirect",
+	Description: "An HTTPRoute with a scheme redirect filter",
+	Manifests:   []string{"tests/mesh/httproute-redirect-scheme.yaml"},
+	Features: []features.FeatureName{
+		features.SupportMesh,
+		features.SupportHTTPRoute,
+		features.SupportMeshHTTPRouteSchemeRedirect,
+	},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-mesh"
+		client := echo.ConnectToApp(t, s, echo.MeshAppEchoV1)
+
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/scheme",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "https",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/scheme-and-host",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Host:   "example.org",
+					Scheme: "https",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/scheme-and-status",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 301,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "https",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Host:             "echo",
+					Path:             "/scheme-and-host-and-status",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Scheme: "https",
+					Host:   "example.org",
+				},
+				Namespace: ns,
+			},
+		}
+		for i := range testCases {
+			// Declare tc here to avoid loop variable
+			// reuse issues across parallel tests.
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				client.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
+			})
+		}
+	},
+}

--- a/conformance/tests/mesh/httproute-redirect-scheme.yaml
+++ b/conformance/tests/mesh/httproute-redirect-scheme.yaml
@@ -1,0 +1,49 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mesh-redirect-scheme
+  namespace: gateway-conformance-mesh
+spec:
+  parentRefs:
+  - group: ""
+    kind: Service
+    name: echo
+    port: 80
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: "https"
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-and-host
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: example.org
+        scheme: "https"
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-and-status
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: "https"
+        statusCode: 301
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /scheme-and-host-and-status
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: "https"
+        statusCode: 302
+        hostname: example.org
+

--- a/conformance/tests/mesh/httproute-rewrite-path.go
+++ b/conformance/tests/mesh/httproute-rewrite-path.go
@@ -34,8 +34,8 @@ var MeshHTTPRouteRewritePath = suite.ConformanceTest{
 	Description: "An HTTPRoute with path rewrite filter",
 	Features: []features.FeatureName{
 		features.SupportMesh,
-		features.SupportMeshHTTPRouteRewritePath,
 		features.SupportHTTPRoute,
+		features.SupportMeshHTTPRouteRewritePath,
 	},
 	Manifests: []string{"tests/mesh/httproute-rewrite-path.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {

--- a/pkg/features/mesh.go
+++ b/pkg/features/mesh.go
@@ -50,6 +50,10 @@ const (
 	SupportMeshConsumerRoute FeatureName = "MeshConsumerRoute"
 	// This option indicates mesh support for HTTPRoute path rewrite (extended conformance)
 	SupportMeshHTTPRouteRewritePath FeatureName = "MeshHTTPRouteRewritePath"
+	// This option indicates mesh support for HTTPRoute scheme redirect (extended conformance)
+	SupportMeshHTTPRouteSchemeRedirect FeatureName = "MeshHTTPRouteSchemeRedirect"
+	// This option indicates mesh support for HTTPRoute port redirect (extended conformance)
+	SupportMeshHTTPRouteRedirectPort FeatureName = "MeshHTTPRouteRedirectPort"
 )
 
 var (
@@ -69,6 +73,18 @@ var (
 		Name:    SupportMeshHTTPRouteRewritePath,
 		Channel: FeatureChannelStandard,
 	}
+
+	// MeshHTTPRouteSchemeRedirect contains metadata for the MeshHTTPRouteSchemeRedirect feature.
+	MeshHTTPRouteSchemeRedirect = Feature{
+		Name:    SupportMeshHTTPRouteRewritePath,
+		Channel: FeatureChannelStandard,
+	}
+
+	// MeshHTTPRouteRedirectPort contains metadata for the MeshHTTPRouteRedirectPort feature.
+	MeshHTTPRouteRedirectPort = Feature{
+		Name:    SupportMeshHTTPRouteRedirectPort,
+		Channel: FeatureChannelStandard,
+	}
 )
 
 // MeshExtendedFeatures includes all the supported features for the service mesh at
@@ -77,4 +93,5 @@ var MeshExtendedFeatures = sets.New(
 	MeshClusterIPMatchingFeature,
 	MeshConsumerRouteFeature,
 	MeshHTTPRouteRewritePath,
+	MeshHTTPRouteSchemeRedirect,
 )

--- a/pkg/features/mesh.go
+++ b/pkg/features/mesh.go
@@ -54,6 +54,8 @@ const (
 	SupportMeshHTTPRouteSchemeRedirect FeatureName = "MeshHTTPRouteSchemeRedirect"
 	// This option indicates mesh support for HTTPRoute port redirect (extended conformance)
 	SupportMeshHTTPRouteRedirectPort FeatureName = "MeshHTTPRouteRedirectPort"
+	// This option indicates mesh support for HTTPRoute path redirect (extended conformance)
+	SupportMeshHTTPRouteRedirectPath FeatureName = "MeshHTTPRouteRedirectPath"
 )
 
 var (
@@ -85,6 +87,12 @@ var (
 		Name:    SupportMeshHTTPRouteRedirectPort,
 		Channel: FeatureChannelStandard,
 	}
+
+	// MeshHTTPRouteRedirectPath contains metadata for the MeshHTTPRouteRedirectPath feature.
+	MeshHTTPRouteRedirectPath = Feature{
+		Name:    SupportMeshHTTPRouteRedirectPath,
+		Channel: FeatureChannelStandard,
+	}
 )
 
 // MeshExtendedFeatures includes all the supported features for the service mesh at
@@ -94,4 +102,5 @@ var MeshExtendedFeatures = sets.New(
 	MeshConsumerRouteFeature,
 	MeshHTTPRouteRewritePath,
 	MeshHTTPRouteSchemeRedirect,
+	MeshHTTPRouteRedirectPath,
 )


### PR DESCRIPTION
**What type of PR is this?**
/area conformance-test

Add mesh tests for port and scheme redirect
This is a follow up to https://github.com/kubernetes-sigs/gateway-api/pull/3729

**What this PR does / why we need it**:
Add mesh tests coverage

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related https://github.com/kubernetes-sigs/gateway-api/issues/3581

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add mesh conformance tests for httproute path host and status redirect
```
