### PR TITLE
chore(build): Clean up excessive warnings from "make generate"

### DIFF
--- a/apis/v1alpha2/object_reference_types.go
+++ b/apis/v1alpha2/object_reference_types.go
@@ -18,43 +18,8 @@ package v1alpha2
 
 import v1 "sigs.k8s.io/gateway-api/apis/v1"
 
-// LocalObjectReference identifies an API object within the namespace of the
-// referrer.
-// The API object must be valid in the cluster; the Group and Kind must
-// be registered in the cluster for this reference to be valid.
-//
-// References to objects with invalid Group and Kind are not valid, and must
-// be rejected by the implementation, with appropriate Conditions set
-// on the containing object.
-// +k8s:deepcopy-gen=false
 type LocalObjectReference = v1.LocalObjectReference
 
-// SecretObjectReference identifies an API object including its namespace,
-// defaulting to Secret.
-//
-// The API object must be valid in the cluster; the Group and Kind must
-// be registered in the cluster for this reference to be valid.
-//
-// References to objects with invalid Group and Kind are not valid, and must
-// be rejected by the implementation, with appropriate Conditions set
-// on the containing object.
-// +k8s:deepcopy-gen=false
 type SecretObjectReference = v1.SecretObjectReference
 
-// BackendObjectReference defines how an ObjectReference that is
-// specific to BackendRef. It includes a few additional fields and features
-// than a regular ObjectReference.
-//
-// Note that when a namespace different than the local namespace is specified, a
-// ReferenceGrant object is required in the referent namespace to allow that
-// namespace's owner to accept the reference. See the ReferenceGrant
-// documentation for details.
-//
-// The API object must be valid in the cluster; the Group and Kind must
-// be registered in the cluster for this reference to be valid.
-//
-// References to objects with invalid Group and Kind are not valid, and must
-// be rejected by the implementation, with appropriate Conditions set
-// on the containing object.
-// +k8s:deepcopy-gen=false
 type BackendObjectReference = v1.BackendObjectReference

--- a/apis/v1alpha2/referencegrant_types.go
+++ b/apis/v1alpha2/referencegrant_types.go
@@ -59,16 +59,8 @@ type ReferenceGrantList struct {
 	Items           []ReferenceGrant `json:"items"`
 }
 
-// ReferenceGrantSpec identifies a cross namespace relationship that is trusted
-// for Gateway API.
-// +k8s:deepcopy-gen=false
 type ReferenceGrantSpec = v1beta1.ReferenceGrantSpec
 
-// ReferenceGrantFrom describes trusted namespaces and kinds.
-// +k8s:deepcopy-gen=false
 type ReferenceGrantFrom = v1beta1.ReferenceGrantFrom
 
-// ReferenceGrantTo describes what Kinds are allowed as targets of the
-// references.
-// +k8s:deepcopy-gen=false
 type ReferenceGrantTo = v1beta1.ReferenceGrantTo

--- a/apis/v1alpha2/shared_types.go
+++ b/apis/v1alpha2/shared_types.go
@@ -18,44 +18,11 @@ package v1alpha2
 
 import v1 "sigs.k8s.io/gateway-api/apis/v1"
 
-// ParentReference identifies an API object (usually a Gateway) that can be considered
-// a parent of this resource (usually a route). The only kind of parent resource
-// with "Core" support is Gateway. This API may be extended in the future to
-// support additional kinds of parent resources, such as HTTPRoute.
-//
-// Note that there are specific rules for ParentRefs which cross namespace
-// boundaries. Cross-namespace references are only valid if they are explicitly
-// allowed by something in the namespace they are referring to. For example:
-// Gateway has the AllowedRoutes field, and ReferenceGrant provides a
-// generic way to enable any other kind of cross-namespace reference.
-//
-// The API object must be valid in the cluster; the Group and Kind must
-// be registered in the cluster for this reference to be valid.
-// +k8s:deepcopy-gen=false
 type ParentReference = v1.ParentReference
-
-// CommonRouteSpec defines the common attributes that all Routes MUST include
-// within their spec.
-// +k8s:deepcopy-gen=false
 type CommonRouteSpec = v1.CommonRouteSpec
-
-// PortNumber defines a network port.
 type PortNumber = v1.PortNumber
-
-// BackendRef defines how a Route should forward a request to a Kubernetes
-// resource.
-//
-// Note that when a namespace different than the local namespace is specified, a
-// ReferenceGrant object is required in the referent namespace to allow that
-// namespace's owner to accept the reference. See the ReferenceGrant
-// documentation for details.
-// +k8s:deepcopy-gen=false
 type BackendRef = v1.BackendRef
-
-// RouteConditionType is a type of condition for a route.
 type RouteConditionType = v1.RouteConditionType
-
-// RouteConditionReason is a reason for a route condition.
 type RouteConditionReason = v1.RouteConditionReason
 
 const (
@@ -140,214 +107,19 @@ const (
 	RouteReasonBackendNotFound RouteConditionReason = "BackendNotFound"
 )
 
-// RouteParentStatus describes the status of a route with respect to an
-// associated Parent.
-// +k8s:deepcopy-gen=false
 type RouteParentStatus = v1.RouteParentStatus
-
-// RouteStatus defines the common attributes that all Routes MUST include within
-// their status.
-// +k8s:deepcopy-gen=false
 type RouteStatus = v1.RouteStatus
-
-// Hostname is the fully qualified domain name of a network host. This matches
-// the RFC 1123 definition of a hostname with 2 notable exceptions:
-//
-//  1. IPs are not allowed.
-//  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
-//     label must appear by itself as the first label.
-//
-// Hostname can be "precise" which is a domain name without the terminating
-// dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
-// domain name prefixed with a single wildcard label (e.g. `*.example.com`).
-//
-// Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
-// alphanumeric characters or '-', and must start and end with an alphanumeric
-// character. No other punctuation is allowed.
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 type Hostname = v1.Hostname
-
-// PreciseHostname is the fully qualified domain name of a network host. This
-// matches the RFC 1123 definition of a hostname with 1 notable exception that
-// numeric IP addresses are not allowed.
-//
-// Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
-// alphanumeric characters or '-', and must start and end with an alphanumeric
-// character. No other punctuation is allowed.
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 type PreciseHostname = v1.PreciseHostname
-
-// Group refers to a Kubernetes Group. It must either be an empty string or a
-// RFC 1123 subdomain.
-//
-// This validation is based off of the corresponding Kubernetes validation:
-// https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/util/validation/validation.go#L208
-//
-// Valid values include:
-//
-// * "" - empty string implies core Kubernetes API group
-// * "networking.k8s.io"
-// * "foo.example.com"
-//
-// Invalid values include:
-//
-// * "example.com/bar" - "/" is an invalid character
-//
-// +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 type Group = v1.Group
-
-// Kind refers to a Kubernetes Kind.
-//
-// Valid values include:
-//
-// * "Service"
-// * "HTTPRoute"
-//
-// Invalid values include:
-//
-// * "invalid/kind" - "/" is an invalid character
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=63
-// +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
 type Kind = v1.Kind
-
-// ObjectName refers to the name of a Kubernetes object.
-// Object names can have a variety of forms, including RFC1123 subdomains,
-// RFC 1123 labels, or RFC 1035 labels.
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
 type ObjectName = v1.ObjectName
-
-// Namespace refers to a Kubernetes namespace. It must be a RFC 1123 label.
-//
-// This validation is based off of the corresponding Kubernetes validation:
-// https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/util/validation/validation.go#L187
-//
-// This is used for Namespace name validation here:
-// https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/api/validation/generic.go#L63
-//
-// Valid values include:
-//
-// * "example"
-//
-// Invalid values include:
-//
-// * "example.com" - "." is an invalid character
-//
-// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=63
 type Namespace = v1.Namespace
-
-// SectionName is the name of a section in a Kubernetes resource.
-//
-// In the following resources, SectionName is interpreted as the following:
-//
-// * Gateway: Listener name
-// * HTTPRoute: HTTPRouteRule name
-// * Service: Port name
-//
-// Section names can have a variety of forms, including RFC 1123 subdomains,
-// RFC 1123 labels, or RFC 1035 labels.
-//
-// This validation is based off of the corresponding Kubernetes validation:
-// https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/util/validation/validation.go#L208
-//
-// Valid values include:
-//
-// * "example"
-// * "foo-example"
-// * "example.com"
-// * "foo.example.com"
-//
-// Invalid values include:
-//
-// * "example.com/bar" - "/" is an invalid character
-//
-// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
 type SectionName = v1.SectionName
-
-// GatewayController is the name of a Gateway API controller. It must be a
-// domain prefixed path.
-//
-// Valid values include:
-//
-// * "example.com/bar"
-//
-// Invalid values include:
-//
-// * "example.com" - must include path
-// * "foo.example.com" - must include path
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`
 type GatewayController = v1.GatewayController
-
-// AnnotationKey is the key of an annotation in Gateway API. This is used for
-// validation of maps such as TLS options. This matches the Kubernetes
-// "qualified name" validation that is used for annotations and other common
-// values.
-//
-// Valid values include:
-//
-// * example
-// * example.com
-// * example.com/path
-// * example.com/path.html
-//
-// Invalid values include:
-//
-// * example~ - "~" is an invalid character
-// * example.com. - cannot start or end with "."
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]/?)*$`
 type AnnotationKey = v1.AnnotationKey
-
-// AnnotationValue is the value of an annotation in Gateway API. This is used
-// for validation of maps such as TLS options. This roughly matches Kubernetes
-// annotation validation, although the length validation in that case is based
-// on the entire size of the annotations struct.
-//
-// +kubebuilder:validation:MinLength=0
-// +kubebuilder:validation:MaxLength=4096
 type AnnotationValue = v1.AnnotationValue
-
-// AddressType defines how a network address is represented as a text string.
-// This may take two possible forms:
-//
-// * A predefined CamelCase string identifier (currently limited to `IPAddress` or `Hostname`)
-// * A domain-prefixed string identifier (like `acme.io/CustomAddressType`)
-//
-// Values `IPAddress` and `Hostname` have Extended support.
-//
-// The `NamedAddress` value has been deprecated in favor of implementation
-// specific domain-prefixed strings.
-//
-// All other values, including domain-prefixed values have Implementation-specific support,
-// which are used in implementation-specific behaviors. Support for additional
-// predefined CamelCase identifiers may be added in future releases.
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`
 type AddressType = v1.AddressType
-
-// Duration is a string value representing a duration in time. The format is as specified
-// in GEP-2257, a strict subset of the syntax parsed by Golang time.ParseDuration.
 type Duration = v1.Duration
 
 const (
@@ -382,7 +154,4 @@ const (
 	NamedAddressType AddressType = "NamedAddress"
 )
 
-// SessionPersistence defines the desired state of
-// SessionPersistence.
-// +k8s:deepcopy-gen=false
 type SessionPersistence = v1.SessionPersistence

--- a/apis/v1alpha3/shared_types.go
+++ b/apis/v1alpha3/shared_types.go
@@ -18,72 +18,12 @@ package v1alpha3
 
 import v1 "sigs.k8s.io/gateway-api/apis/v1"
 
-// CommonRouteSpec defines the common attributes that all Routes MUST include
-// within their spec.
-// +k8s:deepcopy-gen=false
 type CommonRouteSpec = v1.CommonRouteSpec
 
-// BackendRef defines how a Route should forward a request to a Kubernetes
-// resource.
-//
-// Note that when a namespace different than the local namespace is specified, a
-// ReferenceGrant object is required in the referent namespace to allow that
-// namespace's owner to accept the reference. See the ReferenceGrant
-// documentation for details.
-// +k8s:deepcopy-gen=false
 type BackendRef = v1.BackendRef
 
-// RouteStatus defines the common attributes that all Routes MUST include within
-// their status.
-// +k8s:deepcopy-gen=false
 type RouteStatus = v1.RouteStatus
 
-// Hostname is the fully qualified domain name of a network host. This matches
-// the RFC 1123 definition of a hostname with 2 notable exceptions:
-//
-//  1. IPs are not allowed.
-//  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
-//     label must appear by itself as the first label.
-//
-// Hostname can be "precise" which is a domain name without the terminating
-// dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
-// domain name prefixed with a single wildcard label (e.g. `*.example.com`).
-//
-// Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
-// alphanumeric characters or '-', and must start and end with an alphanumeric
-// character. No other punctuation is allowed.
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 type Hostname = v1.Hostname
 
-// SectionName is the name of a section in a Kubernetes resource.
-//
-// In the following resources, SectionName is interpreted as the following:
-//
-// * Gateway: Listener name
-// * HTTPRoute: HTTPRouteRule name
-// * Service: Port name
-//
-// Section names can have a variety of forms, including RFC 1123 subdomains,
-// RFC 1123 labels, or RFC 1035 labels.
-//
-// This validation is based off of the corresponding Kubernetes validation:
-// https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/util/validation/validation.go#L208
-//
-// Valid values include:
-//
-// * "example"
-// * "foo-example"
-// * "example.com"
-// * "foo.example.com"
-//
-// Invalid values include:
-//
-// * "example.com/bar" - "/" is an invalid character
-//
-// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
 type SectionName = v1.SectionName

--- a/apis/v1beta1/gateway_types.go
+++ b/apis/v1beta1/gateway_types.go
@@ -44,123 +44,34 @@ type GatewayList struct {
 	Items           []Gateway `json:"items"`
 }
 
-// GatewaySpec defines the desired state of Gateway.
-//
-// Not all possible combinations of options specified in the Spec are
-// valid. Some invalid configurations can be caught synchronously via CRD
-// validation, but there are many cases that will require asynchronous
-// signaling via the GatewayStatus block.
-// +k8s:deepcopy-gen=false
 type GatewaySpec = v1.GatewaySpec
 
-// Listener embodies the concept of a logical endpoint where a Gateway accepts
-// network connections.
-// +k8s:deepcopy-gen=false
 type Listener = v1.Listener
 
-// ProtocolType defines the application protocol accepted by a Listener.
-// Implementations are not required to accept all the defined protocols. If an
-// implementation does not support a specified protocol, it MUST set the
-// "Accepted" condition to False for the affected Listener with a reason of
-// "UnsupportedProtocol".
-//
-// Core ProtocolType values are listed in the table below.
-//
-// Implementations can define their own protocols if a core ProtocolType does not
-// exist. Such definitions must use prefixed name, such as
-// `mycompany.com/my-custom-protocol`. Un-prefixed names are reserved for core
-// protocols. Any protocol defined by implementations will fall under
-// implementation-specific conformance.
-//
-// Valid values include:
-//
-// * "HTTP" - Core support
-// * "example.com/bar" - Implementation-specific support
-//
-// Invalid values include:
-//
-// * "example.com" - must include path if domain is used
-// * "foo.example.com" - must include path if domain is used
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=255
-// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9]([-a-zSA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$`
-// +k8s:deepcopy-gen=false
 type ProtocolType = v1.ProtocolType
 
-// ListenerTLSConfig describes a TLS configuration.
-// +k8s:deepcopy-gen=false
 type ListenerTLSConfig = v1.ListenerTLSConfig
 
-// TLSModeType type defines how a Gateway handles TLS sessions.
-//
-// Note that values may be added to this enum, implementations
-// must ensure that unknown values will not cause a crash.
-//
-// Unknown values here must result in the implementation setting the
-// Ready Condition for the Listener to `status: False`, with a
-// Reason of `Invalid`.
-//
-// +kubebuilder:validation:Enum=Terminate;Passthrough
-// +k8s:deepcopy-gen=false
 type TLSModeType = v1.TLSModeType
 
-// AllowedRoutes defines which Routes may be attached to this Listener.
-// +k8s:deepcopy-gen=false
 type AllowedRoutes = v1.AllowedRoutes
 
-// FromNamespaces specifies namespace from which Routes may be attached to a
-// Gateway.
-//
-// Note that values may be added to this enum, implementations
-// must ensure that unknown values will not cause a crash.
-//
-// Unknown values here must result in the implementation setting the
-// Ready Condition for the Listener to `status: False`, with a
-// Reason of `Invalid`.
-//
-// +kubebuilder:validation:Enum=All;Selector;Same
-// +k8s:deepcopy-gen=false
 type FromNamespaces = v1.FromNamespaces
 
-// RouteNamespaces indicate which namespaces Routes should be selected from.
-// +k8s:deepcopy-gen=false
 type RouteNamespaces = v1.RouteNamespaces
 
-// RouteGroupKind indicates the group and kind of a Route resource.
-// +k8s:deepcopy-gen=false
 type RouteGroupKind = v1.RouteGroupKind
 
-// GatewaySpecAddress describes an address that can be bound to a Gateway.
-// +k8s:deepcopy-gen=false
 type GatewaySpecAddress = v1.GatewaySpecAddress
 
-// GatewayStatus defines the observed state of Gateway.
-// +k8s:deepcopy-gen=false
 type GatewayStatus = v1.GatewayStatus
 
-// GatewayConditionType is a type of condition associated with a
-// Gateway. This type should be used with the GatewayStatus.Conditions
-// field.
-// +k8s:deepcopy-gen=false
 type GatewayConditionType = v1.GatewayConditionType
 
-// GatewayConditionReason defines the set of reasons that explain why a
-// particular Gateway condition type has been raised.
-// +k8s:deepcopy-gen=false
 type GatewayConditionReason = v1.GatewayConditionReason
 
-// ListenerStatus is the status associated with a Listener.
-// +k8s:deepcopy-gen=false
 type ListenerStatus = v1.ListenerStatus
 
-// ListenerConditionType is a type of condition associated with the
-// listener. This type should be used with the ListenerStatus.Conditions
-// field.
-// +k8s:deepcopy-gen=false
 type ListenerConditionType = v1.ListenerConditionType
 
-// ListenerConditionReason defines the set of reasons that explain
-// why a particular Listener condition type has been raised.
-// +k8s:deepcopy-gen=false
 type ListenerConditionReason = v1.ListenerConditionReason

--- a/apis/v1beta1/gatewayclass_types.go
+++ b/apis/v1beta1/gatewayclass_types.go
@@ -60,26 +60,12 @@ type GatewayClassList struct {
 	Items           []GatewayClass `json:"items"`
 }
 
-// GatewayClassSpec reflects the configuration of a class of Gateways.
-// +k8s:deepcopy-gen=false
 type GatewayClassSpec = v1.GatewayClassSpec
 
-// ParametersReference identifies an API object containing controller-specific
-// configuration resource within the cluster.
-// +k8s:deepcopy-gen=false
 type ParametersReference = v1.ParametersReference
 
-// GatewayClassConditionType is the type for status conditions on
-// Gateway resources. This type should be used with the
-// GatewayClassStatus.Conditions field.
-// +k8s:deepcopy-gen=false
 type GatewayClassConditionType = v1.GatewayClassConditionType
 
-// GatewayClassConditionReason defines the set of reasons that explain why a
-// particular GatewayClass condition type has been raised.
-// +k8s:deepcopy-gen=false
 type GatewayClassConditionReason = v1.GatewayClassConditionReason
 
-// GatewayClassStatus is the current status for the GatewayClass.
-// +k8s:deepcopy-gen=false
 type GatewayClassStatus = v1.GatewayClassStatus

--- a/apis/v1beta1/httproute_types.go
+++ b/apis/v1beta1/httproute_types.go
@@ -44,198 +44,48 @@ type HTTPRouteList struct {
 	Items           []HTTPRoute `json:"items"`
 }
 
-// HTTPRouteSpec defines the desired state of HTTPRoute
-// +k8s:deepcopy-gen=false
 type HTTPRouteSpec = v1.HTTPRouteSpec
 
-// HTTPRouteRule defines semantics for matching an HTTP request based on
-// conditions (matches), processing it (filters), and forwarding the request to
-// an API object (backendRefs).
-// +k8s:deepcopy-gen=false
 type HTTPRouteRule = v1.HTTPRouteRule
 
-// PathMatchType specifies the semantics of how HTTP paths should be compared.
-// Valid PathMatchType values, along with their conformance level, are:
-//
-// * "Exact" - Core
-// * "PathPrefix" - Core
-// * "RegularExpression" - Implementation Specific
-//
-// PathPrefix and Exact paths must be syntactically valid:
-//
-// - Must begin with the `/` character
-// - Must not contain consecutive `/` characters (e.g. `/foo///`, `//`).
-//
-// Note that values may be added to this enum, implementations
-// must ensure that unknown values will not cause a crash.
-//
-// Unknown values here must result in the implementation setting the
-// Accepted Condition for the Route to `status: False`, with a
-// Reason of `UnsupportedValue`.
-//
-// +kubebuilder:validation:Enum=Exact;PathPrefix;RegularExpression
-// +k8s:deepcopy-gen=false
 type PathMatchType = v1.PathMatchType
 
-// HTTPPathMatch describes how to select a HTTP route by matching the HTTP request path.
-// +k8s:deepcopy-gen=false
 type HTTPPathMatch = v1.HTTPPathMatch
 
-// HeaderMatchType specifies the semantics of how HTTP header values should be
-// compared. Valid HeaderMatchType values, along with their conformance levels, are:
-//
-// * "Exact" - Core
-// * "RegularExpression" - Implementation Specific
-//
-// Note that values may be added to this enum, implementations
-// must ensure that unknown values will not cause a crash.
-//
-// Unknown values here must result in the implementation setting the
-// Accepted Condition for the Route to `status: False`, with a
-// Reason of `UnsupportedValue`.
-//
-// +kubebuilder:validation:Enum=Exact;RegularExpression
-// +k8s:deepcopy-gen=false
 type HeaderMatchType = v1.HeaderMatchType
 
-// HTTPHeaderName is the name of an HTTP header.
-//
-// Valid values include:
-// * "Authorization"
-// * "Set-Cookie"
-//
-// Invalid values include:
-//
-//   - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-//     headers are not currently supported by this type.
-//
-// * "/invalid" - "/" is an invalid character
-// +k8s:deepcopy-gen=false
 type HTTPHeaderName = v1.HTTPHeaderName
 
-// HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
-// headers.
-// +k8s:deepcopy-gen=false
 type HTTPHeaderMatch = v1.HTTPHeaderMatch
 
-// QueryParamMatchType specifies the semantics of how HTTP query parameter
-// values should be compared. Valid QueryParamMatchType values, along with their
-// conformance levels, are:
-//
-// * "Exact" - Core
-// * "RegularExpression" - Implementation Specific
-//
-// Note that values may be added to this enum, implementations
-// must ensure that unknown values will not cause a crash.
-//
-// Unknown values here must result in the implementation setting the
-// Accepted Condition for the Route to `status: False`, with a
-// Reason of `UnsupportedValue`.
-//
-// +kubebuilder:validation:Enum=Exact;RegularExpression
-// +k8s:deepcopy-gen=false
 type QueryParamMatchType = v1.QueryParamMatchType
 
-// HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
-// query parameters.
-// +k8s:deepcopy-gen=false
 type HTTPQueryParamMatch = v1.HTTPQueryParamMatch
 
-// HTTPMethod describes how to select a HTTP route by matching the HTTP
-// method as defined by
-// [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-4) and
-// [RFC 5789](https://datatracker.ietf.org/doc/html/rfc5789#section-2).
-// The value is expected in upper case.
-//
-// Note that values may be added to this enum, implementations
-// must ensure that unknown values will not cause a crash.
-//
-// Unknown values here must result in the implementation setting the
-// Accepted Condition for the Route to `status: False`, with a
-// Reason of `UnsupportedValue`.
-//
-// +kubebuilder:validation:Enum=GET;HEAD;POST;PUT;DELETE;CONNECT;OPTIONS;TRACE;PATCH
-// +k8s:deepcopy-gen=false
 type HTTPMethod = v1.HTTPMethod
 
-// HTTPRouteMatch defines the predicate used to match requests to a given
-// action. Multiple match types are ANDed together, i.e. the match will
-// evaluate to true only if all conditions are satisfied.
-//
-// For example, the match below will match a HTTP request only if its path
-// starts with `/foo` AND it contains the `version: v1` header:
-//
-// ```
-// match:
-//
-//	path:
-//	  value: "/foo"
-//	headers:
-//	- name: "version"
-//	  value "v1"
-//
-// ```
-// +k8s:deepcopy-gen=false
 type HTTPRouteMatch = v1.HTTPRouteMatch
 
-// HTTPRouteFilter defines processing steps that must be completed during the
-// request or response lifecycle. HTTPRouteFilters are meant as an extension
-// point to express processing that may be done in Gateway implementations. Some
-// examples include request or response modification, implementing
-// authentication strategies, rate-limiting, and traffic shaping. API
-// guarantee/conformance is defined based on the type of the filter.
-// +k8s:deepcopy-gen=false
 type HTTPRouteFilter = v1.HTTPRouteFilter
 
-// HTTPRouteFilterType identifies a type of HTTPRoute filter.
-// +k8s:deepcopy-gen=false
 type HTTPRouteFilterType = v1.HTTPRouteFilterType
 
-// HTTPRouteTimeouts defines timeouts that can be configured for an HTTPRoute.
-// +k8s:deepcopy-gen=false
 type HTTPRouteTimeouts = v1.HTTPRouteTimeouts
 
-// HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.
-// +k8s:deepcopy-gen=false
 type HTTPHeader = v1.HTTPHeader
 
-// HTTPHeaderFilter defines a filter that modifies the headers of an HTTP request
-// or response.
-// +k8s:deepcopy-gen=false
 type HTTPHeaderFilter = v1.HTTPHeaderFilter
 
-// HTTPPathModifierType defines the type of path redirect or rewrite.
-// +k8s:deepcopy-gen=false
 type HTTPPathModifierType = v1.HTTPPathModifierType
 
-// HTTPPathModifier defines configuration for path modifiers.
-// <gateway:experimental>
-// +k8s:deepcopy-gen=false
 type HTTPPathModifier = v1.HTTPPathModifier
 
-// HTTPRequestRedirect defines a filter that redirects a request. This filter
-// MUST NOT be used on the same Route rule as a HTTPURLRewrite filter.
-// +k8s:deepcopy-gen=false
 type HTTPRequestRedirectFilter = v1.HTTPRequestRedirectFilter
 
-// HTTPURLRewriteFilter defines a filter that modifies a request during
-// forwarding. At most one of these filters may be used on a Route rule. This
-// MUST NOT be used on the same Route rule as a HTTPRequestRedirect filter.
-//
-// Support: Extended
-//
-// <gateway:experimental>
-// +k8s:deepcopy-gen=false
 type HTTPURLRewriteFilter = v1.HTTPURLRewriteFilter
 
-// HTTPRequestMirrorFilter defines configuration for the RequestMirror filter.
-// +k8s:deepcopy-gen=false
 type HTTPRequestMirrorFilter = v1.HTTPRequestMirrorFilter
 
-// HTTPBackendRef defines how a HTTPRoute should forward an HTTP request.
-// +k8s:deepcopy-gen=false
 type HTTPBackendRef = v1.HTTPBackendRef
 
-// HTTPRouteStatus defines the observed state of HTTPRoute.
-// +k8s:deepcopy-gen=false
 type HTTPRouteStatus = v1.HTTPRouteStatus

--- a/apis/v1beta1/object_reference_types.go
+++ b/apis/v1beta1/object_reference_types.go
@@ -18,43 +18,8 @@ package v1beta1
 
 import v1 "sigs.k8s.io/gateway-api/apis/v1"
 
-// LocalObjectReference identifies an API object within the namespace of the
-// referrer.
-// The API object must be valid in the cluster; the Group and Kind must
-// be registered in the cluster for this reference to be valid.
-//
-// References to objects with invalid Group and Kind are not valid, and must
-// be rejected by the implementation, with appropriate Conditions set
-// on the containing object.
-// +k8s:deepcopy-gen=false
 type LocalObjectReference = v1.LocalObjectReference
 
-// SecretObjectReference identifies an API object including its namespace,
-// defaulting to Secret.
-//
-// The API object must be valid in the cluster; the Group and Kind must
-// be registered in the cluster for this reference to be valid.
-//
-// References to objects with invalid Group and Kind are not valid, and must
-// be rejected by the implementation, with appropriate Conditions set
-// on the containing object.
-// +k8s:deepcopy-gen=false
 type SecretObjectReference = v1.SecretObjectReference
 
-// BackendObjectReference defines how an ObjectReference that is
-// specific to BackendRef. It includes a few additional fields and features
-// than a regular ObjectReference.
-//
-// Note that when a namespace different than the local namespace is specified, a
-// ReferenceGrant object is required in the referent namespace to allow that
-// namespace's owner to accept the reference. See the ReferenceGrant
-// documentation for details.
-//
-// The API object must be valid in the cluster; the Group and Kind must
-// be registered in the cluster for this reference to be valid.
-//
-// References to objects with invalid Group and Kind are not valid, and must
-// be rejected by the implementation, with appropriate Conditions set
-// on the containing object.
-// +k8s:deepcopy-gen=false
 type BackendObjectReference = v1.BackendObjectReference

--- a/apis/v1beta1/shared_types.go
+++ b/apis/v1beta1/shared_types.go
@@ -18,44 +18,16 @@ package v1beta1
 
 import v1 "sigs.k8s.io/gateway-api/apis/v1"
 
-// ParentReference identifies an API object (usually a Gateway) that can be considered
-// a parent of this resource (usually a route). The only kind of parent resource
-// with "Core" support is Gateway. This API may be extended in the future to
-// support additional kinds of parent resources, such as HTTPRoute.
-//
-// Note that there are specific rules for ParentRefs which cross namespace
-// boundaries. Cross-namespace references are only valid if they are explicitly
-// allowed by something in the namespace they are referring to. For example:
-// Gateway has the AllowedRoutes field, and ReferenceGrant provides a
-// generic way to enable any other kind of cross-namespace reference.
-//
-// The API object must be valid in the cluster; the Group and Kind must
-// be registered in the cluster for this reference to be valid.
-// +k8s:deepcopy-gen=false
 type ParentReference = v1.ParentReference
 
-// CommonRouteSpec defines the common attributes that all Routes MUST include
-// within their spec.
-// +k8s:deepcopy-gen=false
 type CommonRouteSpec = v1.CommonRouteSpec
 
-// PortNumber defines a network port.
 type PortNumber = v1.PortNumber
 
-// BackendRef defines how a Route should forward a request to a Kubernetes
-// resource.
-//
-// Note that when a namespace different than the local namespace is specified, a
-// ReferenceGrant object is required in the referent namespace to allow that
-// namespace's owner to accept the reference. See the ReferenceGrant
-// documentation for details.
-// +k8s:deepcopy-gen=false
 type BackendRef = v1.BackendRef
 
-// RouteConditionType is a type of condition for a route.
 type RouteConditionType = v1.RouteConditionType
 
-// RouteConditionReason is a reason for a route condition.
 type RouteConditionReason = v1.RouteConditionReason
 
 const (
@@ -140,214 +112,32 @@ const (
 	RouteReasonBackendNotFound RouteConditionReason = "BackendNotFound"
 )
 
-// RouteParentStatus describes the status of a route with respect to an
-// associated Parent.
-// +k8s:deepcopy-gen=false
 type RouteParentStatus = v1.RouteParentStatus
 
-// RouteStatus defines the common attributes that all Routes MUST include within
-// their status.
-// +k8s:deepcopy-gen=false
 type RouteStatus = v1.RouteStatus
 
-// Hostname is the fully qualified domain name of a network host. This matches
-// the RFC 1123 definition of a hostname with 2 notable exceptions:
-//
-//  1. IPs are not allowed.
-//  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
-//     label must appear by itself as the first label.
-//
-// Hostname can be "precise" which is a domain name without the terminating
-// dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
-// domain name prefixed with a single wildcard label (e.g. `*.example.com`).
-//
-// Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
-// alphanumeric characters or '-', and must start and end with an alphanumeric
-// character. No other punctuation is allowed.
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 type Hostname = v1.Hostname
 
-// PreciseHostname is the fully qualified domain name of a network host. This
-// matches the RFC 1123 definition of a hostname with 1 notable exception that
-// numeric IP addresses are not allowed.
-//
-// Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
-// alphanumeric characters or '-', and must start and end with an alphanumeric
-// character. No other punctuation is allowed.
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 type PreciseHostname = v1.PreciseHostname
 
-// Group refers to a Kubernetes Group. It must either be an empty string or a
-// RFC 1123 subdomain.
-//
-// This validation is based off of the corresponding Kubernetes validation:
-// https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/util/validation/validation.go#L208
-//
-// Valid values include:
-//
-// * "" - empty string implies core Kubernetes API group
-// * "networking.k8s.io"
-// * "foo.example.com"
-//
-// Invalid values include:
-//
-// * "example.com/bar" - "/" is an invalid character
-//
-// +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 type Group = v1.Group
 
-// Kind refers to a Kubernetes Kind.
-//
-// Valid values include:
-//
-// * "Service"
-// * "HTTPRoute"
-//
-// Invalid values include:
-//
-// * "invalid/kind" - "/" is an invalid character
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=63
-// +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
 type Kind = v1.Kind
 
-// ObjectName refers to the name of a Kubernetes object.
-// Object names can have a variety of forms, including RFC 1123 subdomains,
-// RFC 1123 labels, or RFC 1035 labels.
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
 type ObjectName = v1.ObjectName
 
-// Namespace refers to a Kubernetes namespace. It must be a RFC 1123 label.
-//
-// This validation is based off of the corresponding Kubernetes validation:
-// https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/util/validation/validation.go#L187
-//
-// This is used for Namespace name validation here:
-// https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/api/validation/generic.go#L63
-//
-// Valid values include:
-//
-// * "example"
-//
-// Invalid values include:
-//
-// * "example.com" - "." is an invalid character
-//
-// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=63
 type Namespace = v1.Namespace
 
-// SectionName is the name of a section in a Kubernetes resource.
-//
-// In the following resources, SectionName is interpreted as the following:
-//
-// * Gateway: Listener name
-// * HTTPRoute: HTTPRouteRule name
-// * Service: Port name
-//
-// Section names can have a variety of forms, including RFC 1123 subdomains,
-// RFC 1123 labels, or RFC 1035 labels.
-//
-// This validation is based off of the corresponding Kubernetes validation:
-// https://github.com/kubernetes/apimachinery/blob/02cfb53916346d085a6c6c7c66f882e3c6b0eca6/pkg/util/validation/validation.go#L208
-//
-// Valid values include:
-//
-// * "example"
-// * "foo-example"
-// * "example.com"
-// * "foo.example.com"
-//
-// Invalid values include:
-//
-// * "example.com/bar" - "/" is an invalid character
-//
-// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
 type SectionName = v1.SectionName
 
-// GatewayController is the name of a Gateway API controller. It must be a
-// domain prefixed path.
-//
-// Valid values include:
-//
-// * "example.com/bar"
-//
-// Invalid values include:
-//
-// * "example.com" - must include path
-// * "foo.example.com" - must include path
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`
 type GatewayController = v1.GatewayController
 
-// AnnotationKey is the key of an annotation in Gateway API. This is used for
-// validation of maps such as TLS options. This matches the Kubernetes
-// "qualified name" validation that is used for annotations and other common
-// values.
-//
-// Valid values include:
-//
-// * example
-// * example.com
-// * example.com/path
-// * example.com/path.html
-//
-// Invalid values include:
-//
-// * example~ - "~" is an invalid character
-// * example.com. - cannot start or end with "."
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]/?)*$`
 type AnnotationKey = v1.AnnotationKey
 
-// AnnotationValue is the value of an annotation in Gateway API. This is used
-// for validation of maps such as TLS options. This roughly matches Kubernetes
-// annotation validation, although the length validation in that case is based
-// on the entire size of the annotations struct.
-//
-// +kubebuilder:validation:MinLength=0
-// +kubebuilder:validation:MaxLength=4096
 type AnnotationValue = v1.AnnotationValue
 
-// AddressType defines how a network address is represented as a text string.
-// This may take two possible forms:
-//
-// * A predefined CamelCase string identifier (currently limited to `IPAddress` or `Hostname`)
-// * A domain-prefixed string identifier (like `acme.io/CustomAddressType`)
-//
-// Values `IPAddress` and `Hostname` have Extended support.
-//
-// The `NamedAddress` value has been deprecated in favor of implementation
-// specific domain-prefixed strings.
-//
-// All other values, including domain-prefixed values have Implementation-specific support,
-// which are used in implementation-specific behaviors. Support for additional
-// predefined CamelCase identifiers may be added in future releases.
-//
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern=`^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$`
 type AddressType = v1.AddressType
 
-// Duration is a string value representing a duration in time. The format is as specified
-// in GEP-2257, a strict subset of the syntax parsed by Golang time.ParseDuration.
 type Duration = v1.Duration
 
 const (

--- a/apisx/v1alpha1/shared_types.go
+++ b/apisx/v1alpha1/shared_types.go
@@ -22,36 +22,21 @@ import (
 )
 
 type (
-	// +k8s:deepcopy-gen=false
-	AllowedRoutes = v1.AllowedRoutes
-	// +k8s:deepcopy-gen=false
-	ListenerTLSConfig = v1.ListenerTLSConfig
-	// +k8s:deepcopy-gen=false
-	Group = v1.Group
-	// +k8s:deepcopy-gen=false
-	Hostname = v1.Hostname
-	// +k8s:deepcopy-gen=false
-	Kind = v1.Kind
-	// +k8s:deepcopy-gen=false
-	ObjectName = v1.ObjectName
-	// +k8s:deepcopy-gen=false
-	PortNumber = v1.PortNumber
-	// +k8s:deepcopy-gen=false
-	ProtocolType = v1.ProtocolType
-	// +k8s:deepcopy-gen=false
-	RouteGroupKind = v1.RouteGroupKind
-	// +k8s:deepcopy-gen=false
-	SectionName = v1.SectionName
-	// +k8s:deepcopy-gen=false
-	Namespace = v1.Namespace
-	// +k8s:deepcopy-gen=false
-	Duration = v1.Duration
-	// +k8s:deepcopy-gen=false
-	PolicyStatus = v1alpha2.PolicyStatus
-	// +k8s:deepcopy-gen=false
+	AllowedRoutes              = v1.AllowedRoutes
+	ListenerTLSConfig          = v1.ListenerTLSConfig
+	Group                      = v1.Group
+	Hostname                   = v1.Hostname
+	Kind                       = v1.Kind
+	ObjectName                 = v1.ObjectName
+	PortNumber                 = v1.PortNumber
+	ProtocolType               = v1.ProtocolType
+	RouteGroupKind             = v1.RouteGroupKind
+	SectionName                = v1.SectionName
+	Namespace                  = v1.Namespace
+	Duration                   = v1.Duration
+	PolicyStatus               = v1alpha2.PolicyStatus
 	LocalPolicyTargetReference = v1alpha2.LocalPolicyTargetReference
-	// +k8s:deepcopy-gen=false
-	SessionPersistence = v1.SessionPersistence
+	SessionPersistence         = v1.SessionPersistence
 )
 
 // ParentGatewayReference identifies an API object including its namespace,


### PR DESCRIPTION
/kind cleanup

Upgrading to the K8s 1.34 machinery caused `make generate` to generate (literally) thousands of lines of output like this:

```text
W0828 14:34:24.245772   41402 parse.go:399] Mismatched comments seen for type sigs.k8s.io/gateway-api/apis/v1.AnnotationKey. Using comments:
```
AnnotationKey is the key of an annotation in Gateway API. This is used for
validation of maps such as TLS options. This matches the Kubernetes
"qualified name" validation that is used for annotations and other common
values.

Valid values include:

* example
* example.com
* example.com/path
* example.com/path.html

Invalid values include:

* example~ - "~" is an invalid character
* example.com. - cannot start or end with "."

+kubebuilder:validation:MinLength=1
+kubebuilder:validation:MaxLength=253
+kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$`
```
Ignoring comments from type alias:
```
AnnotationKey is the key of an annotation in Gateway API. This is used for
validation of maps such as TLS options. This matches the Kubernetes
"qualified name" validation that is used for annotations and other common
values.

Valid values include:

* example
* example.com
* example.com/path
* example.com/path.html

Invalid values include:

* example~ - "~" is an invalid character
* example.com. - cannot start or end with "."

+kubebuilder:validation:MinLength=1
+kubebuilder:validation:MaxLength=253
+kubebuilder:validation:Pattern=`^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]/?)*$`
```

where, basically, we're using type aliases but we also left the comments on the alias... and then edited the comments for the `v1` type without editing the comments on the alias to match.

This change deletes all the comments on all the aliased types, which shuts up the errors and results in no changes to the generated code.

Signed-off-by: Flynn <emissary@flynn.kodachi.com>

```release-note
NONE
```
