### PR TITLE
WIP: Remove stale implementations from implementation list

### DIFF
--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -6,44 +6,27 @@ and provides status and resource references for them.
 Implementors and integrators of Gateway API are encouraged to update this
 document with status information about their implementations, the versions they
 cover, and documentation to help users get started.
-
+Any implementation that has a recent conformance report (regardless of the result) may be added to the list.
 
 !!! info "Compare extended supported features across implementations"
 
-    [View a table to quickly compare supported features of projects](implementations/v1.1.md). These outline Gateway controller implementations that have passed core conformance tests, and focus on extended conformance features that they have implemented.
+    [View a table to quickly compare supported features of projects](implementations/v1.2.md). These outline Gateway controller implementations that have passed core conformance tests, and focus on extended conformance features that they have implemented.
 
 ## Gateway Controller Implementation Status <a name="gateways"></a>
 
-- [Acnodal EPIC][1]
 - [Airlock Microgateway][34]
-- [Amazon Elastic Kubernetes Service][23] (GA)
-- [Apache APISIX][2] (beta)
-- [Avi Kubernetes Operator][31]
 - [Azure Application Gateway for Containers][27] (GA)
 - [Cilium][16] (beta)
 - [Contour][3] (GA)
-- [Easegress][30] (GA)
-- [Emissary-Ingress (Ambassador API Gateway)][4] (alpha)
 - [Envoy Gateway][18] (GA)
-- [Flomesh Service Mesh][17] (beta)
 - [Gloo Gateway][5] (GA)
 - [Google Kubernetes Engine][6] (GA)
-- [HAProxy Ingress][7] (alpha)
-- [HAProxy Kubernetes Ingress Controller][32] (GA)
-- [HashiCorp Consul][8]
 - [Istio][9] (GA)
 - [kgateway][37] (GA)
 - [Kong Ingress Controller][10] (GA)
-- [Kong Gateway Operator][35] (GA)
 - [Kuma][11] (GA)
-- [LiteSpeed Ingress Controller][19]
-- [LoxiLB][36] (beta)
 - [NGINX Gateway Fabric][12] (GA)
-- [ngrok][33] (preview)
-- [STUNner][21] (beta)
 - [Traefik Proxy][13] (GA)
-- [Tyk][29] (work in progress)
-- [WSO2 APK][25] (GA)
 
 ## Service Mesh Implementation Status <a name="meshes"></a>
 


### PR DESCRIPTION

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

The goal of this PR is to help users understand which viable options they have when choosing an implementation. 

Recently, I put on my 'user hat' and was very frustrated to find that many implementations I had chosen were unusable. Some had only support for ancient versions like 0.4, while others point to an entirely empty repository. We should give users an **up to date** list of implementations to help guide them.

My goal here is not to force out any implementation -- I think a large active list/community is ideal. It is only to weed out implementations that are entirely dead.

That being said, I think this PR goes too far. My initial criteria I came up with "Has ever submitted a conformance report" I assumed would be easily met, yet it excludes 17/30 implementations!

So I think before merging this we will want to either:
a) Come up with a new criteria.
b) Give implementations a N month warning to send a conformance report or be removed

To re-iterate, the criteria I am proposing is not "passes conformance tests", merely has submitted one, which is a very low bar. I also included "recently", which I interpreted as "since 1.0 (when we first started collecting reports)" for now. In the future, we would likely make this something like in the past year/past N releases/etc.

Note: if we are to move forward with this, we also need to remove the stale descriptions of the removed projects. I will do that once we come to some consensus.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
