### PR TITLE
conformance: add a conformance test for BackendTLSPolicy

### DIFF
--- a/conformance/tests/backendtlspolicy.go
+++ b/conformance/tests/backendtlspolicy.go
@@ -17,10 +17,14 @@ limitations under the License.
 package tests
 
 import (
+	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	h "sigs.k8s.io/gateway-api/conformance/utils/http"
@@ -152,5 +156,98 @@ var BackendTLSPolicy = suite.ConformanceTest{
 					},
 				})
 		})
+
+		// Verify that changing a ConfigMap content should be reconciled by the controller
+		t.Run("Changing the content of a ConfigMap used by BackendTLSPolicy as CA certificate should be reconciled by the controller", func(t *testing.T) {
+			ctx := t.Context()
+			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+			testPolicyNN := types.NamespacedName{Name: "reconcile-test", Namespace: ns}
+
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, testPolicyNN, gwNN, acceptedCond)
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, testPolicyNN, gwNN, resolvedRefsCond)
+
+			sharedCMNN := types.NamespacedName{Name: "tls-checks-ca-certificate", Namespace: ns}
+			sharedCM := &corev1.ConfigMap{}
+			err := suite.Client.Get(ctx, sharedCMNN, sharedCM)
+			require.NoError(t, err, "failed to get shared configmap")
+			originalCAData := sharedCM.Data["ca.crt"]
+
+			// Create test specific ConfigMap with copied CA data
+			testCMName := "tls-checks-ca-certificate-reconcile-test"
+			testCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testCMName,
+					Namespace: ns,
+				},
+				Data: map[string]string{
+					"ca.crt": originalCAData,
+				},
+			}
+
+			testCMNN := types.NamespacedName{Name: testCMName, Namespace: ns}
+
+			policy := &gatewayv1.BackendTLSPolicy{}
+			err = suite.Client.Get(ctx, testPolicyNN, policy)
+			require.NoError(t, err, "failed to get BackendTLSPolicy")
+			originalCACertRefs := policy.Spec.Validation.CACertificateRefs
+
+			updatedPolicy := policy.DeepCopy()
+			updatedPolicy.Spec.Validation.CACertificateRefs = []gatewayv1.LocalObjectReference{
+				{
+					Group: "",
+					Kind:  "ConfigMap",
+					Name:  gatewayv1.ObjectName(testCMName),
+				},
+			}
+			err = suite.Client.Patch(ctx, updatedPolicy, client.MergeFrom(policy))
+			require.NoError(t, err, "failed to update BackendTLSPolicy to use test-specific ConfigMap")
+
+			invalidAcceptedCond := metav1.Condition{
+				Type:   string(gatewayv1.PolicyConditionAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(gatewayv1.BackendTLSPolicyReasonNoValidCACertificate),
+			}
+			invalidResolvedRefsCond := metav1.Condition{
+				Type:   string(gatewayv1.BackendTLSPolicyConditionResolvedRefs),
+				Status: metav1.ConditionFalse,
+				Reason: string(gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef),
+			}
+
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, testPolicyNN, gwNN, invalidAcceptedCond)
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, testPolicyNN, gwNN, invalidResolvedRefsCond)
+			suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{testCM}, suite.Cleanup)
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, testPolicyNN, gwNN, acceptedCond)
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, testPolicyNN, gwNN, resolvedRefsCond)
+
+			patchConfigMapCACert(ctx, t, suite.Client, testCMNN, "")
+
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, testPolicyNN, gwNN, invalidAcceptedCond)
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, testPolicyNN, gwNN, invalidResolvedRefsCond)
+
+			patchConfigMapCACert(ctx, t, suite.Client, testCMNN, originalCAData)
+
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, testPolicyNN, gwNN, acceptedCond)
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, testPolicyNN, gwNN, resolvedRefsCond)
+
+			err = suite.Client.Get(ctx, testPolicyNN, policy)
+			require.NoError(t, err, "failed to get BackendTLSPolicy for cleanup")
+
+			restoredPolicy := policy.DeepCopy()
+			restoredPolicy.Spec.Validation.CACertificateRefs = originalCACertRefs
+			err = suite.Client.Patch(ctx, restoredPolicy, client.MergeFrom(policy))
+			require.NoError(t, err, "failed to restore BackendTLSPolicy to use shared ConfigMap")
+		})
 	},
+}
+
+func patchConfigMapCACert(ctx context.Context, t *testing.T, c client.Client, cmNN types.NamespacedName, caCertData string) {
+	t.Helper()
+	currentCM := &corev1.ConfigMap{}
+	err := c.Get(ctx, cmNN, currentCM)
+	require.NoError(t, err, "failed to get ConfigMap", "namespace", cmNN.Namespace, "name", cmNN.Name)
+
+	patchedCM := currentCM.DeepCopy()
+	patchedCM.Data["ca.crt"] = caCertData
+	err = c.Patch(ctx, patchedCM, client.MergeFrom(currentCM))
+	require.NoError(t, err, "failed to patch ConfigMap", "namespace", cmNN.Namespace, "name", cmNN.Name)
 }

--- a/conformance/tests/backendtlspolicy.yaml
+++ b/conformance/tests/backendtlspolicy.yaml
@@ -37,6 +37,16 @@ spec:
     - path:
         type: Exact
         value: /backendtlspolicy-cert-mismatch
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: backendtlspolicy-reconcile-test
+      port: 443
+    matches:
+    - path:
+        type: Exact
+        value: /backendtlspolicy-reconcile-test
+
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -104,6 +114,20 @@ spec:
     port: 443
     targetPort: 8443
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendtlspolicy-reconcile-test
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: tls-backend
+  ports:
+  - name: "btls"
+    protocol: TCP
+    port: 443
+    targetPort: 8443
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
@@ -163,3 +187,23 @@ spec:
       # It contains a random, unused CA certificate to force validation to fail.
       name: "mismatch-ca-certificate"
     hostname: "abc.example.com"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: reconcile-test
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: "backendtlspolicy-reconcile-test"
+    sectionName: "btls"
+  validation:
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      # This will point to a test-specific ConfigMap
+      name: "tls-checks-ca-certificate"
+    hostname: "abc.example.com"
+


### PR DESCRIPTION
Changing a ConfigMap content should be reconciled by the controller.

**What type of PR is this?**

/kind test
/area conformance-test

**What this PR does / why we need it**:

This PR adds a conformance test for BackendTLSPolicy so that when a ConfigMap contents are changed, it should be reconciled by the controller.

**Which issue(s) this PR fixes**:

Fixes #4338 

**Does this PR introduce a user-facing change?**:

```release-note
Adds a conformance test for BackendTLSPolicy so that when a ConfigMap contents are changed, it should be reconciled by the controller.
```
