### PR TITLE
conformance: add v1.3.0 report for Kong Operator v2.0.6

### DIFF
--- a/conformance/reports/v1.3.0/kong-operator/README.md
+++ b/conformance/reports/v1.3.0/kong-operator/README.md
@@ -1,0 +1,48 @@
+# Kong Operator
+
+## Table of Contents
+
+| API channel | Implementation version                                              | Mode                   | Report                                                                                       |
+|-------------|---------------------------------------------------------------------|------------------------|----------------------------------------------------------------------------------------------|
+| standard    | [v2.0.6](https://github.com/Kong/kong-operator/releases/tag/v2.0.6) | expressions            | [v2.0.6 expressions report](./standard-v2.0.6-expressions-report.yaml)                       |
+| standard    | [v2.0.6](https://github.com/Kong/kong-operator/releases/tag/v2.0.6) | traditional_compatible | [v2.0.6 traditional compatible report](./standard-v2.0.6-traditional_compatible-report.yaml) |
+
+## Reproduce
+
+### Prerequisites
+
+In order to properly run the conformance tests, you need to have the following
+tools installed on your local machine:
+- [KinD](https://github.com/kubernetes-sigs/kind)
+- [Helm](https://github.com/helm/helm)
+- [mise](https://github.com/jdx/mise)
+
+The test suite will create a fresh KinD cluster and will use Helm to deploy some additional
+components.
+
+### Steps
+
+1. Clone the Kong Operator GitHub repository
+
+   ```bash
+   git clone https://github.com/kong/kong-operator.git && cd kong-operator
+   ```
+
+2. Check out the desired version
+
+   ```bash
+   export VERSION=v<x.y.z>
+   git checkout $VERSION
+   ```
+
+3. Run the conformance tests
+
+   ```bash
+   TEST_KONG_ROUTER_FLAVOR=<traditional_compatible|expressions> make test.conformance
+   ```
+
+4. Check the produced report
+
+   ```bash
+   cat ./*report.yaml
+   ```

--- a/conformance/reports/v1.3.0/kong-operator/standard-v2.0.6-expressions-report.yaml
+++ b/conformance/reports/v1.3.0/kong-operator/standard-v2.0.6-expressions-report.yaml
@@ -1,0 +1,55 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2025-12-10T14:21:52Z"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.3.0
+implementation:
+  contact:
+  - https://github.com/kong/kong-operator/issues/new/choose
+  organization: Kong
+  project: kong-operator
+  url: https://github.com/kong/kong-operator
+  version: v2.0.6
+kind: ConformanceReport
+mode: expressions
+profiles:
+- core:
+    result: partial
+    skippedTests:
+    - HTTPRouteWeight
+    statistics:
+      Failed: 0
+      Passed: 32
+      Skipped: 1
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 6
+      Skipped: 0
+    supportedFeatures:
+    - GatewayPort8080
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRoutePathRewrite
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteResponseHeaderModification
+    unsupportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRedirect
+    - HTTPRoutePortRedirect
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestPercentageMirror
+    - HTTPRouteRequestTimeout
+    - HTTPRouteSchemeRedirect
+  name: GATEWAY-HTTP
+  summary: Core tests partially succeeded with 1 test skips. Extended tests succeeded.

--- a/conformance/reports/v1.3.0/kong-operator/standard-v2.0.6-traditional_compatible-report.yaml
+++ b/conformance/reports/v1.3.0/kong-operator/standard-v2.0.6-traditional_compatible-report.yaml
@@ -1,0 +1,57 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2025-12-10T14:22:04Z"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.3.0
+implementation:
+  contact:
+  - https://github.com/kong/kong-operator/issues/new/choose
+  organization: Kong
+  project: kong-operator
+  url: https://github.com/kong/kong-operator
+  version: v2.0.6
+kind: ConformanceReport
+mode: traditional_compatible
+profiles:
+- core:
+    result: partial
+    skippedTests:
+    - HTTPRouteHeaderMatching
+    - HTTPRouteInvalidBackendRefUnknownKind
+    - HTTPRouteWeight
+    statistics:
+      Failed: 0
+      Passed: 30
+      Skipped: 3
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 4
+      Skipped: 0
+    supportedFeatures:
+    - GatewayPort8080
+    - HTTPRouteHostRewrite
+    - HTTPRoutePathRewrite
+    - HTTPRouteResponseHeaderModification
+    unsupportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteMethodMatching
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRedirect
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestPercentageMirror
+    - HTTPRouteRequestTimeout
+    - HTTPRouteSchemeRedirect
+  name: GATEWAY-HTTP
+  summary: Core tests partially succeeded with 3 test skips. Extended tests succeeded.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

Adds conformance 1.3.0 report for Kong Operator [v2.0.6](https://github.com/Kong/kong-operator/releases/tag/v2.0.6).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
