### PR TITLE
conformance: make backend TLS tests IPv6-safe

### DIFF
--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -344,7 +344,7 @@ func GatewayAndRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutConfig
 	// If the Gateway has multiple listeners, get a portless gwAddr.
 	// Otherwise, you get the first listener's port, which might not be the one you want.
 	if !usePort {
-		gwAddr, _, _ = strings.Cut(gwAddr, ":")
+		gwAddr, _, _ = net.SplitHostPort(gwAddr)
 	}
 
 	ns := gatewayv1.Namespace(gw.Namespace)


### PR DESCRIPTION

**What type of PR is this?**
/kind bug
/area conformance-test

**What this PR does / why we need it**:
otherwise we send requests to
`http://[fc00/backendtlspolicy-nonexistent-ca-certificate-ref"` which is very wrong

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
