### PR TITLE
Perform Implementations page review for v1.4

### DIFF
--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -86,7 +86,7 @@ other functions (like managing DNS or creating certificates).
 ### Conformant
 - [Agent Gateway][40]
 - [Airlock Microgateway][34]
-- [Cilium][16] (beta)
+- [Cilium][16]
 - [Envoy Gateway][18] (GA)
 - [Istio][9] (GA)
 - [kgateway][37] (GA)
@@ -128,6 +128,7 @@ other functions (like managing DNS or creating certificates).
 ### Conformant
 - [Istio][9] (GA)
 - [Linkerd][28] (GA)
+- [Cilium][16] (GA)
 
 ### Stale
 - [Google Cloud Service Mesh][38] (GA)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
This commit performs the Implementations page review for Gateway API v1.4, using the process documented in the Implementations page.

Note that, as the Implementations page stands, we are not meeting the third-party links policy outlined in
kubernetes/enhancements#1327. There was further discussion around this in kubernetes/steering#292, which led to opening #3863 here some time ago.

The process allows for a minimum right-of-reply time of two weeks, but because it's Kubecon this week, I'm adding a week and making it three weeks instead.

So, implementations that wish to update their status can submit a conformance report sometime in the next three weeks (from the date of opening of this PR), and I will update the PR accordingly.

Otherwise, three weeks from today, this PR will be reviewed and merged as any normal PR, and these changes will become official.

This is the first time we've run this process, so I'm happy to accept feedback on it, although as I said above, any changes need to be satisfying the third-party links policy that covers the whole Kubernetes process.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
