### PR TITLE
TLSRoute: Set rules MaxItems to 1 in v1alpha3

### DIFF
--- a/apis/v1alpha3/tlsroute_types.go
+++ b/apis/v1alpha3/tlsroute_types.go
@@ -96,7 +96,7 @@ type TLSRouteSpec struct {
 	//
 	// +required
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=1
 	// <gateway:experimental:validation:XValidation:message="Rule name must be unique within the route",rule="self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name) && l1.name == l2.name))">
 	Rules []v1alpha2.TLSRouteRule `json:"rules"`
 }

--- a/apis/v1alpha3/tlsroute_types.go
+++ b/apis/v1alpha3/tlsroute_types.go
@@ -98,7 +98,7 @@ type TLSRouteSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=1
 	// <gateway:experimental:validation:XValidation:message="Rule name must be unique within the route",rule="self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name) && l1.name == l2.name))">
-	Rules []v1alpha2.TLSRouteRule `json:"rules"`
+	Rules []v1alpha2.TLSRouteRule `json:"rules,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -1274,7 +1274,7 @@ spec:
                   required:
                   - backendRefs
                   type: object
-                maxItems: 16
+                maxItems: 1
                 minItems: 1
                 type: array
                 x-kubernetes-validations:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR sets `TLSRoute.rules[]` `MaxItems` to 1. Currently, [`TLSRouteRule`](https://gateway-api.sigs.k8s.io/reference/spec/#tlsrouterule) only has `backendRefs` and no matches. Supporting more than one `TLSRouteRule` does NOT make much sense at this moment.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3970 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
- Sets MaxItems=1 for TLSRoute.rules[] in v1alpha3.
```
