### PR TITLE
docs: add rikatz to OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -46,3 +46,4 @@ aliases:
     - gcs278
     - kflynn
     - LiorLieberman
+    - rikatz


### PR DESCRIPTION
@rikatz has offered to become a GEP reviewer, spending time helping us ensure proposals move forward and consensus is built. This adds him to the corresponding alias. Thank you @rikatz!

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
