### PR TITLE
Update OWNERS_ALIASES for gateway-api teams

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,7 +11,6 @@ aliases:
 
   # Reference: https://github.com/kubernetes/org/blob/main/config/kubernetes-sigs/sig-network/teams.yaml
   gateway-api-maintainers:
-    - mlavacca
     - robscott
     - shaneutt
     - youngnick
@@ -21,6 +20,7 @@ aliases:
     - danehans
     - hbagdi
     - jpeach
+    - mlavacca
 
   gateway-api-mesh-leads:
     - howardjohn


### PR DESCRIPTION
Moved Mattia to emeritus maintainer status as per [this discussion](https://groups.google.com/g/kubernetes-sig-network/c/zlN8BhPxDHI). Thank you for all your hard work helping to make this project what it is today @mlavacca :vulcan_salute: 