### PR TITLE
add mesh conformance for request header modifier

### DIFF
--- a/conformance/tests/mesh/httproute-request-header-modifier-backend.yaml
+++ b/conformance/tests/mesh/httproute-request-header-modifier-backend.yaml
@@ -1,0 +1,93 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mesh-request-header-modifier
+  namespace: gateway-conformance-mesh
+spec:
+  parentRefs:
+  - group: ""
+    kind: Service
+    name: echo
+    port: 80
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /set
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+          - name: X-Header-Set
+            value: set-overwrites-values
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /add
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          add:
+          - name: X-Header-Add
+            value: add-appends-values
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /remove
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          remove:
+          - X-Header-Remove
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /multiple
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+          - name: X-Header-Set-1
+            value: header-set-1
+          - name: X-Header-Set-2
+            value: header-set-2
+          add:
+          - name: X-Header-Add-1
+            value: header-add-1
+          - name: X-Header-Add-2
+            value: header-add-2
+          - name: X-Header-Add-3
+            value: header-add-3
+          remove:
+          - X-Header-Remove-1
+          - X-Header-Remove-2
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /case-insensitivity
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+          - name: X-Header-Set
+            value: header-set
+          add:
+          - name: X-Header-Add
+            value: header-add
+          remove:
+          - X-Header-Remove

--- a/conformance/tests/mesh/httproute-request-header-modifier.go
+++ b/conformance/tests/mesh/httproute-request-header-modifier.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meshtests
+
+import (
+	"testing"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/echo"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	MeshConformanceTests = append(MeshConformanceTests,
+		MeshHHTTPRouteRequestHeaderModifier,
+		MeshHHTTPRouteBackendRequestHeaderModifier,
+	)
+}
+
+var MeshHHTTPRouteBackendRequestHeaderModifier = suite.ConformanceTest{
+	ShortName:   "MeshHHTTPRouteBackendRequestHeaderModifier",
+	Description: "An HTTPRoute backend has request header modifier filters applied correctly",
+	Features: []features.FeatureName{
+		features.SupportMesh,
+		features.SupportHTTPRoute,
+		features.SupportMeshHTTPRouteBackendRequestHeaderModification,
+	},
+	Manifests: []string{"tests/mesh/httproute-request-header-modifier-backend.yaml"},
+	Test:      MeshHHTTPRouteRequestHeaderModifier.Test,
+}
+
+var MeshHHTTPRouteRequestHeaderModifier = suite.ConformanceTest{
+	ShortName:   "MeshHHTTPRouteRequestHeaderModifier",
+	Description: "An HTTPRoute has request header modifier filters applied correctly",
+	Features: []features.FeatureName{
+		features.SupportMesh,
+		features.SupportHTTPRoute,
+	},
+	Manifests: []string{"tests/mesh/httproute-request-header-modifier.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-mesh"
+		client := echo.ConnectToApp(t, s, echo.MeshAppEchoV1)
+
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Path: "/set",
+					Headers: map[string]string{
+						"Some-Other-Header": "val",
+					},
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/set",
+						Headers: map[string]string{
+							"Some-Other-Header": "val",
+							"X-Header-Set":      "set-overwrites-values",
+						},
+					},
+				},
+				Backend:   "echo-v1",
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path: "/set",
+					Headers: map[string]string{
+						"Some-Other-Header": "val",
+						"X-Header-Set":      "some-other-value",
+					},
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/set",
+						Headers: map[string]string{
+							"Some-Other-Header": "val",
+							"X-Header-Set":      "set-overwrites-values",
+						},
+					},
+				},
+				Backend:   "echo-v1",
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path: "/add",
+					Headers: map[string]string{
+						"Some-Other-Header": "val",
+					},
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/add",
+						Headers: map[string]string{
+							"Some-Other-Header": "val",
+							"X-Header-Add":      "add-appends-values",
+						},
+					},
+				},
+				Backend:   "echo-v1",
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path: "/add",
+					Headers: map[string]string{
+						"Some-Other-Header": "val",
+						"X-Header-Add":      "some-other-value",
+					},
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/add",
+						Headers: map[string]string{
+							"Some-Other-Header": "val",
+							"X-Header-Add":      "some-other-value,add-appends-values",
+						},
+					},
+				},
+				Backend:   "echo-v1",
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path: "/remove",
+					Headers: map[string]string{
+						"X-Header-Remove": "val",
+					},
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/remove",
+					},
+					AbsentHeaders: []string{"X-Header-Remove"},
+				},
+				Backend:   "echo-v1",
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path: "/multiple",
+					Headers: map[string]string{
+						"X-Header-Set-2":    "set-val-2",
+						"X-Header-Add-2":    "add-val-2",
+						"X-Header-Remove-2": "remove-val-2",
+						"Another-Header":    "another-header-val",
+					},
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/multiple",
+						Headers: map[string]string{
+							"X-Header-Set-1": "header-set-1",
+							"X-Header-Set-2": "header-set-2",
+							"X-Header-Add-1": "header-add-1",
+							"X-Header-Add-2": "add-val-2,header-add-2",
+							"X-Header-Add-3": "header-add-3",
+							"Another-Header": "another-header-val",
+						},
+					},
+					AbsentHeaders: []string{"X-Header-Remove-1", "X-Header-Remove-2"},
+				},
+				Backend:   "echo-v1",
+				Namespace: ns,
+			}, {
+				Request: http.Request{
+					Path: "/case-insensitivity",
+					// The filter uses canonicalized header names,
+					// the request uses lowercase names.
+					Headers: map[string]string{
+						"x-header-set":    "original-val-set",
+						"x-header-add":    "original-val-add",
+						"x-header-remove": "original-val-remove",
+						"Another-Header":  "another-header-val",
+					},
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/case-insensitivity",
+						Headers: map[string]string{
+							"X-Header-Set":   "header-set",
+							"X-Header-Add":   "original-val-add,header-add",
+							"Another-Header": "another-header-val",
+						},
+					},
+					AbsentHeaders: []string{"x-header-remove", "X-Header-Remove"},
+				},
+				Backend:   "echo-v1",
+				Namespace: ns,
+			},
+		}
+
+		for i := range testCases {
+			// Declare tc here to avoid loop variable
+			// reuse issues across parallel tests.
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				client.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
+			})
+		}
+	},
+}

--- a/conformance/tests/mesh/httproute-request-header-modifier.go
+++ b/conformance/tests/mesh/httproute-request-header-modifier.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2025 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,13 +27,13 @@ import (
 
 func init() {
 	MeshConformanceTests = append(MeshConformanceTests,
-		MeshHHTTPRouteRequestHeaderModifier,
-		MeshHHTTPRouteBackendRequestHeaderModifier,
+		MeshHTTPRouteRequestHeaderModifier,
+		MeshHTTPRouteBackendRequestHeaderModifier,
 	)
 }
 
-var MeshHHTTPRouteBackendRequestHeaderModifier = suite.ConformanceTest{
-	ShortName:   "MeshHHTTPRouteBackendRequestHeaderModifier",
+var MeshHTTPRouteBackendRequestHeaderModifier = suite.ConformanceTest{
+	ShortName:   "MeshHTTPRouteBackendRequestHeaderModifier",
 	Description: "An HTTPRoute backend has request header modifier filters applied correctly",
 	Features: []features.FeatureName{
 		features.SupportMesh,
@@ -41,11 +41,11 @@ var MeshHHTTPRouteBackendRequestHeaderModifier = suite.ConformanceTest{
 		features.SupportMeshHTTPRouteBackendRequestHeaderModification,
 	},
 	Manifests: []string{"tests/mesh/httproute-request-header-modifier-backend.yaml"},
-	Test:      MeshHHTTPRouteRequestHeaderModifier.Test,
+	Test:      MeshHTTPRouteRequestHeaderModifier.Test,
 }
 
-var MeshHHTTPRouteRequestHeaderModifier = suite.ConformanceTest{
-	ShortName:   "MeshHHTTPRouteRequestHeaderModifier",
+var MeshHTTPRouteRequestHeaderModifier = suite.ConformanceTest{
+	ShortName:   "MeshHTTPRouteRequestHeaderModifier",
 	Description: "An HTTPRoute has request header modifier filters applied correctly",
 	Features: []features.FeatureName{
 		features.SupportMesh,

--- a/conformance/tests/mesh/httproute-request-header-modifier.yaml
+++ b/conformance/tests/mesh/httproute-request-header-modifier.yaml
@@ -1,0 +1,93 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mesh-request-header-modifier
+  namespace: gateway-conformance-mesh
+spec:
+  parentRefs:
+  - group: ""
+    kind: Service
+    name: echo
+    port: 80
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /set
+    filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        set:
+        - name: X-Header-Set
+          value: set-overwrites-values
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /add
+    filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        add:
+        - name: X-Header-Add
+          value: add-appends-values
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /remove
+    filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        remove:
+        - X-Header-Remove
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /multiple
+    filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        set:
+        - name: X-Header-Set-1
+          value: header-set-1
+        - name: X-Header-Set-2
+          value: header-set-2
+        add:
+        - name: X-Header-Add-1
+          value: header-add-1
+        - name: X-Header-Add-2
+          value: header-add-2
+        - name: X-Header-Add-3
+          value: header-add-3
+        remove:
+        - X-Header-Remove-1
+        - X-Header-Remove-2
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /case-insensitivity
+    filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        set:
+        - name: X-Header-Set
+          value: header-set
+        add:
+        - name: X-Header-Add
+          value: header-add
+        remove:
+        - X-Header-Remove
+    backendRefs:
+    - name: echo-v1
+      port: 8080

--- a/conformance/utils/echo/parse.go
+++ b/conformance/utils/echo/parse.go
@@ -184,9 +184,8 @@ func ParseResponse(output string) Response {
 		if len(sl) != 2 {
 			continue
 		}
-		out.RequestHeaders.Set(sl[0], sl[1])
+		out.RequestHeaders.Add(sl[0], sl[1])
 	}
-
 	matches = responseHeaderFieldRegex.FindAllStringSubmatch(output, -1)
 	for _, kv := range matches {
 		sl := strings.SplitN(kv[1], ":", 2)

--- a/conformance/utils/echo/pod.go
+++ b/conformance/utils/echo/pod.go
@@ -121,7 +121,8 @@ func compareRequest(exp http.ExpectedResponse, resp Response) error {
 			actualVal, ok := resp.RequestHeaders[strings.ToLower(name)]
 			if !ok {
 				return fmt.Errorf("expected %s header to be set, actual headers: %v", name, resp.RequestHeaders)
-			} else if strings.Join(actualVal, ",") != expectedVal {
+			}
+			if strings.Join(actualVal, ",") != expectedVal {
 				return fmt.Errorf("expected %s header to be set to %s, got %s", name, expectedVal, strings.Join(actualVal, ","))
 			}
 		}

--- a/conformance/utils/echo/pod.go
+++ b/conformance/utils/echo/pod.go
@@ -57,16 +57,8 @@ const (
 func (m *MeshPod) MakeRequestAndExpectEventuallyConsistentResponse(t *testing.T, exp http.ExpectedResponse, timeoutConfig config.TimeoutConfig) {
 	t.Helper()
 
-	if exp.Request.Method == "" {
-		exp.Request.Method = "GET"
-	}
-
-	if exp.Response.StatusCode == 0 {
-		exp.Response.StatusCode = 200
-	}
-
 	http.AwaitConvergence(t, timeoutConfig.RequiredConsecutiveSuccesses, timeoutConfig.MaxTimeToConsistency, func(elapsed time.Duration) bool {
-		req := makeRequest(t, exp.Request)
+		req := makeRequest(t, &exp)
 
 		resp, err := m.request(req)
 		if err != nil {
@@ -84,7 +76,19 @@ func (m *MeshPod) MakeRequestAndExpectEventuallyConsistentResponse(t *testing.T,
 	tlog.Logf(t, "Request passed")
 }
 
-func makeRequest(t *testing.T, r http.Request) []string {
+func makeRequest(t *testing.T, exp *http.ExpectedResponse) []string {
+	if exp.Request.Host == "" {
+		exp.Request.Host = "echo"
+	}
+	if exp.Request.Method == "" {
+		exp.Request.Method = "GET"
+	}
+
+	if exp.Response.StatusCode == 0 {
+		exp.Response.StatusCode = 200
+	}
+
+	r := exp.Request
 	protocol := strings.ToLower(r.Protocol)
 	if protocol == "" {
 		protocol = "http"
@@ -95,22 +99,52 @@ func makeRequest(t *testing.T, r http.Request) []string {
 		args = append(args, "--method="+r.Method)
 	}
 	for k, v := range r.Headers {
-		args = append(args, "-H", fmt.Sprintf("%v: %v", k, v))
+		args = append(args, "-H", fmt.Sprintf("%v:%v", k, v))
 	}
 	return args
 }
 
 func compareRequest(exp http.ExpectedResponse, resp Response) error {
-	want := exp.Response
-	if fmt.Sprint(want.StatusCode) != resp.Code {
-		return fmt.Errorf("wanted status code %v, got %v", want.StatusCode, resp.Code)
+	wantReq := exp.ExpectedRequest
+	wantResp := exp.Response
+	if fmt.Sprint(wantResp.StatusCode) != resp.Code {
+		return fmt.Errorf("wanted status code %v, got %v", wantResp.StatusCode, resp.Code)
 	}
-	for _, name := range want.AbsentHeaders {
+	if wantReq.Headers != nil {
+		if resp.RequestHeaders == nil {
+			return fmt.Errorf("no headers captured, expected %v", len(wantReq.Headers))
+		}
+		for name, val := range resp.RequestHeaders {
+			resp.RequestHeaders[strings.ToLower(name)] = val
+		}
+		for name, expectedVal := range wantReq.Headers {
+			actualVal, ok := resp.RequestHeaders[strings.ToLower(name)]
+			if !ok {
+				return fmt.Errorf("expected %s header to be set, actual headers: %v", name, resp.RequestHeaders)
+			} else if strings.Join(actualVal, ",") != expectedVal {
+				return fmt.Errorf("expected %s header to be set to %s, got %s", name, expectedVal, strings.Join(actualVal, ","))
+			}
+		}
+	}
+	if len(wantReq.AbsentHeaders) > 0 {
+		for name, val := range resp.RequestHeaders {
+			resp.RequestHeaders[strings.ToLower(name)] = val
+		}
+
+		for _, name := range wantReq.AbsentHeaders {
+			val, ok := resp.RequestHeaders[strings.ToLower(name)]
+			if ok {
+				return fmt.Errorf("expected %s header to not be set, got %s", name, val)
+			}
+		}
+	}
+
+	for _, name := range wantResp.AbsentHeaders {
 		if v := resp.ResponseHeaders.Values(name); len(v) != 0 {
 			return fmt.Errorf("expected no header %q, got %v", name, v)
 		}
 	}
-	for k, v := range want.Headers {
+	for k, v := range wantResp.Headers {
 		if got := resp.ResponseHeaders.Get(k); got != v {
 			return fmt.Errorf("expected header %v=%v, got %v", k, v, got)
 		}

--- a/pkg/features/mesh.go
+++ b/pkg/features/mesh.go
@@ -56,6 +56,8 @@ const (
 	SupportMeshHTTPRouteRedirectPort FeatureName = "MeshHTTPRouteRedirectPort"
 	// This option indicates mesh support for HTTPRoute path redirect (extended conformance)
 	SupportMeshHTTPRouteRedirectPath FeatureName = "MeshHTTPRouteRedirectPath"
+	// This option indicates support for HTTPRoute backend request header modification
+	SupportMeshHTTPRouteBackendRequestHeaderModification FeatureName = "MeshHTTPRouteBackendRequestHeaderModification"
 )
 
 var (
@@ -93,6 +95,12 @@ var (
 		Name:    SupportMeshHTTPRouteRedirectPath,
 		Channel: FeatureChannelStandard,
 	}
+
+	// MeshHTTPRouteRedirectPath contains metadata for the MeshHTTPRouteRedirectPath feature.
+	MeshHTTPRouteBackendRequestHeaderModification = Feature{
+		Name:    SupportMeshHTTPRouteBackendRequestHeaderModification,
+		Channel: FeatureChannelStandard,
+	}
 )
 
 // MeshExtendedFeatures includes all the supported features for the service mesh at
@@ -103,4 +111,5 @@ var MeshExtendedFeatures = sets.New(
 	MeshHTTPRouteRewritePath,
 	MeshHTTPRouteSchemeRedirect,
 	MeshHTTPRouteRedirectPath,
+	MeshHTTPRouteBackendRequestHeaderModification,
 )


### PR DESCRIPTION
**What type of PR is this?**
/area conformance-test

Add mesh tests for request header modifier
This is a follow up to https://github.com/kubernetes-sigs/gateway-api/pull/3729

**What this PR does / why we need it**:
Add mesh tests coverage

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related https://github.com/kubernetes-sigs/gateway-api/issues/3581

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add mesh conformance tests for httproute request header modifier
```

/cc @robscott 
