### PR TITLE
conformance: Optimize mesh weight conformance tests using batch requests

### DIFF
--- a/conformance/tests/mesh/httproute-weight.go
+++ b/conformance/tests/mesh/httproute-weight.go
@@ -58,20 +58,21 @@ var MeshHTTPRouteWeight = suite.ConformanceTest{
 				"echo-v2": 0.3,
 			}
 
-			sender := weight.NewFunctionBasedSender(func() (string, error) {
-				uniqueExpected := expected
-				if err := http.AddEntropy(&uniqueExpected); err != nil {
-					return "", fmt.Errorf("error adding entropy: %w", err)
-				}
-				_, cRes, err := client.CaptureRequestResponseAndCompare(t, uniqueExpected)
+			sender := weight.NewBatchFunctionBasedSender(func(count int) ([]string, error) {
+				responses, err := client.RequestBatch(t, expected, count)
 				if err != nil {
-					return "", fmt.Errorf("failed mesh request: %w", err)
+					return nil, fmt.Errorf("failed batch mesh request: %w", err)
 				}
-				return cRes.Hostname, nil
+
+				hostnames := make([]string, len(responses))
+				for i, resp := range responses {
+					hostnames[i] = resp.Hostname
+				}
+				return hostnames, nil
 			})
 
-			for i := 0; i < weight.MaxTestRetries; i++ {
-				if err := weight.TestWeightedDistribution(sender, expectedWeights); err != nil {
+			for i := range weight.MaxTestRetries {
+				if err := weight.TestWeightedDistributionBatch(sender, expectedWeights); err != nil {
 					t.Logf("Traffic distribution test failed (%d/%d): %s", i+1, weight.MaxTestRetries, err)
 				} else {
 					return

--- a/conformance/utils/echo/parse.go
+++ b/conformance/utils/echo/parse.go
@@ -210,6 +210,29 @@ func ParseResponse(output string) Response {
 	return out
 }
 
+// parseMultipleResponses parses output containing multiple responses separated by blank lines
+func parseMultipleResponses(output string) []Response {
+	// Split by double newline which typically separates individual responses
+	// in batch mode output
+	responseSections := strings.Split(output, "\n\n")
+
+	var responses []Response
+	for _, section := range responseSections {
+		section = strings.TrimSpace(section)
+		if section == "" {
+			continue
+		}
+		// Parse each section as a separate response
+		resp := ParseResponse(section)
+		// Only add responses that have meaningful content (at least a hostname or code)
+		if resp.Hostname != "" || resp.Code != "" {
+			responses = append(responses, resp)
+		}
+	}
+
+	return responses
+}
+
 // HeaderType is a helper enum for retrieving Headers from a Response.
 type HeaderType string
 

--- a/conformance/utils/echo/pod.go
+++ b/conformance/utils/echo/pod.go
@@ -79,6 +79,10 @@ func (m *MeshPod) MakeRequestAndExpectEventuallyConsistentResponse(t *testing.T,
 }
 
 func makeRequest(t *testing.T, exp *http.ExpectedResponse) []string {
+	return makeRequestWithCount(t, exp, 0)
+}
+
+func makeRequestWithCount(t *testing.T, exp *http.ExpectedResponse, count int) []string {
 	if exp.Request.Host == "" {
 		exp.Request.Host = "echo"
 	}
@@ -111,6 +115,9 @@ func makeRequest(t *testing.T, exp *http.ExpectedResponse) []string {
 	}
 	for k, v := range r.Headers {
 		args = append(args, "-H", fmt.Sprintf("%v:%v", k, v))
+	}
+	if count > 0 {
+		args = append(args, fmt.Sprintf("--count=%d", count))
 	}
 	return args
 }
@@ -274,4 +281,24 @@ func (m *MeshPod) CaptureRequestResponseAndCompare(t *testing.T, exp http.Expect
 		return []string{}, Response{}, err
 	}
 	return req, resp, nil
+}
+
+// RequestBatch executes a batch of requests using the --count flag and returns all responses
+func (m *MeshPod) RequestBatch(t *testing.T, exp http.ExpectedResponse, count int) ([]Response, error) {
+	req := makeRequestWithCount(t, &exp, count)
+
+	resp, err := m.request(req)
+	if err != nil {
+		return nil, fmt.Errorf("batch request failed: %w", err)
+	}
+
+	// Split the output by response boundaries
+	// Each response is separated by a blank line in the output
+	responses := parseMultipleResponses(resp.RawContent)
+
+	if len(responses) != count {
+		tlog.Logf(t, "Warning: expected %d responses but got %d", count, len(responses))
+	}
+
+	return responses, nil
 }

--- a/conformance/utils/weight/senders.go
+++ b/conformance/utils/weight/senders.go
@@ -29,3 +29,17 @@ func (s *FunctionBasedSender) SendRequest() (string, error) {
 func NewFunctionBasedSender(sendFunc func() (string, error)) RequestSender {
 	return &FunctionBasedSender{sendFunc: sendFunc}
 }
+
+// BatchFunctionBasedSender implements BatchRequestSender using a function
+type BatchFunctionBasedSender struct {
+	sendBatchFunc func(count int) ([]string, error)
+}
+
+func (s *BatchFunctionBasedSender) SendBatchRequest(count int) ([]string, error) {
+	return s.sendBatchFunc(count)
+}
+
+// NewBatchFunctionBasedSender creates a BatchRequestSender from a function
+func NewBatchFunctionBasedSender(sendBatchFunc func(count int) ([]string, error)) BatchRequestSender {
+	return &BatchFunctionBasedSender{sendBatchFunc: sendBatchFunc}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The mesh weight conformance tests were executing 500 separate kubectl exec commands with random delays, resulting in very slow test execution.

This PR implements an optimization using the echo client's --count flag to execute all 500 requests in a single batch, dramatically reducing test time.

The new implementation maintains the same test behavior (validating
traffic distribution matches configured weights) while eliminating
the overhead of 500 separate kubectl exec calls and removing the
random delays that were adding significant wait time.


Testing:
Ran the mesh tests on istio in a GKE cluster

Performance improvement varies by environment - my tests showed the time went from 60-70s -> 3-4s per test (~95% faster)

Current main:
```
--- PASS: TestConformance (201.69s)
    --- PASS: TestConformance/MeshGRPCRouteWeight (64.10s)
        --- PASS: TestConformance/MeshGRPCRouteWeight/Requests_should_have_a_distribution_that_matches_the_weight (63.72s)
    --- PASS: TestConformance/MeshHTTPRouteWeight (66.91s)
        --- PASS: TestConformance/MeshHTTPRouteWeight/Requests_should_have_a_distribution_that_matches_the_weight (66.54s)
PASS
```

With the batch requests:
```
--- PASS: TestConformance (91.34s)
    --- PASS: TestConformance/MeshGRPCRouteWeight (3.51s)
        --- PASS: TestConformance/MeshGRPCRouteWeight/Requests_should_have_a_distribution_that_matches_the_weight (3.08s)
    --- PASS: TestConformance/MeshHTTPRouteWeight (3.92s)
        --- PASS: TestConformance/MeshHTTPRouteWeight/Requests_should_have_a_distribution_that_matches_the_weight (3.45s)
PASS
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4101 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
