### PR TITLE
Oops. It's GEP-3779, not GEP-3379.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,7 +130,7 @@ nav:
       - geps/gep-1494/index.md
       - geps/gep-1651/index.md
       - geps/gep-2648/index.md
-      - geps/gep-3379/index.md
+      - geps/gep-3779/index.md
       - geps/gep-3792/index.md
       - geps/gep-3793/index.md
     - Implementable:


### PR DESCRIPTION
Fix a typo in `mkdocs.yml`. Sigh.

/kind cleanup
/kind documentation

```release-note
NONE
```
