### PR TITLE
fix(build): build-install-yaml needs to tolerate $1 being unset. Oops.

### DIFF
--- a/hack/build-install-yaml.sh
+++ b/hack/build-install-yaml.sh
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 set -o errexit
-set -o nounset
 set -o pipefail
 
 CHANNELS=(standard experimental)
@@ -24,6 +23,8 @@ if [ "$1" == "--experimental-only" ]; then
     CHANNELS=(experimental)
     shift
 fi
+
+set -o nounset
 
 readonly YEAR=$(date +"%Y")
 


### PR DESCRIPTION
Stupid fix for a stupid bug that I created. :man_facepalming:

/kind bug

```release-note
NONE
```
