### PR TITLE
Remove unused dependabot config for Github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,17 +30,6 @@ updates:
       - ok-to-test
       - release-note-none
 
-  # Dependencies listed in .github/workflows/*.yml
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    labels:
-      - github_actions
-      - dependencies
-      - ok-to-test
-      - release-note-none
-
   # Dependencies listed in Dockerfile
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the Dependabot configuration for the `github-actions` package ecosystem since Github Actions are not used in this repository. There is no PR ever created with a `dependencies` tag which is not for `go`, `docker`, or `python`.

**What type of PR is this?**
/kind cleanup

-->
```release-note
NONE
```
