### PR TITLE
Revise GEP-1713: Update gateway status and conformance test details for ListenerSets

### DIFF
--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -977,10 +977,6 @@ The following Gateway Conformance (Extended) features will be added
 	//  SupportGatewayListenerSet option indicates support for a Gateway
 	//  with ListenerSets
 	SupportGatewayListenerSet FeatureName = "GatewayListenerSet"
-
-	//  SupportListenerSetDynamicPortAssignment option indicates support for a ListenerSet
-	//  to dynamically assign ports
-	SupportListenerSetDynamicPortAssignment FeatureName = "ListenerSetDynamicPortAssignment"
 ```
 They will validate the following scenarios :
 
@@ -1500,47 +1496,6 @@ They will validate the following scenarios :
           status: True
           reason: HostnameConflict
       // Other accepted listeners
-      ```
-
-1. A listener on a ListenerSet without a defined port
-    - If the implementation supports `ListenerSetDynamicPortAssignment` :
-      - The listener must have the following status :
-        ```
-        name: listener-without-port
-        port: <unique dynamically assigned port value>
-        conditions:
-        - type: Accepted
-          status: True
-          reason: Accepted
-        - type: Programmed
-          status: True
-          reason: Programmed
-        ```
-
-      - The parent gateway has the following status :
-      ```
-      status:
-        AttachedListenerSets: 1
-      ```
-
-      - The request to the ListenerSet port must succeed.
-
-    - If the implementation does not support `ListenerSetDynamicPortAssignment` :
-        ```
-        name: listener-without-port
-        conditions:
-        - type: Accepted
-          status: False
-          reason: UnsupportedPort
-        - type: Programmed
-          status: False
-          reason: UnsupportedPort
-        ```
-
-      - The parent gateway has the following status :
-      ```
-      status:
-        AttachedListenerSets: 0
       ```
 
 1. A listener on a ListenerSet allows routes from the same namespace as the ListenerSet


### PR DESCRIPTION
**What type of PR is this?**
Add one of the following kinds:
/kind documentation
/kind gep

Optionally add one or more of the following kinds if applicable:
/area conformance-test

**What this PR does / why we need it**:
This PR does the following :
- Adds the list of conformance tests to be added to ListenerSets (GEP-1713)
- Updates the status of the Gateway to include `AttachedListeners` that is the count of successful ListenerSet attachments to the gateway. Ref: [slack theraad](https://kubernetes.slack.com/archives/CR0H13KGA/p1761684861400469)

The aim is to get consensus for the set of conformance tests required to validate this feature against implementations, and move towards promoting this to Standard

**Does this PR introduce a user-facing change?**:
```release-note
Adds the `AttachedListeners` conditions to the Gateway status for the GEP and details for ListenerSets conformance tests
```
