### PR TITLE
Make feature name required for Experimental

### DIFF
--- a/geps/gep-696/index.md
+++ b/geps/gep-696/index.md
@@ -47,6 +47,8 @@ Every feature should:
 3. Not exceed 128 characters.
 4. Contain only letters and numbers
 
+GEPs cannot move to Experimental without a Feature Name.
+
 ### Conformance tests 
 
 Conformance tests file names should try to follow the `pascal-case-name.go` format.

--- a/geps/overview.md
+++ b/geps/overview.md
@@ -151,6 +151,8 @@ use the `experimental` Golang build tag to denote experimental functionality.
 Some other requirements must be met before marking a GEP `Experimental`:
 
 - the graduation criteria to reach `Standard` MUST be filled out
+- the GEP must have at least one Feature Name for features described inside that
+  will need to be tested by conformance tests.
 - a proposed probationary period (see next section) must be included in the GEP
   and approved by maintainers.
 


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:

We have discussed this in community meetings and
Slack, and have informally agreed that
a conformance Feature Name must be set for a
GEP to graduate to Experimental.

This PR adds changes to the GEP process page and the GEP template to make this official.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Feature Names are now required for moving GEPs to Experimental status.
```
