### PR TITLE
Fix cors cel

### DIFF
--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -1404,8 +1404,9 @@ type HTTPCORSFilter struct {
 	// Support: Extended
 	// +listType=set
 	// +kubebuilder:validation:MaxItems=64
+	// +kubebuilder:validation:XValidation:message="AllowOrigins cannot contain '*' alongside other origins",rule="!('*' in self && self.size() > 1)"
 	// +optional
-	AllowOrigins []AbsoluteURI `json:"allowOrigins,omitempty"`
+	AllowOrigins []CORSOrigin `json:"allowOrigins,omitempty"`
 
 	// AllowCredentials indicates whether the actual cross-origin request allows
 	// to include credentials.

--- a/apis/v1/shared_types.go
+++ b/apis/v1/shared_types.go
@@ -608,6 +608,17 @@ type PreciseHostname string
 // +kubebuilder:validation:Pattern=`^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?`
 type AbsoluteURI string
 
+// The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+// encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+// scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+// URIs that include an authority MUST include a fully qualified domain name or
+// IP address as the host.
+// <gateway:util:excludeFromCRD> The below regex was generated to simplify the assertion of scheme://host:<port> being port optional </gateway:util:excludeFromCRD>
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern=`(^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)`
+type CORSOrigin string
+
 // Group refers to a Kubernetes Group. It must either be an empty string or a
 // RFC 1123 subdomain.
 //

--- a/apis/v1/zz_generated.deepcopy.go
+++ b/apis/v1/zz_generated.deepcopy.go
@@ -956,7 +956,7 @@ func (in *HTTPCORSFilter) DeepCopyInto(out *HTTPCORSFilter) {
 	*out = *in
 	if in.AllowOrigins != nil {
 		in, out := &in.AllowOrigins, &out.AllowOrigins
-		*out = make([]AbsoluteURI, len(*in))
+		*out = make([]CORSOrigin, len(*in))
 		copy(*out, *in)
 	}
 	if in.AllowCredentials != nil {

--- a/applyconfiguration/apis/v1/httpcorsfilter.go
+++ b/applyconfiguration/apis/v1/httpcorsfilter.go
@@ -25,7 +25,7 @@ import (
 // HTTPCORSFilterApplyConfiguration represents a declarative configuration of the HTTPCORSFilter type for use
 // with apply.
 type HTTPCORSFilterApplyConfiguration struct {
-	AllowOrigins     []apisv1.AbsoluteURI            `json:"allowOrigins,omitempty"`
+	AllowOrigins     []apisv1.CORSOrigin             `json:"allowOrigins,omitempty"`
 	AllowCredentials *bool                           `json:"allowCredentials,omitempty"`
 	AllowMethods     []apisv1.HTTPMethodWithWildcard `json:"allowMethods,omitempty"`
 	AllowHeaders     []apisv1.HTTPHeaderName         `json:"allowHeaders,omitempty"`
@@ -42,7 +42,7 @@ func HTTPCORSFilter() *HTTPCORSFilterApplyConfiguration {
 // WithAllowOrigins adds the given value to the AllowOrigins field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AllowOrigins field.
-func (b *HTTPCORSFilterApplyConfiguration) WithAllowOrigins(values ...apisv1.AbsoluteURI) *HTTPCORSFilterApplyConfiguration {
+func (b *HTTPCORSFilterApplyConfiguration) WithAllowOrigins(values ...apisv1.CORSOrigin) *HTTPCORSFilterApplyConfiguration {
 	for i := range values {
 		b.AllowOrigins = append(b.AllowOrigins, values[i])
 	}

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -657,18 +657,22 @@ spec:
                                         Support: Extended
                                       items:
                                         description: |-
-                                          The AbsoluteURI MUST NOT be a relative URI, and it MUST follow the URI syntax and
-                                          encoding rules specified in RFC3986.  The AbsoluteURI MUST include both a
-                                          scheme (e.g., "http" or "spiffe") and a scheme-specific-part.  URIs that
-                                          include an authority MUST include a fully qualified domain name or
+                                          The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                          encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                          scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                          URIs that include an authority MUST include a fully qualified domain name or
                                           IP address as the host.
                                         maxLength: 253
                                         minLength: 1
-                                        pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                                        pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
                                         type: string
                                       maxItems: 64
                                       type: array
                                       x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowOrigins cannot contain '*' alongside
+                                          other origins
+                                        rule: '!(''*'' in self && self.size() > 1)'
                                     exposeHeaders:
                                       description: |-
                                         ExposeHeaders indicates which HTTP response headers can be exposed
@@ -2139,18 +2143,22 @@ spec:
                                   Support: Extended
                                 items:
                                   description: |-
-                                    The AbsoluteURI MUST NOT be a relative URI, and it MUST follow the URI syntax and
-                                    encoding rules specified in RFC3986.  The AbsoluteURI MUST include both a
-                                    scheme (e.g., "http" or "spiffe") and a scheme-specific-part.  URIs that
-                                    include an authority MUST include a fully qualified domain name or
+                                    The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                    encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                    scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                    URIs that include an authority MUST include a fully qualified domain name or
                                     IP address as the host.
                                   maxLength: 253
                                   minLength: 1
-                                  pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                                  pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
                                   type: string
                                 maxItems: 64
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowOrigins cannot contain '*' alongside
+                                    other origins
+                                  rule: '!(''*'' in self && self.size() > 1)'
                               exposeHeaders:
                                 description: |-
                                   ExposeHeaders indicates which HTTP response headers can be exposed
@@ -4801,18 +4809,22 @@ spec:
                                         Support: Extended
                                       items:
                                         description: |-
-                                          The AbsoluteURI MUST NOT be a relative URI, and it MUST follow the URI syntax and
-                                          encoding rules specified in RFC3986.  The AbsoluteURI MUST include both a
-                                          scheme (e.g., "http" or "spiffe") and a scheme-specific-part.  URIs that
-                                          include an authority MUST include a fully qualified domain name or
+                                          The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                          encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                          scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                          URIs that include an authority MUST include a fully qualified domain name or
                                           IP address as the host.
                                         maxLength: 253
                                         minLength: 1
-                                        pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                                        pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
                                         type: string
                                       maxItems: 64
                                       type: array
                                       x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowOrigins cannot contain '*' alongside
+                                          other origins
+                                        rule: '!(''*'' in self && self.size() > 1)'
                                     exposeHeaders:
                                       description: |-
                                         ExposeHeaders indicates which HTTP response headers can be exposed
@@ -6283,18 +6295,22 @@ spec:
                                   Support: Extended
                                 items:
                                   description: |-
-                                    The AbsoluteURI MUST NOT be a relative URI, and it MUST follow the URI syntax and
-                                    encoding rules specified in RFC3986.  The AbsoluteURI MUST include both a
-                                    scheme (e.g., "http" or "spiffe") and a scheme-specific-part.  URIs that
-                                    include an authority MUST include a fully qualified domain name or
+                                    The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                    encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                    scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                    URIs that include an authority MUST include a fully qualified domain name or
                                     IP address as the host.
                                   maxLength: 253
                                   minLength: 1
-                                  pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                                  pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
                                   type: string
                                 maxItems: 64
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowOrigins cannot contain '*' alongside
+                                    other origins
+                                  rule: '!(''*'' in self && self.size() > 1)'
                               exposeHeaders:
                                 description: |-
                                   ExposeHeaders indicates which HTTP response headers can be exposed


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind test

**What this PR does / why we need it**: 
- Adds support for a single "*" as a CORS origin
- Adds validation tests for the AllowOrigins and AllowMethods fields

**Which issue(s) this PR fixes**:
Fixes #3648 

**Does this PR introduce a user-facing change?**:
```release-note
Adds support for a single '*' character on CORS origins
```
