### PR TITLE
fix(docs): remove unnecessary array in incorrect example @ gep-1767

### DIFF
--- a/geps/gep-1767/index.md
+++ b/geps/gep-1767/index.md
@@ -516,7 +516,7 @@ spec:
         value: /resource/foo
     filters:
     - cors:
-      - allowOrigins:
+        allowOrigins:
         - *
         allowMethods: 
         - GET
@@ -575,7 +575,7 @@ spec:
         value: /resource/foo
     filters:
     - cors:
-      - allowOrigins:
+        allowOrigins:
         - https://foo.example
         - http://foo.example
         allowCredentials: true


### PR DESCRIPTION

/kind documentation

Fixes #3988

```release-note
NONE
```
