### PR TITLE
Improve distribution tests in conformance for MeshHTTPRouteWeight

### DIFF
--- a/conformance/tests/mesh/httproute-weight.go
+++ b/conformance/tests/mesh/httproute-weight.go
@@ -148,9 +148,9 @@ func testDistribution(t *testing.T, client echo.MeshPod, expected http.ExpectedR
 
 // addEntropy adds jitter to the request by adding either a delay up to 1 second, or a random header value, or both.
 func addEntropy(exp *http.ExpectedResponse) {
-	delay := func() { time.Sleep(time.Duration(rand.Intn(1000)) * time.Millisecond) }
-	randomHeader := func() { exp.Request.Headers["X-Jitter"] = fmt.Sprintf("%d", rand.Intn(9999)) }
-	switch rand.Intn(3) {
+	delay := func() { time.Sleep(time.Duration(rand.Intn(1000)) * time.Millisecond) }               //nolint:gosec // This is test code to get random value.
+	randomHeader := func() { exp.Request.Headers["X-Jitter"] = fmt.Sprintf("%d", rand.Intn(9999)) } //nolint:gosec // This is test code to get random value.
+	switch rand.Intn(3) {                                                                           //nolint:gosec // This is test code to get random value
 	case 0:
 		delay()
 	case 1:

--- a/conformance/tests/mesh/httproute-weight.go
+++ b/conformance/tests/mesh/httproute-weight.go
@@ -196,6 +196,6 @@ func addEntropy(exp *http.ExpectedResponse) error {
 		}
 		return randomHeader(10000)
 	default:
-		return nil
+		return fmt.Errorf("invalid random value: %d", *random)
 	}
 }

--- a/conformance/tests/mesh/httproute-weight.go
+++ b/conformance/tests/mesh/httproute-weight.go
@@ -186,13 +186,16 @@ func addEntropy(exp *http.ExpectedResponse) error {
 	}
 
 	switch *random {
-	case int64(0):
-		delay(1000)
+	case 0:
+		return delay(1000)
 	case 1:
-		randomHeader(10000)
+		return randomHeader(10000)
 	case 2:
-		delay(1000)
-		randomHeader(10000)
+		if err := delay(1000); err != nil {
+			return err
+		}
+		return randomHeader(10000)
+	default:
+		return nil
 	}
-	return nil
 }

--- a/conformance/tests/mesh/httproute-weight.go
+++ b/conformance/tests/mesh/httproute-weight.go
@@ -54,7 +54,7 @@ var MeshHTTPRouteWeight = suite.ConformanceTest{
 		t.Run("Requests should have a distribution that matches the weight", func(t *testing.T) {
 			host := "echo"
 			expected := http.ExpectedResponse{
-				Request:   http.Request{Path: "/", Host: host, Headers: make(map[string]string)},
+				Request:   http.Request{Path: "/", Host: host},
 				Response:  http.Response{StatusCode: 200},
 				Namespace: "gateway-conformance-mesh",
 			}
@@ -148,9 +148,12 @@ func testDistribution(t *testing.T, client echo.MeshPod, expected http.ExpectedR
 
 // addEntropy adds jitter to the request by adding either a delay up to 1 second, or a random header value, or both.
 func addEntropy(exp *http.ExpectedResponse) {
-	delay := func() { time.Sleep(time.Duration(rand.Intn(1000)) * time.Millisecond) }               //nolint:gosec // This is test code to get random value.
-	randomHeader := func() { exp.Request.Headers["X-Jitter"] = fmt.Sprintf("%d", rand.Intn(9999)) } //nolint:gosec // This is test code to get random value.
-	switch rand.Intn(3) {                                                                           //nolint:gosec // This is test code to get random value
+	delay := func() { time.Sleep(time.Duration(rand.Intn(1000)) * time.Millisecond) } //nolint:gosec // This is test code to get random value.
+	randomHeader := func() {
+		exp.Request.Headers = make(map[string]string)
+		exp.Request.Headers["X-Jitter"] = fmt.Sprintf("%d", rand.Intn(9999)) //nolint:gosec // This is test code to get random value.
+	}
+	switch rand.Intn(3) { //nolint:gosec // This is test code to get random value
 	case 0:
 		delay()
 	case 1:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/area conformance-test


**What this PR does / why we need it**:
Adding entropy to distribution tests as per comment https://github.com/kubernetes-sigs/gateway-api/pull/3827#discussion_r2123121430

This is done by introducing random jitter by adding either a short delay, or adding random header values, or both.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3832 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Improve mesh conformance distribution tests for httproute weights routing
```