### PR TITLE
Add provisional GEPs back to TOC

### DIFF
--- a/cmd/gepstoc/main.go
+++ b/cmd/gepstoc/main.go
@@ -44,6 +44,7 @@ var (
 // Those are the GEPs that will be included in the final navigation bar
 // The order established below will be the order that the statuses will be shown
 var includeGEPStatus = []gep.GEPStatus{
+	gep.GEPStatusProvisional,
 	gep.GEPStatusImplementable,
 	gep.GEPStatusExperimental,
 	gep.GEPStatusStandard,

--- a/nav.yml
+++ b/nav.yml
@@ -60,6 +60,15 @@ nav:
     - Policy Attachment: reference/policy-attachment.md
   - Enhancements:
     - Overview: geps/overview.md
+    - Provisional:
+      - geps/gep-91/index.md
+      - geps/gep-1619/index.md
+      - geps/gep-1651/index.md
+      - geps/gep-2627/index.md
+      - geps/gep-2648/index.md
+      - geps/gep-2649/index.md
+      - geps/gep-3779/index.md
+      - geps/gep-3792/index.md
     - Implementable:
       - geps/gep-1494/index.md
       - geps/gep-3388/index.md


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Adds Provisional GEPs back to Website navigation

**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
