### PR TITLE
Fix GCL version with bugfix for git problem

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,4 +1,4 @@
-version: v2.2.1
+version: v2.7.0
 name: golangci-kube-api-linter
 destination: ./bin
 plugins:

--- a/.github/workflows/kal.yml
+++ b/.github/workflows/kal.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # tag=v5.5.0
       - name: Install Golang CI Lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.2.1
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.0
       - name: Build KAL
         run: golangci-lint custom
       - name: run api linter


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
GCL is broken on git version used on github action runners, pinning to a fixed version while tag 2.6.3 is not released

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
