### PR TITLE
Increase TLSRoute hostnames limit from 16 to 1024

### DIFF
--- a/apis/v1/tlsroute_types.go
+++ b/apis/v1/tlsroute_types.go
@@ -101,7 +101,7 @@ type TLSRouteSpec struct {
 	// +required
 	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=1024
 	// +kubebuilder:validation:XValidation:message="Hostnames cannot contain an IP",rule="self.all(h, !isIP(h))"
 	// +kubebuilder:validation:XValidation:message="Hostnames must be valid based on RFC-1123",rule="self.all(h, !h.contains('*') ? h.matches('^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$') : true)"
 	// +kubebuilder:validation:XValidation:message="Wildcards on hostnames must be the first label, and the rest of hostname must be valid based on RFC-1123",rule="self.all(h, h.contains('*') ? (h.startsWith('*.') && h.substring(2).matches('^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$')) : true)"

--- a/apis/v1alpha2/tlsroute_types.go
+++ b/apis/v1alpha2/tlsroute_types.go
@@ -86,7 +86,7 @@ type TLSRouteSpec struct {
 	//
 	// +optional
 	// +listType=atomic
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=1024
 	Hostnames []Hostname `json:"hostnames,omitempty"`
 
 	// Rules are a list of TLS matchers and actions.

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -81,7 +81,7 @@ spec:
                   minLength: 1
                   pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
-                maxItems: 16
+                maxItems: 1024
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
@@ -887,7 +887,7 @@ spec:
                   minLength: 1
                   pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
-                maxItems: 16
+                maxItems: 1024
                 type: array
                 x-kubernetes-list-type: atomic
               parentRefs:
@@ -1661,7 +1661,7 @@ spec:
                   minLength: 1
                   pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
-                maxItems: 16
+                maxItems: 1024
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic

--- a/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
@@ -81,7 +81,7 @@ spec:
                   minLength: 1
                   pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
-                maxItems: 16
+                maxItems: 1024
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
@@ -803,7 +803,7 @@ spec:
                   minLength: 1
                   pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
-                maxItems: 16
+                maxItems: 1024
                 type: array
                 x-kubernetes-list-type: atomic
               parentRefs:
@@ -1489,7 +1489,7 @@ spec:
                   minLength: 1
                   pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
-                maxItems: 16
+                maxItems: 1024
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind feature
/kind documentation

**What this PR does / why we need it**:
This PR updates the TLSRoute CRD validation rationale and proposes increasing the `maxItem` bound for hostnames from 16 to 4096. This change is proposed only to accommodate very large orgs. In large orgs, the current limit of 16, this can lead to hundred of thousands TLSRoute objects. These objects multiply storage, watch traffic, and controller memory/CPU, which drives up API-server latency and risks OOMs and instability.

In a similar PR the limit has been increased: https://github.com/kubernetes-sigs/gateway-api/pull/3205/
To safely deploy the change the author employed a XValidation rule. For my case, such a rule would likely be rejected for being too complex. One idea would be to add the validation to a Validating Webhook. However, the webhook as been removed:

```
The validating webhook has been removed. CEL validation is now built-in to CRDs and replaces the webhook. (#2595, @robscott)
```
Do you have any ideas on how to solve this issue? I would be happy for further assistance on how to tackle this. 

Rationale:
- Hostname size on the wire: DNS RFCs limit a full domain name to 255 octets on the wire (see RFC 2181 §11). In practice this means up to roughly 253 printable characters in common textual form (no trailing dot); for SNI and Gateway API usage the ACE/Punycode representation should be used for IDNs and the same limits apply.
  - RFC reference: https://datatracker.ietf.org/doc/html/rfc2181#section-11
  - TLS/SNI reference: https://datatracker.ietf.org/doc/html/rfc6066#section-3
- etcd / API server request-size guidance: etcd dev-guide (v3.3) documents a practical per-request/message size ~1.5 MiB. kube-apiserver also commonly enforces a request-size cap). See: https://etcd.io/docs/v3.3/dev-guide/limit/#:~:text=etcd%20is%20designed%20to%20handle,any%20request%20is%201.5%20MiB
- Based on these assumptions, I did the following napkin calculation: I assume a base overhead ≈ 4 KB, then I get  (1,572,864 − 4,096) / 256 = 1,568,768 / 256 = 6,128, so 4096 could be a conservative upper limit. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
No issue yet. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->

```release-note
The TLSRoute CRD validation has been adjusted to allow up to 4096 hostnames and rules per TLSRoute resource. Operators must validate kube-apiserver, etcd and Gateway controller behavior with representative manifests prior to enabling the new limit in production.
```
