### PR TITLE
[Breaking change] Mark grpcroutes spec as required

### DIFF
--- a/apis/v1/grpcroute_types.go
+++ b/apis/v1/grpcroute_types.go
@@ -60,6 +60,7 @@ type GRPCRoute struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the desired state of GRPCRoute.
+	// +required
 	Spec GRPCRouteSpec `json:"spec,omitempty"`
 
 	// Status defines the current state of GRPCRoute.

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -2204,6 +2204,8 @@ spec:
             required:
             - parents
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
@@ -2047,6 +2047,8 @@ spec:
             required:
             - parents
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3286,6 +3286,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_GRPCRoute(ref common.ReferenceCallback
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -5927,6 +5928,7 @@ func schema_sigsk8sio_gateway_api_apis_v1alpha2_GRPCRoute(ref common.ReferenceCa
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: 

This PR marks grpcroute.spec as required. During this API implementation, the field `omitempty` was added to .spec, as opposed to other APIs. 

Because we don't rely (yet) on explicit required markers, this caused the spec field of grpcroute to be optional, making it "useless'ish"  (as the .spec field of grpc route contains vital information to implement a route, it will simply fail).


**Which issue(s) this PR fixes**:
Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
Mark grpcroute.spec field as required
```
