### PR TITLE
Make single TargetRef Core for BackendTLSPolicy

### DIFF
--- a/apisx/v1alpha1/xbackendtrafficpolicy_types.go
+++ b/apisx/v1alpha1/xbackendtrafficpolicy_types.go
@@ -69,6 +69,10 @@ type BackendTrafficPolicySpec struct {
 	// Currently, a TargetRef can not be scoped to a specific port on a
 	// Service.
 	//
+	// Because of concerns over recording status correctly in some edge cases,
+	// currently, Core support is only given to one (1) TargetRef. More than
+	// one TargetRef is Implementation Specific.
+	//
 	// +listType=map
 	// +listMapKey=group
 	// +listMapKey=kind

--- a/config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
+++ b/config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
@@ -253,6 +253,10 @@ spec:
 
                   Currently, a TargetRef can not be scoped to a specific port on a
                   Service.
+
+                  Because of concerns over recording status correctly in some edge cases,
+                  currently, Core support is only given to one (1) TargetRef. More than
+                  one TargetRef is Implementation Specific.
                 items:
                   description: |-
                     LocalPolicyTargetReference identifies an API object to apply a direct or

--- a/geps/gep-1897/index.md
+++ b/geps/gep-1897/index.md
@@ -625,6 +625,20 @@ While in some cases adding new fields may be seen as a backwards compatibility r
 knowing to respect the fields, these fields (or similar, should future GEPs decide on new names) are pre-approved to be
 added in a future release, should the GEPs to add them are approved in the first place.
 
+## Outstanding issues
+
+### Multiple TargetRefs rolling up to the same Gateway cannot be represented in status
+
+It is possible to have a BackendTLSPolicy target multiple, different Services that are used in HTTPRoutes that attach
+to the same Gateway.
+
+As written, the Status section of BackendTLSPolicy does not have a way to represent these separate statuses, as the
+status is namespaced by `controllerName` and `ancestorRef` (where "ancestor" is the Gateway in this case).
+
+We need to decide if this is enough of an issue to change the status design, or if we record this as a design decision
+and accept the tradeoff.
+
+
 ## Alternatives
 Most alternatives are enumerated in the section "The history of backend TLS".  A couple of additional
 alternatives are also listed here.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -8776,7 +8776,7 @@ func schema_sigsk8sio_gateway_api_apisx_v1alpha1_BackendTrafficPolicySpec(ref co
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "TargetRefs identifies API object(s) to apply this policy to. Currently, Backends (A grouping of like endpoints such as Service, ServiceImport, or any implementation-specific backendRef) are the only valid API target references.\n\nCurrently, a TargetRef can not be scoped to a specific port on a Service.",
+							Description: "TargetRefs identifies API object(s) to apply this policy to. Currently, Backends (A grouping of like endpoints such as Service, ServiceImport, or any implementation-specific backendRef) are the only valid API target references.\n\nCurrently, a TargetRef can not be scoped to a specific port on a Service.\n\nBecause of concerns over recording status correctly in some edge cases, currently, Core support is only given to one (1) TargetRef. More than one TargetRef is Implementation Specific.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{


### PR DESCRIPTION
Make Core conformance for BackendTLSPolicy only support a single TargetRef for now, while we figure out what to do about representing some edge cases in status.

/kind cleanup
/kind documentation

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
BackendTLSPolicy now only supports a single TargetRef in Core conformance. This is temporary while we define some edge case behavior.
```
