### PR TITLE
Update External Auth GEP to be Experimental

### DIFF
--- a/geps/gep-1494/index.md
+++ b/geps/gep-1494/index.md
@@ -1,7 +1,7 @@
 # GEP-1494: HTTP Auth in Gateway API
 
 * Issue: [#1494](https://github.com/kubernetes-sigs/gateway-api/issues/1494)
-* Status: Implementable
+* Status: Experimental
 
 (See [status definitions](../overview.md#gep-states).)
 

--- a/geps/gep-1494/metadata.yaml
+++ b/geps/gep-1494/metadata.yaml
@@ -2,7 +2,7 @@ apiVersion: internal.gateway.networking.k8s.io/v1alpha1
 kind: GEPDetails
 number: 1494
 name: HTTP Auth in Gateway API
-status: Implementable
+status: Experimental
 # Any authors who contribute to the GEP in any way should be listed here using
 # their GitHub handle.
 authors:

--- a/nav.yml
+++ b/nav.yml
@@ -69,12 +69,12 @@ nav:
   - Enhancements:
     - Overview: geps/overview.md
     - Implementable:
-      - geps/gep-1494/index.md
       - geps/gep-3779/index.md
       - geps/gep-3793/index.md
       - geps/gep-3949/index.md
     - Experimental:
       - geps/gep-91/index.md
+      - geps/gep-1494/index.md
       - geps/gep-1619/index.md
       - geps/gep-1713/index.md
       - geps/gep-1731/index.md


### PR DESCRIPTION
/kind cleanup
/kind gep

**What this PR does / why we need it**:

When I made the Go types PR that moved External Auth to Experimental, I forgot to update the GEP status. This fixes that issue.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
