### PR TITLE
tests: Add conformace tests for listenersets

### DIFF
--- a/conformance/conformance.go
+++ b/conformance/conformance.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1alpha3"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	xv1alpha1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
 	confv1 "sigs.k8s.io/gateway-api/conformance/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/tests"
 	conformanceconfig "sigs.k8s.io/gateway-api/conformance/utils/config"
@@ -61,6 +62,7 @@ func DefaultOptions(t *testing.T) suite.ConformanceOptions {
 	require.NoError(t, v1alpha3.Install(client.Scheme()))
 	require.NoError(t, v1alpha2.Install(client.Scheme()))
 	require.NoError(t, v1beta1.Install(client.Scheme()))
+	require.NoError(t, xv1alpha1.Install(client.Scheme()))
 	require.NoError(t, v1.Install(client.Scheme()))
 	require.NoError(t, apiextensionsv1.AddToScheme(client.Scheme()))
 

--- a/conformance/tests/listenerset-http-listener.go
+++ b/conformance/tests/listenerset-http-listener.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayxv1a1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, ListenerSetHTTPRoute)
+}
+
+var ListenerSetHTTPRoute = suite.ConformanceTest{
+	ShortName:   "ListenerSetHTTPRoute",
+	Description: "Listener Set with HTTP Listener and HTTPRoutes",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportGatewayListenerSet,
+		features.SupportHTTPRoute,
+	},
+	Manifests: []string{
+		"tests/listenerset-http-listener.yaml",
+	},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+
+		testCases := []http.ExpectedResponse{
+			// Requests to the route defined on the gateway (should match all listeners)
+			{
+				Request:   http.Request{Host: "baz.com", Path: "/gateway-route"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+			{
+				Request:   http.Request{Host: "example.com", Path: "/gateway-route"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+			{
+				Request:   http.Request{Host: "foo.com", Path: "/gateway-route"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+			{
+				Request:   http.Request{Host: "bar.com", Path: "/gateway-route"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+			// Requests to the route defined on the gateway that targets the example-com listener
+			{
+				Request:  http.Request{Host: "baz.com", Path: "/example-com"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:   http.Request{Host: "example.com", Path: "/example-com"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+			{
+				Request:  http.Request{Host: "foo.com", Path: "/example-com"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:  http.Request{Host: "bar.com", Path: "/example-com"},
+				Response: http.Response{StatusCode: 404},
+			},
+			// Requests to the route defined on the listener set (should only match listeners defined on the listenerset)
+			{
+				Request:  http.Request{Host: "baz.com", Path: "/listenerset-route"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:  http.Request{Host: "example.com", Path: "/listenerset-route"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:   http.Request{Host: "foo.com", Path: "/listenerset-route"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+			{
+				Request:   http.Request{Host: "bar.com", Path: "/listenerset-route"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+			// Requests to the route defined on the listenerset that targets the bar-com listener
+			{
+				Request:  http.Request{Host: "baz.com", Path: "/bar-com"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:  http.Request{Host: "example.com", Path: "/bar-com"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:  http.Request{Host: "foo.com", Path: "/bar-com"},
+				Response: http.Response{StatusCode: 404},
+			},
+			{
+				Request:   http.Request{Host: "bar.com", Path: "/bar-com"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+		}
+
+		gwNN := types.NamespacedName{Name: "gateway-with-listenerset-http-listener", Namespace: ns}
+		gwRoutes := []types.NamespacedName{
+			{Namespace: ns, Name: "attaches-to-all-listeners"},
+			{Namespace: ns, Name: "attaches-to-example-com-on-gateway"},
+		}
+
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), gwRoutes...)
+		for _, routeNN := range gwRoutes {
+			kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+		}
+
+		lsNN := types.NamespacedName{Name: "listenerset-with-http-listener", Namespace: ns}
+		lsRoutes := []types.NamespacedName{
+			{Namespace: ns, Name: "attaches-to-all-listeners-on-listenerset"},
+			{Namespace: ns, Name: "attaches-to-bar-com-on-listenerset"},
+		}
+		listenerSetGK := schema.GroupKind{
+			Group: gatewayxv1a1.GroupVersion.Group,
+			Kind:  "XListenerSet",
+		}
+		listenerSetRef := kubernetes.NewResourceRef(listenerSetGK, lsNN)
+		kubernetes.RoutesAndParentMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, listenerSetRef, &gatewayv1.HTTPRoute{}, lsRoutes...)
+		for _, routeNN := range lsRoutes {
+			kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, lsNN)
+		}
+
+		kubernetes.GatewayMustHaveCondition(t, suite.Client, suite.TimeoutConfig, gwNN, metav1.Condition{
+			Type:   "AttachedListenerSets",
+			Status: metav1.ConditionTrue,
+		})
+
+		for i := range testCases {
+			// Declare tc here to avoid loop variable
+			// reuse issues across parallel tests.
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/listenerset-http-listener.yaml
+++ b/conformance/tests/listenerset-http-listener.yaml
@@ -1,0 +1,131 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-with-listenerset-http-listener
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: empty-hostname
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: example-com
+    port: 80
+    protocol: HTTP
+    hostname: "example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+  allowedListeners:
+    namespaces:
+      from: All
+---
+apiVersion: gateway.networking.x-k8s.io/v1alpha1
+kind: XListenerSet
+metadata:
+  name: listenerset-with-http-listener
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    kind: Gateway
+    group: gateway.networking.k8s.io
+    name: gateway-with-listenerset-http-listener
+    namespace: gateway-conformance-infra
+  listeners:
+  - name: foo-com
+    port: 80
+    protocol: HTTP
+    hostname: "foo.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: bar-com
+    port: 80
+    protocol: HTTP
+    hostname: "bar.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: attaches-to-all-listeners
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: gateway-with-listenerset-http-listener
+    namespace: gateway-conformance-infra
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /gateway-route
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: attaches-to-example-com-on-gateway
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: gateway-with-listenerset-http-listener
+    namespace: gateway-conformance-infra
+    sectionName: example-com
+  hostnames:
+  - "example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /example-com
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: attaches-to-all-listeners-on-listenerset
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - kind: XListenerSet
+    group: gateway.networking.x-k8s.io
+    name: listenerset-with-http-listener
+    namespace: gateway-conformance-infra
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /listenerset-route
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: attaches-to-bar-com-on-listenerset
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - kind: XListenerSet
+    group: gateway.networking.x-k8s.io
+    name: listenerset-with-http-listener
+    namespace: gateway-conformance-infra
+    sectionName: bar-com
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /bar-com
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/pkg/features/gateway.go
+++ b/pkg/features/gateway.go
@@ -64,6 +64,10 @@ const (
 	//  SupportGatewayAddressEmpty option indicates support for an empty
 	//  spec.addresses.value field
 	SupportGatewayAddressEmpty FeatureName = "GatewayAddressEmpty"
+
+	//  SupportGatewayListenerSet option indicates support for a Gateway
+	//  with ListenerSets
+	SupportGatewayListenerSet FeatureName = "GatewayListenerSet"
 )
 
 var (
@@ -92,6 +96,11 @@ var (
 		Name:    SupportGatewayAddressEmpty,
 		Channel: FeatureChannelStandard,
 	}
+	// GatewayListenerSetFeature contains metadata for the SupportGatewayListenerSet feature.
+	GatewayListenerSetFeature = Feature{
+		Name:    SupportGatewayListenerSet,
+		Channel: FeatureChannelExperimental,
+	}
 )
 
 // GatewayExtendedFeatures are extra generic features that implementations may
@@ -102,4 +111,5 @@ var GatewayExtendedFeatures = sets.New(
 	GatewayHTTPListenerIsolationFeature,
 	GatewayInfrastructurePropagationFeature,
 	GatewayEmptyAddressFeature,
+	GatewayListenerSetFeature,
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind test
/area conformance-test

**What this PR does / why we need it**:

This PR contains an initial conformance test for listenersets. This aims to verify the following :
- Translation of a listenerset by an implementer
- Route inheritance of gateway-level routes by the listenerset
- Route isolation between gateways and listenersets based on parentRef and sectionName

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/3785

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Adding initial conformance tests for XListenerSets
```
