### PR TITLE
conformance: fix invalid BackendTLSPolicy conformance test

### DIFF
--- a/conformance/tests/backendtlspolicy-observed-generation-bump.yaml
+++ b/conformance/tests/backendtlspolicy-observed-generation-bump.yaml
@@ -37,9 +37,5 @@ spec:
       name: "observed-generation-bump-test"
       sectionName: "https"
   validation:
-    caCertificateRefs:
-      - group: ""
-        kind: ConfigMap
-        # This ConfigMap is generated dynamically by the test suite.
-        name: "backend-tls-checks-certificate"
+    wellKnownCACertificates: System
     hostname: "abc.example.com"


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The BackendTLSPolicyObservedGenerationBump has

```yaml
  validation:
    caCertificateRefs:
      - group: ""
        kind: ConfigMap
        # This ConfigMap is generated dynamically by the test suite.
        name: "backend-tls-checks-certificate"
    hostname: "abc.example.com"
```

`backend-tls-checks-certificate` does not exist, nor is it created by the test suite (despite the comment).

Our implementation sets Accepted=false for this, because there were no valid caCertificateRefs, therefor we cannot accept the policy. This is in line with the specification:
```
	// If ALL CACertificateRefs are invalid, the implementation MUST also
	// ensure the `Accepted` Condition on the BackendTLSPolicy is set to
	// `status: False`, with a Reason `NoValidCACertificate`.
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4103

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
