### PR TITLE
submit report for cloud provider kind

### DIFF
--- a/conformance/reports/v1.3.0/cloud-provider-kind/README.md
+++ b/conformance/reports/v1.3.0/cloud-provider-kind/README.md
@@ -1,0 +1,30 @@
+# Cloud Provider KIND
+
+## Table of Contents
+
+|API channel|Implementation version|Mode|Report|
+|-----------|----------------------|----|------|
+|standard|[v0.8.0-alpha.1]|default|[report](./standard-v0.8.0-alpha.1-default-report.yaml)|
+
+## Reproduce
+
+1. `[Install `cloud-provider-kind`](https://github.com/kubernetes-sigs/cloud-provider-kind/tree/v0.8.0-alpha.1?tab=readme-ov-file#install)
+
+2. [Run a `KIND` cluster](https://kind.sigs.k8s.io/docs/user/quick-start/)
+
+3. [Start the `cloud-provider-kind`](https://github.com/kubernetes-sigs/cloud-provider-kind/tree/v0.8.0-alpha.1?tab=readme-ov-file#gateway-api-support-alpha)
+
+4. Run the conformance tests:
+
+```sh
+go test ./conformance -run TestConformance \
+  --report-output /tmp/report.yaml \
+  --organization=sigs.k8s.io \
+  --project=cloud-provider-kind \
+  --url=https://github.com/kubernetes-sigs/cloud-provider-kind \
+  --version=v0.8.0-alpha.1 \
+  --contact=https://github.com/kubernetes-sigs/cloud-provider-kind/issues/new \
+  --gateway-class=cloud-provider-kind \
+  --conformance-profiles=GATEWAY-HTTP \
+  --supported-features=Gateway,HTTPRoute,ReferenceGrant
+```

--- a/conformance/reports/v1.3.0/cloud-provider-kind/standard-v0.8.0-alpha.1-default-report.yaml
+++ b/conformance/reports/v1.3.0/cloud-provider-kind/standard-v0.8.0-alpha.1-default-report.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2025-09-07T12:44:41Z"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.3.0
+implementation:
+  contact:
+  - https://github.com/kubernetes-sigs/cloud-provider-kind/issues/new
+  organization: sigs.k8s.io
+  project: cloud-provider-kind
+  url: https://github.com/kubernetes-sigs/cloud-provider-kind
+  version: v0.8.0-alpha.1
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 33
+      Skipped: 0
+  name: GATEWAY-HTTP
+  summary: Core tests succeeded.


### PR DESCRIPTION

/kind documentation

/area conformance-test
```release-note
NONE
```

Cloud-provider-kind gateway-http profile conformance report

The conformance results can also be obtained directly from the github actions job https://github.com/kubernetes-sigs/cloud-provider-kind/actions/runs/17528832596?pr=285 , are included in the artifiact
