### PR TITLE
Gravitee Kubernetes Operator 4.8.5 conformance report for 1.3.0

### DIFF
--- a/conformance/reports/v1.3.0/gravitee/README.md
+++ b/conformance/reports/v1.3.0/gravitee/README.md
@@ -1,0 +1,67 @@
+# Gravitee
+
+## Table of Contents
+
+| API channel  | Implementation version                    | Mode    | Report                                                 |
+|--------------|-------------------------------------------|---------|--------------------------------------------------------|
+| standard     | [version-4.8.5](https://github.com/gravitee-io/gravitee-kubernetes-operator/releases/tag/4.8.5) | default | [version-4.8.5 report](./standard-4.8.5-default-report.yaml) |
+
+> The Gravitee Kubernetes Operator provides partial conformance for Gateway - HTTP features in version 4.8.5. It does not support matching rules across routes or defining services of a type other than Kubernetes Core v1 services. These features will be introduced in a future release.
+
+## Prerequisites
+
+The following binaries are assumed to be installed on your device
+  
+  - [docker](https://docs.docker.com/get-started/get-docker/)
+  - [kubectl](https://kubernetes.io/docs/tasks/tools/)
+  - [kind](https://github.com/kubernetes-sigs/kind)
+  - [go](https://go.dev/learn/)
+
+The reproducer has been tested on macOS and Linux only.
+
+## Reproducer
+
+1. Clone the Gravitee Kubernetes Operator repository
+
+```bash
+git clone --depth 1 --branch 4.8.5 https://github.com/gravitee-io/gravitee-kubernetes-operator.git && cd gravitee-kubernetes-operator
+```
+
+2. Start the Kubernetes cluster
+
+```bash
+make start-conformance-cluster
+```
+
+3. Run a local Load Balancer Service
+
+> The make target runs [cloud-provider-kind](https://kind.sigs.k8s.io/docs/user/loadbalancer). If you are reproducing on a macOS device, the binary requires `sudo` privileges and you will be prompted for a password. For Linux devices, cloud-provider-kind will be run using Docker compose.
+
+```bash
+make cloud-lb
+```
+
+4. Run the operator
+
+```bash
+make run
+```
+
+5. Install the Gravitee GatewayClass
+
+```bash
+kubectl apply -f ./test/conformance/gateway-class-parameters.report.yaml -f ./test/conformance/gateway-class.yaml
+```
+
+6. Run the conformance tests
+
+```bash
+make conformance
+```
+
+7. Print report
+
+```bash
+cat test/conformance/kubernetes.io/gateway-api/report/standard-4.8.5-default-report.yaml
+```
+

--- a/conformance/reports/v1.3.0/gravitee/standard-4.8.5-default-report.yaml
+++ b/conformance/reports/v1.3.0/gravitee/standard-4.8.5-default-report.yaml
@@ -1,0 +1,29 @@
+typemeta:
+  kind: ConformanceReport
+  apiversion: gateway.networking.k8s.io/v1
+implementation:
+  organization: gravitee.io
+  project: gravitee-kubernetes-operator
+  url: https://github.com/gravitee-io/gravitee-kubernetes-operator
+  version: 4.8.5
+  contact:
+  - team-devex@graviteesource.com
+date: "2025-09-02T11:08:29+02:00"
+gatewayapiversion: v1.3.0
+mode: default
+gatewayapichannel: standard
+profilereports:
+- name: GATEWAY-HTTP
+  summary: Core tests partially succeeded with 2 test skips.
+  core:
+    result: partial
+    statistics:
+      passed: 31
+      skipped: 2
+      failed: 0
+    skippedtests:
+    - HTTPRouteMatchingAcrossRoutes
+    - HTTPRouteServiceTypes
+    failedtests: []
+  extended: null
+succeededprovisionaltests: []


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
/area conformance-test


**What this PR does / why we need it**:

Adds Gravitee Kubernetes Operator version 4.8.5 conformance report for gateway API 1.3.0

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
