### PR TITLE
Update golangci v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,79 +1,107 @@
+version: "2"
 run:
-  timeout: 10m
+  modules-download-mode: readonly
   issues-exit-code: 1
   tests: true
-  modules-download-mode: readonly
   allow-parallel-runners: false
-
 linters:
-  fast: false
   enable:
-  - errcheck
-  - copyloopvar
-  - gocritic
-  - gofumpt
-  - goimports
-  - gomodguard
-  - gosec
-  - govet
-  - misspell
-  - revive
-  - unconvert
-  - unparam
-  - unused
-  - whitespace
-  disable-all: false
-  presets:
-  - bugs
-  - unused
-
-# all available settings of specific linters
-linters-settings:
-  gofmt:
-    # simplify code: gofmt with `-s` option, true by default
-    simplify: true
-  goimports:
-    local-prefixes: sigs.k8s.io/gateway-api
-  govet:
-    enable:
-      - shadow
-    settings:
-      shadow:
-        # Whether to be strict about shadowing; can be noisy.
-        strict: false
-  misspell:
-    locale: US
-    ignore-words: []
-  gomodguard:
-    blocked:
-    # List of blocked modules.
-      modules:
-        - io/ioutil:
-            recommendations:
-              - io
-              - os
-            reason: "Deprecation of package ioutil in Go 1.16."
-
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - copyloopvar
+    - durationcheck
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - gocritic
+    - gomodguard
+    - gosec
+    - gosmopolitan
+    - loggercheck
+    - makezero
+    - misspell
+    - musttag
+    - nilerr
+    - nilnesserr
+    - noctx
+    - protogetter
+    - reassign
+    - recvcheck
+    - revive
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
+    - testifylint
+    - unconvert
+    - unparam
+    - whitespace
+    - zerologlint
+  settings:
+    gomodguard:
+      blocked:
+        modules:
+          - io/ioutil:
+              recommendations:
+                - io
+                - os
+              reason: Deprecation of package ioutil in Go 1.16.
+    govet:
+      enable:
+        - shadow
+      settings:
+        shadow:
+          strict: false
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - errcheck
+          - gocyclo
+        path: _test\.go
+      - linters:
+          - testifylint
+        text: require must only be used in the goroutine running the test function
+      - linters:
+          - testifylint
+        text: contains assertions that must only be used in the goroutine running the test function
+      - linters:
+          - errorlint
+        text: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
+      - path: (.+)\.go$
+        text: Using the variable on range scope `tc` in function literal
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
-        - gocyclo
-        - errcheck
-        - dupl
-     # Too many false positives - for examples see: https://github.com/Antonboom/testifylint/issues/67
-    - linters:
-      - testifylint
-      text: "require must only be used in the goroutine running the test function"
-    - linters:
-      - testifylint
-      text: "contains assertions that must only be used in the goroutine running the test function"
-    # It is valid usage to wrap errors without using %w to not make them part of
-    # the API contract.
-    - linters: ["errorlint"]
-      text: "non-wrapping format verb for fmt.Errorf. Use `%w` to format errors"
-  exclude:
-    - Using the variable on range scope `tc` in function literal
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+    goimports:
+      local-prefixes:
+        - sigs.k8s.io/gateway-api
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/modelschema/main.go
+++ b/cmd/modelschema/main.go
@@ -34,7 +34,7 @@ import (
 func main() {
 	err := output()
 	if err != nil {
-		os.Stderr.WriteString(fmt.Sprintf("Failed: %v", err))
+		fmt.Fprintf(os.Stderr, "Failed: %v", err)
 		os.Exit(1)
 	}
 }

--- a/conformance/echo-basic/echo-basic_test.go
+++ b/conformance/echo-basic/echo-basic_test.go
@@ -171,8 +171,8 @@ func TestEchoHandler(t *testing.T) {
 
 	// Test RequestAssertions struct contains expected context namespace
 	expectedNamespace := context.Namespace
-	if responseAssertions.Context.Namespace != expectedNamespace {
-		t.Errorf("Expected X-Content-Type-Options header %s, but got %s", expectedNamespace, responseAssertions.Context.Namespace)
+	if responseAssertions.Namespace != expectedNamespace {
+		t.Errorf("Expected X-Content-Type-Options header %s, but got %s", expectedNamespace, responseAssertions.Namespace)
 	}
 }
 

--- a/conformance/tests/httproute-request-percentage-mirror.go
+++ b/conformance/tests/httproute-request-percentage-mirror.go
@@ -145,8 +145,7 @@ var HTTPRouteRequestPercentageMirror = suite.ConformanceTest{
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expected)
 
 				// Override to not have more requests than expected
-				var dedicatedTimeoutConfig config.TimeoutConfig
-				dedicatedTimeoutConfig = suite.TimeoutConfig
+				dedicatedTimeoutConfig := suite.TimeoutConfig
 				dedicatedTimeoutConfig.RequiredConsecutiveSuccesses = 1
 				// used to limit number of parallel go routines
 				semaphore := make(chan struct{}, concurrentRequests)
@@ -225,7 +224,7 @@ func testMirroredRequestsDistribution(t *testing.T, suite *suite.ConformanceTest
 		tlog.Logf(t, "Pod: %s, Expected: %f (min: %f, max: %f), Actual: %f", mirrorPod.Name, expected, minExpected, maxExpected, actual)
 
 		if actual < minExpected || actual > maxExpected {
-			errs = append(errs, fmt.Errorf("Pod %s did not meet the mirroring percentage within tolerance. Expected between %f and %f, but got %f", mirrorPod.Name, minExpected, maxExpected, actual))
+			errs = append(errs, fmt.Errorf("pod %s did not meet the mirroring percentage within tolerance. Expected between %f and %f, but got %f", mirrorPod.Name, minExpected, maxExpected, actual))
 		}
 	}
 	if len(errs) > 0 {

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -208,7 +208,7 @@ func AwaitConvergence(t *testing.T, threshold int, maxTimeToConsistency time.Dur
 		default:
 		}
 
-		completed := fn(time.Now().Sub(start))
+		completed := fn(time.Since(start))
 		attempts++
 		if completed {
 			successes++

--- a/conformance/utils/kubernetes/apply_test.go
+++ b/conformance/utils/kubernetes/apply_test.go
@@ -179,7 +179,7 @@ spec:
 			resources, err := tc.applier.prepareResources(t, decoder)
 
 			require.NoError(t, err, "unexpected error preparing resources")
-			require.EqualValues(t, tc.expected, resources)
+			require.Equal(t, tc.expected, resources)
 		})
 	}
 }

--- a/conformance/utils/kubernetes/helpers_test.go
+++ b/conformance/utils/kubernetes/helpers_test.go
@@ -68,7 +68,7 @@ func TestNewGatewayRef(t *testing.T) {
 			require.IsType(t, GatewayRef{}, ref)
 			if test.listenerNames == nil {
 				require.Len(t, ref.listenerNames, 1)
-				assert.Equal(t, "", string(*ref.listenerNames[0]))
+				assert.Empty(t, ref.listenerNames[0])
 			} else {
 				require.Len(t, ref.listenerNames, len(test.listenerNames))
 				for i := 0; i < len(ref.listenerNames); i++ {

--- a/conformance/utils/suite/reports.go
+++ b/conformance/utils/suite/reports.go
@@ -67,9 +67,9 @@ func (p profileReportsMap) addTestResults(conformanceProfile ConformanceProfile,
 			if report.Extended == nil {
 				report.Extended = &confv1.ExtendedStatus{}
 			}
-			report.Extended.Statistics.Passed++
+			report.Extended.Passed++
 		} else {
-			report.Core.Statistics.Passed++
+			report.Core.Passed++
 		}
 	case testFailed:
 		if testIsExtended {
@@ -77,9 +77,9 @@ func (p profileReportsMap) addTestResults(conformanceProfile ConformanceProfile,
 				report.Extended = &confv1.ExtendedStatus{}
 			}
 			report.Extended.FailedTests = append(report.Extended.FailedTests, result.test.ShortName)
-			report.Extended.Statistics.Failed++
+			report.Extended.Failed++
 		} else {
-			report.Core.Statistics.Failed++
+			report.Core.Failed++
 			if report.Core.FailedTests == nil {
 				report.Core.FailedTests = []string{}
 			}
@@ -90,10 +90,10 @@ func (p profileReportsMap) addTestResults(conformanceProfile ConformanceProfile,
 			if report.Extended == nil {
 				report.Extended = &confv1.ExtendedStatus{}
 			}
-			report.Extended.Statistics.Skipped++
+			report.Extended.Skipped++
 			report.Extended.SkippedTests = append(report.Extended.SkippedTests, result.test.ShortName)
 		} else {
-			report.Core.Statistics.Skipped++
+			report.Core.Skipped++
 			report.Core.SkippedTests = append(report.Core.SkippedTests, result.test.ShortName)
 		}
 	}
@@ -196,9 +196,9 @@ func buildReportSummary(status confv1.Status) string {
 	case confv1.Success:
 		message = "succeeded"
 	case confv1.Partial:
-		message = fmt.Sprintf("partially succeeded with %d test skips", status.Statistics.Skipped)
+		message = fmt.Sprintf("partially succeeded with %d test skips", status.Skipped)
 	case confv1.Failure:
-		message = fmt.Sprintf("failed with %d test failures", status.Statistics.Failed)
+		message = fmt.Sprintf("failed with %d test failures", status.Failed)
 	}
 	return message
 }

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -97,12 +97,12 @@ func main() {
 			crdRaw := parser.CustomResourceDefinitions[groupKind]
 
 			// Inline version of "addAttribution(&crdRaw)" ...
-			if crdRaw.ObjectMeta.Annotations == nil {
-				crdRaw.ObjectMeta.Annotations = map[string]string{}
+			if crdRaw.Annotations == nil {
+				crdRaw.Annotations = map[string]string{}
 			}
-			crdRaw.ObjectMeta.Annotations[consts.BundleVersionAnnotation] = consts.BundleVersion
-			crdRaw.ObjectMeta.Annotations[consts.ChannelAnnotation] = channel
-			crdRaw.ObjectMeta.Annotations[apiext.KubeAPIApprovedAnnotation] = consts.ApprovalLink
+			crdRaw.Annotations[consts.BundleVersionAnnotation] = consts.BundleVersion
+			crdRaw.Annotations[consts.ChannelAnnotation] = channel
+			crdRaw.Annotations[apiext.KubeAPIApprovedAnnotation] = consts.ApprovalLink
 
 			// Prevent the top level metadata for the CRD to be generated regardless of the intention in the arguments
 			crd.FixTopLevelMetadata(crdRaw)
@@ -136,7 +136,7 @@ func main() {
 
 func gatewayTweaksMap(channel string, props map[string]apiext.JSONSchemaProps) map[string]apiext.JSONSchemaProps {
 	for name := range props {
-		jsonProps, _ := props[name]
+		jsonProps := props[name]
 		p := gatewayTweaks(channel, name, jsonProps)
 		if p == nil {
 			delete(props, name)

--- a/pkg/utils/duration.go
+++ b/pkg/utils/duration.go
@@ -38,7 +38,7 @@ func ParseDuration(s string) (*time.Duration, error) {
 		See https://gateway-api.sigs.k8s.io/geps/gep-2257/ for more details.
 	*/
 	if !re.MatchString(s) {
-		return nil, errors.New("Invalid duration format")
+		return nil, errors.New("invalid duration format")
 	}
 	parsedTime, err := time.ParseDuration(s)
 	if err != nil {
@@ -72,17 +72,17 @@ func FormatDuration(duration time.Duration) (string, error) {
 
 	// check if a negative value
 	if duration < 0 {
-		return "", errors.New("Invalid duration format. Cannot have negative durations")
+		return "", errors.New("invalid duration format. Cannot have negative durations")
 	}
 	// check for the maximum value allowed to be expressed
 	if duration > maxDuration {
-		return "", errors.New("Invalid duration format. Duration larger than maximum expression allowed in GEP-2257")
+		return "", errors.New("invalid duration format. Duration larger than maximum expression allowed in GEP-2257")
 	}
 	// time.Duration allows for floating point ms, which is not allowed in GEP-2257
 	durationMicroseconds := duration.Microseconds()
 
 	if durationMicroseconds%1000 != 0 {
-		return "", errors.New("Cannot express sub-milliseconds precision in GEP-2257")
+		return "", errors.New("cannot express sub-milliseconds precision in GEP-2257")
 	}
 
 	output := ""


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This PR updates golangci-lint to v2 to keep the linters and linting tool up to date.

NOTE: I broke the fix for a specific lint `static check QF1008` into a second commit as different projects tend to have different opinions on this. If it's desired to leave those in place and instead ignore this lint, we can go back and drop that commit instead and either configure this in the config file or use `//nolint` where appropriate.

**Which issue(s) this PR fixes**:

Fixes #3801 

**Does this PR introduce a user-facing change?**:
NONE
