### PR TITLE
Fix link to 1.28.0 default report in README

### DIFF
--- a/conformance/reports/v1.4.0/istio-istio/README.md
+++ b/conformance/reports/v1.4.0/istio-istio/README.md
@@ -4,7 +4,7 @@
 
 |API channel|Implementation version|Mode|Report|
 |-----------|----------------------|----|------|
-|x|[1.28.0](https://github.com/istio/istio/releases/tag/1.28.0)|x|[1.28.0 report](./experimental-1.28.0-default-report.yaml)|
+|x|[1.28.0](https://github.com/istio/istio/releases/tag/1.28.0)|x|[1.28.0 report](./1.28.0-default-report.yaml)|
 
 ## Reproduce
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes the broken link to the conformance report.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4222

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
