### PR TITLE
chore: remove inactive reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -32,9 +32,7 @@ aliases:
 
   gateway-api-conformance-reviewers:
     - candita
-    - michaelbeaumont
     - sunjayBhatia
-    - xunzhuo
 
   gateway-api-conformance-approvers:
     - arkodg


### PR DESCRIPTION
This removes some of the reviewers that have not been active for some time.