### PR TITLE
Fix doc building and unreadable mermaid

### DIFF
--- a/site-src/api-types/backendtlspolicy.md
+++ b/site-src/api-types/backendtlspolicy.md
@@ -69,15 +69,10 @@ The following illustrates a BackendTLSPolicy that configures TLS for a Service s
 flowchart LR
     client(["client"])
     gateway["Gateway"]
-    style gateway fill:#3af
     httproute["HTTP<BR>Route"]
-    style httproute fill:#3af
     service["Service"]
-    style service fill:#3af
     pod1["Pod"]
-    style pod1 fill:#3af
     pod2["Pod"]
-    style pod2 fill:#3af
     client -.->|HTTP <br> request| gateway
     gateway --> httproute
     httproute -.->|BackendTLSPolicy|service


### PR DESCRIPTION


**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Currently, the mermaid diagram for the [backendtlspolicy](https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/) is unreadable.

<img width="1870" height="630" alt="image" src="https://github.com/user-attachments/assets/29dca47a-ce02-4483-aecd-84eb4d918b01" />

It seems like mermaid is not picking up on `color:fff`, so we can just make the background color a bit lighter

<img width="1759" height="577" alt="image" src="https://github.com/user-attachments/assets/0cb765a4-2aef-4ab2-af25-f12dd67cf8e1" />

Also, fix some notes on how to build docs.

```release-note
NONE
```
