### PR TITLE
Fix Airlock link checks in conformance reports

### DIFF
--- a/conformance/reports/v1.1.0/airlock-microgateway/README.md
+++ b/conformance/reports/v1.1.0/airlock-microgateway/README.md
@@ -15,7 +15,7 @@ The Airlock Microgateway conformance report can be reproduced by following the s
 
 > [!NOTE]
 > The `HTTPRouteWeight` test fires 10 concurrent request to 3 backends totaling in 500 requests to assert a distribution that matches the configured weight.
-> Please be aware that this test exceeds the [5 req/sec rate-limit](https://docs.airlock.com/microgateway/latest/?topic=MGW-00000056) enforced in the <!-- markdown-link-check-disable --> [community edition](https://www.airlock.com/en/secure-access-hub/components/microgateway/community-edition) <!-- markdown-link-check-enable -->, causing the test to fail.
+> Please be aware that this test exceeds the <!-- markdown-link-check-disable --> [5 req/sec rate-limit](https://docs.airlock.com/microgateway/latest/?topic=MGW-00000056) enforced in the [community edition](https://www.airlock.com/en/secure-access-hub/components/microgateway/community-edition) <!-- markdown-link-check-enable -->, causing the test to fail.
 > To successfully pass this test a <!-- markdown-link-check-disable --> [premium license](https://www.airlock.com/en/secure-access-hub/components/microgateway/premium-edition)  <!-- markdown-link-check-enable --> is required.
 > 
 > The Airlock Microgateway drops all request headers except for a well-known built-in standard and tracing headers list (e.g., Accept, Cookie, X-CSRF-TOKEN) to reduce the attack surface.

--- a/conformance/reports/v1.1.1/airlock-microgateway/README.md
+++ b/conformance/reports/v1.1.1/airlock-microgateway/README.md
@@ -14,7 +14,7 @@ The Airlock Microgateway conformance report can be reproduced by following the s
 
 > [!NOTE]
 > The `HTTPRouteWeight` test fires 10 concurrent request to 3 backends totaling in 500 requests to assert a distribution that matches the configured weight.
-> Please be aware that this test exceeds the [5 req/sec rate-limit](https://docs.airlock.com/microgateway/latest/?topic=MGW-00000056) enforced in the <!-- markdown-link-check-disable --> [community edition](https://www.airlock.com/en/secure-access-hub/components/microgateway/community-edition) <!-- markdown-link-check-enable -->, causing the test to fail.
+> Please be aware that this test exceeds the <!-- markdown-link-check-disable --> [5 req/sec rate-limit](https://docs.airlock.com/microgateway/latest/?topic=MGW-00000056) enforced in the [community edition](https://www.airlock.com/en/secure-access-hub/components/microgateway/community-edition) <!-- markdown-link-check-enable -->, causing the test to fail.
 > To successfully pass this test a <!-- markdown-link-check-disable --> [premium license](https://www.airlock.com/en/secure-access-hub/components/microgateway/premium-edition)  <!-- markdown-link-check-enable --> is required.
 > 
 > The Airlock Microgateway drops all request headers except for a well-known built-in standard and tracing headers list (e.g., Accept, Cookie, X-CSRF-TOKEN) to reduce the attack surface.

--- a/conformance/reports/v1.2.0/airlock-microgateway/README.md
+++ b/conformance/reports/v1.2.0/airlock-microgateway/README.md
@@ -14,7 +14,7 @@ The Airlock Microgateway conformance report can be reproduced by following the s
 
 > [!NOTE]
 > The `HTTPRouteWeight` test fires 10 concurrent request to 3 backends totaling in 500 requests to assert a distribution that matches the configured weight.
-> Please be aware that this test exceeds the [5 req/sec rate-limit](https://docs.airlock.com/microgateway/latest/?topic=MGW-00000056) enforced in the <!-- markdown-link-check-disable --> [community edition](https://www.airlock.com/en/secure-access-hub/components/microgateway/community-edition) <!-- markdown-link-check-enable -->, causing the test to fail.
+> Please be aware that this test exceeds the <!-- markdown-link-check-disable --> [5 req/sec rate-limit](https://docs.airlock.com/microgateway/latest/?topic=MGW-00000056) enforced in the [community edition](https://www.airlock.com/en/secure-access-hub/components/microgateway/community-edition) <!-- markdown-link-check-enable -->, causing the test to fail.
 > To successfully pass this test a <!-- markdown-link-check-disable --> [premium license](https://www.airlock.com/en/secure-access-hub/components/microgateway/premium-edition)  <!-- markdown-link-check-enable --> is required.
 > 
 > The Airlock Microgateway drops all request headers except for a well-known built-in standard and tracing headers list (e.g., Accept, Cookie, X-CSRF-TOKEN) to reduce the attack surface.

--- a/conformance/reports/v1.2.1/airlock-microgateway/README.md
+++ b/conformance/reports/v1.2.1/airlock-microgateway/README.md
@@ -14,7 +14,7 @@ The Airlock Microgateway conformance report can be reproduced by following the s
 
 > [!NOTE]
 > The `HTTPRouteWeight` test fires 10 concurrent request to 3 backends totaling in 500 requests to assert a distribution that matches the configured weight.
-> Please be aware that this test exceeds the [5 req/sec rate-limit](https://docs.airlock.com/microgateway/latest/?topic=MGW-00000056) enforced in the <!-- markdown-link-check-disable --> [community edition](https://www.airlock.com/en/secure-access-hub/components/microgateway/community-edition) <!-- markdown-link-check-enable -->, causing the test to fail.
+> Please be aware that this test exceeds the <!-- markdown-link-check-disable --> [5 req/sec rate-limit](https://docs.airlock.com/microgateway/latest/?topic=MGW-00000056) enforced in the [community edition](https://www.airlock.com/en/secure-access-hub/components/microgateway/community-edition) <!-- markdown-link-check-enable -->, causing the test to fail.
 > To successfully pass this test a <!-- markdown-link-check-disable --> [premium license](https://www.airlock.com/en/secure-access-hub/components/microgateway/premium-edition)  <!-- markdown-link-check-enable --> is required.
 > 
 > The Airlock Microgateway drops all request headers except for a well-known built-in standard and tracing headers list (e.g., Accept, Cookie, X-CSRF-TOKEN) to reduce the attack surface.

--- a/conformance/reports/v1.3.0/airlock-microgateway/README.md
+++ b/conformance/reports/v1.3.0/airlock-microgateway/README.md
@@ -13,7 +13,7 @@ The Airlock Microgateway conformance report can be reproduced by following the s
 
 > [!NOTE]
 > The `HTTPRouteWeight` test fires 10 concurrent request to 3 backends totaling in 500 requests to assert a distribution that matches the configured weight.
-> Please be aware that this test exceeds the [5 req/sec rate-limit](https://docs.airlock.com/microgateway/latest/?topic=MGW-00000056) enforced in the <!-- markdown-link-check-disable --> [community edition](https://www.airlock.com/en/secure-access-hub/components/microgateway/community-edition) <!-- markdown-link-check-enable -->, causing the test to fail.
+> Please be aware that this test exceeds the <!-- markdown-link-check-disable --> [5 req/sec rate-limit](https://docs.airlock.com/microgateway/latest/?topic=MGW-00000056) enforced in the [community edition](https://www.airlock.com/en/secure-access-hub/components/microgateway/community-edition) <!-- markdown-link-check-enable -->, causing the test to fail.
 > To successfully pass this test a <!-- markdown-link-check-disable --> [premium license](https://www.airlock.com/en/secure-access-hub/components/microgateway/premium-edition)  <!-- markdown-link-check-enable --> is required.
 >
 > The Airlock Microgateway drops all request headers except for a well-known built-in standard and tracing headers list (e.g., Accept, Cookie, X-CSRF-TOKEN) to reduce the attack surface.


### PR DESCRIPTION
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
Fixes links that don't respond in Airlock's conformance reports because they trigger bot-detection in their hosting.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
