### PR TITLE
Enable dark mode switch on docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,16 @@ theme:
     - navigation.top
     - navigation.expand
   palette:
-    primary: custom
+    - scheme: default
+      primary: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: custom
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
   custom_dir: site-src/overrides
 edit_uri: edit/main/site-src/
 plugins:


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
(because there's no /kind useless!)

**What this PR does / why we need it**:
This PR enables dark switch mode on GW API docs, mostly because my eyes hurt of reading all of the docs :D 

Post change, we have the docs as:
<img width="719" height="463" alt="image" src="https://github.com/user-attachments/assets/95ad2cd3-fc4f-46c8-ae8b-77035e2fe5c8" />

There is a switch, and someone can just use dark mode ;) 

**Which issue(s) this PR fixes**:
Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
