### PR TITLE
add mesh conformance for httproute-queryparmas-match

### DIFF
--- a/conformance/tests/mesh/httproute-query-param-matching.go
+++ b/conformance/tests/mesh/httproute-query-param-matching.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meshtests
+
+import (
+	"testing"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/echo"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	MeshConformanceTests = append(MeshConformanceTests, MeshHTTPRouteQueryParamMatching)
+}
+
+var MeshHTTPRouteQueryParamMatching = suite.ConformanceTest{
+	ShortName:   "MeshHTTPRouteQueryParamMatching",
+	Description: "A single HTTPRoute with query param matching for different backends",
+	Manifests:   []string{"tests/mesh/httproute-query-param-matching.yaml"},
+	Features: []features.FeatureName{
+		features.SupportMesh,
+		features.SupportHTTPRoute,
+		features.SupportMeshHTTPRouteQueryParamMatching,
+	},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-mesh"
+		client := echo.ConnectToApp(t, s, echo.MeshAppEchoV1)
+
+		testCases := []http.ExpectedResponse{{
+			Request:   http.Request{Path: "/?animal=whale"},
+			Backend:   "echo-v1",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Path: "/?animal=dolphin"},
+			Backend:   "echo-v2",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Path: "/?animal=whale&otherparam=irrelevant"},
+			Backend:   "echo-v1",
+			Namespace: ns,
+		}, {
+			Request:   http.Request{Path: "/?animal=dolphin&color=yellow"},
+			Backend:   "echo-v2",
+			Namespace: ns,
+		}, {
+			Request:  http.Request{Path: "/?color=blue"},
+			Response: http.Response{StatusCode: 404},
+		}, {
+			Request:  http.Request{Path: "/?animal=dog"},
+			Response: http.Response{StatusCode: 404},
+		}, {
+			Request:  http.Request{Path: "/?animal=whaledolphin"},
+			Response: http.Response{StatusCode: 404},
+		}, {
+			Request:  http.Request{Path: "/"},
+			Response: http.Response{StatusCode: 404},
+		}}
+
+		// Combinations of query param matching with other core matches.
+		testCases = append(testCases, []http.ExpectedResponse{
+			{
+				Request:   http.Request{Path: "/path1?animal=whale"},
+				Backend:   "echo-v1",
+				Namespace: ns,
+			},
+			{
+				Request:   http.Request{Headers: map[string]string{"version": "one"}, Path: "/?animal=whale"},
+				Backend:   "echo-v2",
+				Namespace: ns,
+			},
+		}...)
+
+		// Ensure that combinations of matches which are OR'd together match
+		// even if only one of them is used in the request.
+		testCases = append(testCases, []http.ExpectedResponse{
+			{
+				Request:   http.Request{Path: "/path3?animal=shark"},
+				Backend:   "echo-v1",
+				Namespace: ns,
+			},
+			{
+				Request:   http.Request{Headers: map[string]string{"version": "three"}, Path: "/path4?animal=kraken"},
+				Backend:   "echo-v1",
+				Namespace: ns,
+			},
+		}...)
+
+		// Ensure that combinations of match types which are ANDed together do not match
+		// when only a subset of match types is used in the request.
+		testCases = append(testCases, []http.ExpectedResponse{
+			{
+				Request:  http.Request{Path: "/?animal=shark"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:  http.Request{Path: "/path4?animal=kraken"},
+				Response: http.Response{StatusCode: 404},
+			},
+		}...)
+
+		// For requests that satisfy multiple matches, ensure precedence order
+		// defined by the Gateway API spec is maintained.
+		testCases = append(testCases, []http.ExpectedResponse{
+			{
+				Request:   http.Request{Path: "/path5?animal=hydra"},
+				Backend:   "echo-v1",
+				Namespace: ns,
+			},
+		}...)
+
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				client.MakeRequestAndExpectEventuallyConsistentResponse(t, tc, s.TimeoutConfig)
+			})
+		}
+	},
+}

--- a/conformance/tests/mesh/httproute-query-param-matching.yaml
+++ b/conformance/tests/mesh/httproute-query-param-matching.yaml
@@ -1,0 +1,85 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mesh-query-param-matching
+  namespace: gateway-conformance-mesh
+spec:
+  parentRefs:
+  - group: ""
+    kind: Service
+    name: echo
+    port: 80
+  rules:
+  - matches:
+    - queryParams:
+      - name: animal
+        value: whale
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+  - matches:
+    - queryParams:
+      - name: animal
+        value: dolphin
+    backendRefs:
+    - name: echo-v2
+      port: 8080
+
+  # Combinations with core match types.
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /path1
+      queryParams:
+      - name: animal
+        value: whale
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+  - matches:
+    - headers:
+      - name: version
+        value: one
+      queryParams:
+      - name: animal
+        value: whale
+    backendRefs:
+    - name: echo-v2
+      port: 8080
+
+  # Match of the form (cond1 AND cond2) OR (cond3 AND cond4 AND cond5)
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /path3
+      queryParams:
+      - name: animal
+        value: shark
+    - path:
+        type: PathPrefix
+        value: /path4
+      headers:
+      - name: version
+        value: three
+      queryParams:
+      - name: animal
+        value: kraken
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+
+  # Matches for checking precedence.
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /path5
+    backendRefs:
+    - name: echo-v1
+      port: 8080
+  - matches:
+    - queryParams:
+      - name: animal
+        value: hydra
+    backendRefs:
+    - name: echo-v2
+      port: 8080

--- a/pkg/features/mesh.go
+++ b/pkg/features/mesh.go
@@ -58,6 +58,8 @@ const (
 	SupportMeshHTTPRouteRedirectPath FeatureName = "MeshHTTPRouteRedirectPath"
 	// This option indicates support for HTTPRoute backend request header modification
 	SupportMeshHTTPRouteBackendRequestHeaderModification FeatureName = "MeshHTTPRouteBackendRequestHeaderModification"
+	// This option indicates mesh support for HTTPRoute query param matching (extended conformance).
+	SupportMeshHTTPRouteQueryParamMatching FeatureName = "MeshHTTPRouteQueryParamMatching"
 )
 
 var (
@@ -101,6 +103,11 @@ var (
 		Name:    SupportMeshHTTPRouteBackendRequestHeaderModification,
 		Channel: FeatureChannelStandard,
 	}
+	// MeshHTTPRouteRedirectPath contains metadata for the MeshHTTPRouteRedirectPath feature.
+	MeshHTTPRouteQueryParamMatching = Feature{
+		Name:    SupportMeshHTTPRouteQueryParamMatching,
+		Channel: FeatureChannelStandard,
+	}
 )
 
 // MeshExtendedFeatures includes all the supported features for the service mesh at
@@ -112,4 +119,5 @@ var MeshExtendedFeatures = sets.New(
 	MeshHTTPRouteSchemeRedirect,
 	MeshHTTPRouteRedirectPath,
 	MeshHTTPRouteBackendRequestHeaderModification,
+	MeshHTTPRouteQueryParamMatching,
 )


### PR DESCRIPTION
**What type of PR is this?**
/area conformance-test

Add mesh tests for request header modifier
This is a follow up to https://github.com/kubernetes-sigs/gateway-api/pull/3729

**What this PR does / why we need it**:
Add mesh tests coverage

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related https://github.com/kubernetes-sigs/gateway-api/issues/3581

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add mesh conformance for httproute-queryparmas-match
```

