### PR TITLE
Enable Kubernetes API Linter

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,6 +1,6 @@
-version:  v2.2.1
+version: v2.2.1
 name: golangci-kube-api-linter
 destination: ./bin
 plugins:
 - module: 'sigs.k8s.io/kube-api-linter'
-  version: 'b566fe88b73232c10a37b0274ec59efd91002072' # Pin to a commit while there's no tag
+  version: 'v0.0.0-20250715075424-4fab82d26a8e' # Pin to a commit while there's no tag

--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,0 +1,6 @@
+version:  v2.2.1
+name: golangci-kube-api-linter
+destination: ./bin
+plugins:
+- module: 'sigs.k8s.io/kube-api-linter'
+  version: 'b566fe88b73232c10a37b0274ec59efd91002072' # Pin to a commit while there's no tag

--- a/.github/workflows/kal.yml
+++ b/.github/workflows/kal.yml
@@ -1,0 +1,25 @@
+name: PR golangci-lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+# Remove all permissions from GITHUB_TOKEN except metadata.
+permissions: {}
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # tag=v5.5.0
+      - name: Install Golang CI Lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.2.1
+      - name: Build KAL
+        run: golangci-lint custom
+      - name: run api linter
+        run: ./bin/golangci-kube-api-linter run -c ./.golangci-kal.yml ./...

--- a/.github/workflows/kal.yml
+++ b/.github/workflows/kal.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   golangci:
-    name: lint
+    name: kube-api-lint
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -13,6 +13,7 @@ linters:
             enable:
             - "duplicatemarkers" # Ensure there are no exact duplicate markers. for types and fields.
             - "jsontags" # Ensure every field has a json tag.
+            - "nofloats" # Ensure floats are not used.
             disable:
             - "*"
           lintersConfig: {}

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -10,6 +10,8 @@ linters:
         description: Kube API LInter lints Kube like APIs based on API conventions and best practices.
         settings:
           linters:
+            enable:
+            - "duplicatemarkers" # Ensure there are no exact duplicate markers. for types and fields.
             disable:
             - "*"
           lintersConfig: {}

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -18,6 +18,7 @@ linters:
             - "nophase" # Phase fields are discouraged by the Kube API conventions, use conditions instead.
             - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
             - "statussubresource" # All root objects that have a `status` field should have a status subresource.
+            - "uniquemarkers" # Ensure that types and fields do not contain more than a single definition of a marker that should only be present once.
             disable:
             - "*"
           lintersConfig: {}

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -1,0 +1,28 @@
+version: "2"
+linters:
+  default: none
+  enable:
+    - kubeapilinter
+  settings:
+    custom:
+      kubeapilinter:
+        type: module
+        description: Kube API LInter lints Kube like APIs based on API conventions and best practices.
+        settings:
+          linters:
+            disable:
+            - "*"
+          lintersConfig: {}
+  exclusions:
+    generated: strict
+    paths:
+    - conformance/
+    paths-except:
+    - apis/
+    - apisx/
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+run:
+  timeout: 5m
+  tests: false

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -16,6 +16,7 @@ linters:
             - "nofloats" # Ensure floats are not used.
             - "nomaps" # Ensure maps are not used.
             - "nophase" # Phase fields are discouraged by the Kube API conventions, use conditions instead.
+            - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
             disable:
             - "*"
           lintersConfig: {}

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -15,6 +15,7 @@ linters:
             - "jsontags" # Ensure every field has a json tag.
             - "nofloats" # Ensure floats are not used.
             - "nomaps" # Ensure maps are not used.
+            - "nophase" # Phase fields are discouraged by the Kube API conventions, use conditions instead.
             disable:
             - "*"
           lintersConfig: {}

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -16,7 +16,6 @@ linters:
               - "nofloats" # Ensure floats are not used.
               - "nomaps" # Ensure maps are not used.
               - "nophase" # Phase fields are discouraged by the Kube API conventions, use conditions instead.
-              - "requiredfields" # Required fields should not be pointers. Having `omitempty` is optional
               - "statussubresource" # All root objects that have a `status` field should have a status subresource.
               - "uniquemarkers" # Ensure that types and fields do not contain more than a single definition of a marker that should only be present once.
             disable:

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -11,24 +11,24 @@ linters:
         settings:
           linters:
             enable:
-            - "duplicatemarkers" # Ensure there are no exact duplicate markers. for types and fields.
-            - "jsontags" # Ensure every field has a json tag.
-            - "nofloats" # Ensure floats are not used.
-            - "nomaps" # Ensure maps are not used.
-            - "nophase" # Phase fields are discouraged by the Kube API conventions, use conditions instead.
-            - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
-            - "statussubresource" # All root objects that have a `status` field should have a status subresource.
-            - "uniquemarkers" # Ensure that types and fields do not contain more than a single definition of a marker that should only be present once.
+              - "duplicatemarkers" # Ensure there are no exact duplicate markers. for types and fields.
+              - "jsontags" # Ensure every field has a json tag.
+              - "nofloats" # Ensure floats are not used.
+              - "nomaps" # Ensure maps are not used.
+              - "nophase" # Phase fields are discouraged by the Kube API conventions, use conditions instead.
+              - "requiredfields" # Required fields should not be pointers. Having `omitempty` is optional
+              - "statussubresource" # All root objects that have a `status` field should have a status subresource.
+              - "uniquemarkers" # Ensure that types and fields do not contain more than a single definition of a marker that should only be present once.
             disable:
-            - "*"
+              - "*"
           lintersConfig: {}
   exclusions:
     generated: strict
     paths:
-    - conformance/
+      - conformance/
     paths-except:
-    - apis/
-    - apisx/
+      - apis/
+      - apisx/
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -17,6 +17,7 @@ linters:
             - "nomaps" # Ensure maps are not used.
             - "nophase" # Phase fields are discouraged by the Kube API conventions, use conditions instead.
             - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
+            - "statussubresource" # All root objects that have a `status` field should have a status subresource.
             disable:
             - "*"
           lintersConfig: {}

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -14,6 +14,7 @@ linters:
             - "duplicatemarkers" # Ensure there are no exact duplicate markers. for types and fields.
             - "jsontags" # Ensure every field has a json tag.
             - "nofloats" # Ensure floats are not used.
+            - "nomaps" # Ensure maps are not used.
             disable:
             - "*"
           lintersConfig: {}

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -12,6 +12,7 @@ linters:
           linters:
             enable:
             - "duplicatemarkers" # Ensure there are no exact duplicate markers. for types and fields.
+            - "jsontags" # Ensure every field has a json tag.
             disable:
             - "*"
           lintersConfig: {}

--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -1590,7 +1590,6 @@ type HTTPBackendRef struct {
 	// +optional
 	// +kubebuilder:validation:MaxItems=16
 	// +kubebuilder:validation:XValidation:message="May specify either httpRouteFilterRequestRedirect or httpRouteFilterRequestRewrite, but not both",rule="!(self.exists(f, f.type == 'RequestRedirect') && self.exists(f, f.type == 'URLRewrite'))"
-	// +kubebuilder:validation:XValidation:message="May specify either httpRouteFilterRequestRedirect or httpRouteFilterRequestRewrite, but not both",rule="!(self.exists(f, f.type == 'RequestRedirect') && self.exists(f, f.type == 'URLRewrite'))"
 	// +kubebuilder:validation:XValidation:message="RequestHeaderModifier filter cannot be repeated",rule="self.filter(f, f.type == 'RequestHeaderModifier').size() <= 1"
 	// +kubebuilder:validation:XValidation:message="ResponseHeaderModifier filter cannot be repeated",rule="self.filter(f, f.type == 'ResponseHeaderModifier').size() <= 1"
 	// +kubebuilder:validation:XValidation:message="RequestRedirect filter cannot be repeated",rule="self.filter(f, f.type == 'RequestRedirect').size() <= 1"

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -1528,10 +1528,6 @@ spec:
                                 or httpRouteFilterRequestRewrite, but not both
                               rule: '!(self.exists(f, f.type == ''RequestRedirect'')
                                 && self.exists(f, f.type == ''URLRewrite''))'
-                            - message: May specify either httpRouteFilterRequestRedirect
-                                or httpRouteFilterRequestRewrite, but not both
-                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
-                                && self.exists(f, f.type == ''URLRewrite''))'
                             - message: RequestHeaderModifier filter cannot be repeated
                               rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
                                 <= 1
@@ -5144,10 +5140,6 @@ spec:
                             maxItems: 16
                             type: array
                             x-kubernetes-validations:
-                            - message: May specify either httpRouteFilterRequestRedirect
-                                or httpRouteFilterRequestRewrite, but not both
-                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
-                                && self.exists(f, f.type == ''URLRewrite''))'
                             - message: May specify either httpRouteFilterRequestRedirect
                                 or httpRouteFilterRequestRewrite, but not both
                               rule: '!(self.exists(f, f.type == ''RequestRedirect'')

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -1195,10 +1195,6 @@ spec:
                                 or httpRouteFilterRequestRewrite, but not both
                               rule: '!(self.exists(f, f.type == ''RequestRedirect'')
                                 && self.exists(f, f.type == ''URLRewrite''))'
-                            - message: May specify either httpRouteFilterRequestRedirect
-                                or httpRouteFilterRequestRewrite, but not both
-                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
-                                && self.exists(f, f.type == ''URLRewrite''))'
                             - message: RequestHeaderModifier filter cannot be repeated
                               rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
                                 <= 1
@@ -3995,10 +3991,6 @@ spec:
                             maxItems: 16
                             type: array
                             x-kubernetes-validations:
-                            - message: May specify either httpRouteFilterRequestRedirect
-                                or httpRouteFilterRequestRewrite, but not both
-                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
-                                && self.exists(f, f.type == ''URLRewrite''))'
                             - message: May specify either httpRouteFilterRequestRedirect
                                 or httpRouteFilterRequestRewrite, but not both
                               rule: '!(self.exists(f, f.type == ''RequestRedirect'')


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**: This PR enables Kube API Linter with a small set of validations. The enabled validations doesn't present a breaking change on existing APIs, and the plan is to progressively enable other linters that may present more disrupting changes on follow up PRs after discussion with Gateway API group.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Note for reviewers**:
The ongoing discussion is part of the document https://docs.google.com/document/d/1DSyP7Vt9E9wX2ku1C0AvCLqQe9cCiDPCLiPP0wXFYQw/edit?tab=t.0 and the thread https://kubernetes.slack.com/archives/CR0H13KGA/p1751923997220399

The proposed changes on this PR contains fix for validations that are not breaking change, and are separated on different commits per enabled linter.

For newer validations, we should enable the linters just for new changes and existing violations should be fixed individually as they may not break existing GA'd APIs.

This [run](https://github.com/kubernetes-sigs/gateway-api/actions/runs/16277119689/job/45958592299?pr=3917) contains the execution of the linter as per this PR without enabling the feature for only changed files, showing that the enabled linters don't trigger any violation.
