### PR TITLE
Update the ListenerSet GEP per Kubecon discussions

### DIFF
--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -68,7 +68,7 @@ type GatewaySpec struct {
 
 type GatewayStatus struct {
 	...
-	// AttachedListeners represents the total number of ListenerSets that have been
+	// AttachedListenerSets represents the total number of ListenerSets that have been
 	// successfully attached to this Gateway.
 	//
   // A ListenerSet is successfully attached to a Gateway when all the following conditions are met:
@@ -76,10 +76,10 @@ type GatewayStatus struct {
 	// - The ListenerSet has a valid ParentRef selecting the Gateway
 	// - The ListenerSet's status has the condition "Accepted: true"
 	//
-	// Uses for this field include troubleshooting AttachedListeners attachment and
+	// Uses for this field include troubleshooting AttachedListenerSets attachment and
 	// measuring blast radius/impact of changes to a Gateway.
 	// +optional
-	AttachedListeners *int32 `json:"attachedListeners,omitempty"`
+	AttachedListenerSets *int32 `json:"attachedListenerSets,omitempty"`
 }
 
 type AllowedListeners struct {
@@ -916,7 +916,7 @@ status:
 
 ### Gateway Status
 
-`Gateway` status MUST report the number of successful attached listeners to `.status.attachedListeners`.
+`Gateway` status MUST report the number of successful attached listeners to `.status.attachedListenerSets`.
 
 ### Gateway Conditions
 


### PR DESCRIPTION
**What type of PR is this?**
/kind gep

**What this PR does / why we need it**:
This PR updates ListenerSet per Kubecon discussions on dynamic ports and attachedListenerSets. It also adds some more context on ListenerSet needs

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
