### PR TITLE
Add conformance report for Contour 1.31.0

### DIFF
--- a/conformance/reports/v1.2.1/projectcontour-contour/README.md
+++ b/conformance/reports/v1.2.1/projectcontour-contour/README.md
@@ -1,0 +1,48 @@
+# Projectcontour Contour
+
+## Table of Contents
+
+|API channel|Implementation version|Mode|Report|
+|-----------|----------------------|----|------|
+|experimental|[v1.31.0](https://github.com/projectcontour/contour/releases/tag/v1.31.0)|x|[v1.31.0 report](./experimental-v1.31.0-default-report.yaml)|
+
+## Reproduce
+
+### Prerequisites
+
+Follow the Contour [contribution guide][0] documentation for setting up your local development environment, which includes ensuring `kubectl`, `docker`, `kinD`, and other tools are installed.
+
+### Steps
+
+1. Clone the Contour GitHub repository
+
+   ```bash
+   git clone https://github.com/projectcontour/contour && cd contour
+   ```
+
+2. Check out the desired version
+
+   ```bash
+   export VERSION=v<x.y.z>
+   git checkout $VERSION
+   ```
+
+3. Run the conformance tests
+
+   ```bash
+   export CONTOUR_E2E_IMAGE="ghcr.io/projectcontour/contour:$VERSION"
+   export GENERATE_GATEWAY_CONFORMANCE_REPORT="true"
+   make setup-kind-cluster run-gateway-conformance cleanup-kind
+   ```
+
+   Note: you can omit the `cleanup-kind` target if you would prefer to keep the `kinD` cluster.
+
+4. Check the produced report
+
+   ```bash
+   cat gateway-conformance-report/projectcontour-contour-*.yaml
+   ```
+
+   Note: you can set `GATEWAY_CONFORMANCE_REPORT_OUTDIR` before running the tests to customize the output location.
+
+[0]: https://github.com/projectcontour/contour/blob/main/CONTRIBUTING.md#building-from-source

--- a/conformance/reports/v1.2.1/projectcontour-contour/experimental-v1.31.0-default-report.yaml
+++ b/conformance/reports/v1.2.1/projectcontour-contour/experimental-v1.31.0-default-report.yaml
@@ -1,0 +1,101 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2025-05-06T14:44:31-04:00"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.2.1
+implementation:
+  contact:
+  - '@projectcontour/maintainers'
+  organization: projectcontour
+  project: contour
+  url: https://projectcontour.io/
+  version: v1.31.0
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: partial
+    skippedTests:
+    - HTTPRouteHTTPSListener
+    statistics:
+      Failed: 0
+      Passed: 32
+      Skipped: 1
+  extended:
+    result: partial
+    skippedTests:
+    - GatewayStaticAddresses
+    - HTTPRouteInvalidParentRefSectionNameNotMatchingPort
+    - HTTPRouteRedirectPortAndScheme
+    statistics:
+      Failed: 0
+      Passed: 20
+      Skipped: 3
+    supportedFeatures:
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructurePropagation
+    - GatewayPort8080
+    - GatewayStaticAddresses
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRedirect
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestTimeout
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+  name: GATEWAY-HTTP
+  summary: Core tests partially succeeded with 1 test skips. Extended tests partially
+    succeeded with 3 test skips.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 11
+      Skipped: 0
+  extended:
+    result: partial
+    skippedTests:
+    - GatewayStaticAddresses
+    statistics:
+      Failed: 0
+      Passed: 1
+      Skipped: 1
+    supportedFeatures:
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructurePropagation
+    - GatewayPort8080
+    - GatewayStaticAddresses
+  name: GATEWAY-TLS
+  summary: Core tests succeeded. Extended tests partially succeeded with 1 test skips.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 12
+      Skipped: 0
+  extended:
+    result: partial
+    skippedTests:
+    - GatewayStaticAddresses
+    statistics:
+      Failed: 0
+      Passed: 1
+      Skipped: 1
+    supportedFeatures:
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructurePropagation
+    - GatewayPort8080
+    - GatewayStaticAddresses
+  name: GATEWAY-GRPC
+  summary: Core tests succeeded. Extended tests partially succeeded with 1 test skips.
+succeededProvisionalTests:
+- GatewayInfrastructure

--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -209,13 +209,13 @@ effort, check out the #development channel or join our [weekly developer meeting
 
 ### Contour
 
-[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.1.0-Contour-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.1.0/projectcontour-contour)
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.2.1-Contour-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.2.1/projectcontour-contour)
 
 [Contour][contour] is a CNCF open source Envoy-based ingress controller for Kubernetes.
 
-Contour [v1.30.0][contour-release] implements Gateway API v1.1.0.
+Contour [v1.31.0][contour-release] implements Gateway API v1.2.1.
 All [Standard channel][contour-standard] v1 API group resources (GatewayClass, Gateway, HTTPRoute, ReferenceGrant), plus most v1alpha2 API group resources (TLSRoute, TCPRoute, GRPCRoute, ReferenceGrant, and BackendTLSPolicy) are supported.
-Contour's implementation passes all core and most extended Gateway API conformance tests included in the v1.1.0 release.
+Contour's implementation passes most core extended Gateway API conformance tests included in the v1.2.1 release.
 
 See the [Contour Gateway API Guide][contour-guide] for information on how to deploy and use Contour's Gateway API implementation.
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds conformance report for new Contour 1.31.0 release which supports Gateway API 1.2.1

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
