### PR TITLE
Correct wrong list type on set fields

### DIFF
--- a/apis/v1/grpcroute_types.go
+++ b/apis/v1/grpcroute_types.go
@@ -139,7 +139,7 @@ type GRPCRouteSpec struct {
 	// Support: Core
 	//
 	// +optional
-	// +listType=atomic
+	// +listType=set
 	// +kubebuilder:validation:MaxItems=16
 	Hostnames []Hostname `json:"hostnames,omitempty"`
 

--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -114,7 +114,7 @@ type HTTPRouteSpec struct {
 	// Support: Core
 	//
 	// +optional
-	// +listType=atomic
+	// +listType=set
 	// +kubebuilder:validation:MaxItems=16
 	Hostnames []Hostname `json:"hostnames,omitempty"`
 
@@ -387,7 +387,7 @@ type HTTPRouteRetry struct {
 	// Support: Extended
 	//
 	// +optional
-	// +listType=atomic
+	// +listType=set
 	Codes []HTTPRouteRetryStatusCode `json:"codes,omitempty"`
 
 	// Attempts specifies the maximum number of times an individual request

--- a/apis/v1alpha2/tlsroute_types.go
+++ b/apis/v1alpha2/tlsroute_types.go
@@ -85,7 +85,7 @@ type TLSRouteSpec struct {
 	// Support: Core
 	//
 	// +optional
-	// +listType=atomic
+	// +listType=set
 	// +kubebuilder:validation:MaxItems=16
 	Hostnames []Hostname `json:"hostnames,omitempty"`
 

--- a/apis/v1alpha3/tlsroute_types.go
+++ b/apis/v1alpha3/tlsroute_types.go
@@ -88,7 +88,7 @@ type TLSRouteSpec struct {
 	// Support: Core
 	//
 	// +required
-	// +listType=atomic
+	// +listType=set
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=16
 	Hostnames []Hostname `json:"hostnames,omitempty"`

--- a/applyconfiguration/internal/internal.go
+++ b/applyconfiguration/internal/internal.go
@@ -450,7 +450,7 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             scalar: string
-          elementRelationship: atomic
+          elementRelationship: associative
     - name: parentRefs
       type:
         list:
@@ -928,7 +928,7 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             scalar: numeric
-          elementRelationship: atomic
+          elementRelationship: associative
 - name: io.k8s.sigs.gateway-api.apis.v1.HTTPRouteRule
   map:
     fields:
@@ -970,7 +970,7 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             scalar: string
-          elementRelationship: atomic
+          elementRelationship: associative
     - name: parentRefs
       type:
         list:
@@ -1432,7 +1432,7 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             scalar: string
-          elementRelationship: atomic
+          elementRelationship: associative
     - name: parentRefs
       type:
         list:
@@ -1614,7 +1614,7 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             scalar: string
-          elementRelationship: atomic
+          elementRelationship: associative
     - name: parentRefs
       type:
         list:

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -151,7 +151,7 @@ spec:
                   type: string
                 maxItems: 16
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-type: set
               parentRefs:
                 description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -131,7 +131,7 @@ spec:
                   type: string
                 maxItems: 16
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-type: set
               parentRefs:
                 description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
@@ -3148,7 +3148,7 @@ spec:
                             minimum: 400
                             type: integer
                           type: array
-                          x-kubernetes-list-type: atomic
+                          x-kubernetes-list-type: set
                       type: object
                     sessionPersistence:
                       description: |-
@@ -3757,7 +3757,7 @@ spec:
                   type: string
                 maxItems: 16
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-type: set
               parentRefs:
                 description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
@@ -6774,7 +6774,7 @@ spec:
                             minimum: 400
                             type: integer
                           type: array
-                          x-kubernetes-list-type: atomic
+                          x-kubernetes-list-type: set
                       type: object
                     sessionPersistence:
                       description: |-

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -110,7 +110,7 @@ spec:
                   type: string
                 maxItems: 16
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-type: set
               parentRefs:
                 description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
@@ -888,7 +888,7 @@ spec:
                 maxItems: 16
                 minItems: 1
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-type: set
               parentRefs:
                 description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants

--- a/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
@@ -151,7 +151,7 @@ spec:
                   type: string
                 maxItems: 16
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-type: set
               parentRefs:
                 description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -131,7 +131,7 @@ spec:
                   type: string
                 maxItems: 16
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-type: set
               parentRefs:
                 description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
@@ -2940,7 +2940,7 @@ spec:
                   type: string
                 maxItems: 16
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-type: set
               parentRefs:
                 description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3574,7 +3574,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_GRPCRouteSpec(ref common.ReferenceCall
 					"hostnames": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-type": "set",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -5062,7 +5062,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_HTTPRouteRetry(ref common.ReferenceCal
 					"codes": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-type": "set",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -5225,7 +5225,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_HTTPRouteSpec(ref common.ReferenceCall
 					"hostnames": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-type": "set",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -6820,7 +6820,7 @@ func schema_sigsk8sio_gateway_api_apis_v1alpha2_TLSRouteSpec(ref common.Referenc
 					"hostnames": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-type": "set",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -7525,7 +7525,7 @@ func schema_sigsk8sio_gateway_api_apis_v1alpha3_TLSRouteSpec(ref common.Referenc
 					"hostnames": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-type": "set",
 							},
 						},
 						SchemaProps: spec.SchemaProps{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind bug

**What this PR does / why we need it**:

This fixes some list-type markers in APIs from atomic to set. The main benefit of this change is that multiple SSA managers can act on the same list field, as each value is tracked separately. This is technically a breaking change, as the API will now reject duplicate values. But I cannot imagine that duplicate values make any sense here, and order is irrelevant, which is also a requirement for the set list type.

Extracted from https://github.com/kubernetes-sigs/gateway-api/pull/3964.

I [asked for advice](https://kubernetes.slack.com/archives/C0EG7JC6T/p1753980723308699) on changes like this in the #sig-api-machinery Slack channel and received some feedback. Here are the main quotes:

> Technically breaking. But when we introduced them in Kube itself apparently this was done without version change.

> I would expect fun side effects, even if you do it as part of an API version bump. We did it in CAPI and it was not a good experience. Depending on use case you may be able to tolerate the issues that generally come with this change,


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Hostname and retry status code fields are now treated as sets
```
