### PR TITLE
Fix typo for the file name case type in GEP-2162 doc.

### DIFF
--- a/geps/gep-2162/index.md
+++ b/geps/gep-2162/index.md
@@ -123,7 +123,7 @@ Every feature should:
 
 #### Conformance test names
 
-Conformance tests file names should try to follow the `pascal-case-name.go` format.
+Conformance tests file names should try to follow the `kebab-case-name.go` format.
 For example for `HTTPRoutePortRedirect` - the test file would be `httproute-port-redirect.go`.
 
 We should treat this guidance as "best effort" because we might have test files that check the combination of several features and can't follow the same format.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes:**
Fixes the incorrect description of the naming convention used in the document. Described naming convention is kebab case but document says its pascal case.

**Fixes #**

**Special notes for your reviewer:**

**Does this PR introduce a user-facing change?:**
No

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**