### PR TITLE
Allow preprepared CoreDNS image to be used 

### DIFF
--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -705,6 +705,7 @@ spec:
         - -conf
         - /root/Corefile
         image: coredns/coredns
+        imagePullPolicy: IfNotPresent
         name: coredns
         securityContext:
           allowPrivilegeEscalation: false

--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -340,18 +340,21 @@ func getContentsFromPathOrURL(manifestFS []fs.FS, location string, timeoutConfig
 		}
 		return manifests, nil
 	}
-	var err error
-	var buf []byte
+
+	var buffer bytes.Buffer
 	for _, mfs := range manifestFS {
-		buf, err = fs.ReadFile(mfs, location)
+		buf, err := fs.ReadFile(mfs, location)
 		if err != nil && errors.Is(err, fs.ErrNotExist) {
 			continue
 		} else if err != nil {
 			return nil, err
 		}
-		return bytes.NewBuffer(buf), nil
+		_, err = buffer.Write(buf)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return nil, err
+	return &buffer, nil
 }
 
 // convertGatewayAddrsToPrimitives converts a slice of Gateway addresses


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind bug
/kind conformance-machinery
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:
For folks that are pulling images from Docker's public registry in an unauthenticated way rate limits are an immediate problem. This PR fixes two things:
1. Explicitly sets the pull policy for CoreDNS to be `IfNotPresent`, allowing for a cluster with an already-prepared CoreDNS image to be used
2. Fixes `getContentsFromPathOrURL` to correctly handle multiple `fs.FS`. If this was already supported client code could've easily done something like this to work around the issue:
```
virtFS := fstest.MapFS{...} // Imagine this to hold an override for the manifest with issues.
suite.ConformanceOptions{
...
    ManifestFS:               []fs.FS{&conformance.Manifests, &virtFS},
...
}
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
