### PR TITLE
Fix that allows to --all-features and --exampt-features flags work together

### DIFF
--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -233,6 +233,22 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 		return nil, fmt.Errorf("no supported features were determined for test suite")
 	}
 
+	extendedSupportedFeatures := make(map[ConformanceProfileName]FeaturesSet, 0)
+	extendedUnsupportedFeatures := make(map[ConformanceProfileName]FeaturesSet, 0)
+
+	for _, conformanceProfileName := range options.ConformanceProfiles.UnsortedList() {
+		conformanceProfile, err := getConformanceProfileForName(conformanceProfileName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve conformance profile: %w", err)
+		}
+		// the use of a conformance profile implicitly enables any features of
+		// that profile which are supported at a Core level of support.
+		supportedFeatures = supportedFeatures.Union(conformanceProfile.CoreFeatures)
+
+		extendedSupportedFeatures[conformanceProfileName] = conformanceProfile.ExtendedFeatures.Intersection(supportedFeatures)
+		extendedUnsupportedFeatures[conformanceProfileName] = conformanceProfile.ExtendedFeatures.Difference(supportedFeatures)
+	}
+
 	config.SetupTimeoutConfig(&options.TimeoutConfig)
 
 	roundTripper := options.RoundTripper
@@ -290,8 +306,8 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 		UsableNetworkAddresses:      options.UsableNetworkAddresses,
 		UnusableNetworkAddresses:    options.UnusableNetworkAddresses,
 		results:                     make(map[string]testResult),
-		extendedUnsupportedFeatures: make(map[ConformanceProfileName]sets.Set[features.FeatureName]),
-		extendedSupportedFeatures:   make(map[ConformanceProfileName]sets.Set[features.FeatureName]),
+		extendedUnsupportedFeatures: extendedUnsupportedFeatures,
+		extendedSupportedFeatures:   extendedSupportedFeatures,
 		conformanceProfiles:         options.ConformanceProfiles,
 		implementation:              options.Implementation,
 		mode:                        mode,
@@ -299,37 +315,6 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 		apiChannel:                  apiChannel,
 		supportedFeaturesSource:     source,
 		Hook:                        options.Hook,
-	}
-
-	for _, conformanceProfileName := range options.ConformanceProfiles.UnsortedList() {
-		conformanceProfile, err := getConformanceProfileForName(conformanceProfileName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve conformance profile: %w", err)
-		}
-		// the use of a conformance profile implicitly enables any features of
-		// that profile which are supported at a Core level of support.
-		for _, f := range conformanceProfile.CoreFeatures.UnsortedList() {
-			if !options.SupportedFeatures.Has(f) {
-				suite.SupportedFeatures.Insert(f)
-			}
-		}
-		for _, f := range conformanceProfile.ExtendedFeatures.UnsortedList() {
-			if options.SupportedFeatures.Has(f) {
-				if suite.extendedSupportedFeatures[conformanceProfileName] == nil {
-					suite.extendedSupportedFeatures[conformanceProfileName] = FeaturesSet{}
-				}
-				suite.extendedSupportedFeatures[conformanceProfileName].Insert(f)
-			} else {
-				if suite.extendedUnsupportedFeatures[conformanceProfileName] == nil {
-					suite.extendedUnsupportedFeatures[conformanceProfileName] = FeaturesSet{}
-				}
-				suite.extendedUnsupportedFeatures[conformanceProfileName].Insert(f)
-			}
-			// Add Exempt Features into unsupported features list
-			if options.ExemptFeatures.Has(f) {
-				suite.extendedUnsupportedFeatures[conformanceProfileName].Insert(f)
-			}
-		}
 	}
 
 	// apply defaults

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -487,6 +487,13 @@ func TestInferGWCSupportedFeatures(t *testing.T) {
 				}),
 			},
 		},
+		{
+			name:             "all features combined with exampt features",
+			allowAllFeatures: true,
+			exemptFeatures:   sets.New[features.FeatureName]("ReferenceGrant", "HTTPRoute"),
+			expectedSource:   supportedFeaturesSourceManual,
+			expectedFeatures: features.SetsToNamesSet(features.AllFeatures).Difference(sets.New[features.FeatureName]("ReferenceGrant", "HTTPRoute")),
+		},
 	}
 
 	gwcName := "ochopintre"


### PR DESCRIPTION
**What type of PR is this?**
Add one of the following kinds:
/kind bug
/area conformance-machinery

**What this PR does / why we need it**:
If you currently try to combine `--all-features` and `--exampt-features` flags for local testing it will be a noop. This fixes the issue.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
