### PR TITLE
Update CRD generator to handle errors encountered during generation.

### DIFF
--- a/apis/v1/backendtlspolicy_types.go
+++ b/apis/v1/backendtlspolicy_types.go
@@ -189,7 +189,6 @@ type BackendTLSPolicyValidation struct {
 	// Support: Implementation-specific
 	//
 	// +optional
-	// +listType=atomic
 	WellKnownCACertificates *WellKnownCACertificatesType `json:"wellKnownCACertificates,omitempty"`
 
 	// Hostname is used for two purposes in the connection between Gateways and

--- a/apis/v1/gateway_types.go
+++ b/apis/v1/gateway_types.go
@@ -803,7 +803,6 @@ type AllowedRoutes struct {
 	// Support: Core
 	//
 	// +optional
-	// +listType=atomic
 	// +kubebuilder:default={from: Same}
 	Namespaces *RouteNamespaces `json:"namespaces,omitempty"`
 

--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -1671,7 +1671,7 @@ type GRPCAuthConfig struct {
 	//
 	// +optional
 	// +listType=set
-	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:MaxItems=64
 	AllowedRequestHeaders []string `json:"allowedHeaders,omitempty"`
 }
 
@@ -1719,7 +1719,7 @@ type HTTPAuthConfig struct {
 	//
 	// +optional
 	// +listType=set
-	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:MaxItems=64
 	AllowedRequestHeaders []string `json:"allowedHeaders,omitempty"`
 
 	// AllowedResponseHeaders specifies what headers from the authorization response
@@ -1730,7 +1730,7 @@ type HTTPAuthConfig struct {
 	//
 	// +optional
 	// +listType=set
-	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:MaxItems=64
 	AllowedResponseHeaders []string `json:"allowedResponseHeaders,omitempty"`
 }
 

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -915,6 +915,7 @@ spec:
                                             If the list has entries, only those entries must be sent.
                                           items:
                                             type: string
+                                          maxItems: 64
                                           type: array
                                           x-kubernetes-list-type: set
                                       type: object
@@ -953,6 +954,7 @@ spec:
                                             request must be set to the actual number of bytes forwarded.
                                           items:
                                             type: string
+                                          maxItems: 64
                                           type: array
                                           x-kubernetes-list-type: set
                                         allowedResponseHeaders:
@@ -964,6 +966,7 @@ spec:
                                             except Authority or Host must be copied.
                                           items:
                                             type: string
+                                          maxItems: 64
                                           type: array
                                           x-kubernetes-list-type: set
                                         path:
@@ -2395,6 +2398,7 @@ spec:
                                       If the list has entries, only those entries must be sent.
                                     items:
                                       type: string
+                                    maxItems: 64
                                     type: array
                                     x-kubernetes-list-type: set
                                 type: object
@@ -2433,6 +2437,7 @@ spec:
                                       request must be set to the actual number of bytes forwarded.
                                     items:
                                       type: string
+                                    maxItems: 64
                                     type: array
                                     x-kubernetes-list-type: set
                                   allowedResponseHeaders:
@@ -2444,6 +2449,7 @@ spec:
                                       except Authority or Host must be copied.
                                     items:
                                       type: string
+                                    maxItems: 64
                                     type: array
                                     x-kubernetes-list-type: set
                                   path:
@@ -5073,6 +5079,7 @@ spec:
                                             If the list has entries, only those entries must be sent.
                                           items:
                                             type: string
+                                          maxItems: 64
                                           type: array
                                           x-kubernetes-list-type: set
                                       type: object
@@ -5111,6 +5118,7 @@ spec:
                                             request must be set to the actual number of bytes forwarded.
                                           items:
                                             type: string
+                                          maxItems: 64
                                           type: array
                                           x-kubernetes-list-type: set
                                         allowedResponseHeaders:
@@ -5122,6 +5130,7 @@ spec:
                                             except Authority or Host must be copied.
                                           items:
                                             type: string
+                                          maxItems: 64
                                           type: array
                                           x-kubernetes-list-type: set
                                         path:
@@ -6553,6 +6562,7 @@ spec:
                                       If the list has entries, only those entries must be sent.
                                     items:
                                       type: string
+                                    maxItems: 64
                                     type: array
                                     x-kubernetes-list-type: set
                                 type: object
@@ -6591,6 +6601,7 @@ spec:
                                       request must be set to the actual number of bytes forwarded.
                                     items:
                                       type: string
+                                    maxItems: 64
                                     type: array
                                     x-kubernetes-list-type: set
                                   allowedResponseHeaders:
@@ -6602,6 +6613,7 @@ spec:
                                       except Authority or Host must be copied.
                                     items:
                                       type: string
+                                    maxItems: 64
                                     type: array
                                     x-kubernetes-list-type: set
                                   path:

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/net v0.44.0
 	golang.org/x/sync v0.17.0
+	golang.org/x/tools v0.36.0
 	google.golang.org/grpc v1.75.1
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1
 	google.golang.org/protobuf v1.36.8
@@ -81,7 +82,6 @@ require (
 	golang.org/x/term v0.35.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
-	golang.org/x/tools v0.36.0 // indirect
 	golang.org/x/tools/go/expect v0.1.1-deprecated // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250826171959-ef028d996bc1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -2882,11 +2882,6 @@ func schema_sigsk8sio_gateway_api_apis_v1_AllowedRoutes(ref common.ReferenceCall
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"namespaces": {
-						VendorExtensible: spec.VendorExtensible{
-							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
-							},
-						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Namespaces indicates namespaces from which Routes may be attached to this Listener. This is restricted to the namespace of this Gateway by default.\n\nSupport: Core",
 							Ref:         ref("sigs.k8s.io/gateway-api/apis/v1.RouteNamespaces"),
@@ -3210,11 +3205,6 @@ func schema_sigsk8sio_gateway_api_apis_v1_BackendTLSPolicyValidation(ref common.
 						},
 					},
 					"wellKnownCACertificates": {
-						VendorExtensible: spec.VendorExtensible{
-							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
-							},
-						},
 						SchemaProps: spec.SchemaProps{
 							Description: "WellKnownCACertificates specifies whether system CA certificates may be used in the TLS handshake between the gateway and backend pod.\n\nIf WellKnownCACertificates is unspecified or empty (\"\"), then CACertificateRefs must be specified with at least one entry for a valid configuration. Only one of CACertificateRefs or WellKnownCACertificates may be specified, not both. If an implementation does not support the WellKnownCACertificates field, or the supplied value is not recognized, the implementation MUST ensure the `Accepted` Condition on the BackendTLSPolicy is set to `status: False`, with a Reason `Invalid`.\n\nSupport: Implementation-specific",
 							Type:        []string{"string"},

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 	"strings"
 
+	"golang.org/x/tools/go/packages"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-tools/pkg/crd"
 	"sigs.k8s.io/controller-tools/pkg/loader"
@@ -134,6 +135,10 @@ func main() {
 				log.Fatalf("failed to write CRD: %s", err)
 			}
 		}
+	}
+
+	if loader.PrintErrors(roots, packages.TypeError) {
+		log.Fatalf("not all generators ran successfully")
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

There are a handful of invalid markers on CRDs today as a result of the CRD generator not handling errors encountered during generation. This leads to either unnecessary metadata in CRD manifests, or missing validation (in the case of MaxLength being used instead of MaxItems).

Prior to correcting the markers on the existing CRDs, the generator produced the following errors:

```shell
/dev/gateway-api/apis/v1/backendtlspolicy_types.go:193:2: must apply listType to an array, found 
/dev/gateway-api/apis/v1/gateway_types.go:808:2: must apply listType to an array, found 
/dev/gateway-api/apis/v1/httproute_types.go:1675:2: must apply maxlength to a textual value, found type "array"
/dev/gateway-api/apis/v1/httproute_types.go:1723:2: must apply maxlength to a textual value, found type "array"
/dev/gateway-api/apis/v1/httproute_types.go:1734:2: must apply maxlength to a textual value, found type "array"
2025/10/08 16:13:20 not all generators ran successfully
exit status 1
```

The use of `loader.PrintErrors` was taken from https://github.com/kubernetes-sigs/controller-tools/blob/5c2d62552c97a0139c1dfdc6276c69f2a5f6120d/pkg/genall/genall.go#L282.

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:


```release-note
The ExternalAuth HTTPRouteFilter now enforces a maximum of 64 items in the following fields:

- `grpc.allowedHeaders`
- `http.allowedHeaders`
- `http.allowedResponseHeaders`
```
