### PR TITLE
BackendTLSPolicy conformance tests for conflict resolution

### DIFF
--- a/conformance/tests/backendtlspolicy-conflict-resolution.go
+++ b/conformance/tests/backendtlspolicy-conflict-resolution.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	h "sigs.k8s.io/gateway-api/conformance/utils/http"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, BackendTLSPolicyConflictResolution)
+}
+
+var BackendTLSPolicyConflictResolution = suite.ConformanceTest{
+	ShortName:   "BackendTLSPolicyConflictResolution",
+	Description: "Verifies that when multiple BackendTLSPolicies target the same Service, only one policy is accepted while conflicting policies are rejected, and traffic continues to route successfully.",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportBackendTLSPolicy,
+	},
+	Manifests: []string{"tests/backendtlspolicy-conflict-resolution.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Name: "backendtlspolicy-conflict-resolution", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gatewayv1.HTTPRoute{}, false, routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		acceptedCond := metav1.Condition{
+			Type:   string(v1alpha2.PolicyConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(v1alpha2.PolicyReasonAccepted),
+		}
+		conflictedCond := metav1.Condition{
+			Type:   string(v1alpha2.PolicyConditionAccepted),
+			Status: metav1.ConditionFalse,
+			Reason: string(v1alpha2.PolicyReasonConflicted),
+		}
+
+		t.Run("Conflicting BackendTLSPolicies targeting the same Service without a section name", func(t *testing.T) {
+			t.Run("First BackendTLSPolicy should be accepted", func(t *testing.T) {
+				policyNN := types.NamespacedName{Name: "conflicted-without-section-name-1", Namespace: ns}
+				kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, policyNN, gwNN, acceptedCond)
+			})
+
+			t.Run("Second BackendTLSPolicy should have a false Accepted condition with reason Conflicted ", func(t *testing.T) {
+				conflictedPolicyNN := types.NamespacedName{Name: "conflicted-without-section-name-2", Namespace: ns}
+				kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, conflictedPolicyNN, gwNN, conflictedCond)
+			})
+
+			t.Run("HTTP request sent to Service using the accepted BackendTLSPolicy should succeed", func(t *testing.T) {
+				h.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
+					h.ExpectedResponse{
+						Namespace: ns,
+						Request: h.Request{
+							Host: "abc.example.com",
+							Path: "/backendtlspolicy-conflicted-without-section-name",
+							SNI:  "other.example.com",
+						},
+						Response: h.Response{StatusCode: 200},
+					})
+			})
+		})
+
+		t.Run("Conflicting BackendTLSPolicies targeting the same Service with the same section name", func(t *testing.T) {
+			t.Run("First BackendTLSPolicy should be accepted", func(t *testing.T) {
+				policyNN := types.NamespacedName{Name: "conflicted-with-section-name-1", Namespace: ns}
+				kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, policyNN, gwNN, acceptedCond)
+			})
+
+			t.Run("Second BackendTLSPolicy should have a false Accepted condition with reason Conflicted ", func(t *testing.T) {
+				conflictedPolicyNN := types.NamespacedName{Name: "conflicted-with-section-name-2", Namespace: ns}
+				kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, conflictedPolicyNN, gwNN, conflictedCond)
+			})
+
+			t.Run("HTTP request sent to Service using the accepted BackendTLSPolicy should succeed", func(t *testing.T) {
+				h.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
+					h.ExpectedResponse{
+						Namespace: ns,
+						Request: h.Request{
+							Host: "abc.example.com",
+							Path: "/backendtlspolicy-conflicted-with-section-name",
+							SNI:  "other.example.com",
+						},
+						Response: h.Response{StatusCode: 200},
+					})
+			})
+		})
+
+		t.Run("BackendTLSPolicies targeting the same Service with and without a section name", func(t *testing.T) {
+			t.Run("BackendTLSPolicy with section name should be accepted", func(t *testing.T) {
+				policyNN := types.NamespacedName{Name: "not-conflicted-with-section-name", Namespace: ns}
+				kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, policyNN, gwNN, acceptedCond)
+			})
+
+			t.Run("BackendTLSPolicy without section name should be accepted", func(t *testing.T) {
+				policyNN := types.NamespacedName{Name: "not-conflicted-without-section-name", Namespace: ns}
+				kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, policyNN, gwNN, acceptedCond)
+			})
+
+			t.Run("HTTP request sent to Service using the BackendTLSPolicy with section name should succeed", func(t *testing.T) {
+				h.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
+					h.ExpectedResponse{
+						Namespace: ns,
+						Request: h.Request{
+							Host: "abc.example.com",
+							Path: "/backendtlspolicy-not-conflicted-with-section-name",
+							SNI:  "other.example.com",
+						},
+						Response: h.Response{StatusCode: 200},
+					})
+			})
+			t.Run("HTTP request sent to Service using the BackendTLSPolicy without section name should succeed", func(t *testing.T) {
+				h.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
+					h.ExpectedResponse{
+						Namespace: ns,
+						Request: h.Request{
+							Host: "abc.example.com",
+							Path: "/backendtlspolicy-not-conflicted-without-section-name",
+							SNI:  "abc.example.com",
+						},
+						Response: h.Response{StatusCode: 200},
+					})
+			})
+		})
+	},
+}

--- a/conformance/tests/backendtlspolicy-conflict-resolution.yaml
+++ b/conformance/tests/backendtlspolicy-conflict-resolution.yaml
@@ -1,0 +1,214 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backendtlspolicy-conflict-resolution
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  hostnames:
+    - abc.example.com
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: backendtlspolicy-conflicted-without-section-name-test
+          port: 443
+      matches:
+        - path:
+            type: Exact
+            value: /backendtlspolicy-conflicted-without-section-name
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: backendtlspolicy-conflicted-with-section-name-test
+          port: 443
+      matches:
+        - path:
+            type: Exact
+            value: /backendtlspolicy-conflicted-with-section-name
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: backendtlspolicy-not-conflicted-test
+          port: 443
+      matches:
+        - path:
+            type: Exact
+            value: /backendtlspolicy-not-conflicted-with-section-name
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: backendtlspolicy-not-conflicted-test
+          port: 8443
+      matches:
+        - path:
+            type: Exact
+            value: /backendtlspolicy-not-conflicted-without-section-name
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendtlspolicy-conflicted-without-section-name-test
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: tls-backend
+  ports:
+    - name: "https"
+      protocol: TCP
+      port: 443
+      targetPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendtlspolicy-conflicted-with-section-name-test
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: tls-backend
+  ports:
+    - name: "https-1"
+      protocol: TCP
+      port: 443
+      targetPort: 8443
+    - name: "https-2"
+      protocol: TCP
+      port: 8443
+      targetPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendtlspolicy-not-conflicted-test
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: tls-backend
+  ports:
+    - name: "https-1"
+      protocol: TCP
+      port: 443
+      targetPort: 8443
+    - name: "https-2"
+      protocol: TCP
+      port: 8443
+      targetPort: 8443
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: conflicted-without-section-name-1
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: "backendtlspolicy-conflicted-without-section-name-test"
+  validation:
+    caCertificateRefs:
+      - group: ""
+        kind: ConfigMap
+        # This ConfigMap is generated dynamically by the test suite.
+        # It contains the CA certificate used to sign the tls-backend serving certificate.
+        name: "tls-checks-ca-certificate"
+    hostname: "other.example.com"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: conflicted-without-section-name-2
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: "backendtlspolicy-conflicted-without-section-name-test"
+  validation:
+    caCertificateRefs:
+      - group: ""
+        kind: ConfigMap
+        # This ConfigMap is generated dynamically by the test suite.
+        # It contains the CA certificate used to sign the tls-backend serving certificate.
+        name: "tls-checks-ca-certificate"
+    hostname: "abc.example.com"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: conflicted-with-section-name-1
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: "backendtlspolicy-conflicted-with-section-name-test"
+      sectionName: "https-1"
+  validation:
+    caCertificateRefs:
+      - group: ""
+        kind: ConfigMap
+        # This ConfigMap is generated dynamically by the test suite.
+        # It contains the CA certificate used to sign the tls-backend serving certificate.
+        name: "tls-checks-ca-certificate"
+    hostname: "other.example.com"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: conflicted-with-section-name-2
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: "backendtlspolicy-conflicted-with-section-name-test"
+      sectionName: "https-1"
+  validation:
+    caCertificateRefs:
+      - group: ""
+        kind: ConfigMap
+        # This ConfigMap is generated dynamically by the test suite.
+        # It contains the CA certificate used to sign the tls-backend serving certificate.
+        name: "tls-checks-ca-certificate"
+    hostname: "abc.example.com"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: not-conflicted-with-section-name
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: "backendtlspolicy-not-conflicted-test"
+      sectionName: "https-1"
+  validation:
+    caCertificateRefs:
+      - group: ""
+        kind: ConfigMap
+        # This ConfigMap is generated dynamically by the test suite.
+        # It contains the CA certificate used to sign the tls-backend serving certificate.
+        name: "tls-checks-ca-certificate"
+    hostname: "other.example.com"
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: not-conflicted-without-section-name
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: "backendtlspolicy-not-conflicted-test"
+  validation:
+    caCertificateRefs:
+      - group: ""
+        kind: ConfigMap
+        # This ConfigMap is generated dynamically by the test suite.
+        # It contains the CA certificate used to sign the tls-backend serving certificate.
+        name: "tls-checks-ca-certificate"
+    hostname: "abc.example.com"

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -390,7 +390,7 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T, tests []ConformanceTest) 
 		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{secret}, suite.Cleanup)
 		caConfigMap, ca, caPrivKey := kubernetes.MustCreateCACertConfigMap(t, "gateway-conformance-infra", "tls-checks-ca-certificate")
 		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{caConfigMap}, suite.Cleanup)
-		secret = kubernetes.MustCreateCASignedCertSecret(t, "gateway-conformance-infra", "tls-checks-certificate", []string{"abc.example.com", "spiffe://abc.example.com/test-identity"}, ca, caPrivKey)
+		secret = kubernetes.MustCreateCASignedCertSecret(t, "gateway-conformance-infra", "tls-checks-certificate", []string{"abc.example.com", "spiffe://abc.example.com/test-identity", "other.example.com"}, ca, caPrivKey)
 		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{secret}, suite.Cleanup)
 
 		// The following CA ceritficate is used for BackendTLSPolicy testing to intentionally force TLS validation to fail.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind test
/area conformance-test

**What this PR does / why we need it**:
This PR introduces some basic conformance tests to ensure that the status condition `Accepted` on a BackendTLSPolicy is set to `false` with `Reason: Conflicted` when a policy cannot be accepted due to another policy already targeting the  same target (including the `sectionName`).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3953 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
