### PR TITLE
Fix PortNumber type to support controller-gen

### DIFF
--- a/apis/v1/shared_types.go
+++ b/apis/v1/shared_types.go
@@ -232,7 +232,7 @@ type CommonRouteSpec struct {
 }
 
 // PortNumber defines a network port.
-type PortNumber int32
+type PortNumber = int32
 
 // BackendRef defines how a Route should forward a request to a Kubernetes
 // resource.

--- a/applyconfiguration/apis/v1/backendobjectreference.go
+++ b/applyconfiguration/apis/v1/backendobjectreference.go
@@ -29,7 +29,7 @@ type BackendObjectReferenceApplyConfiguration struct {
 	Kind      *apisv1.Kind       `json:"kind,omitempty"`
 	Name      *apisv1.ObjectName `json:"name,omitempty"`
 	Namespace *apisv1.Namespace  `json:"namespace,omitempty"`
-	Port      *apisv1.PortNumber `json:"port,omitempty"`
+	Port      *int32             `json:"port,omitempty"`
 }
 
 // BackendObjectReferenceApplyConfiguration constructs a declarative configuration of the BackendObjectReference type for use with
@@ -73,7 +73,7 @@ func (b *BackendObjectReferenceApplyConfiguration) WithNamespace(value apisv1.Na
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Port field is set to the value of the last call.
-func (b *BackendObjectReferenceApplyConfiguration) WithPort(value apisv1.PortNumber) *BackendObjectReferenceApplyConfiguration {
+func (b *BackendObjectReferenceApplyConfiguration) WithPort(value int32) *BackendObjectReferenceApplyConfiguration {
 	b.Port = &value
 	return b
 }

--- a/applyconfiguration/apis/v1/backendref.go
+++ b/applyconfiguration/apis/v1/backendref.go
@@ -70,7 +70,7 @@ func (b *BackendRefApplyConfiguration) WithNamespace(value apisv1.Namespace) *Ba
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Port field is set to the value of the last call.
-func (b *BackendRefApplyConfiguration) WithPort(value apisv1.PortNumber) *BackendRefApplyConfiguration {
+func (b *BackendRefApplyConfiguration) WithPort(value int32) *BackendRefApplyConfiguration {
 	b.BackendObjectReferenceApplyConfiguration.Port = &value
 	return b
 }

--- a/applyconfiguration/apis/v1/grpcbackendref.go
+++ b/applyconfiguration/apis/v1/grpcbackendref.go
@@ -70,7 +70,7 @@ func (b *GRPCBackendRefApplyConfiguration) WithNamespace(value apisv1.Namespace)
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Port field is set to the value of the last call.
-func (b *GRPCBackendRefApplyConfiguration) WithPort(value apisv1.PortNumber) *GRPCBackendRefApplyConfiguration {
+func (b *GRPCBackendRefApplyConfiguration) WithPort(value int32) *GRPCBackendRefApplyConfiguration {
 	b.BackendObjectReferenceApplyConfiguration.Port = &value
 	return b
 }

--- a/applyconfiguration/apis/v1/httpbackendref.go
+++ b/applyconfiguration/apis/v1/httpbackendref.go
@@ -70,7 +70,7 @@ func (b *HTTPBackendRefApplyConfiguration) WithNamespace(value apisv1.Namespace)
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Port field is set to the value of the last call.
-func (b *HTTPBackendRefApplyConfiguration) WithPort(value apisv1.PortNumber) *HTTPBackendRefApplyConfiguration {
+func (b *HTTPBackendRefApplyConfiguration) WithPort(value int32) *HTTPBackendRefApplyConfiguration {
 	b.BackendObjectReferenceApplyConfiguration.Port = &value
 	return b
 }

--- a/applyconfiguration/apis/v1/httprequestredirectfilter.go
+++ b/applyconfiguration/apis/v1/httprequestredirectfilter.go
@@ -28,7 +28,7 @@ type HTTPRequestRedirectFilterApplyConfiguration struct {
 	Scheme     *string                             `json:"scheme,omitempty"`
 	Hostname   *apisv1.PreciseHostname             `json:"hostname,omitempty"`
 	Path       *HTTPPathModifierApplyConfiguration `json:"path,omitempty"`
-	Port       *apisv1.PortNumber                  `json:"port,omitempty"`
+	Port       *int32                              `json:"port,omitempty"`
 	StatusCode *int                                `json:"statusCode,omitempty"`
 }
 
@@ -65,7 +65,7 @@ func (b *HTTPRequestRedirectFilterApplyConfiguration) WithPath(value *HTTPPathMo
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Port field is set to the value of the last call.
-func (b *HTTPRequestRedirectFilterApplyConfiguration) WithPort(value apisv1.PortNumber) *HTTPRequestRedirectFilterApplyConfiguration {
+func (b *HTTPRequestRedirectFilterApplyConfiguration) WithPort(value int32) *HTTPRequestRedirectFilterApplyConfiguration {
 	b.Port = &value
 	return b
 }

--- a/applyconfiguration/apis/v1/listener.go
+++ b/applyconfiguration/apis/v1/listener.go
@@ -27,7 +27,7 @@ import (
 type ListenerApplyConfiguration struct {
 	Name          *apisv1.SectionName                  `json:"name,omitempty"`
 	Hostname      *apisv1.Hostname                     `json:"hostname,omitempty"`
-	Port          *apisv1.PortNumber                   `json:"port,omitempty"`
+	Port          *int32                               `json:"port,omitempty"`
 	Protocol      *apisv1.ProtocolType                 `json:"protocol,omitempty"`
 	TLS           *ListenerTLSConfigApplyConfiguration `json:"tls,omitempty"`
 	AllowedRoutes *AllowedRoutesApplyConfiguration     `json:"allowedRoutes,omitempty"`
@@ -58,7 +58,7 @@ func (b *ListenerApplyConfiguration) WithHostname(value apisv1.Hostname) *Listen
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Port field is set to the value of the last call.
-func (b *ListenerApplyConfiguration) WithPort(value apisv1.PortNumber) *ListenerApplyConfiguration {
+func (b *ListenerApplyConfiguration) WithPort(value int32) *ListenerApplyConfiguration {
 	b.Port = &value
 	return b
 }

--- a/applyconfiguration/apis/v1/parentreference.go
+++ b/applyconfiguration/apis/v1/parentreference.go
@@ -30,7 +30,7 @@ type ParentReferenceApplyConfiguration struct {
 	Namespace   *apisv1.Namespace   `json:"namespace,omitempty"`
 	Name        *apisv1.ObjectName  `json:"name,omitempty"`
 	SectionName *apisv1.SectionName `json:"sectionName,omitempty"`
-	Port        *apisv1.PortNumber  `json:"port,omitempty"`
+	Port        *int32              `json:"port,omitempty"`
 }
 
 // ParentReferenceApplyConfiguration constructs a declarative configuration of the ParentReference type for use with
@@ -82,7 +82,7 @@ func (b *ParentReferenceApplyConfiguration) WithSectionName(value apisv1.Section
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Port field is set to the value of the last call.
-func (b *ParentReferenceApplyConfiguration) WithPort(value apisv1.PortNumber) *ParentReferenceApplyConfiguration {
+func (b *ParentReferenceApplyConfiguration) WithPort(value int32) *ParentReferenceApplyConfiguration {
 	b.Port = &value
 	return b
 }

--- a/applyconfiguration/apis/v1/tlsportconfig.go
+++ b/applyconfiguration/apis/v1/tlsportconfig.go
@@ -18,14 +18,10 @@ limitations under the License.
 
 package v1
 
-import (
-	apisv1 "sigs.k8s.io/gateway-api/apis/v1"
-)
-
 // TLSPortConfigApplyConfiguration represents a declarative configuration of the TLSPortConfig type for use
 // with apply.
 type TLSPortConfigApplyConfiguration struct {
-	Port *apisv1.PortNumber           `json:"port,omitempty"`
+	Port *int32                       `json:"port,omitempty"`
 	TLS  *TLSConfigApplyConfiguration `json:"tls,omitempty"`
 }
 
@@ -38,7 +34,7 @@ func TLSPortConfig() *TLSPortConfigApplyConfiguration {
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Port field is set to the value of the last call.
-func (b *TLSPortConfigApplyConfiguration) WithPort(value apisv1.PortNumber) *TLSPortConfigApplyConfiguration {
+func (b *TLSPortConfigApplyConfiguration) WithPort(value int32) *TLSPortConfigApplyConfiguration {
 	b.Port = &value
 	return b
 }

--- a/applyconfiguration/apisx/v1alpha1/listenerentry.go
+++ b/applyconfiguration/apisx/v1alpha1/listenerentry.go
@@ -28,7 +28,7 @@ import (
 type ListenerEntryApplyConfiguration struct {
 	Name          *v1.SectionName                             `json:"name,omitempty"`
 	Hostname      *v1.Hostname                                `json:"hostname,omitempty"`
-	Port          *v1.PortNumber                              `json:"port,omitempty"`
+	Port          *int32                                      `json:"port,omitempty"`
 	Protocol      *v1.ProtocolType                            `json:"protocol,omitempty"`
 	TLS           *apisv1.ListenerTLSConfigApplyConfiguration `json:"tls,omitempty"`
 	AllowedRoutes *apisv1.AllowedRoutesApplyConfiguration     `json:"allowedRoutes,omitempty"`
@@ -59,7 +59,7 @@ func (b *ListenerEntryApplyConfiguration) WithHostname(value v1.Hostname) *Liste
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Port field is set to the value of the last call.
-func (b *ListenerEntryApplyConfiguration) WithPort(value v1.PortNumber) *ListenerEntryApplyConfiguration {
+func (b *ListenerEntryApplyConfiguration) WithPort(value int32) *ListenerEntryApplyConfiguration {
 	b.Port = &value
 	return b
 }

--- a/applyconfiguration/apisx/v1alpha1/listenerentrystatus.go
+++ b/applyconfiguration/apisx/v1alpha1/listenerentrystatus.go
@@ -28,7 +28,7 @@ import (
 // with apply.
 type ListenerEntryStatusApplyConfiguration struct {
 	Name           *v1.SectionName                           `json:"name,omitempty"`
-	Port           *v1.PortNumber                            `json:"port,omitempty"`
+	Port           *int32                                    `json:"port,omitempty"`
 	SupportedKinds []apisv1.RouteGroupKindApplyConfiguration `json:"supportedKinds,omitempty"`
 	AttachedRoutes *int32                                    `json:"attachedRoutes,omitempty"`
 	Conditions     []metav1.ConditionApplyConfiguration      `json:"conditions,omitempty"`
@@ -51,7 +51,7 @@ func (b *ListenerEntryStatusApplyConfiguration) WithName(value v1.SectionName) *
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Port field is set to the value of the last call.
-func (b *ListenerEntryStatusApplyConfiguration) WithPort(value v1.PortNumber) *ListenerEntryStatusApplyConfiguration {
+func (b *ListenerEntryStatusApplyConfiguration) WithPort(value int32) *ListenerEntryStatusApplyConfiguration {
 	b.Port = &value
 	return b
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind bug

**What this PR does / why we need it**:

This PR suggests a workaround for https://github.com/kubernetes-sigs/controller-tools/issues/1269. There is an open PR to fix this issue, https://github.com/kubernetes-sigs/controller-tools/pull/1270, but it appears like the required change is a bit controversial and will at least take some time to get available in a new release of controller-tools.

With the minor change in this PR, I am able to generate CRDs in my WIP PR to upgrade cert-manager to K8s 1.34. See https://github.com/cert-manager/cert-manager/pull/8018/commits/a122dd644acc61b08b9d7dbe92ad6205c051cb81.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```

CC: @dprotaso @JoelSpeed 