### PR TITLE
Fix the API ref links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,6 @@ go.work.sum
 release/
 site-src/reference/spec.md
 site-src/reference/specx.md
+site-src/reference/**/spec.md
+site-src/reference/**/specx.md
 

--- a/hack/mkdocs/generate.sh
+++ b/hack/mkdocs/generate.sh
@@ -45,7 +45,10 @@ for i in "${arr[@]}"; do
     git fetch ${REMOTE} ${i}
 	git --work-tree=${tmpdir} checkout ${REMOTE}/${i} -- apis apisx
 	
+    # Start removing any "release-" prefix from docpath
     docpath=${i#"release-"}
+    # If the release is "main" simply remove it
+    docpath=${docpath#"main"}
 	mkdir -p "${PWD}/site-src/reference/${docpath}"
 
     $GOTOOL crd-ref-docs \

--- a/nav.yml
+++ b/nav.yml
@@ -57,8 +57,8 @@ nav:
       - ReferenceGrant: api-types/referencegrant.md
     - API specification:
       - Development:
-        - Standard: reference/main/spec.md
-        - Experimental: reference/main/specx.md
+        - Standard: reference/spec.md
+        - Experimental: reference/specx.md
       - v1.4:
         - Standard: reference/1.4/spec.md
         - Experimental: reference/1.4/specx.md

--- a/nav.yml.tmpl
+++ b/nav.yml.tmpl
@@ -57,8 +57,8 @@ nav:
       - ReferenceGrant: api-types/referencegrant.md
     - API specification:
       - Development:
-        - Standard: reference/main/spec.md
-        - Experimental: reference/main/specx.md
+        - Standard: reference/spec.md
+        - Experimental: reference/specx.md
       - v1.4:
         - Standard: reference/1.4/spec.md
         - Experimental: reference/1.4/specx.md


### PR DESCRIPTION
Since we started to version the API reference, the links that were previously pointing to the ref are broken. This happens because there is no reference on the parent directory anymore.

To fix this, the development reference has been moved back to the original location, so documentation can still keep working pointing to the development version of api reference

**What type of PR is this?**
/kind bug
/kind documentation

**What this PR does / why we need it**:
Rollback the API reference for development versions to the parent directory.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4212

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
