### PR TITLE
Create a simple k8s job that can install or upgrade Gateway API CRDs

### DIFF
--- a/pkg/upgrade/Dockerfile
+++ b/pkg/upgrade/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.19
+
+# Install dependencies:
+# - ca-certificates: required for HTTPS calls to GitHub/Kubernetes API
+# - wget: used to download the CRD manifests
+# - openssl: often required for robust HTTPS support with wget
+RUN apk add --no-cache ca-certificates curl openssl wget
+
+# Install kubectl matching the target architecture
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+  chmod +x kubectl && \
+  mv kubectl /usr/local/bin/kubectl
+
+
+# Create a directory for our scripts
+WORKDIR /scripts
+
+# Copy the installation script into the image
+COPY install.sh /scripts/install.sh
+RUN chmod +x /scripts/install.sh
+
+# Set the script as the entrypoint
+ENTRYPOINT ["/bin/sh", "/scripts/install.sh"]

--- a/pkg/upgrade/README.md
+++ b/pkg/upgrade/README.md
@@ -1,0 +1,80 @@
+# Gateway API CRD Installer
+
+This directory contains a Kubernetes Job designed to safely install or upgrade [Gateway API](https://gateway-api.sigs.k8s.io/) Custom Resource Definitions (CRDs) in a cluster.
+
+## Overview
+
+Bundling Gateway API CRDs directly with add-ons (e.g., via Helm charts) can lead to conflicts when multiple controllers try to manage the same CRDs, potentially downgrading them or switching release channels unexpectedly.
+
+This Job provides a safe mechanism to:
+1.  **Install** missing Gateway API CRDs.
+2.  **Upgrade** existing CRDs to a requested version *only if* the requested version is newer.
+3.  **Avoid Conflicts** by refusing to overwrite CRDs from a different release channel (e.g., Standard vs. Experimental).
+
+## Components
+
+*   **`job-list.yaml`**: Job to list installed Gateway API CRDs and their versions.
+*   **`job-all.yaml`**: Job to install/upgrade **all** Gateway API CRDs.
+*   **`job-subset.yaml`**: Job to install/upgrade a **specific subset** of CRDs.
+*   **`rbac.yaml`**: ServiceAccount, ClusterRole, and ClusterRoleBinding allowing the Job to manage CRDs.
+*   **`Dockerfile`**: Builds the container image containing the `install.sh` script.
+
+## Configuration
+
+The Jobs are configured via environment variables set in the YAML files:
+...
+## Usage
+
+### 1. Build and Apply Prerequisites
+1.  **Build the Docker Image:**
+    ```bash
+    docker build -t gateway-api-crd-installer:local .
+    ```
+    *Note: If running in a Kind/Minikube cluster, ensure you load this image into the cluster nodes (e.g., `kind load docker-image gateway-api-crd-installer:local`).*
+
+2.  **Apply RBAC:**
+    ```bash
+    kubectl apply -f rbac.yaml
+    ```
+
+### 2. Run a Job
+Choose the appropriate job manifest for your needs.
+
+#### Option A: List Installed CRDs
+To see which Gateway API CRDs are currently installed and their versions:
+
+```bash
+kubectl apply -f job-list.yaml
+kubectl logs -l job-name=gateway-api-crd-list
+```
+
+#### Option B: Upgrade Existing CRDs
+To upgrade **all** currently installed Gateway API CRDs:
+1.  Edit `job-all.yaml` to set your desired `GATEWAY_API_VERSION` and `RELEASE_CHANNEL`.
+2.  Run:
+    ```bash
+    kubectl apply -f job-all.yaml
+    kubectl logs -l job-name=gateway-api-crd-install-all
+    ```
+    *Note: This option only updates CRDs that are already present in the cluster. It will not install new, missing CRDs.*
+
+#### Option C: Upgrade/Install Subset of CRDs
+To upgrade or install only specific CRDs (e.g., if you only use `Gateway` and `HTTPRoute`):
+1.  Edit `job-subset.yaml` to set `GATEWAY_API_VERSION`, `RELEASE_CHANNEL`, and `CRD_SUBSET`.
+2.  Run:
+    ```bash
+    kubectl apply -f job-subset.yaml
+    kubectl logs -l job-name=gateway-api-crd-install-subset
+    ```
+
+## Logic Details
+
+For every CRD processed, the installer script performs the following checks:
+
+1.  **Existence Check:** If the CRD does not exist in the cluster, it is installed immediately from the official upstream source.
+2.  **Channel Safety Check:** If the CRD exists, it checks the `gateway.networking.k8s.io/channel` label. If the installed channel does not match the requested `RELEASE_CHANNEL`, the script skips this CRD to avoid accidentally switching a cluster from Experimental to Standard (or vice-versa) potentially breaking fields.
+3.  **Upgrade Safety Check:** Automated upgrades are **only** supported for the `standard` channel. If `RELEASE_CHANNEL` is not `standard`, the job will exit with an error.
+4.  **Version Check:** It compares the requested `GATEWAY_API_VERSION` with the installed `gateway.networking.k8s.io/bundle-version` annotation.
+    *   If installed version < requested version: **UPGRADE**.
+    *   If installed version >= requested version: **SKIP** (already up-to-date).
+

--- a/pkg/upgrade/install.sh
+++ b/pkg/upgrade/install.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+set -e
+
+# Define all known Gateway API CRDs for --all and --list
+ALL_KNOWN_CRDS="gatewayclasses.gateway.networking.k8s.io gateways.gateway.networking.k8s.io httproutes.gateway.networking.k8s.io grpcroutes.gateway.networking.k8s.io referencegrants.gateway.networking.k8s.io tlsroutes.gateway.networking.k8s.io tcproutes.gateway.networking.k8s.io udproutes.gateway.networking.k8s.io backendtlspolicies.gateway.networking.k8s.io backendlbpolicies.gateway.networking.k8s.io"
+
+LIST_MODE=false
+ALL_MODE=false
+
+# Argument parsing
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -l|--list)
+      LIST_MODE=true
+      shift
+      ;;
+    -a|--all)
+      ALL_MODE=true
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [ "$LIST_MODE" = "true" ]; then
+  echo "Installed Gateway API CRDs:"
+  printf "%-50s %-20s %-20s\n" "CRD NAME" "VERSION" "CHANNEL"
+  for CRD in $ALL_KNOWN_CRDS; do
+    if kubectl get crd "$CRD" >/dev/null 2>&1; then
+      VER=$(kubectl get crd "$CRD" -o jsonpath='{.metadata.annotations.gateway\.networking\.k8s\.io/bundle-version}' 2>/dev/null || echo "Unknown")
+      CHAN=$(kubectl get crd "$CRD" -o jsonpath='{.metadata.annotations.gateway\.networking\.k8s\.io/channel}' 2>/dev/null || echo "Unknown")
+      printf "%-50s %-20s %-20s\n" "$CRD" "$VER" "$CHAN"
+    fi
+  done
+  exit 0
+fi
+
+if [ "$ALL_MODE" = "true" ]; then
+  echo "Fetching all installed Gateway API CRDs..."
+  # Fetch all CRDs that have the Gateway API suffix
+  INSTALLED_CRDS=$(kubectl get crds -o name | grep "gateway.networking.k8s.io" | cut -d/ -f2)
+  
+  if [ -z "$INSTALLED_CRDS" ]; then
+    echo "No Gateway API CRDs found in the cluster."
+    exit 0
+  fi
+  # Replace newlines with spaces for the loop
+  CRDS=$(echo "$INSTALLED_CRDS" | tr '\n' ' ')
+else
+  if [ -z "$CRD_SUBSET" ]; then
+    echo "Error: CRD_SUBSET environment variable is not set (and --all not used)."
+    exit 1
+  fi
+  # Split comma-separated CRD list.
+  CRDS=$(echo $CRD_SUBSET | tr "," " ")
+fi
+
+if [ -z "$GATEWAY_API_VERSION" ]; then
+  echo "Error: GATEWAY_API_VERSION environment variable is not set."
+  exit 1
+fi
+if [ -z "$RELEASE_CHANNEL" ]; then
+  echo "Error: RELEASE_CHANNEL environment variable is not set."
+  exit 1
+fi
+
+if [ "$RELEASE_CHANNEL" != "standard" ]; then
+  echo "Error: This installer only supports the 'standard' release channel. Target channel is '$RELEASE_CHANNEL'."
+  exit 1
+fi
+
+echo "Starting Gateway API CRD Installer"
+echo "Target Version: $GATEWAY_API_VERSION"
+echo "Target Channel: $RELEASE_CHANNEL"
+
+for CRD in $CRDS; do
+  echo "----------------------------------------------------------------"
+  echo "Processing CRD: $CRD"
+  
+  if kubectl get crd "$CRD" >/dev/null 2>&1; then
+    # Fetch annotations.
+    EXISTING_CHANNEL=$(kubectl get crd "$CRD" -o jsonpath='{.metadata.annotations.gateway\.networking\.k8s\.io/channel}' 2>/dev/null || true)
+    EXISTING_VERSION=$(kubectl get crd "$CRD" -o jsonpath='{.metadata.annotations.gateway\.networking\.k8s\.io/bundle-version}' 2>/dev/null || true)
+    
+    if [ -z "$EXISTING_CHANNEL" ] || [ -z "$EXISTING_VERSION" ]; then
+       echo "Warning: Existing CRD $CRD is missing standard Gateway API version/channel annotations. Proceeding with caution."
+    else
+       echo "Found installed CRD: $CRD"
+       echo "  Current Version: $EXISTING_VERSION"
+       echo "  Current Channel: $EXISTING_CHANNEL"
+       
+       if [ "$EXISTING_CHANNEL" != "$RELEASE_CHANNEL" ]; then
+          echo "Mismatch: Existing channel ($EXISTING_CHANNEL) != Target channel ($RELEASE_CHANNEL). Skipping."
+          continue
+       fi
+
+       # Compare versions
+       NEWER_VERSION=$(printf "%s\n%s" "$EXISTING_VERSION" "$GATEWAY_API_VERSION" | sort -V | tail -n1)
+       if [ "$NEWER_VERSION" = "$EXISTING_VERSION" ] && [ "$EXISTING_VERSION" != "$GATEWAY_API_VERSION" ]; then
+          echo "Skipping: Existing version $EXISTING_VERSION is newer than target $GATEWAY_API_VERSION."
+          continue
+       elif [ "$EXISTING_VERSION" = "$GATEWAY_API_VERSION" ]; then
+          echo "Skipping: Existing version $EXISTING_VERSION is already installed."
+          continue
+       fi
+       echo "Upgrading $CRD from $EXISTING_VERSION to $GATEWAY_API_VERSION..."
+    fi
+  else
+    echo "CRD $CRD not found. Proceeding to install."
+  fi
+
+  # Construct Raw GitHub URL
+  CRD_GROUP=$(echo "$CRD" | cut -d. -f2-)
+  CRD_PLURAL=$(echo "$CRD" | cut -d. -f1)
+  REPO_FILENAME="${CRD_GROUP}_${CRD_PLURAL}.yaml"
+  
+  URL="https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${GATEWAY_API_VERSION}/config/crd/${RELEASE_CHANNEL}/${REPO_FILENAME}"
+  
+  echo "Downloading manifest from: $URL"
+  if ! wget -qO /tmp/${CRD}.yaml "$URL"; then
+      echo "Error: Failed to download manifest for $CRD from $URL"
+      exit 1
+  fi
+
+  echo "Applying manifest for $CRD..."
+  if kubectl apply --server-side -f /tmp/${CRD}.yaml; then
+     INSTALLED_VERSION=$(kubectl get crd "$CRD" -o jsonpath='{.metadata.annotations.gateway\.networking\.k8s\.io/bundle-version}' 2>/dev/null || true)
+     echo "Success: $CRD successfully applied. New version: $INSTALLED_VERSION"
+  else
+     echo "Error: Failed to apply manifest for $CRD."
+     exit 1
+  fi
+done
+
+echo "----------------------------------------------------------------"
+echo "Gateway API CRD installation/upgrade process complete."⏎   

--- a/pkg/upgrade/job-all.yaml
+++ b/pkg/upgrade/job-all.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gateway-api-crd-install-all
+  namespace: default
+  labels:
+    app: gateway-api-crd-installer
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: gateway-api-crd-installer
+    spec:
+      serviceAccountName: gateway-api-crd-installer
+      restartPolicy: OnFailure
+      containers:
+      - name: installer
+        image: gateway-api-crd-installer:local
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "/scripts/install.sh", "-a"]
+        env:
+        - name: GATEWAY_API_VERSION
+          value: "v1.2.0"
+        - name: RELEASE_CHANNEL
+          value: "standard"

--- a/pkg/upgrade/job-list.yaml
+++ b/pkg/upgrade/job-list.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gateway-api-crd-list
+  namespace: default
+  labels:
+    app: gateway-api-crd-installer
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: gateway-api-crd-installer
+    spec:
+      serviceAccountName: gateway-api-crd-installer
+      restartPolicy: OnFailure
+      containers:
+      - name: lister
+        image: gateway-api-crd-installer:local
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "/scripts/install.sh", "-l"]

--- a/pkg/upgrade/job-subset.yaml
+++ b/pkg/upgrade/job-subset.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gateway-api-crd-install-subset
+  namespace: default
+  labels:
+    app: gateway-api-crd-installer
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: gateway-api-crd-installer
+    spec:
+      serviceAccountName: gateway-api-crd-installer
+      restartPolicy: OnFailure
+      containers:
+      - name: installer
+        image: gateway-api-crd-installer:local
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "/scripts/install.sh"]
+        env:
+        - name: GATEWAY_API_VERSION
+          value: "v1.2.0"
+        - name: RELEASE_CHANNEL
+          value: "standard"
+        - name: CRD_SUBSET
+          value: "gatewayclasses.gateway.networking.k8s.io"

--- a/pkg/upgrade/rbac.yaml
+++ b/pkg/upgrade/rbac.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-api-crd-installer
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gateway-api-crd-installer
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gateway-api-crd-installer
+subjects:
+- kind: ServiceAccount
+  name: gateway-api-crd-installer
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: gateway-api-crd-installer
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

This code provides a safe, automated mechanism to install and upgrade Gateway API Custom Resource Definitions (CRDs) using Kubernetes Jobs. It enforces a strict
  "standard-channel-only" policy to prevent accidental downgrades or channel conflicts (e.g., Experimental vs. Standard).

The solution offers three modes of operation:

1. List: Reports the version and channel of all currently installed Gateway API CRDs.
2. Upgrade Existing: Scans the cluster for installed CRDs and upgrades them if a newer version is requested.
3. Install/Upgrade Subset: Installs or upgrades a specific list of CRDs defined by the user.

More details and test log in this document: https://docs.google.com/document/d/1th_QTfO6I7t7l1EVe7yppwtwyDSVO34RSd9_FBsC9Z4/edit?usp=sharing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2678 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Gateway API CRD Installer: Safe CRD Upgrade Job

This release introduces a dedicated Kubernetes Job to safely manage the lifecycle of Gateway API CRDs. This tool addresses issues where bundling CRDs with Helm charts or other
  add-ons can lead to conflicts, downgrades, or unintended channel switching.

Key Features:
   * Safe Upgrades: Automatically upgrades CRDs to a target version only if the new version is strictly newer than the installed version.
   * Standard Channel Enforcement: Strictly enforces the standard release channel. Operations targeting experimental channels are blocked to prevent stability regressions.
   * Conflict Prevention: Detects and skips upgrades if a channel mismatch is found (e.g., attempting to upgrade a standard CRD with an experimental manifest).
   * Flexible Modes: Supports listing installed CRDs, upgrading all existing CRDs, or targeting a specific subset of CRDs for installation.

Usage: Users can build the provided Docker image and deploy the appropriate Job manifest (job-all.yaml, job-subset.yaml, or job-list.yaml) to perform the desired operation. See README.md for detailed instructions.

```
