### PR TITLE
Added logic to block conformance report if support features source is manual for non-gateway features.

### DIFF
--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -519,6 +519,12 @@ func (suite *ConformanceTestSuite) Report() (*confv1.ConformanceReport, error) {
 	}
 	defer suite.lock.RUnlock()
 
+	if suite.supportedFeaturesSource == supportedFeaturesSourceManual &&
+		!hasMeshFeatures(suite.SupportedFeatures) &&
+		!suite.conformanceProfiles.HasAny(MeshHTTPConformanceProfileName, MeshGRPCConformanceProfileName) {
+		return nil, fmt.Errorf("can't generate report for Gateway's manually supplied features")
+	}
+
 	testNames := make([]string, 0, len(suite.results))
 	for tN := range suite.results {
 		testNames = append(testNames, tN)

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -522,7 +522,7 @@ func (suite *ConformanceTestSuite) Report() (*confv1.ConformanceReport, error) {
 	if suite.supportedFeaturesSource == supportedFeaturesSourceManual &&
 		!hasMeshFeatures(suite.SupportedFeatures) &&
 		!suite.conformanceProfiles.HasAny(MeshHTTPConformanceProfileName, MeshGRPCConformanceProfileName) {
-		return nil, fmt.Errorf("can't generate report for Gateway's manually supplied features")
+		return nil, fmt.Errorf("can't generate report: Gateway's supported features should be read from Status and not supplied through flags")
 	}
 
 	testNames := make([]string, 0, len(suite.results))

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -412,6 +412,46 @@ func TestSuiteReport(t *testing.T) {
 	}
 }
 
+func TestSuiteReportBlocksManualSource(t *testing.T) {
+	testCases := []struct {
+		name              string
+		supportedFeatures FeaturesSet
+		profiles          sets.Set[ConformanceProfileName]
+		wantErr           bool
+	}{
+		{
+			name:              "should block with no mesh features",
+			supportedFeatures: namesToFeatureSet(statusFeatureNames),
+			profiles:          sets.New(testProfileName),
+			wantErr:           true,
+		},
+		{
+			name:              "should not block with mesh features",
+			supportedFeatures: sets.New(features.SupportMeshClusterIPMatching, features.SupportMeshConsumerRoute),
+		},
+		{
+			name:              "should not block with mesh profile",
+			supportedFeatures: namesToFeatureSet(statusFeatureNames),
+			profiles:          sets.New(MeshHTTPConformanceProfileName),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conformanceProfileMap[testProfileName] = testProfile
+
+			suite := ConformanceTestSuite{
+				supportedFeaturesSource: supportedFeaturesSourceManual,
+				conformanceProfiles:     tc.profiles,
+				SupportedFeatures:       tc.supportedFeatures,
+			}
+			_, err := suite.Report()
+			if tc.wantErr && err == nil {
+				t.Errorf("Expected an error but got nil")
+			}
+		})
+	}
+}
+
 var statusFeatureNames = []string{
 	"Gateway",
 	"GatewayPort8080",


### PR DESCRIPTION
**What type of PR is this?**
/area conformance-test

**What this PR does / why we need it**:
To guide conformance test users in a right direction, we want to discourage manually supplying supported features for conformance tests, instead those features should be inferred from GWC status. This change will block report generation if above mentioned logic is not followed.

**Does this PR introduce a user-facing change?**:
```release-note
For generating conformance report for Gateway features, there will be no need to use flags like `--supported-features` or `--exempt-features`, instead conformance suite will automatically read them from GWC status. This is the behavior we want to encourage to reduce manual intervention in the report generation process, those manually supplied (or excluded) features should only be used for local development/testing.
```
