### PR TITLE
fix meshredirectport and schemeredirect mesh conformance features

### DIFF
--- a/pkg/features/mesh.go
+++ b/pkg/features/mesh.go
@@ -82,7 +82,7 @@ var (
 
 	// MeshHTTPRouteSchemeRedirect contains metadata for the MeshHTTPRouteSchemeRedirect feature.
 	MeshHTTPRouteSchemeRedirect = Feature{
-		Name:    SupportMeshHTTPRouteRewritePath,
+		Name:    SupportMeshHTTPRouteSchemeRedirect,
 		Channel: FeatureChannelStandard,
 	}
 

--- a/pkg/features/mesh.go
+++ b/pkg/features/mesh.go
@@ -117,6 +117,7 @@ var MeshExtendedFeatures = sets.New(
 	MeshConsumerRouteFeature,
 	MeshHTTPRouteRewritePath,
 	MeshHTTPRouteSchemeRedirect,
+	MeshHTTPRouteRedirectPort,
 	MeshHTTPRouteRedirectPath,
 	MeshHTTPRouteBackendRequestHeaderModification,
 	MeshHTTPRouteQueryParamMatching,


### PR DESCRIPTION
/kind bug
/area conformance-machinery

**What this PR does / why we need it**:
include missing feature in extended mesh tests suite and fixing a typo 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
