### PR TITLE
Add Conformance tests for BackendTLSPolicy validating SANs with Type dsnName

### DIFF
--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -95,6 +95,39 @@ spec:
           matchLabels:
             gateway-conformance: backend
 ---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-backendtlspolicy
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    hostname: "abc.example.com"
+    allowedRoutes:
+      namespaces:
+        from: Same
+      kinds:
+      - kind: HTTPRoute
+  - name: https
+    port: 443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: tls-checks-certificate
+    hostname: "abc.example.com"
+    allowedRoutes:
+      namespaces:
+        from: Same
+      kinds:
+      - kind: HTTPRoute
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/conformance/tests/backendtlspolicy-san.go
+++ b/conformance/tests/backendtlspolicy-san.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	h "sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, BackendTLSPolicySANValidation)
+}
+
+var BackendTLSPolicySANValidation = suite.ConformanceTest{
+	ShortName:   "BackendTLSPolicySANValidation",
+	Description: "BackendTLSPolicySANValidation extend BackendTLSPolicy with SubjectAltNames validation",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportBackendTLSPolicy,
+		features.SupportBackendTLSPolicySANValidation,
+	},
+	Manifests: []string{"tests/backendtlspolicy-san.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Name: "route-backendtlspolicy-san-test", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "gateway-backendtlspolicy", Namespace: ns}
+
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gatewayv1.HTTPRoute{}, false, routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		policyCond := metav1.Condition{
+			Type:   string(v1alpha2.PolicyConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(v1alpha2.PolicyReasonAccepted),
+		}
+
+		serverStr := "abc.example.com"
+
+		// Verify that the request sent to Service with valid BackendTLSPolicy containing dns SAN should succeed.
+		t.Run("HTTP request sent to Service with valid BackendTLSPolicy containing dns SAN should succeed", func(t *testing.T) {
+			policyNN := types.NamespacedName{Name: "backendtlspolicy-san-dns", Namespace: ns}
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, policyNN, gwNN, policyCond)
+
+			h.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
+				h.ExpectedResponse{
+					Namespace: ns,
+					Request: h.Request{
+						Host: serverStr,
+						Path: "/backendTLSSanDns",
+						SNI:  serverStr,
+					},
+					Response: h.Response{StatusCode: 200},
+				})
+		})
+
+		// Verify that the request sent to a Service targeted by a BackendTLSPolicy with mismatched dns SAN should fail.
+		t.Run("HTTP request sent to Service targeted by BackendTLSPolicy with mismatched dns SAN should return an HTTP error", func(t *testing.T) {
+			policyNN := types.NamespacedName{Name: "backendtlspolicy-san-dns-mismatch", Namespace: ns}
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, policyNN, gwNN, policyCond)
+
+			h.MakeRequestAndExpectFailure(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
+				h.ExpectedResponse{
+					Namespace: ns,
+					Request: h.Request{
+						Host: serverStr,
+						Path: "/backendTLSSanDnsMismatch",
+						SNI:  serverStr,
+					},
+				})
+		})
+
+		// Verify that the request sent to Service with valid BackendTLSPolicy containing uri SAN should succeed.
+		t.Run("HTTP request sent to Service with valid BackendTLSPolicy containing uri SAN should succeed", func(t *testing.T) {
+			policyNN := types.NamespacedName{Name: "backendtlspolicy-san-uri", Namespace: ns}
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, policyNN, gwNN, policyCond)
+
+			h.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
+				h.ExpectedResponse{
+					Namespace: ns,
+					Request: h.Request{
+						Host: serverStr,
+						Path: "/backendTLSSanUri",
+						SNI:  serverStr,
+					},
+					Response: h.Response{StatusCode: 200},
+				})
+		})
+
+		// Verify that the request sent to a Service targeted by a BackendTLSPolicy with mismatched uri SAN should fail.
+		t.Run("HTTP request sent to Service targeted by BackendTLSPolicy with mismatched uri SAN should return an HTTP error", func(t *testing.T) {
+			policyNN := types.NamespacedName{Name: "backendtlspolicy-san-uri-mismatch", Namespace: ns}
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, policyNN, gwNN, policyCond)
+
+			h.MakeRequestAndExpectFailure(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
+				h.ExpectedResponse{
+					Namespace: ns,
+					Request: h.Request{
+						Host: serverStr,
+						Path: "/backendTLSSanUriMismatch",
+						SNI:  serverStr,
+					},
+				})
+		})
+
+		// Verify that the request sent to Service with valid BackendTLSPolicy containing multi SANs should succeed.
+		t.Run("HTTP request sent to Service with valid BackendTLSPolicy containing multi SAN should succeed", func(t *testing.T) {
+			policyNN := types.NamespacedName{Name: "backendtlspolicy-multiple-sans", Namespace: ns}
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, policyNN, gwNN, policyCond)
+
+			h.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
+				h.ExpectedResponse{
+					Namespace: ns,
+					Request: h.Request{
+						Host: serverStr,
+						Path: "/backendTLSMultiSans",
+						SNI:  serverStr,
+					},
+					Response: h.Response{StatusCode: 200},
+				})
+		})
+
+		// Verify that the request sent to a Service targeted by a BackendTLSPolicy with mismatched multi SAN should fail.
+		t.Run("HTTP request sent to Service targeted by BackendTLSPolicy with mismatched multi SAN should return an HTTP error", func(t *testing.T) {
+			policyNN := types.NamespacedName{Name: "backendtlspolicy-multiple-mismatch-sans", Namespace: ns}
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, policyNN, gwNN, policyCond)
+
+			h.MakeRequestAndExpectFailure(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
+				h.ExpectedResponse{
+					Namespace: ns,
+					Request: h.Request{
+						Host: serverStr,
+						Path: "/backendTLSMultiMismatchSans",
+						SNI:  serverStr,
+					},
+				})
+		})
+	},
+}

--- a/conformance/tests/backendtlspolicy-san.yaml
+++ b/conformance/tests/backendtlspolicy-san.yaml
@@ -1,0 +1,341 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-backendtlspolicy-san-test
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: gateway-backendtlspolicy
+    namespace: gateway-conformance-infra
+  hostnames:
+  - abc.example.com
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: backendtlspolicy-san-dns-test
+      port: 443
+    matches:
+    - path:
+        type: Exact
+        value: /backendTLSSanDns
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: backendtlspolicy-san-dns-mismatch-test
+      port: 443
+    matches:
+    - path:
+        type: Exact
+        value: /backendTLSSanDnsMismatch
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: backendtlspolicy-san-uri-test
+      port: 443
+    matches:
+    - path:
+        type: Exact
+        value: /backendTLSSanUri
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: backendtlspolicy-san-uri-mismatch-test
+      port: 443
+    matches:
+    - path:
+        type: Exact
+        value: /backendTLSSanUriMismatch
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: backendtlspolicy-multiple-sans-test
+      port: 443
+    matches:
+    - path:
+        type: Exact
+        value: /backendTLSMultiSans
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: backendtlspolicy-multiple-mismatch-sans-test
+      port: 443
+    matches:
+    - path:
+        type: Exact
+        value: /backendTLSMultiMismatchSans
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendtlspolicy-san-dns-test
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: backendtlspolicy-san-test
+  ports:
+  - name: "btls"
+    protocol: TCP
+    port: 443
+    targetPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendtlspolicy-san-dns-mismatch-test
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: backendtlspolicy-san-test
+  ports:
+  - name: "btls"
+    protocol: TCP
+    appProtocol: HTTPS
+    port: 443
+    targetPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendtlspolicy-san-uri-test
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: backendtlspolicy-san-test
+  ports:
+  - name: "btls"
+    protocol: TCP
+    appProtocol: HTTPS
+    port: 443
+    targetPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendtlspolicy-san-uri-mismatch-test
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: backendtlspolicy-san-test
+  ports:
+  - name: "btls"
+    protocol: TCP
+    appProtocol: HTTPS
+    port: 443
+    targetPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendtlspolicy-multiple-sans-test
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: backendtlspolicy-san-test
+  ports:
+  - name: "btls"
+    protocol: TCP
+    appProtocol: HTTPS
+    port: 443
+    targetPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendtlspolicy-multiple-mismatch-sans-test
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: backendtlspolicy-san-test
+  ports:
+  - name: "btls"
+    protocol: TCP
+    appProtocol: HTTPS
+    port: 443
+    targetPort: 8443
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backendtlspolicy-san-test
+  namespace: gateway-conformance-infra
+  labels:
+    app: backendtlspolicy-san-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backendtlspolicy-san-test
+  template:
+    metadata:
+      labels:
+        app: backendtlspolicy-san-test
+    spec:
+      containers:
+      - name: backendtlspolicy-san-test
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+        volumeMounts:
+        - name: secret-volume
+          mountPath: /etc/secret-volume
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: TLS_SERVER_CERT
+          value: /etc/secret-volume/crt
+        - name: TLS_SERVER_PRIVKEY
+          value: /etc/secret-volume/key
+        resources:
+          requests:
+            cpu: 10m
+      volumes:
+      - name: secret-volume
+        secret:
+          # This secret is generated dynamically by the test suite.
+          secretName: tls-with-san-certificate
+          items:
+          - key: tls.crt
+            path: crt
+          - key: tls.key
+            path: key
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: backendtlspolicy-san-dns
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: backendtlspolicy-san-dns-test
+    sectionName: "btls"
+  validation:
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      # This secret is generated dynamically by the test suite.
+      name: "backend-tls-with-san-certificate"
+    hostname: "abc.example.com"
+    subjectAltNames:
+    - type: "Hostname"
+      hostname: "abc.example.com"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: backendtlspolicy-san-dns-mismatch
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: backendtlspolicy-san-dns-mismatch-test
+    sectionName: "btls"
+  validation:
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      # This secret is generated dynamically by the test suite.
+      name: "backend-tls-with-san-certificate"
+    hostname: "abc.example.com"
+    subjectAltNames:
+    - type: "Hostname"
+      hostname: "dce.example.com"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: backendtlspolicy-san-uri
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: backendtlspolicy-san-uri-test
+    sectionName: "btls"
+  validation:
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      # This secret is generated dynamically by the test suite.
+      name: "backend-tls-with-san-certificate"
+    hostname: "abc.example.com"
+    subjectAltNames:
+    - type: "URI"
+      uri: "spiffe://abc.example.com/test-identity"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: backendtlspolicy-san-uri-mismatch
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: backendtlspolicy-san-uri-mismatch-test
+    sectionName: "btls"
+  validation:
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      # This secret is generated dynamically by the test suite.
+      name: "backend-tls-with-san-certificate"
+    hostname: "abc.example.com"
+    subjectAltNames:
+    - type: "URI"
+      uri: "spiffe://def.example.com/test-identity"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: backendtlspolicy-multiple-sans
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: backendtlspolicy-multiple-sans-test
+    sectionName: "btls"
+  validation:
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      # This secret is generated dynamically by the test suite.
+      name: "backend-tls-with-san-certificate"
+    hostname: "abc.example.com"
+    subjectAltNames:
+    - type: "URI"
+      uri: "spiffe://abc.example.com/test-identity"
+    - type: "Hostname"
+      hostname: "abc.example.com"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: backendtlspolicy-multiple-mismatch-sans
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: backendtlspolicy-multiple-mismatch-sans-test
+    sectionName: "btls"
+  validation:
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      # This secret is generated dynamically by the test suite.
+      name: "backend-tls-with-san-certificate"
+    hostname: "abc.example.com"
+    subjectAltNames:
+    - type: "URI"
+      uri: "spiffe://def.example.com/test-identity"
+    - type: "Hostname"
+      hostname: "def.example.com"

--- a/conformance/tests/backendtlspolicy.go
+++ b/conformance/tests/backendtlspolicy.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/types"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -67,15 +68,6 @@ var BackendTLSPolicy = suite.ConformanceTest{
 
 		invalidCertPolicyNN := types.NamespacedName{Name: "backendtlspolicy-cert-mismatch", Namespace: ns}
 		kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, invalidCertPolicyNN, gwNN, policyCond)
-
-		invalidSanPolicyNN := types.NamespacedName{Name: "backendtlspolicy-san-mismatch", Namespace: ns}
-		kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, invalidSanPolicyNN, gwNN, policyCond)
-
-		validSanPolicyNN := types.NamespacedName{Name: "backendtlspolicy-san", Namespace: ns}
-		kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, validSanPolicyNN, gwNN, policyCond)
-
-		validMultiSanPolicyNN := types.NamespacedName{Name: "backendtlspolicy-multiple-sans", Namespace: ns}
-		kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, validMultiSanPolicyNN, gwNN, policyCond)
 
 		serverStr := "abc.example.com"
 
@@ -135,44 +127,6 @@ var BackendTLSPolicy = suite.ConformanceTest{
 						Host: serverStr,
 						Path: "/backendTLSCertMismatch",
 						SNI:  serverStr,
-					},
-				})
-		})
-
-		// Verify that the request sent to Service with BackendTLSPolicy configured with SANs should succeed.
-		t.Run("HTTP request sent to Service with BackendTLSPolicy configured with SAN should succeed", func(t *testing.T) {
-			h.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
-				h.ExpectedResponse{
-					Namespace: ns,
-					Request: h.Request{
-						Host: serverStr,
-						Path: "/backendTLSSan",
-					},
-					Response: h.Response{StatusCode: 200},
-				})
-		})
-
-		// Verify that the request sent to Service with BackendTLSPolicy configured with multiple SANs should succeed.
-		t.Run("HTTP request sent to Service with BackendTLSPolicy configured with multiple SANs should succeed", func(t *testing.T) {
-			h.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
-				h.ExpectedResponse{
-					Namespace: ns,
-					Request: h.Request{
-						Host: serverStr,
-						Path: "/backendTLSMultiSans",
-					},
-					Response: h.Response{StatusCode: 200},
-				})
-		})
-
-		// Verify that request sent to Service targeted by BackendTLSPolicy with mismatched SAN should failed.
-		t.Run("HTTP request send to Service targeted by BackendTLSPolicy with mismatched SAN should return HTTP error", func(t *testing.T) {
-			h.MakeRequestAndExpectFailure(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
-				h.ExpectedResponse{
-					Namespace: ns,
-					Request: h.Request{
-						Host: serverStr,
-						Path: "/backendTLSSanMismatch",
 					},
 				})
 		})

--- a/conformance/tests/backendtlspolicy.yaml
+++ b/conformance/tests/backendtlspolicy.yaml
@@ -1,37 +1,4 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: gateway-backendtlspolicy
-  namespace: gateway-conformance-infra
-spec:
-  gatewayClassName: "{GATEWAY_CLASS_NAME}"
-  listeners:
-  - name: http
-    port: 80
-    protocol: HTTP
-    hostname: "abc.example.com"
-    allowedRoutes:
-      namespaces:
-        from: Same
-      kinds:
-      - kind: HTTPRoute
-  - name: https
-    port: 443
-    protocol: HTTPS
-    tls:
-      mode: Terminate
-      certificateRefs:
-      - group: ""
-        kind: Secret
-        name: tls-checks-certificate
-    hostname: "abc.example.com"
-    allowedRoutes:
-      namespaces:
-        from: Same
-      kinds:
-      - kind: HTTPRoute
----
-apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: gateway-conformance-infra-test
@@ -70,33 +37,6 @@ spec:
     - path:
         type: Exact
         value: /backendTLSCertMismatch
-  - backendRefs:
-    - group: ""
-      kind: Service
-      name: backendtlspolicy-san-mismatch-test
-      port: 443
-    matches:
-    - path:
-        type: Exact
-        value: /backendTLSSanMismatch
-  - backendRefs:
-    - group: ""
-      kind: Service
-      name: backendtlspolicy-san-test
-      port: 443
-    matches:
-    - path:
-        type: Exact
-        value: /backendTLSSan
-  - backendRefs:
-    - group: ""
-      kind: Service
-      name: backendtlspolicy-multiple-sans-test
-      port: 443
-    matches:
-    - path:
-        type: Exact
-        value: /backendTLSMultiSans
 ---
 apiVersion: v1
 kind: Service
@@ -131,51 +71,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: backendtlspolicy-cert-mismatch-test
-  namespace: gateway-conformance-infra
-spec:
-  selector:
-    app: backendtlspolicy-test
-  ports:
-  - name: "btls"
-    protocol: TCP
-    appProtocol: HTTPS
-    port: 443
-    targetPort: 8443
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: backendtlspolicy-san-mismatch-test
-  namespace: gateway-conformance-infra
-spec:
-  selector:
-    app: backendtlspolicy-test
-  ports:
-  - name: "btls"
-    protocol: TCP
-    appProtocol: HTTPS
-    port: 443
-    targetPort: 8443
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: backendtlspolicy-san-test
-  namespace: gateway-conformance-infra
-spec:
-  selector:
-    app: backendtlspolicy-test
-  ports:
-  - name: "btls"
-    protocol: TCP
-    appProtocol: HTTPS
-    port: 443
-    targetPort: 8443
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: backendtlspolicy-multiple-sans-test
   namespace: gateway-conformance-infra
 spec:
   selector:
@@ -309,73 +204,3 @@ spec:
       # This secret is generated dynamically by the test suite.
       name: "backend-tls-mismatch-certificate"
     hostname: "abc.example.com"
----
-apiVersion: gateway.networking.k8s.io/v1alpha3
-kind: BackendTLSPolicy
-metadata:
-  name: backendtlspolicy-san
-  namespace: gateway-conformance-infra
-spec:
-  targetRefs:
-  - group: ""
-    kind: Service
-    name: "backendtlspolicy-san-test"
-    sectionName: "btls"
-  validation:
-    caCertificateRefs:
-    - group: ""
-      kind: ConfigMap
-      # This secret is generated dynamically by the test suite.
-      name: "backend-tls-checks-certificate"
-    hostname: "abc.example.com"
-    subjectAltNames:
-    - type: Hostname
-      hostname: abc.example.com
----
-apiVersion: gateway.networking.k8s.io/v1alpha3
-kind: BackendTLSPolicy
-metadata:
-  name: backendtlspolicy-multiple-sans
-  namespace: gateway-conformance-infra
-spec:
-  targetRefs:
-  - group: ""
-    kind: Service
-    name: "backendtlspolicy-multiple-sans-test"
-    sectionName: "btls"
-  validation:
-    caCertificateRefs:
-    - group: ""
-      kind: ConfigMap
-      # This secret is generated dynamically by the test suite.
-      name: "backend-tls-checks-certificate"
-    hostname: "abc.example.com"
-    subjectAltNames:
-    - type: Hostname
-      hostname: abc.example.com
-    - type: Hostname
-      hostname: efg.example.com
-    - type: Hostname
-      hostname: yjh.example.com
----
-apiVersion: gateway.networking.k8s.io/v1alpha3
-kind: BackendTLSPolicy
-metadata:
-  name: backendtlspolicy-san-mismatch
-  namespace: gateway-conformance-infra
-spec:
-  targetRefs:
-  - group: ""
-    kind: Service
-    name: "backendtlspolicy-san-mismatch-test"
-    sectionName: "btls"
-  validation:
-    caCertificateRefs:
-    - group: ""
-      kind: ConfigMap
-      # This secret is generated dynamically by the test suite.
-      name: "backend-tls-checks-certificate"
-    hostname: "abc.example.com"
-    subjectAltNames:
-    - type: Hostname
-      hostname: cde.example.com

--- a/conformance/utils/kubernetes/certificate.go
+++ b/conformance/utils/kubernetes/certificate.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"math/big"
 	"net"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -119,6 +120,8 @@ func generateRSACert(hosts []string, keyOut, certOut io.Writer, ca *x509.Certifi
 			template.IPAddresses = append(template.IPAddresses, ip)
 		} else if err = validateHost(h); err == nil {
 			template.DNSNames = append(template.DNSNames, h)
+		} else if u, parseErr := url.Parse(h); parseErr == nil {
+			template.URIs = append(template.URIs, u)
 		}
 	}
 
@@ -215,6 +218,8 @@ func generateCACert(hosts []string) (*x509.Certificate, []byte, *rsa.PrivateKey,
 			ca.IPAddresses = append(ca.IPAddresses, ip)
 		} else if err := validateHost(h); err == nil {
 			ca.DNSNames = append(ca.DNSNames, h)
+		} else if u, err := url.Parse(h); err == nil {
+			ca.URIs = append(ca.URIs, u)
 		}
 	}
 

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -389,6 +389,11 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T, tests []ConformanceTest) 
 		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{caConfigMap}, suite.Cleanup)
 		secret = kubernetes.MustCreateCASignedCertSecret(t, "gateway-conformance-infra", "tls-checks-certificate", []string{"abc.example.com"}, ca, caPrivKey)
 		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{secret}, suite.Cleanup)
+		// TODO(kl52752) Merge CA certificates for Backend TLS Policy and move Deployment to common file.
+		caConfigMap, ca, caPrivKey = kubernetes.MustCreateCACertConfigMap(t, "gateway-conformance-infra", "backend-tls-with-san-certificate", []string{"abc.example.com", "spiffe://abc.example.com/test-identity"})
+		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{caConfigMap}, suite.Cleanup)
+		secret = kubernetes.MustCreateCASignedCertSecret(t, "gateway-conformance-infra", "tls-with-san-certificate", []string{"abc.example.com", "spiffe://abc.example.com/test-identity"}, ca, caPrivKey)
+		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{secret}, suite.Cleanup)
 
 		tlog.Logf(t, "Test Setup: Ensuring Gateways and Pods from base manifests are ready")
 		namespaces := []string{

--- a/pkg/features/backendtlspolicy.go
+++ b/pkg/features/backendtlspolicy.go
@@ -25,6 +25,9 @@ import "k8s.io/apimachinery/pkg/util/sets"
 const (
 	// This option indicates support for BackendTLSPolicy.
 	SupportBackendTLSPolicy FeatureName = "BackendTLSPolicy"
+
+	// This option indicates support for BackendTLSPolicy SubjectAltName Validation.
+	SupportBackendTLSPolicySANValidation FeatureName = "BackendTLSPolicySANValidation"
 )
 
 // TLSRouteFeature contains metadata for the TLSRoute feature.
@@ -33,8 +36,21 @@ var BackendTLSPolicyFeature = Feature{
 	Channel: FeatureChannelExperimental,
 }
 
+// BackendTLSPolicySanValidationFeature contains metadata for the BackendTLSPolicy
+// SubjectAltName Validation feature.
+var BackendTLSPolicySanValidationFeature = Feature{
+	Name:    SupportBackendTLSPolicySANValidation,
+	Channel: FeatureChannelExperimental,
+}
+
 // BackendTLSPolicyCoreFeatures includes all the supported features for the
 // BackendTLSPolicy API at a Core level of support.
 var BackendTLSPolicyCoreFeatures = sets.New(
 	BackendTLSPolicyFeature,
+)
+
+// BackendTLSPolicyExtendedFeatures includes all the supported features for the
+// BackendTLSPolicy API at a Extended level of support.
+var BackendTLSPolicyExtendedFeatures = sets.New(
+	BackendTLSPolicySanValidationFeature,
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind test 
**What this PR does / why we need it**:
Add Conformance tests for BackendTLSPolicy validating SANs set with Type dns name
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Relates to #3979

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
