### PR TITLE
Add verbose flag to golangci-lint command

### DIFF
--- a/.github/workflows/kal.yml
+++ b/.github/workflows/kal.yml
@@ -23,6 +23,6 @@ jobs:
       - name: Install Golang CI Lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.0
       - name: Build KAL
-        run: golangci-lint custom
+        run: golangci-lint custom -v
       - name: run api linter
         run: ./bin/golangci-kube-api-linter run -c ./.golangci-kal.yml ./...


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
proved to be useful when debugging recent errors in KAL and golangcli

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```

/cc @rikatz @kflynn @robscott 