### PR TITLE
Add conformance report for Traefik Proxy

### DIFF
--- a/conformance/reports/v1.3.0/traefik-traefik/README.md
+++ b/conformance/reports/v1.3.0/traefik-traefik/README.md
@@ -1,0 +1,29 @@
+# Traefik Proxy
+
+## Table of Contents
+
+| API channel  | Implementation version                                           | Mode    | Report                                                     |
+|--------------|------------------------------------------------------------------|---------|------------------------------------------------------------|
+| experimental | [v3.5.0](https://github.com/traefik/traefik/releases/tag/v3.5.0) | default | [v3.5.0 report](./experimental-v3.5.0-default-report.yaml) |
+
+## Reproduce
+
+To reproduce the results, clone the Traefik Proxy repository:
+
+```shell
+git clone https://github.com/traefik/traefik.git && cd traefik
+```
+
+Check out the desired version:
+
+```shell
+git checkout vX.Y
+```
+
+Run the conformance tests with:
+
+```shell
+make test-gateway-api-conformance
+```
+
+Check the produced report in the `./integration/conformance-reports` folder.

--- a/conformance/reports/v1.3.0/traefik-traefik/experimental-v3.5.0-default-report.yaml
+++ b/conformance/reports/v1.3.0/traefik-traefik/experimental-v3.5.0-default-report.yaml
@@ -1,0 +1,69 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: '-'
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.3.0
+implementation:
+  contact:
+    - '@traefik/maintainers'
+  organization: traefik
+  project: traefik
+  url: https://traefik.io/
+  version: v3.5
+kind: ConformanceReport
+mode: default
+profiles:
+  - core:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 12
+        Skipped: 0
+    name: GATEWAY-GRPC
+    summary: Core tests succeeded.
+  - core:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 33
+        Skipped: 0
+    extended:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 13
+        Skipped: 0
+      supportedFeatures:
+        - GatewayPort8080
+        - HTTPRouteBackendProtocolH2C
+        - HTTPRouteBackendProtocolWebSocket
+        - HTTPRouteDestinationPortMatching
+        - HTTPRouteHostRewrite
+        - HTTPRouteMethodMatching
+        - HTTPRoutePathRedirect
+        - HTTPRoutePathRewrite
+        - HTTPRoutePortRedirect
+        - HTTPRouteQueryParamMatching
+        - HTTPRouteResponseHeaderModification
+        - HTTPRouteSchemeRedirect
+      unsupportedFeatures:
+        - GatewayAddressEmpty
+        - GatewayHTTPListenerIsolation
+        - GatewayInfrastructurePropagation
+        - GatewayStaticAddresses
+        - HTTPRouteBackendRequestHeaderModification
+        - HTTPRouteBackendTimeout
+        - HTTPRouteParentRefPort
+        - HTTPRouteRequestMirror
+        - HTTPRouteRequestMultipleMirrors
+        - HTTPRouteRequestPercentageMirror
+        - HTTPRouteRequestTimeout
+    name: GATEWAY-HTTP
+    summary: Core tests succeeded. Extended tests succeeded.
+  - core:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 11
+        Skipped: 0
+    name: GATEWAY-TLS
+    summary: Core tests succeeded.

--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -600,11 +600,11 @@ STUNner currently supports version `v1alpha2` of the Gateway API specification. 
 
 ### Traefik Proxy
 
-[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.2.1-Traefik Proxy-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.2.1/traefik-traefik)
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.3.0-Traefik Proxy-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.3.0/traefik-traefik)
 
 [Traefik Proxy][traefik-proxy] is an open source cloud-native application proxy.
 
-Traefik Proxy currently supports version `v1.2.1` of the Gateway API specification, check the [Kubernetes Gateway Provider Documentation][traefik-proxy-gateway-api-doc] for more information on how to deploy and use it.
+Traefik Proxy currently supports version `v1.3.0` of the Gateway API specification, check the [Kubernetes Gateway Provider Documentation][traefik-proxy-gateway-api-doc] for more information on how to deploy and use it.
 Traefik Proxy's implementation passes all HTTP core and some extended conformance tests, like GRPCRoute, but also supports TCPRoute and TLSRoute features from the Experimental channel.
 
 For help and support with Traefik Proxy, [create an issue][traefik-proxy-issue-new] or ask for help in the [Traefik Labs Community Forum][traefiklabs-community-forum].


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**

/kind documentation
/area conformance-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-tes
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

This pull request adds the conformance report for v1.3.0 for Traefik Proxy.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
