### PR TITLE
docs: add provisional GEP for extending TLS Validation in BackendTLSPolicy

### DIFF
--- a/geps/gep-1897/metadata.yaml
+++ b/geps/gep-1897/metadata.yaml
@@ -15,3 +15,6 @@ relationships:
     - number: 1282
       name: Describing Backend Properties
       description: Implements just part of the Backend Properties GEP.
+extendedBy:
+  - number: 4152
+    name: Extending TLS Validation in BackendTLSPolicy

--- a/geps/gep-4152/index.md
+++ b/geps/gep-4152/index.md
@@ -38,7 +38,7 @@ CA bundles.
 * As an application developer, I want an alternative to disabling verification,
   such as certificate or SPKI pinning, so I can securely communicate with
   backends using self-signed certificates without managing CA bundles.
-* As a gateway operator, I want to control whether skipping TLS verification is
+* As a gateway operator, I want to control whether skipping TLS validation is
   permitted for specific Gateways.
 * As a security officer, I want transparency and auditability into where TLS
   verification has been disabled.
@@ -46,13 +46,15 @@ CA bundles.
 ## Goals
 
 * Enable connecting to backends over TLS without requiring certificate
-  validation.
+  verification.
 * Support certificate and SPKI pinning as alternatives to disabling verification
   or relying on CA trust chains.
 * Maintain a secure-by-default approach, with certificate verification enabled
   unless explicitly opted out.
 * Provide operator-level controls so Gateway constraints can restrict or permit
   the use of skip-verify.
+* Provide clear runtime indicators that security is degraded when TLS validation
+  is disabled.
 
 ## API
 

--- a/geps/gep-4152/index.md
+++ b/geps/gep-4152/index.md
@@ -1,0 +1,65 @@
+# GEP-4152: Allow flexible TLS Validation in BackendTLSPolicy
+
+* Issue: [#4152](https://github.com/kubernetes-sigs/gateway-api/issues/4152)
+* Status: Provisional
+
+## TLDR
+
+The ability for the `BackendTLSPolicy` to skip TLS verification or to validate
+certificates based on their fingerprint or public key hash.
+
+## Motivation
+
+The current `BackendTLSPolicy` follows a secure-by-default approach that requires
+users to provide a trusted CA certificate bundle or rely on the system’s default
+certificate store (which typically includes root CAs) to validate backend server
+certificates. However, real-world deployments include cases where strict
+certificate validation may not be possible or practical, e.g., Development and
+testing environments that use self-signed certificates generated dynamically at
+runtime.
+
+In such scenarios, users may need the flexibility to disable certificate
+verification or to use certificate pinning. Certificate pinning offers a safer
+and more controlled alternative, instead of bypassing TLS validation, the gateway
+verifies that the backend’s certificate matches a known fingerprint or public key
+hash. This preserves the confidentiality and integrity guarantees of TLS while
+removing the operational overhead of managing full certificate chains or trusted
+CA bundles.
+
+### User Stories
+
+* As an application developer, I want the option to disable backend TLS
+  certificate verification on a per-backend basis, so I can connect to services
+  using dynamically generated or self-signed certificates during development or
+  testing.
+* As an application developer, I want secure-by-default behavior, ensuring that
+  certificate verification is always enabled unless I explicitly opt out, to
+  prevent accidentally deploying insecure configurations to production.
+* As an application developer, I want an alternative to disabling verification,
+  such as certificate or SPKI pinning, so I can securely communicate with
+  backends using self-signed certificates without managing CA bundles.
+* As a gateway operator, I want to control whether skipping TLS verification is
+  permitted for specific Gateways.
+* As a security officer, I want transparency and auditability into where TLS
+  verification has been disabled.
+
+## Goals
+
+* Enable connecting to backends over TLS without requiring certificate
+  validation.
+* Support certificate and SPKI pinning as alternatives to disabling verification
+  or relying on CA trust chains.
+* Maintain a secure-by-default approach, with certificate verification enabled
+  unless explicitly opted out.
+* Provide operator-level controls so Gateway constraints can restrict or permit
+  the use of skip-verify.
+
+## API
+
+**TODO**: First PR will not include any implementation details, in favor of
+building consensus on the motivation, goals and non-goals first. _"How?"_ we
+implement shall be left open-ended until _"What?"_ and _"Why?"_ are solid.
+
+## References
+
+* [GEP-1897: BackendTLSPolicy - Explicit Backend TLS Connection Configuration](https://gateway-api.sigs.k8s.io/geps/gep-1897/)

--- a/geps/gep-4152/index.md
+++ b/geps/gep-4152/index.md
@@ -1,4 +1,4 @@
-# GEP-4152: Allow flexible TLS Validation in BackendTLSPolicy
+# GEP-4152: Extending TLS Validation in BackendTLSPolicy
 
 * Issue: [#4152](https://github.com/kubernetes-sigs/gateway-api/issues/4152)
 * Status: Provisional

--- a/geps/gep-4152/metadata.yaml
+++ b/geps/gep-4152/metadata.yaml
@@ -1,0 +1,7 @@
+apiVersion: internal.gateway.networking.k8s.io/v1alpha1
+kind: GEPDetails
+number: 4152
+name: Allow flexible TLS Validation in BackendTLSPolicy
+status: Provisional
+authors:
+  - snorwin

--- a/geps/gep-4152/metadata.yaml
+++ b/geps/gep-4152/metadata.yaml
@@ -1,7 +1,10 @@
 apiVersion: internal.gateway.networking.k8s.io/v1alpha1
 kind: GEPDetails
 number: 4152
-name: Allow flexible TLS Validation in BackendTLSPolicy
+name: Extending TLS Validation in BackendTLSPolicy
 status: Provisional
 authors:
   - snorwin
+extends:
+  - number: 1897
+    name: BackendTLSPolicy - Explicit Backend TLS Connection Configuration


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind gep

**What this PR does / why we need it**:
This proposes a first provisional GEP (what/why/who) for enabling flexible TLS validation in `BackendTLSPolicy`, allowing options such as skip verification and certificate pinning to better support scenarios as described in #3761.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This supports, but does not resolve #4152.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
