### PR TITLE
[GEP-2162] Updated a new field on supported features inference from boolean to enum and remove from report.

### DIFF
--- a/conformance/apis/v1/conformancereport.go
+++ b/conformance/apis/v1/conformancereport.go
@@ -51,17 +51,17 @@ type ConformanceReport struct {
 	// have been successfully run.
 	SucceededProvisionalTests []string `json:"succeededProvisionalTests,omitempty"`
 
-	// InferredSupportedFeatures indicates whether the supported features were
+	// SupportedFeaturesSource indicates whether the supported features were
 	// automatically detected by the conformance suite.
-	InferredSupportedFeatures InferredSupportedFeatures `json:"inferredSupportedFeatures"`
+	SupportedFeaturesSource SupportedFeaturesSource `json:"SupportedFeaturesSource"`
 }
 
-type InferredSupportedFeatures int
+type SupportedFeaturesSource int
 
 const (
-	InferredSupportedFeaturesFalse InferredSupportedFeatures = iota
-	InferredSupportedFeaturesTrue
-	InferredSupportedFeaturesUnsupported
+	SupportedFeaturesSourceUndefined SupportedFeaturesSource = iota
+	SupportedFeaturesSourceManual
+	SupportedFeaturesSourceInferred
 )
 
 // Implementation provides metadata information on the downstream

--- a/conformance/apis/v1/conformancereport.go
+++ b/conformance/apis/v1/conformancereport.go
@@ -50,22 +50,7 @@ type ConformanceReport struct {
 	// SucceededProvisionalTests is a list of the names of the provisional tests that
 	// have been successfully run.
 	SucceededProvisionalTests []string `json:"succeededProvisionalTests,omitempty"`
-
-	// SupportedFeaturesSource indicates whether the supported features were
-	// automatically detected by the conformance suite.
-	SupportedFeaturesSource SupportedFeaturesSource `json:"supportedFeaturesSource"`
 }
-
-// SupportedFeaturesSource represents the source from which supported features are derived.
-// It is used to distinguish between them being inferred from GWC Status or manually
-// supplied for the conformance report.
-type SupportedFeaturesSource string
-
-const (
-	SupportedFeaturesSourceUndefined SupportedFeaturesSource = "Undefined"
-	SupportedFeaturesSourceManual    SupportedFeaturesSource = "Manual"
-	SupportedFeaturesSourceInferred  SupportedFeaturesSource = "Inferred"
-)
 
 // Implementation provides metadata information on the downstream
 // implementation of Gateway API which ran conformance tests.

--- a/conformance/apis/v1/conformancereport.go
+++ b/conformance/apis/v1/conformancereport.go
@@ -56,6 +56,9 @@ type ConformanceReport struct {
 	SupportedFeaturesSource SupportedFeaturesSource `json:"SupportedFeaturesSource"`
 }
 
+// SupportedFeaturesSource represents the source from which supported features are derived.
+// It is used to distinguish between them being inferred from GWC Status or manually
+// supplied for the conformance report.
 type SupportedFeaturesSource int
 
 const (

--- a/conformance/apis/v1/conformancereport.go
+++ b/conformance/apis/v1/conformancereport.go
@@ -59,12 +59,12 @@ type ConformanceReport struct {
 // SupportedFeaturesSource represents the source from which supported features are derived.
 // It is used to distinguish between them being inferred from GWC Status or manually
 // supplied for the conformance report.
-type SupportedFeaturesSource string 
+type SupportedFeaturesSource string
 
 const (
 	SupportedFeaturesSourceUndefined SupportedFeaturesSource = "Undefined"
-	SupportedFeaturesSourceManual SupportedFeaturesSource = "Manual"
-	SupportedFeaturesSourceInferred SupportedFeaturesSource = "Inferred"
+	SupportedFeaturesSourceManual    SupportedFeaturesSource = "Manual"
+	SupportedFeaturesSourceInferred  SupportedFeaturesSource = "Inferred"
 )
 
 // Implementation provides metadata information on the downstream

--- a/conformance/apis/v1/conformancereport.go
+++ b/conformance/apis/v1/conformancereport.go
@@ -53,18 +53,18 @@ type ConformanceReport struct {
 
 	// SupportedFeaturesSource indicates whether the supported features were
 	// automatically detected by the conformance suite.
-	SupportedFeaturesSource SupportedFeaturesSource `json:"SupportedFeaturesSource"`
+	SupportedFeaturesSource SupportedFeaturesSource `json:"supportedFeaturesSource"`
 }
 
 // SupportedFeaturesSource represents the source from which supported features are derived.
 // It is used to distinguish between them being inferred from GWC Status or manually
 // supplied for the conformance report.
-type SupportedFeaturesSource int
+type SupportedFeaturesSource string 
 
 const (
-	SupportedFeaturesSourceUndefined SupportedFeaturesSource = iota
-	SupportedFeaturesSourceManual
-	SupportedFeaturesSourceInferred
+	SupportedFeaturesSourceUndefined SupportedFeaturesSource = "Undefined"
+	SupportedFeaturesSourceManual SupportedFeaturesSource = "Manual"
+	SupportedFeaturesSourceInferred SupportedFeaturesSource = "Inferred"
 )
 
 // Implementation provides metadata information on the downstream

--- a/conformance/apis/v1/conformancereport.go
+++ b/conformance/apis/v1/conformancereport.go
@@ -53,8 +53,16 @@ type ConformanceReport struct {
 
 	// InferredSupportedFeatures indicates whether the supported features were
 	// automatically detected by the conformance suite.
-	InferredSupportedFeatures bool `json:"inferredSupportedFeatures"`
+	InferredSupportedFeatures InferredSupportedFeatures `json:"inferredSupportedFeatures"`
 }
+
+type InferredSupportedFeatures int
+
+const (
+	InferredSupportedFeaturesFalse InferredSupportedFeatures = iota
+	InferredSupportedFeaturesTrue
+	InferredSupportedFeaturesUnsupported
+)
 
 // Implementation provides metadata information on the downstream
 // implementation of Gateway API which ran conformance tests.

--- a/conformance/utils/suite/conformance.go
+++ b/conformance/utils/suite/conformance.go
@@ -81,11 +81,11 @@ func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) {
 
 // ParseSupportedFeatures parses flag arguments and converts the string to
 // sets.Set[features.FeatureName]
-func ParseSupportedFeatures(f string) sets.Set[features.FeatureName] {
+func ParseSupportedFeatures(f string) FeaturesSet {
 	if f == "" {
 		return nil
 	}
-	res := sets.Set[features.FeatureName]{}
+	res := FeaturesSet{}
 	for _, value := range strings.Split(f, ",") {
 		res.Insert(features.FeatureName(value))
 	}

--- a/conformance/utils/suite/conformance.go
+++ b/conformance/utils/suite/conformance.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
 	"sigs.k8s.io/gateway-api/pkg/features"
 )
@@ -79,11 +81,11 @@ func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) {
 
 // ParseSupportedFeatures parses flag arguments and converts the string to
 // sets.Set[features.FeatureName]
-func ParseSupportedFeatures(f string) FeaturesSet {
+func ParseSupportedFeatures(f string) sets.Set[features.FeatureName] {
 	if f == "" {
 		return nil
 	}
-	res := FeaturesSet{}
+	res := sets.Set[features.FeatureName]{}
 	for _, value := range strings.Split(f, ",") {
 		res.Insert(features.FeatureName(value))
 	}

--- a/conformance/utils/suite/conformance.go
+++ b/conformance/utils/suite/conformance.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
 	"sigs.k8s.io/gateway-api/pkg/features"
 )

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -211,7 +211,7 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 			return nil, fmt.Errorf("cannot infer supported features: %w", err)
 		}
 
-		if hasMeshFeatures(supportedFeatures, &options) {
+		if hasMeshFeatures(supportedFeatures) {
 			return nil, fmt.Errorf("mesh features should not be populated in GatewayClass")
 		}
 		source = supportedFeaturesSourceInferred

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -212,7 +212,7 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 		}
 
 		if hasMeshFeatures(supportedFeatures, &options) {
-			source = supportedFeaturesSourceManual
+			return nil, fmt.Errorf("mesh features should not be populated in GatewayClass")
 		} else {
 			source = supportedFeaturesSourceInferred
 		}

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -613,7 +613,6 @@ func shouldInferSupportedFeatures(opts *ConformanceOptions) bool {
 	return !opts.EnableAllSupportedFeatures &&
 		opts.SupportedFeatures.Len() == 0 &&
 		opts.ExemptFeatures.Len() == 0 &&
-		len(opts.SkipTests) == 0 &&
 		opts.RunTest == ""
 }
 

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -652,6 +652,6 @@ func getAPIVersionAndChannel(crds []apiextensionsv1.CustomResourceDefinition) (v
 	return version, channel, nil
 }
 
-func hasMeshFeatures(f FeaturesSet, opt *ConformanceOptions) bool {
+func hasMeshFeatures(f FeaturesSet) bool {
 	return f.HasAny(features.SetsToNamesSet(features.MeshCoreFeatures, features.MeshExtendedFeatures).UnsortedList()...)
 }

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -210,7 +210,7 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 		var err error
 		supportedFeatures, err = fetchSupportedFeatures(options.Client, options.GatewayClassName)
 		if err != nil {
-			return nil, fmt.Errorf("Cannot infer supported features: %w", err)
+			return nil, fmt.Errorf("cannot infer supported features: %w", err)
 		}
 		source = supportedFeaturesSourceInferred
 	case isOnlyMeshProfile(&options):

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -191,7 +191,7 @@ const (
 // NewConformanceTestSuite is a helper to use for creating a new ConformanceTestSuite.
 func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite, error) {
 	supportedFeatures := options.SupportedFeatures.Difference(options.ExemptFeatures)
-	status := confv1.SupportedFeaturesSourceManual
+	source := confv1.SupportedFeaturesSourceManual
 	switch {
 	case options.EnableAllSupportedFeatures:
 		supportedFeatures = features.SetsToNamesSet(features.AllFeatures)
@@ -201,13 +201,13 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 		if err != nil {
 			return nil, fmt.Errorf("Cannot infer supported features: %w", err)
 		}
-		status = confv1.SupportedFeaturesSourceInferred
+		source = confv1.SupportedFeaturesSourceInferred
 	case isOnlyMeshProfile(&options):
-		status = confv1.SupportedFeaturesSourceUndefined
+		source = confv1.SupportedFeaturesSourceUndefined
 	}
 
 	// If features were not inferred from Status, it's a GWC issue.
-	if status == confv1.SupportedFeaturesSourceInferred && supportedFeatures.Len() == 0 {
+	if source == confv1.SupportedFeaturesSourceInferred && supportedFeatures.Len() == 0 {
 		return nil, fmt.Errorf("no supported features were determined for test suite")
 	}
 
@@ -275,7 +275,7 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 		mode:                        mode,
 		apiVersion:                  apiVersion,
 		apiChannel:                  apiChannel,
-		supportedFeaturesSource:     status,
+		supportedFeaturesSource:     source,
 		Hook:                        options.Hook,
 	}
 

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -654,6 +654,5 @@ func getAPIVersionAndChannel(crds []apiextensionsv1.CustomResourceDefinition) (v
 }
 
 func hasMeshFeatures(f FeaturesSet, opt *ConformanceOptions) bool {
-	return f.HasAny(features.SetsToNamesSet(features.MeshCoreFeatures, features.MeshExtendedFeatures).UnsortedList()...) ||
-		opt.ConformanceProfiles.HasAny(MeshGRPCConformanceProfileName, MeshHTTPConformanceProfileName)
+	return f.HasAny(features.SetsToNamesSet(features.MeshCoreFeatures, features.MeshExtendedFeatures).UnsortedList()...)
 }

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -407,10 +407,6 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T, tests []ConformanceTest) 
 	}
 }
 
-func (suite *ConformanceTestSuite) SupportedFeaturesSource() supportedFeaturesSource {
-	return suite.supportedFeaturesSource
-}
-
 func (suite *ConformanceTestSuite) setClientsetForTest(test ConformanceTest) error {
 	featureNames := []string{}
 	for _, v := range test.Features {

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -213,9 +213,8 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 
 		if hasMeshFeatures(supportedFeatures, &options) {
 			return nil, fmt.Errorf("mesh features should not be populated in GatewayClass")
-		} else {
-			source = supportedFeaturesSourceInferred
 		}
+		source = supportedFeaturesSourceInferred
 	}
 
 	// If features were not inferred from Status, it's a GWC issue.

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -289,7 +289,6 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 		for _, f := range conformanceProfile.CoreFeatures.UnsortedList() {
 			if !options.SupportedFeatures.Has(f) {
 				suite.SupportedFeatures.Insert(f)
-				suite.supportedFeaturesSource = confv1.SupportedFeaturesSourceManual
 			}
 		}
 		for _, f := range conformanceProfile.ExtendedFeatures.UnsortedList() {

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -648,8 +648,8 @@ func getAPIVersionAndChannel(crds []apiextensionsv1.CustomResourceDefinition) (v
 	return version, channel, nil
 }
 
-func isOnlyMeshProfile(options *ConformanceOptions) bool {
-	// TODO(bexxmodd): Currently a placeholder to add logic that determines if 
+func isOnlyMeshProfile(_ *ConformanceOptions) bool {
+	// TODO(bexxmodd): Currently a placeholder to add logic that determines if
 	// it's only Mesh profile without GWC.
 	return false
 }

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -280,7 +280,6 @@ func TestSuiteReport(t *testing.T) {
 					coreProvisionalTest.ShortName,
 					extendedProvisionalTest.ShortName,
 				},
-				SupportedFeaturesSource: confv1.SupportedFeaturesSourceInferred,
 			},
 		},
 		{
@@ -390,7 +389,6 @@ func TestSuiteReport(t *testing.T) {
 						},
 					},
 				},
-				SupportedFeaturesSource: confv1.SupportedFeaturesSourceInferred,
 			},
 		},
 	}
@@ -434,37 +432,37 @@ func TestInferSupportedFeatures(t *testing.T) {
 		exemptFeatures     FeaturesSet
 		ConformanceProfile sets.Set[ConformanceProfileName]
 		expectedFeatures   FeaturesSet
-		expectedSource     confv1.SupportedFeaturesSource
+		expectedSource     supportedFeaturesSource
 	}{
 		{
 			name:             "properly infer supported features",
 			expectedFeatures: namesToFeatureSet(statusFeatureNames),
-			expectedSource:   confv1.SupportedFeaturesSourceInferred,
+			expectedSource:   supportedFeaturesSourceInferred,
 		},
 		{
 			name:              "no features",
 			supportedFeatures: sets.New[features.FeatureName]("Gateway"),
 			expectedFeatures:  sets.New[features.FeatureName]("Gateway"),
-			expectedSource:    confv1.SupportedFeaturesSourceManual,
+			expectedSource:    supportedFeaturesSourceManual,
 		},
 		{
 			name:              "remove exempt features",
 			supportedFeatures: sets.New[features.FeatureName]("Gateway", "HTTPRoute"),
 			exemptFeatures:    sets.New[features.FeatureName]("HTTPRoute"),
 			expectedFeatures:  sets.New[features.FeatureName]("Gateway"),
-			expectedSource:    confv1.SupportedFeaturesSourceManual,
+			expectedSource:    supportedFeaturesSourceManual,
 		},
 		{
 			name:             "allow all features",
 			allowAllFeatures: true,
 			expectedFeatures: features.SetsToNamesSet(features.AllFeatures),
-			expectedSource:   confv1.SupportedFeaturesSourceManual,
+			expectedSource:   supportedFeaturesSourceManual,
 		},
 		{
 			name:               "supports conformance profile - core",
 			ConformanceProfile: sets.New(GatewayHTTPConformanceProfileName),
 			expectedFeatures:   namesToFeatureSet(statusFeatureNames),
-			expectedSource:     confv1.SupportedFeaturesSourceInferred,
+			expectedSource:     supportedFeaturesSourceInferred,
 		},
 	}
 

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -434,37 +434,37 @@ func TestInferSupportedFeatures(t *testing.T) {
 		exemptFeatures     FeaturesSet
 		ConformanceProfile sets.Set[ConformanceProfileName]
 		expectedFeatures   FeaturesSet
-		expectedIsInferred confv1.SupportedFeaturesSource
+		expectedSource     confv1.SupportedFeaturesSource
 	}{
 		{
-			name:               "properly infer supported features",
-			expectedFeatures:   namesToFeatureSet(statusFeatureNames),
-			expectedIsInferred: confv1.SupportedFeaturesSourceInferred,
+			name:             "properly infer supported features",
+			expectedFeatures: namesToFeatureSet(statusFeatureNames),
+			expectedSource:   confv1.SupportedFeaturesSourceInferred,
 		},
 		{
-			name:               "no features",
-			supportedFeatures:  sets.New[features.FeatureName]("Gateway"),
-			expectedFeatures:   sets.New[features.FeatureName]("Gateway"),
-			expectedIsInferred: confv1.SupportedFeaturesSourceManual,
+			name:              "no features",
+			supportedFeatures: sets.New[features.FeatureName]("Gateway"),
+			expectedFeatures:  sets.New[features.FeatureName]("Gateway"),
+			expectedSource:    confv1.SupportedFeaturesSourceManual,
 		},
 		{
-			name:               "remove exempt features",
-			supportedFeatures:  sets.New[features.FeatureName]("Gateway", "HTTPRoute"),
-			exemptFeatures:     sets.New[features.FeatureName]("HTTPRoute"),
-			expectedFeatures:   sets.New[features.FeatureName]("Gateway"),
-			expectedIsInferred: confv1.SupportedFeaturesSourceManual,
+			name:              "remove exempt features",
+			supportedFeatures: sets.New[features.FeatureName]("Gateway", "HTTPRoute"),
+			exemptFeatures:    sets.New[features.FeatureName]("HTTPRoute"),
+			expectedFeatures:  sets.New[features.FeatureName]("Gateway"),
+			expectedSource:    confv1.SupportedFeaturesSourceManual,
 		},
 		{
-			name:               "allow all features",
-			allowAllFeatures:   true,
-			expectedFeatures:   features.SetsToNamesSet(features.AllFeatures),
-			expectedIsInferred: confv1.SupportedFeaturesSourceManual,
+			name:             "allow all features",
+			allowAllFeatures: true,
+			expectedFeatures: features.SetsToNamesSet(features.AllFeatures),
+			expectedSource:   confv1.SupportedFeaturesSourceManual,
 		},
 		{
 			name:               "supports conformance profile - core",
 			ConformanceProfile: sets.New(GatewayHTTPConformanceProfileName),
-			expectedFeatures:   namesToFeatureSet([]string{"Gateway", "HTTPRoute", "ReferenceGrant"}),
-			expectedIsInferred: confv1.SupportedFeaturesSourceManual,
+			expectedFeatures:   namesToFeatureSet(statusFeatureNames),
+			expectedSource:     confv1.SupportedFeaturesSourceManual,
 		},
 	}
 
@@ -516,8 +516,8 @@ func TestInferSupportedFeatures(t *testing.T) {
 				t.Fatalf("error initializing conformance suite: %v", err)
 			}
 
-			if cSuite.SupportedFeaturesSource() != tc.expectedIsInferred {
-				t.Errorf("InferredSupportedFeatures mismatch: got %v, want %v", cSuite.SupportedFeaturesSource(), tc.expectedIsInferred)
+			if cSuite.SupportedFeaturesSource() != tc.expectedSource {
+				t.Errorf("InferredSupportedFeatures mismatch: got %v, want %v", cSuite.SupportedFeaturesSource(), tc.expectedSource)
 			}
 
 			if equal := cSuite.SupportedFeatures.Equal(tc.expectedFeatures); !equal {

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -464,7 +464,7 @@ func TestInferSupportedFeatures(t *testing.T) {
 			name:               "supports conformance profile - core",
 			ConformanceProfile: sets.New(GatewayHTTPConformanceProfileName),
 			expectedFeatures:   namesToFeatureSet(statusFeatureNames),
-			expectedSource:     confv1.SupportedFeaturesSourceManual,
+			expectedSource:     confv1.SupportedFeaturesSourceInferred,
 		},
 	}
 

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -530,16 +530,13 @@ func TestGWCStatusPublishedMeshFeatures(t *testing.T) {
 		name               string
 		supportedFeatures  FeaturesSet
 		ConformanceProfile sets.Set[ConformanceProfileName]
-		expectedSource     supportedFeaturesSource
 	}{
 		{
-			name:           "GWC Status published Mesh features",
-			expectedSource: supportedFeaturesSourceManual,
+			name: "GWC Status published Mesh features",
 		},
 		{
 			name:               "supports conformance Mesh profile",
 			ConformanceProfile: sets.New(MeshGRPCConformanceProfileName),
-			expectedSource:     supportedFeaturesSourceManual,
 		},
 	}
 
@@ -589,13 +586,9 @@ func TestGWCStatusPublishedMeshFeatures(t *testing.T) {
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
-			cSuite, err := NewConformanceTestSuite(options)
-			if err != nil {
-				t.Fatalf("error initializing conformance suite: %v", err)
-			}
-
-			if cSuite.supportedFeaturesSource != tc.expectedSource {
-				t.Errorf("InferredSupportedFeatures mismatch: got %v, want %v", cSuite.supportedFeaturesSource, tc.expectedSource)
+			_, err := NewConformanceTestSuite(options)
+			if err == nil {
+				t.Fatalf("expected an error but got none")
 			}
 		})
 	}

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -514,8 +514,8 @@ func TestInferSupportedFeatures(t *testing.T) {
 				t.Fatalf("error initializing conformance suite: %v", err)
 			}
 
-			if cSuite.SupportedFeaturesSource() != tc.expectedSource {
-				t.Errorf("InferredSupportedFeatures mismatch: got %v, want %v", cSuite.SupportedFeaturesSource(), tc.expectedSource)
+			if cSuite.supportedFeaturesSource != tc.expectedSource {
+				t.Errorf("InferredSupportedFeatures mismatch: got %v, want %v", cSuite.supportedFeaturesSource, tc.expectedSource)
 			}
 
 			if equal := cSuite.SupportedFeatures.Equal(tc.expectedFeatures); !equal {

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -525,21 +525,7 @@ func TestInferSupportedFeatures(t *testing.T) {
 	}
 }
 
-func TestGWCStatusPublishedMeshFeatures(t *testing.T) {
-	testCases := []struct {
-		name               string
-		supportedFeatures  FeaturesSet
-		ConformanceProfile sets.Set[ConformanceProfileName]
-	}{
-		{
-			name: "GWC Status published Mesh features",
-		},
-		{
-			name:               "supports conformance Mesh profile",
-			ConformanceProfile: sets.New(MeshGRPCConformanceProfileName),
-		},
-	}
-
+func TestGWCPublishedMeshFeatures(t *testing.T) {
 	gwcName := "ochopintre"
 	gwc := &gatewayv1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{
@@ -576,21 +562,15 @@ func TestGWCStatusPublishedMeshFeatures(t *testing.T) {
 	gatewayv1.Install(fakeClient.Scheme())
 	apiextensionsv1.AddToScheme(fakeClient.Scheme())
 
-	for _, tc := range testCases {
-		options := ConformanceOptions{
-			AllowCRDsMismatch:   true,
-			GatewayClassName:    gwcName,
-			SupportedFeatures:   tc.supportedFeatures,
-			ConformanceProfiles: tc.ConformanceProfile,
-			Client:              fakeClient,
-		}
+	options := ConformanceOptions{
+		AllowCRDsMismatch: true,
+		GatewayClassName:  gwcName,
+		Client:            fakeClient,
+	}
 
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := NewConformanceTestSuite(options)
-			if err == nil {
-				t.Fatalf("expected an error but got none")
-			}
-		})
+	_, err := NewConformanceTestSuite(options)
+	if err == nil {
+		t.Fatalf("expected an error but got nil")
 	}
 }
 

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -280,7 +280,7 @@ func TestSuiteReport(t *testing.T) {
 					coreProvisionalTest.ShortName,
 					extendedProvisionalTest.ShortName,
 				},
-				InferredSupportedFeatures: confv1.InferredSupportedFeaturesTrue,
+				SupportedFeaturesSource: confv1.SupportedFeaturesSourceInferred,
 			},
 		},
 		{
@@ -390,7 +390,7 @@ func TestSuiteReport(t *testing.T) {
 						},
 					},
 				},
-				InferredSupportedFeatures: confv1.InferredSupportedFeaturesTrue,
+				SupportedFeaturesSource: confv1.SupportedFeaturesSourceInferred,
 			},
 		},
 	}
@@ -434,37 +434,37 @@ func TestInferSupportedFeatures(t *testing.T) {
 		exemptFeatures     FeaturesSet
 		ConformanceProfile sets.Set[ConformanceProfileName]
 		expectedFeatures   FeaturesSet
-		expectedIsInferred confv1.InferredSupportedFeatures 
+		expectedIsInferred confv1.SupportedFeaturesSource
 	}{
 		{
 			name:               "properly infer supported features",
 			expectedFeatures:   namesToFeatureSet(statusFeatureNames),
-			expectedIsInferred: confv1.InferredSupportedFeaturesTrue,
+			expectedIsInferred: confv1.SupportedFeaturesSourceInferred,
 		},
 		{
-			name:              "no features",
-			supportedFeatures: sets.New[features.FeatureName]("Gateway"),
-			expectedFeatures:  sets.New[features.FeatureName]("Gateway"),
-			expectedIsInferred: confv1.InferredSupportedFeaturesFalse,
+			name:               "no features",
+			supportedFeatures:  sets.New[features.FeatureName]("Gateway"),
+			expectedFeatures:   sets.New[features.FeatureName]("Gateway"),
+			expectedIsInferred: confv1.SupportedFeaturesSourceManual,
 		},
 		{
-			name:              "remove exempt features",
-			supportedFeatures: sets.New[features.FeatureName]("Gateway", "HTTPRoute"),
-			exemptFeatures:    sets.New[features.FeatureName]("HTTPRoute"),
-			expectedFeatures:  sets.New[features.FeatureName]("Gateway"),
-			expectedIsInferred: confv1.InferredSupportedFeaturesFalse,
+			name:               "remove exempt features",
+			supportedFeatures:  sets.New[features.FeatureName]("Gateway", "HTTPRoute"),
+			exemptFeatures:     sets.New[features.FeatureName]("HTTPRoute"),
+			expectedFeatures:   sets.New[features.FeatureName]("Gateway"),
+			expectedIsInferred: confv1.SupportedFeaturesSourceManual,
 		},
 		{
-			name:             "allow all features",
-			allowAllFeatures: true,
-			expectedFeatures: features.SetsToNamesSet(features.AllFeatures),
-			expectedIsInferred: confv1.InferredSupportedFeaturesFalse,
+			name:               "allow all features",
+			allowAllFeatures:   true,
+			expectedFeatures:   features.SetsToNamesSet(features.AllFeatures),
+			expectedIsInferred: confv1.SupportedFeaturesSourceManual,
 		},
 		{
 			name:               "supports conformance profile - core",
 			ConformanceProfile: sets.New(GatewayHTTPConformanceProfileName),
 			expectedFeatures:   namesToFeatureSet([]string{"Gateway", "HTTPRoute", "ReferenceGrant"}),
-			expectedIsInferred: confv1.InferredSupportedFeaturesFalse,
+			expectedIsInferred: confv1.SupportedFeaturesSourceManual,
 		},
 	}
 
@@ -516,8 +516,8 @@ func TestInferSupportedFeatures(t *testing.T) {
 				t.Fatalf("error initializing conformance suite: %v", err)
 			}
 
-			if cSuite.IsInferredSupportedFeatures() != tc.expectedIsInferred {
-				t.Errorf("InferredSupportedFeatures mismatch: got %v, want %v", cSuite.IsInferredSupportedFeatures(), tc.expectedIsInferred)
+			if cSuite.SupportedFeaturesSource() != tc.expectedIsInferred {
+				t.Errorf("InferredSupportedFeatures mismatch: got %v, want %v", cSuite.SupportedFeaturesSource(), tc.expectedIsInferred)
 			}
 
 			if equal := cSuite.SupportedFeatures.Equal(tc.expectedFeatures); !equal {

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -280,7 +280,7 @@ func TestSuiteReport(t *testing.T) {
 					coreProvisionalTest.ShortName,
 					extendedProvisionalTest.ShortName,
 				},
-				InferredSupportedFeatures: true,
+				InferredSupportedFeatures: confv1.InferredSupportedFeaturesTrue,
 			},
 		},
 		{
@@ -390,7 +390,7 @@ func TestSuiteReport(t *testing.T) {
 						},
 					},
 				},
-				InferredSupportedFeatures: true,
+				InferredSupportedFeatures: confv1.InferredSupportedFeaturesTrue,
 			},
 		},
 	}
@@ -434,33 +434,37 @@ func TestInferSupportedFeatures(t *testing.T) {
 		exemptFeatures     FeaturesSet
 		ConformanceProfile sets.Set[ConformanceProfileName]
 		expectedFeatures   FeaturesSet
-		expectedIsInferred bool
+		expectedIsInferred confv1.InferredSupportedFeatures 
 	}{
 		{
 			name:               "properly infer supported features",
 			expectedFeatures:   namesToFeatureSet(statusFeatureNames),
-			expectedIsInferred: true,
+			expectedIsInferred: confv1.InferredSupportedFeaturesTrue,
 		},
 		{
 			name:              "no features",
 			supportedFeatures: sets.New[features.FeatureName]("Gateway"),
 			expectedFeatures:  sets.New[features.FeatureName]("Gateway"),
+			expectedIsInferred: confv1.InferredSupportedFeaturesFalse,
 		},
 		{
 			name:              "remove exempt features",
 			supportedFeatures: sets.New[features.FeatureName]("Gateway", "HTTPRoute"),
 			exemptFeatures:    sets.New[features.FeatureName]("HTTPRoute"),
 			expectedFeatures:  sets.New[features.FeatureName]("Gateway"),
+			expectedIsInferred: confv1.InferredSupportedFeaturesFalse,
 		},
 		{
 			name:             "allow all features",
 			allowAllFeatures: true,
 			expectedFeatures: features.SetsToNamesSet(features.AllFeatures),
+			expectedIsInferred: confv1.InferredSupportedFeaturesFalse,
 		},
 		{
 			name:               "supports conformance profile - core",
 			ConformanceProfile: sets.New(GatewayHTTPConformanceProfileName),
 			expectedFeatures:   namesToFeatureSet([]string{"Gateway", "HTTPRoute", "ReferenceGrant"}),
+			expectedIsInferred: confv1.InferredSupportedFeaturesFalse,
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind gep
/area conformance-test

**What this PR does / why we need it**:
This is an update from boolean flag to enum for the report that should capture case when Conformance profile is Mesh without GWC and we can't infer supported features.

**Does this PR introduce a user-facing change?**:
```
NONE
```
