### PR TITLE
Add gateway class label to generated objects

### DIFF
--- a/geps/gep-1762/index.md
+++ b/geps/gep-1762/index.md
@@ -59,6 +59,7 @@ With this configuration, an implementation:
 
 * MUST mark the Gateway as `Programmed` and provide an address in `Status.Addresses` where the Gateway can be reached on each configured port.
 * MUST label all generated resources (Service, Deployment, etc) with `gateway.networking.k8s.io/gateway-name: my-gateway` (where `my-gateway` is the name of the Gateway resource).
+* SHOULD label all generated resources (Service, Deployment, etc) with `gateway.networking.k8s.io/gateway-class-name: my-gateway-class` (where `my-gateway-class` is the name of the GatewayClass resource).
 * MUST provision generated resources in the same namespace as the Gateway if they are namespace scoped resources.
   * Cluster scoped resources are not recommended.
 * SHOULD name all generated resources `my-gateway-example` (`<NAME>-<GATEWAY CLASS>`).


### PR DESCRIPTION

**What type of PR is this?**

/kind gep
/kind test

**What this PR does / why we need it**:
This proposes adding an optional new label to generated objects. This is useful for general querying, such as "find the total CPU usage of all pods created by <implementation>".

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Added a new standardized label `gateway.networking.k8s.io/gateway-class-name` to be added to generated objects. This mirrors the existing `gateway.networking.k8s.io/gateway-name` label.
```
