### PR TITLE
Update coreDNS pod image tag

### DIFF
--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -704,7 +704,7 @@ spec:
       - args:
         - -conf
         - /root/Corefile
-        image: coredns/coredns
+        image: k8s.gcr.io/coredns/coredns:v1.13.1
         name: coredns
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


Optionally add one or more of the following kinds if applicable:
/area conformance-test


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
*Automatically closes linked issue when PR is merged.
Fixes #4239 


**Does this PR introduce a user-facing change?**:
NONE
```
coreDNS pod is never ready due to message:
        message: 'Back-off pulling image "coredns/coredns": ErrImagePull: short name
          mode is enforcing, but image name coredns/coredns:latest returns ambiguous
          list'
        reason: ImagePullBackOff
```
Updating the image tag to: `k8s.gcr.io/coredns/coredns:v1.13.1` allows the pod to go into ready state and conformance tests can continue on
