### PR TITLE
chore: merge in updates from release v1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ the specification and Custom Resource Definitions (CRDs).
 ## Status
 
 The latest supported version is `v1` as released by
-the [v1.3.0 release][gh_release] of this project.
+the [v1.4.0 release][gh_release] of this project.
 
 This version of the API is has GA level support for the following resources:
 
@@ -71,7 +71,7 @@ Participation in the Kubernetes community is governed by the
 [spec]: https://gateway-api.sigs.k8s.io/reference/spec/
 [concepts]: https://gateway-api.sigs.k8s.io/concepts/api-overview
 [security-model]: https://gateway-api.sigs.k8s.io/concepts/security-model
-[gh_release]: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.3.0
+[gh_release]: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.4.0
 [godoc]: https://pkg.go.dev/sigs.k8s.io/gateway-api
 [conformance-docs]: https://gateway-api.sigs.k8s.io/concepts/conformance/
 [reports-readme]: ./conformance/reports/README.md

--- a/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   labels:
     gateway.networking.k8s.io/policy: Direct

--- a/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: gatewayclasses.gateway.networking.k8s.io
 spec:

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: gateways.gateway.networking.k8s.io
 spec:

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: grpcroutes.gateway.networking.k8s.io
 spec:

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: httproutes.gateway.networking.k8s.io
 spec:

--- a/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: referencegrants.gateway.networking.k8s.io
 spec:

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: tcproutes.gateway.networking.k8s.io
 spec:

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: tlsroutes.gateway.networking.k8s.io
 spec:

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: udproutes.gateway.networking.k8s.io
 spec:

--- a/config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
+++ b/config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   labels:
     gateway.networking.k8s.io/policy: Direct

--- a/config/crd/experimental/gateway.networking.x-k8s.io_xlistenersets.yaml
+++ b/config/crd/experimental/gateway.networking.x-k8s.io_xlistenersets.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: xlistenersets.gateway.networking.x-k8s.io
 spec:

--- a/config/crd/experimental/gateway.networking.x-k8s.io_xmeshes.yaml
+++ b/config/crd/experimental/gateway.networking.x-k8s.io_xmeshes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: xmeshes.gateway.networking.x-k8s.io
 spec:

--- a/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: standard
   labels:
     gateway.networking.k8s.io/policy: Direct

--- a/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: standard
   name: gatewayclasses.gateway.networking.k8s.io
 spec:

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: standard
   name: gateways.gateway.networking.k8s.io
 spec:

--- a/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: standard
   name: grpcroutes.gateway.networking.k8s.io
 spec:

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: standard
   name: httproutes.gateway.networking.k8s.io
 spec:

--- a/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: standard
   name: referencegrants.gateway.networking.k8s.io
 spec:

--- a/hack/mkdocs-generate-conformance.py
+++ b/hack/mkdocs-generate-conformance.py
@@ -184,7 +184,7 @@ def generate_profiles_report(reports, route, version):
 
     http_table = http_table.rename(
         columns={"project": "Project", "version": "Version", "mode": "Mode", "core.result": "Core"})
-    if semver.compare(version.removeprefix('v'), '1.3.0') < 0:
+    if semver.compare(version.removeprefix('v'), '1.4.0') < 0:
         http_table = http_table.drop(columns=["Core"])
     if version == 'v1.0.0':
         http_table = http_table.drop(columns=["Mode"])

--- a/nav.yml
+++ b/nav.yml
@@ -19,6 +19,7 @@ nav:
     - Implementations:
         - List: implementations.md
         - Comparisons:
+          - v1.4: implementations/v1.4.md
           - v1.3: implementations/v1.3.md
           - v1.2: implementations/v1.2.md
           - v1.1: implementations/v1.1.md

--- a/nav.yml.tmpl
+++ b/nav.yml.tmpl
@@ -19,6 +19,7 @@ nav:
     - Implementations:
         - List: implementations.md
         - Comparisons:
+          - v1.4: implementations/v1.4.md
           - v1.3: implementations/v1.3.md
           - v1.2: implementations/v1.2.md
           - v1.1: implementations/v1.1.md

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -27,7 +27,7 @@ const (
 
 	// BundleVersion is the value used for the "gateway.networking.k8s.io/bundle-version" annotation.
 	// These value must be updated during the release process.
-	BundleVersion = "v1.4.0-rc.2"
+	BundleVersion = "v1.4.0"
 
 	// ApprovalLink is the value used for the "api-approved.kubernetes.io" annotation.
 	// These value must be updated during the release process.

--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -45,7 +45,7 @@ beta, including GatewayClass, Gateway, HTTPRoute, and ReferenceGrant. To install
 this channel, run the following kubectl command:
 
 ```bash
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml
 ```
 
 ### Install Experimental Channel
@@ -63,7 +63,7 @@ documentation](../concepts/versioning.md).
 To install the experimental channel, run the following kubectl command:
 
 ```bash
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/experimental-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/experimental-install.yaml
 ```
 
 ### v1.2 Upgrade Notes


### PR DESCRIPTION
This merges in the consts.go and documentation changes from the release-v1.4 branch for consistency.