### PR TITLE
Add allowOrigins configuration to CORSAllowCredentialsBehavior and perform cleanup

### DIFF
--- a/conformance/tests/httproute-cors-allow-credentials-behavior.go
+++ b/conformance/tests/httproute-cors-allow-credentials-behavior.go
@@ -28,13 +28,13 @@ import (
 )
 
 func init() {
-	ConformanceTests = append(ConformanceTests, CORSAllowCredentialsBehavior)
+	ConformanceTests = append(ConformanceTests, HTTPRouteCORSAllowCredentialsBehavior)
 }
 
-var CORSAllowCredentialsBehavior = suite.ConformanceTest{
-	ShortName:   "CORSAllowCredentialsBehavior",
-	Description: "Validate ACA-Credentials responses",
-	Manifests:   []string{"tests/cors-allow-credentials-behavior.yaml"},
+var HTTPRouteCORSAllowCredentialsBehavior = suite.ConformanceTest{
+	ShortName:   "HTTPRouteCORSAllowCredentialsBehavior",
+	Description: "An HTTPRoute with CORS includes Access-Control-Allow-Credentials only when configured as 'true', and then only alongside a matching Access-Control-Allow-Origin.",
+	Manifests:   []string{"tests/httproute-cors-allow-credentials-behavior.yaml"},
 	Features: []features.FeatureName{
 		features.SupportGateway,
 		features.SupportHTTPRoute,
@@ -56,6 +56,22 @@ var CORSAllowCredentialsBehavior = suite.ConformanceTest{
 					Path:   "/cors-behavior-creds-false",
 					Headers: map[string]string{
 						"Origin":        origin,
+						"Cookie":        "sid=abc123",
+						"Authorization": "Bearer test",
+					},
+				},
+				Response: http.Response{
+					StatusCode:    200,
+					AbsentHeaders: []string{"Access-Control-Allow-Credentials"},
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Method: "GET",
+					Path:   "/cors-behavior-creds-true",
+					Headers: map[string]string{
+						"Origin":        "http://not-app.example",
 						"Cookie":        "sid=abc123",
 						"Authorization": "Bearer test",
 					},

--- a/conformance/tests/httproute-cors-allow-credentials-behavior.yaml
+++ b/conformance/tests/httproute-cors-allow-credentials-behavior.yaml
@@ -16,6 +16,8 @@ spec:
       port: 8080
     filters:
     - cors:
+        allowOrigins:
+        - https://app.example
         allowCredentials: false
       type: CORS
   - matches:
@@ -27,6 +29,8 @@ spec:
       port: 8080
     filters:
     - cors:
+        allowOrigins:
+        - https://app.example
         allowCredentials: true
       type: CORS
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind bug
/kind cleanup
/area conformance-test

**What this PR does / why we need it**:
Without any `allowOrigins` configured, it’s unlikely that any implementation would be able to pass the `CORSAllowCredentialsBehavior` test. In addition, I added a more meaningful description and updated the test name and files to match the naming conventions used by other HTTPRouteFilter tests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
