### PR TITLE
Group mkdocs bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,10 @@ updates:
     directory: "/hack/mkdocs/image"
     schedule:
       interval: "weekly"
+    groups:
+      mkdocs-deps:
+        patterns:
+          - "*"
     labels:
       - python
       - dependencies


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**: We need it because dependabot is very annoying and opens a lot of PRs for mkdocs bumps :) 

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
