### PR TITLE
prevent controller-runtime stack traces logger

### DIFF
--- a/conformance/conformance.go
+++ b/conformance/conformance.go
@@ -36,6 +36,8 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/yaml"
 )
 
@@ -43,6 +45,9 @@ import (
 // ConformanceOptions struct. It will also initialize the various clients
 // required by the tests.
 func DefaultOptions(t *testing.T) suite.ConformanceOptions {
+	// This line prevents controller-runtime from complaining about log.SetLogger never being called
+	log.SetLogger(zap.New(zap.WriteTo(os.Stdout), zap.UseDevMode(true)))
+
 	cfg, err := config.GetConfig()
 	require.NoError(t, err, "error loading Kubernetes config")
 	clientOptions := client.Options{}

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.2 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.1 // indirect


### PR DESCRIPTION

/kind bug
/kind test

```release-note
NONE
```

Fixes https://github.com/kubernetes-sigs/gateway-api/issues/2090

This seems to be the common solution for this problem across other projects, as seen in https://grep.app/search?f.lang=Go&q=+log.SetLogger+

No idea if these are the best options, just copied the ones from kgateway,  but anything is better than panicing in a test suite, feel free to suggest better options

