### PR TITLE
add flags for using FQDN for host, appending port for all requests, and timeout config

### DIFF
--- a/conformance/conformance.go
+++ b/conformance/conformance.go
@@ -17,6 +17,7 @@ limitations under the License.
 package conformance
 
 import (
+	"encoding/json"
 	"io/fs"
 	"os"
 	"testing"
@@ -81,6 +82,13 @@ func DefaultOptions(t *testing.T) suite.ConformanceOptions {
 		*flags.ImplementationContact,
 	)
 
+	timeoutConfig := conformanceconfig.DefaultTimeoutConfig()
+
+	if *flags.TimeoutConfig != "" {
+		err := json.Unmarshal([]byte(*flags.TimeoutConfig), &timeoutConfig)
+		require.NoError(t, err, "error initializing timeout config from the input")
+	}
+
 	return suite.ConformanceOptions{
 		AllowCRDsMismatch:          *flags.AllowCRDsMismatch,
 		CleanupBaseResources:       *flags.CleanupBaseResources,
@@ -103,7 +111,7 @@ func DefaultOptions(t *testing.T) suite.ConformanceOptions {
 		RunTest:                    *flags.RunTest,
 		SkipTests:                  skipTests,
 		SupportedFeatures:          supportedFeatures,
-		TimeoutConfig:              conformanceconfig.DefaultTimeoutConfig(),
+		TimeoutConfig:              timeoutConfig,
 		SkipProvisionalTests:       *flags.SkipProvisionalTests,
 	}
 }

--- a/conformance/mesh/manifests.yaml
+++ b/conformance/mesh/manifests.yaml
@@ -28,6 +28,11 @@ spec:
       - name: echo
         image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20240412-v1.0.0-394-g40c666fd
         imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+        - containerPort: 8443
+        - containerPort: 9090
+        - containerPort: 7070
         args:
         - --tcp=9090
         - --port=8080
@@ -85,6 +90,11 @@ spec:
       - name: echo
         image: gcr.io/k8s-staging-gateway-api/echo-advanced:v20240412-v1.0.0-394-g40c666fd
         imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+        - containerPort: 8443
+        - containerPort: 9090
+        - containerPort: 7070
         args:
         - --tcp=9090
         - --port=8080

--- a/conformance/utils/echo/pod.go
+++ b/conformance/utils/echo/pod.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/config"
+	"sigs.k8s.io/gateway-api/conformance/utils/flags"
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
@@ -102,6 +103,10 @@ func makeRequest(t *testing.T, exp *http.ExpectedResponse) []string {
 
 	if len(exp.Response.StatusCodes) == 0 {
 		exp.Response.StatusCodes = []int{200}
+	}
+
+	if *flags.UseFQDNHost {
+		r.Host = fmt.Sprintf("%v.%v", strings.Split(r.Host, ".")[0], "gateway-conformance-mesh.svc.cluster.local")
 	}
 
 	host := http.CalculateHost(t, r.Host, protocol)

--- a/conformance/utils/flags/flags.go
+++ b/conformance/utils/flags/flags.go
@@ -50,4 +50,7 @@ var (
 	ConformanceProfiles        = flag.String("conformance-profiles", "", "Comma-separated list of the conformance profiles to run")
 	ReportOutput               = flag.String("report-output", "", "The file where to write the conformance report")
 	SkipProvisionalTests       = flag.Bool("skip-provisional-tests", false, "Whether to skip provisional tests")
+	UseFQDNHost                = flag.Bool("use-fqdn-host", false, "Use FQDN for hosts for all requests")
+	AppendPortToHost           = flag.Bool("append-port-to-host", false, "add port to the host for all ports including 80 and 443")
+	TimeoutConfig              = flag.String("timeout-config", "", "TimeoutConfig object in json format")
 )

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/config"
+	"sigs.k8s.io/gateway-api/conformance/utils/flags"
 	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
 	"sigs.k8s.io/gateway-api/conformance/utils/weight"
@@ -202,12 +203,23 @@ func CalculateHost(t *testing.T, gwAddr, scheme string) string {
 		if !strings.Contains(err.Error(), "missing port in address") {
 			tlog.Logf(t, "Failed to parse host %q: %v", gwAddr, err)
 		}
+		if *flags.AppendPortToHost {
+			if port != "" {
+				return gwAddr
+			}
+			if strings.ToLower(scheme) == "http" {
+				return fmt.Sprintf("%v:%v", gwAddr, "80")
+			}
+			if strings.ToLower(scheme) == "https" {
+				return fmt.Sprintf("%v:%v", gwAddr, "443")
+			}
+		}
 		return gwAddr
 	}
-	if strings.ToLower(scheme) == "http" && port == "80" {
+	if strings.ToLower(scheme) == "http" && port == "80" && !*flags.AppendPortToHost {
 		return Ipv6SafeHost(host)
 	}
-	if strings.ToLower(scheme) == "https" && port == "443" {
+	if strings.ToLower(scheme) == "https" && port == "443" && !*flags.AppendPortToHost {
 		return Ipv6SafeHost(host)
 	}
 	return gwAddr


### PR DESCRIPTION


**What type of PR is this?**
/kind test
/area conformance-test

**What this PR does / why we need it**:
This PR adds 2 flags:
1. To override host : Some implementation has different requirements for host like having FQDN. This flag allows to override the host to a specific value.
2. To add timeout config: To override the default timeout config values similar to the one provided by conformanceoptions.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
