### PR TITLE
Update gRPC Auth config

### DIFF
--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -1665,13 +1665,7 @@ type GRPCAuthConfig struct {
 	// AllowedRequestHeaders specifies what headers from the client request
 	// will be sent to the authorization server.
 	//
-	// If this list is empty, then the following headers must be sent:
-	//
-	// - `Authorization`
-	// - `Location`
-	// - `Proxy-Authenticate`
-	// - `Set-Cookie`
-	// - `WWW-Authenticate`
+	// If this list is empty, then all headers must be sent.
 	//
 	// If the list has entries, only those entries must be sent.
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -910,13 +910,7 @@ spec:
                                             AllowedRequestHeaders specifies what headers from the client request
                                             will be sent to the authorization server.
 
-                                            If this list is empty, then the following headers must be sent:
-
-                                            - `Authorization`
-                                            - `Location`
-                                            - `Proxy-Authenticate`
-                                            - `Set-Cookie`
-                                            - `WWW-Authenticate`
+                                            If this list is empty, then all headers must be sent.
 
                                             If the list has entries, only those entries must be sent.
                                           items:
@@ -2396,13 +2390,7 @@ spec:
                                       AllowedRequestHeaders specifies what headers from the client request
                                       will be sent to the authorization server.
 
-                                      If this list is empty, then the following headers must be sent:
-
-                                      - `Authorization`
-                                      - `Location`
-                                      - `Proxy-Authenticate`
-                                      - `Set-Cookie`
-                                      - `WWW-Authenticate`
+                                      If this list is empty, then all headers must be sent.
 
                                       If the list has entries, only those entries must be sent.
                                     items:
@@ -5062,13 +5050,7 @@ spec:
                                             AllowedRequestHeaders specifies what headers from the client request
                                             will be sent to the authorization server.
 
-                                            If this list is empty, then the following headers must be sent:
-
-                                            - `Authorization`
-                                            - `Location`
-                                            - `Proxy-Authenticate`
-                                            - `Set-Cookie`
-                                            - `WWW-Authenticate`
+                                            If this list is empty, then all headers must be sent.
 
                                             If the list has entries, only those entries must be sent.
                                           items:
@@ -6548,13 +6530,7 @@ spec:
                                       AllowedRequestHeaders specifies what headers from the client request
                                       will be sent to the authorization server.
 
-                                      If this list is empty, then the following headers must be sent:
-
-                                      - `Authorization`
-                                      - `Location`
-                                      - `Proxy-Authenticate`
-                                      - `Set-Cookie`
-                                      - `WWW-Authenticate`
+                                      If this list is empty, then all headers must be sent.
 
                                       If the list has entries, only those entries must be sent.
                                     items:

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3216,7 +3216,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_GRPCAuthConfig(ref common.ReferenceCal
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "AllowedRequestHeaders specifies what headers from the client request will be sent to the authorization server.\n\nIf this list is empty, then the following headers must be sent:\n\n- `Authorization` - `Location` - `Proxy-Authenticate` - `Set-Cookie` - `WWW-Authenticate`\n\nIf the list has entries, only those entries must be sent.",
+							Description: "AllowedRequestHeaders specifies what headers from the client request will be sent to the authorization server.\n\nIf this list is empty, then all headers must be sent.\n\nIf the list has entries, only those entries must be sent.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{


### PR DESCRIPTION

/kind cleanup

**What this PR does / why we need it**:
Update gRPC Auth config so that, if no headers are specified in `allowedHeaders`, _all_ headers must
be sent rather than a specific list.

**Which issue(s) this PR fixes**:
Updates #1494 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
