### PR TITLE
Add default timeout to UDPRoute test and improve logs

### DIFF
--- a/conformance/tests/udproute-simple.go
+++ b/conformance/tests/udproute-simple.go
@@ -27,6 +27,7 @@ import (
 
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
 	"sigs.k8s.io/gateway-api/pkg/features"
 )
 
@@ -53,15 +54,15 @@ var UDPRouteTest = suite.ConformanceTest{
 
 			msg := new(dns.Msg)
 			msg.SetQuestion(domain, dns.TypeA)
-
-			if err := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
+			tlog.Logf(t, "performing DNS query %s on %s", domain, gwAddr)
+			if err := wait.PollUntilContextTimeout(context.TODO(), time.Second, suite.TimeoutConfig.DefaultTestTimeout, true,
 				func(_ context.Context) (done bool, err error) {
-					t.Logf("performing DNS query %s on %s", domain, gwAddr)
-					_, err = dns.Exchange(msg, gwAddr)
+					r, err := dns.Exchange(msg, gwAddr)
 					if err != nil {
-						t.Logf("failed to perform a UDP query: %v", err)
+						tlog.Logf(t, "failed to perform a UDP query: %v", err)
 						return false, nil
 					}
+					tlog.Logf(t, "got DNS response: %s", r.String())
 					return true, nil
 				}); err != nil {
 				t.Errorf("failed to perform DNS query: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind cleanup
/area conformance-test

**What this PR does / why we need it**:

Adding a default timeout configuration for the UDPRoute test and improving the logging structure.
This one came out during adding the test in [Envoy Gateway](https://github.com/envoyproxy/gateway/pull/6839/).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
