### PR TITLE
Render toc always on left

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ theme:
     - navigation.tabs
     - navigation.top
     - navigation.expand
+    - toc.integrate
   palette:
     - scheme: default
       primary: custom


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR makes ToC of the current page be also rendered on left.

As an example, looking into a GEP now:

<img width="1625" height="1517" alt="image" src="https://github.com/user-attachments/assets/7fea5d7c-4504-411c-b7b5-86e95046bd35" />


Worth noticing that this is just for the current active page. While this can make the navigation on left slightly more confusing, it makes available a whole area on the right side and makes visualization of the real page much better

```release-note
NONE
```
