### PR TITLE
Add guidance on API documentation

### DIFF
--- a/site/content/en/contributing/devguide.md
+++ b/site/content/en/contributing/devguide.md
@@ -210,7 +210,7 @@ A good API documentation should cover:
 * What is the main feature of the API and Field - Eg.: "`foo` allows configuring how a
 a header should be forwarded to backends"
 * What is the support level of the field - Eg.: "Support: Core/Extended/Implementation Specific"
-* Caveats of that field - Eg.: "Setting `goo` field can have conflicts with `bar` field, and in this
+* Caveats of that field - Eg.: "Setting `foo` field can have conflicts with `bar` field, and in this
 case it will be shown as a Condition". (we don't need to cover all the conditions).
 
 In one or two phrases, API documentation should help a user who is reading the documentation understand

--- a/site/content/en/contributing/devguide.md
+++ b/site/content/en/contributing/devguide.md
@@ -182,22 +182,22 @@ To execute the new tool, use `go tool -modfile=tools/go.mod toolname`.
 ## API Documentation
 
 When writing API documentation (the `godoc` for API fields and structures) it should be done
- in a meaningful and concise way, where information is provided for the different 
- Gateway API personas (Ian, Chihiro and Ana) without leaking implementation details.
+in a meaningful and concise way, where information is provided for the different 
+[Gateway API personas](../docs/concepts/roles-and-personas.md#key-roles-and-personas)  without leaking implementation details.
 
 The implementation details are still important for Gateway API implementation
 developers, and should still be provided, but we need to ensure they are not 
 exposed in the generated CRDs. That can end up leaking to users in multiple ways,
 such as on the Gateway API documentation website, or via `kubectl explain`.
 
-Additionally, it is worth noticing that API documentation reflects on the CRD generation
-size, which impacts directly on resource consumption like a maximum Kubernetes resource size 
-(which is limited by etcd maximum value size) and avoiding problems with `last-applied-configuration` 
-annotation, when doing a client-side apply.
+Additionally, it is worth noting that API documentation affects the size of generated CRD manifests,
+which directly impacts the Kubernetes resource size, 
+which is in turn limited by etcd maximum value size.  The situation is exacerbated by the `last-applied-configuration` 
+annotation from client-side apply, which roughly doubles the size of the Kubernetes resource.
 
-There are two kind of API documentations: 
+There are two kind of API documentation: 
 
-* User facing - MUST define how a user should be consuming an API and its field, on a concise way.
+* User facing - MUST define how a user should be consuming an API and its fields, in a concise way.
 * Developer facing - MUST define how a controller should implement an API and its fields. 
 
 ### User facing Documentation
@@ -207,22 +207,22 @@ in a way that ensures that their Gateway API implementation does what they want 
 
 A good API documentation should cover:
 
-* What is the main feature of the API and Field - Eg.: "`Foo` allows configuring how a
+* What is the main feature of the API and Field - Eg.: "`foo` allows configuring how a
 a header should be forwarded to backends"
 * What is the support level of the field - Eg.: "Support: Core/Extended/Implementation Specific"
-* Caveats of that field - Eg.: "Setting `Foo` field can have conflicts with `Bar` field, and in this
+* Caveats of that field - Eg.: "Setting `goo` field can have conflicts with `bar` field, and in this
 case it will be shown as a Condition". (we don't need to cover all the conditions).
 
-In a simple way, a user reading the field documentation should understand, on one or two 
-phrases what happens when the field is configured, what can be configured and what are 
-the impacts of that field
+In one or two phrases, API documentation should help a user who is reading the documentation understand
+what happens when the field is configured, what values can be specified, and what any
+additional important implications of setting the field may be. 
 
 When adding a documentation, it is very important to remove your "Developer hat" 
-and put yourself on a user that is trying to solve a problem: Does setting a field
-solves my needs? How can I use it?
+and put yourself in the role of a user who is trying to solve a problem: Does setting a field
+solve my needs? How can I use it?
 
-On an implementation, a user facing documentation belongs to the field documentation. Taking
-`Listeners`, one of the most complex fields as an example:
+The godoc for an API field contains user-facing documentation. Taking
+`Listeners`, one of the most complex fields, as an example:
 
 ```golang
 // Listeners define logical endpoints that are bound on this Gateway's addresses.
@@ -235,40 +235,42 @@ On an implementation, a user facing documentation belongs to the field documenta
 Listeners []Listener `json:"listeners"`
 ```
 
-We don't specify what are the Protocol types (saving this to the `Protocol` field),
-what a hostname means, when a TLS configuration is required. All of these information
-belongs to each field, so when a user does something like `kubectl explain gateway.spec.listeners`
-they will also get the information of each field.
+We don't specify here what the Protocol types are (this information goes in the `Protocol` field itself),
+how a hostname is defined, or when TLS configuration is required. All of this information
+belongs to the respective API fields, which are sub-fields of `Listener`.  Note that `kubectl explain` prints information about both
+the specified field and its sub-fields, so when a user executes the `kubectl explain gateway.spec.listeners` command,
+they get all of this information.
+
 
 ### Developer facing documentation
 
-Developer facing documentation helps during implementations to define the expected
-behavior of it, and should answer questions like:
+Developer-facing documentation helps implementers to define the expected
+behavior of it, and should answer questions such as the following:
 
-* How that field should be reconciled?
+* How should that field be reconciled?
 * What conditions should be set during the reconciliation? 
 * What should be validated during the reconciliation of that field?
 
-In this case, as the API documentation serves as a guide for implementors on how 
-their implementations should behave, it is very important to be as much verbose as
-required to avoid any ambiguity. These information are used also to define expected
-conformance behavior, and can even point to existing GEPs so a developer looking 
-at it can know where to look for more references on what and why are those the expected
-behavior of this field.
+In this case, as the API documentation serves as a guide for implementers on how 
+their implementations should behave, it is very important to be as verbose as
+required to avoid any ambiguity. This information is used also to define expected
+conformance behavior, and it can point to existing GEPs so a developer looking 
+at it can know where to look for more references on what the expected
+behavior of this field is and why.
 
-Still taking the `Listeners` field as an example, it does good definitions of situations 
-like:
+Continuing with the `Listeners` field as an example, it shows how API documentation can provide guidance for situations 
+such as the following:
 
 * Two listeners have different protocols but the same hostname. Should this be a conflict?
 * A listener of type `XXX` sets the field `TLS`. Is this a problem? How to expose this to 
 the user?
 
-Because these information don't matter for a user, they should be hidden from the CRD/OpenAPI
+Because these details don't matter for a user, they should be hidden from the CRD/OpenAPI
 generation and also from the website API Reference.
 
 This can be achieved putting these information between the tags 
 `<gateway:util:excludeFromCRD></gateway:util:excludeFromCRD>` and preferably 
-contain a callout that those are a Note for implementors:
+contain a callout that those are a Note for implementers:
 
 ```golang
 // Mode defines the TLS behavior for the TLS session initiated by the client.
@@ -286,7 +288,7 @@ contain a callout that those are a Note for implementors:
 // Support: Core
 //
 // <gateway:util:excludeFromCRD>
-// Notes for implementors:
+// Notes for implementers:
 //
 // Setting TLSModeType to Passthrough is only supported on Listeners that are of 
 // type HTTP, HTTPS and TLS. In case a user sets a different type, the implementation

--- a/site/content/en/contributing/devguide.md
+++ b/site/content/en/contributing/devguide.md
@@ -268,9 +268,9 @@ the user?
 Because these details don't matter for a user, they should be hidden from the CRD/OpenAPI
 generation and also from the website API Reference.
 
-This can be achieved putting these information between the tags 
+This can be achieved by putting the information between the tags 
 `<gateway:util:excludeFromCRD></gateway:util:excludeFromCRD>` and preferably 
-contain a callout that those are a Note for implementers:
+contain a callout that is a Note for implementers:
 
 ```golang
 // Mode defines the TLS behavior for the TLS session initiated by the client.

--- a/site/content/en/contributing/devguide.md
+++ b/site/content/en/contributing/devguide.md
@@ -178,3 +178,144 @@ To add a new tool, use `go get -tool -modfile tools/go.mod the.tool.repo/toolnam
 and tidy the specific module with `go mod tidy -modfile=tools/go.mod`.
 
 To execute the new tool, use `go tool -modfile=tools/go.mod toolname`.
+
+## API Documentation
+
+When writing API documentation (the `godoc` for API fields and structures) it should be done
+ in a meaningful and concise way, where information are provided for the different 
+ Gateway API personas (Ian, Chihiro and Ana) without leaking implementation details.
+
+The implementation details are still important for a Gateway API implementation
+developer, and they should still be provided but without being exposed on the
+CRD generation, that can end leaking to users on a diverse set of ways, like
+on Gateway API documentation website, or via `kubectl explain`.
+
+Additionally, it is worth noticing that API documentation reflects on the CRD generation
+size, which impacts directly on resource consumption like a maximum Kubernetes resource size 
+(which is limited by etcd maximum value size) and avoiding problems with `last-applied-configuration` 
+annotation, when doing a client-side apply.
+
+There are two kind of API documentations: 
+
+* User facing - MUST define how a user should be consuming an API and its field, on a concise way.
+* Developer facing - MUST define how a controller should implement an API and its fields. 
+
+### User facing Documentation
+
+The API documentation, when meaningful, helps users of it on doing proper configuration
+in a way that Gateway API controllers react and configure the proxies the right way.
+
+A good API documentation should cover:
+
+* What is the main feature of the API and Field - Eg.: "`Foo` allows configuring how a
+a header should be forwarded to backends"
+* What is the support level of the field - Eg.: "Support: Core/Extended/Implementation Specific"
+* Caveats of that field - Eg.: "Setting `Foo` field can have conflicts with `Bar` field, and in this
+case it will be shown as a Condition". (we don't need to cover all the conditions).
+
+In a simple way, a user reading the field documentation should understand, on one or two 
+phrases what happens when the field is configured, what can be configured and what are 
+the impacts of that field
+
+When adding a documentation, it is very important to remove your "Developer hat" 
+and put yourself on a user that is trying to solve a problem: Does setting a field
+solves my needs? How can I use it?
+
+On an implementation, a user facing documentation belongs to the field documentation. Taking
+`Listeners`, one of the most complex fields as an example:
+
+```golang
+// Listeners define logical endpoints that are bound on this Gateway's addresses.
+// At least one Listener MUST be specified. When setting a Listener, conflicts can
+// happen depending on its configuration like protocol, hostname and port, and in 
+// this case a status condition will be added representing what was the conflict.
+// 
+// The definition of a Listener protocol implies what kind of Route can be attached 
+// to it
+Listeners []Listener `json:"listeners"`
+```
+
+We don't specify what are the Protocol types (saving this to the `Protocol` field),
+what a hostname means, when a TLS configuration is required. All of these information
+belongs to each field, so when a user does something like `kubectl explain gateway.spec.listeners`
+they will also get the information of each field.
+
+### Developer facing documentation
+
+Developer facing documentation helps during implementations to define the expected
+behavior of it, and should answer questions like:
+
+* How that field should be reconciled?
+* What conditions should be set during the reconciliation? 
+* What should be validated during the reconciliation of that field?
+
+In this case, as the API documentation serves as a guide for implementors on how 
+their implementations should behave, it is very important to be as much verbose as
+required to avoid any ambiguity. These information are used also to define expected
+conformance behavior, and can even point to existing GEPs so a developer looking 
+at it can know where to look for more references on what and why are those the expected
+behavior of this field.
+
+Still taking the `Listeners` field as an example, it does good definitions of situations 
+like:
+
+* Two listeners have different protocols but the same hostname. Should this be a conflict?
+* A listener of type `XXX` sets the field `TLS`. Is this a problem? How to expose this to 
+the user?
+
+Because these information don't matter for a user, they should be hidden from the CRD/OpenAPI
+generation and also from the website API Reference.
+
+This can be achieved putting these information between the tags 
+`<gateway:util:excludeFromCRD></gateway:util:excludeFromCRD>` and preferably 
+contain a callout that those are a Note for implementors:
+
+```golang
+// Mode defines the TLS behavior for the TLS session initiated by the client.
+// There are two possible modes:
+//
+// - Terminate: The TLS session between the downstream client and the
+//   Gateway is terminated at the Gateway. This mode requires certificates
+//   to be specified in some way, such as populating the certificateRefs
+//   field.
+// - Passthrough: The TLS session is NOT terminated by the Gateway. This
+//   implies that the Gateway can't decipher the TLS stream except for
+//   the ClientHello message of the TLS protocol. The certificateRefs field
+//   is ignored in this mode.
+//
+// Support: Core
+//
+// <gateway:util:excludeFromCRD>
+// Notes for implementors:
+//
+// Setting TLSModeType to Passthrough is only supported on Listeners that are of 
+// type HTTP, HTTPS and TLS. In case a user sets a different type, the implementation
+// MUST set a condition XXX with value XXX and a message specifying why the condition 
+// happened.
+// </gateway:util:excludeFromCRD>
+Mode *TLSModeType `json:"mode,omitempty"`
+```
+
+### Advices when writing the API documentation
+As an advice, the person writing the documentation should always being questioning:
+
+**As a user**:
+
+* Does the documentation provide meaningful information and removes any doubt 
+about what will happen when setting this field?
+* Does the documentation provide information about where should I look if something
+goes wrong?
+* If I do `kubectl explain` or look into the API Reference, do I have enough
+information to achieve my goals without being buried with information I don't care?
+
+**As a developer/implementor**:
+
+* Does the documentation provide enough information for another developer on 
+how they should implement their controller?
+* Does the documentation provide enough information on what other fields/resources
+should be verified to provide the right behavior?
+* Does the documentation provide enough information on how I should signal to the 
+users what went right/wrong and how to fix it?
+
+It is important to exercise changing the personas for which you are writing the 
+documentation.

--- a/site/content/en/contributing/devguide.md
+++ b/site/content/en/contributing/devguide.md
@@ -182,13 +182,13 @@ To execute the new tool, use `go tool -modfile=tools/go.mod toolname`.
 ## API Documentation
 
 When writing API documentation (the `godoc` for API fields and structures) it should be done
- in a meaningful and concise way, where information are provided for the different 
+ in a meaningful and concise way, where information is provided for the different 
  Gateway API personas (Ian, Chihiro and Ana) without leaking implementation details.
 
-The implementation details are still important for a Gateway API implementation
-developer, and they should still be provided but without being exposed on the
-CRD generation, that can end leaking to users on a diverse set of ways, like
-on Gateway API documentation website, or via `kubectl explain`.
+The implementation details are still important for Gateway API implementation
+developers, and should still be provided, but we need to ensure they are not 
+exposed in the generated CRDs. That can end up leaking to users in multiple ways,
+such as on the Gateway API documentation website, or via `kubectl explain`.
 
 Additionally, it is worth noticing that API documentation reflects on the CRD generation
 size, which impacts directly on resource consumption like a maximum Kubernetes resource size 
@@ -202,8 +202,8 @@ There are two kind of API documentations:
 
 ### User facing Documentation
 
-The API documentation, when meaningful, helps users of it on doing proper configuration
-in a way that Gateway API controllers react and configure the proxies the right way.
+The API documentation, when meaningful, helps users of it understand and create configuration
+in a way that ensures that their Gateway API implementation does what they want it to do.
 
 A good API documentation should cover:
 
@@ -296,17 +296,17 @@ contain a callout that those are a Note for implementors:
 Mode *TLSModeType `json:"mode,omitempty"`
 ```
 
-### Advices when writing the API documentation
-As an advice, the person writing the documentation should always being questioning:
+### Advice when writing the API documentation
+When writing the documentation, you should always consider questions like:
 
 **As a user**:
 
-* Does the documentation provide meaningful information and removes any doubt 
+* Does the documentation provide meaningful information and remove any doubt 
 about what will happen when setting this field?
 * Does the documentation provide information about where should I look if something
 goes wrong?
 * If I do `kubectl explain` or look into the API Reference, do I have enough
-information to achieve my goals without being buried with information I don't care?
+information to achieve my goals without being buried with information I don't care about?
 
 **As a developer/implementor**:
 
@@ -317,5 +317,5 @@ should be verified to provide the right behavior?
 * Does the documentation provide enough information on how I should signal to the 
 users what went right/wrong and how to fix it?
 
-It is important to exercise changing the personas for which you are writing the 
-documentation.
+It is important to you consider the personas for which you are writing for, when
+working on each type of documentation.


### PR DESCRIPTION
**What type of PR is this?**
/kind gep
/kind documentation

**What this PR does / why we need it**:
This PR adds the memorandum GEP on how implementor should be writing API documentation, in a way to reduce the CRD size, the burden on Gateway API users and still provide meaningful information for other developers

**Which issue(s) this PR fixes**:
Fixes #4012

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
