### PR TITLE
GEP-3792 and GEP-3793 title fixes :man_facepalming:

### DIFF
--- a/geps/gep-3792/index.md
+++ b/geps/gep-3792/index.md
@@ -1,4 +1,4 @@
-# GEP-3792: External Gateways
+# GEP-3792: Out-of-Cluster Gateways
 
 * Issue: [#3792](https://github.com/kubernetes-sigs/gateway-api/issues/3792)
 * Status: Provisional

--- a/geps/gep-3792/metadata.yaml
+++ b/geps/gep-3792/metadata.yaml
@@ -1,7 +1,7 @@
 apiVersion: internal.gateway.networking.k8s.io/v1alpha1
 kind: GEPDetails
 number: 3792
-name: GEP template
+name: Out-of-Cluster Gateways
 status: Provisional
 # Any authors who contribute to the GEP in any way should be listed here using
 # their GitHub handle.

--- a/geps/gep-3793/metadata.yaml
+++ b/geps/gep-3793/metadata.yaml
@@ -1,7 +1,7 @@
 apiVersion: internal.gateway.networking.k8s.io/v1alpha1
 kind: GEPDetails
 number: 3793
-name: GEP template
+name: Default Gateways
 status: Provisional
 # Any authors who contribute to the GEP in any way should be listed here using
 # their GitHub handle.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,8 @@ nav:
       - geps/gep-1494/index.md
       - geps/gep-1651/index.md
       - geps/gep-2648/index.md
+      - geps/gep-3792/index.md
+      - geps/gep-3793/index.md
     - Implementable:
       - geps/gep-91/index.md
       - geps/gep-3567/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
       - geps/gep-1494/index.md
       - geps/gep-1651/index.md
       - geps/gep-2648/index.md
+      - geps/gep-3379/index.md
       - geps/gep-3792/index.md
       - geps/gep-3793/index.md
     - Implementable:


### PR DESCRIPTION
The `metadata.yaml` files for GEP-3792 and GEP-3793 didn't use the correct titles (and, for that matter, neither did `index.md` for GEP-3792...). 🤦‍♂️ 


/kind cleanup

```release-note
NONE
```
