### PR TITLE
Implement multi version for apiref

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ Session.vim
 .*.timestamp
 /site
 go.work.sum
+/tmp
 
 /cache
 .venv/

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,6 @@ build-docs:
 
 .PHONY: build-docs-netlify
 build-docs-netlify: api-ref-docs
-	hack/mkdocs/generate.sh
 	pip install -r hack/mkdocs/image/requirements.txt
 	python -m mkdocs build
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -74,6 +74,8 @@ The following steps must be done by one of the [Gateway API maintainers][gateway
   Attach these files to the GitHub release.
 - Update the `README.md` and `site-src/guides/index.md` files to point links and examples to the new release.
 - Update the implementation table path (`nav.Implementations.Comparison`) in the nav of `mkdocs.yml` to point to the latest release file (for example Implementation Comparison points to `implementation-table-v1.2.0.md`). Add the now past version under `Past Version Comparisons`, and edit the text blurb in `mkdocs-generate-conformance.py` to also reflect the added past version.
+- Update `hack/mkdocs/generate.sh` and add the new `release-x.x` to the array of releases.
+- Update `nav.yml.tmpl` and add the new release to the `API specification` field. Execute `./hack/update-mkdocs-nav.sh` after that.
 
 #### For an **RC** release:
 - Update `pkg/consts/consts.go` with the new semver tag (like `v1.2.0-rc1`) and any updates to the API review URL.

--- a/hack/mkdocs/generate.sh
+++ b/hack/mkdocs/generate.sh
@@ -24,23 +24,41 @@ GOPATH=${GOPATH:-$(go env GOPATH)}
 # have to manually default it.
 GOBIN=${GOBIN:-$(go env GOBIN)}
 GOBIN=${GOBIN:-${GOPATH}/bin}
+REMOTE=${REMOTE:-origin}
 
 readonly GOTOOL="go tool"
 
 echo $GOBIN
 
 go install github.com/elastic/crd-ref-docs
+declare -a arr=(
+    "release-1.3"
+    "release-1.4"
+    "main"
+)
 
-$GOTOOL crd-ref-docs \
-    --source-path=${PWD}/apis \
-    --config=crd-ref-docs.yaml \
-    --templates-dir=${PWD}/hack/crd-ref-templates/ \
-    --renderer=markdown \
-    --output-path=${PWD}/site-src/reference/spec.md
+mkdir -p ${PWD}/tmp
 
-$GOTOOL crd-ref-docs \
-    --source-path=${PWD}/apisx \
-    --config=crd-ref-docs.yaml \
-    --templates-dir=${PWD}/hack/crd-ref-templates/ \
-    --renderer=markdown \
-    --output-path=${PWD}/site-src/reference/specx.md
+for i in "${arr[@]}"; do
+    tmpdir=$(mktemp -d --tmpdir=${PWD}/tmp)
+    
+    git fetch ${REMOTE} ${i}
+	git --work-tree=${tmpdir} checkout ${REMOTE}/${i} -- apis apisx
+	
+    docpath=${i#"release-"}
+	mkdir -p "${PWD}/site-src/reference/${docpath}"
+
+    $GOTOOL crd-ref-docs \
+        --source-path=${tmpdir}/apis \
+        --config=crd-ref-docs.yaml \
+        --templates-dir=${PWD}/hack/crd-ref-templates/ \
+        --renderer=markdown \
+        --output-path=${PWD}/site-src/reference/${docpath}/spec.md
+
+    $GOTOOL crd-ref-docs \
+        --source-path=${tmpdir}/apisx \
+        --config=crd-ref-docs.yaml \
+        --templates-dir=${PWD}/hack/crd-ref-templates/ \
+        --renderer=markdown \
+        --output-path=${PWD}/site-src/reference/${docpath}/specx.md
+done

--- a/nav.yml
+++ b/nav.yml
@@ -56,8 +56,15 @@ nav:
         - BackendTrafficPolicy: api-types/backendtrafficpolicy.md
       - ReferenceGrant: api-types/referencegrant.md
     - API specification:
-      - Standard: reference/spec.md
-      - Experimental: reference/specx.md
+      - Development:
+        - Standard: reference/main/spec.md
+        - Experimental: reference/main/specx.md
+      - v1.4:
+        - Standard: reference/1.4/spec.md
+        - Experimental: reference/1.4/specx.md
+      - v1.3:
+        - Standard: reference/1.3/spec.md
+        - Experimental: reference/1.3/specx.md
     - Policy Attachment: reference/policy-attachment.md
   - Enhancements:
     - Overview: geps/overview.md

--- a/nav.yml.tmpl
+++ b/nav.yml.tmpl
@@ -56,8 +56,15 @@ nav:
         - BackendTrafficPolicy: api-types/backendtrafficpolicy.md
       - ReferenceGrant: api-types/referencegrant.md
     - API specification:
-      - Standard: reference/spec.md
-      - Experimental: reference/specx.md
+      - Development:
+        - Standard: reference/main/spec.md
+        - Experimental: reference/main/specx.md
+      - v1.4:
+        - Standard: reference/1.4/spec.md
+        - Experimental: reference/1.4/specx.md
+      - v1.3:
+        - Standard: reference/1.3/spec.md
+        - Experimental: reference/1.3/specx.md
     - Policy Attachment: reference/policy-attachment.md
   - Enhancements:
     - Overview: geps/overview.md


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This is an attempt to implement multiversion for our API Reference.

While it is very "rudimentary", it allows us to set different versions of API on the navigation bar.

The rationale about keeping just the current versions (1.3, 1.4 and main) is because before 1.3 we didn't had experimental APIs and I've tried to not overcomplicate it.

Once a new release is cut, the release manager or some contributor must:
* update the `generate.sh` to add the new branch
* update the nav.yml.tmpl to add the new branch/version
* Run the update of nav

**Which issue(s) this PR fixes**:
Fixes #4151 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
