### PR TITLE
feat(httproute): add custom type path match

### DIFF
--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -520,14 +520,14 @@ const (
 // +kubebuilder:validation:XValidation:message="must not contain '#' when type one of ['Exact', 'PathPrefix']",rule="(self.type in ['Exact','PathPrefix']) ? !self.value.contains('#') : true"
 // +kubebuilder:validation:XValidation:message="must not end with '/..' when type one of ['Exact', 'PathPrefix']",rule="(self.type in ['Exact','PathPrefix']) ? !self.value.endsWith('/..') : true"
 // +kubebuilder:validation:XValidation:message="must not end with '/.' when type one of ['Exact', 'PathPrefix']",rule="(self.type in ['Exact','PathPrefix']) ? !self.value.endsWith('/.') : true"
-// +kubebuilder:validation:XValidation:message="type must be one of ['Exact', 'PathPrefix', 'RegularExpression']",rule="self.type in ['Exact','PathPrefix'] || self.type == 'RegularExpression'"
+// +kubebuilder:validation:XValidation:message="type must be one of ['Exact', 'PathPrefix', 'RegularExpression'] or domain-prefixed custom value",rule="self.type in ['Exact','PathPrefix'] || self.type == 'RegularExpression' || self.type.matches('^([^/]+)/(.+)$')"
 // +kubebuilder:validation:XValidation:message="must only contain valid characters (matching ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$) for types ['Exact', 'PathPrefix']",rule="(self.type in ['Exact','PathPrefix']) ? self.value.matches(r\"\"\"^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$\"\"\") : true"
 type HTTPPathMatch struct {
 	// Type specifies how to match against the path Value.
 	//
 	// Support: Core (Exact, PathPrefix)
 	//
-	// Support: Implementation-specific (RegularExpression)
+	// Support: Implementation-specific (RegularExpression, any value domain-prefixed)
 	//
 	// +optional
 	// +kubebuilder:default=PathPrefix

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -2929,7 +2929,7 @@ spec:
 
                                   Support: Core (Exact, PathPrefix)
 
-                                  Support: Implementation-specific (RegularExpression)
+                                  Support: Implementation-specific (RegularExpression, any value domain-prefixed)
                                 enum:
                                 - Exact
                                 - PathPrefix
@@ -2979,9 +2979,9 @@ spec:
                               rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/.'')
                                 : true'
                             - message: type must be one of ['Exact', 'PathPrefix',
-                                'RegularExpression']
+                                'RegularExpression'] or domain-prefixed custom value
                               rule: self.type in ['Exact','PathPrefix'] || self.type
-                                == 'RegularExpression'
+                                == 'RegularExpression' || self.type.matches('^([^/]+)/(.+)$')
                             - message: must only contain valid characters (matching
                                 ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
                                 for types ['Exact', 'PathPrefix']
@@ -6555,7 +6555,7 @@ spec:
 
                                   Support: Core (Exact, PathPrefix)
 
-                                  Support: Implementation-specific (RegularExpression)
+                                  Support: Implementation-specific (RegularExpression, any value domain-prefixed)
                                 enum:
                                 - Exact
                                 - PathPrefix
@@ -6605,9 +6605,9 @@ spec:
                               rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/.'')
                                 : true'
                             - message: type must be one of ['Exact', 'PathPrefix',
-                                'RegularExpression']
+                                'RegularExpression'] or domain-prefixed custom value
                               rule: self.type in ['Exact','PathPrefix'] || self.type
-                                == 'RegularExpression'
+                                == 'RegularExpression' || self.type.matches('^([^/]+)/(.+)$')
                             - message: must only contain valid characters (matching
                                 ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
                                 for types ['Exact', 'PathPrefix']

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -2304,7 +2304,7 @@ spec:
 
                                   Support: Core (Exact, PathPrefix)
 
-                                  Support: Implementation-specific (RegularExpression)
+                                  Support: Implementation-specific (RegularExpression, any value domain-prefixed)
                                 enum:
                                 - Exact
                                 - PathPrefix
@@ -2354,9 +2354,9 @@ spec:
                               rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/.'')
                                 : true'
                             - message: type must be one of ['Exact', 'PathPrefix',
-                                'RegularExpression']
+                                'RegularExpression'] or domain-prefixed custom value
                               rule: self.type in ['Exact','PathPrefix'] || self.type
-                                == 'RegularExpression'
+                                == 'RegularExpression' || self.type.matches('^([^/]+)/(.+)$')
                             - message: must only contain valid characters (matching
                                 ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
                                 for types ['Exact', 'PathPrefix']
@@ -5099,7 +5099,7 @@ spec:
 
                                   Support: Core (Exact, PathPrefix)
 
-                                  Support: Implementation-specific (RegularExpression)
+                                  Support: Implementation-specific (RegularExpression, any value domain-prefixed)
                                 enum:
                                 - Exact
                                 - PathPrefix
@@ -5149,9 +5149,9 @@ spec:
                               rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/.'')
                                 : true'
                             - message: type must be one of ['Exact', 'PathPrefix',
-                                'RegularExpression']
+                                'RegularExpression'] or domain-prefixed custom value
                               rule: self.type in ['Exact','PathPrefix'] || self.type
-                                == 'RegularExpression'
+                                == 'RegularExpression' || self.type.matches('^([^/]+)/(.+)$')
                             - message: must only contain valid characters (matching
                                 ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
                                 for types ['Exact', 'PathPrefix']

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -4524,7 +4524,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_HTTPPathMatch(ref common.ReferenceCall
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Type specifies how to match against the path Value.\n\nSupport: Core (Exact, PathPrefix)\n\nSupport: Implementation-specific (RegularExpression)",
+							Description: "Type specifies how to match against the path Value.\n\nSupport: Core (Exact, PathPrefix)\n\nSupport: Implementation-specific (RegularExpression, any value domain-prefixed)",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind feature

**What this PR does / why we need it**:

Addition of a new custom type path match

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3717 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
`HTTPRoute` now supports a domain-prefixed type as a path match, in addition to the already existing ones.
```
