### PR TITLE
test: AttachedRoutes conformance tests to count only Accepted routes

### DIFF
--- a/conformance/tests/gateway-with-attached-routes.go
+++ b/conformance/tests/gateway-with-attached-routes.go
@@ -91,6 +91,15 @@ var GatewayWithAttachedRoutes = suite.ConformanceTest{
 			}}
 
 			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
+
+			hrouteNA := types.NamespacedName{Name: "http-route-not-accepted", Namespace: "gateway-conformance-infra"}
+			notaccepted := metav1.Condition{
+				Type:   string(v1.RouteConditionAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(v1.RouteReasonNoMatchingListenerHostname),
+			}
+
+			kubernetes.HTTPRouteMustHaveCondition(t, s.Client, s.TimeoutConfig, hrouteNA, gwNN, notaccepted)
 		})
 
 		t.Run("Gateway listener should have AttachedRoutes set even when Gateway has unresolved refs", func(t *testing.T) {

--- a/conformance/tests/gateway-with-attached-routes.yaml
+++ b/conformance/tests/gateway-with-attached-routes.yaml
@@ -46,6 +46,7 @@ spec:
   - name: http
     port: 80
     protocol: HTTP
+    hostname: "foo.example.com"
     allowedRoutes:
       kinds:
       - kind: HTTPRoute
@@ -78,6 +79,24 @@ metadata:
   name: http-route-3
   namespace: gateway-conformance-infra
 spec:
+  parentRefs:
+  - kind: Gateway
+    name: gateway-with-two-attached-routes
+    namespace: gateway-conformance-infra
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-route-not-accepted
+  namespace: gateway-conformance-infra
+spec:
+  hostnames:
+  # mismatched hostname here (listener hostname is foo.example.com) triggers NoMatchingListenerHostname reason
+  - "not-accepted.test.com"
   parentRefs:
   - kind: Gateway
     name: gateway-with-two-attached-routes

--- a/conformance/tests/httproute-hostname-intersection.go
+++ b/conformance/tests/httproute-hostname-intersection.go
@@ -243,6 +243,74 @@ var HTTPRouteHostnameIntersection = suite.ConformanceTest{
 			}
 		})
 
+		t.Run("HTTPRoutes have to be counted in AttachedRoutes only if they are Accepted", func(t *testing.T) {
+			// HTTPRoute no-intersecting-hosts should not be attached to any of the listeners.
+			listeners := []v1.ListenerStatus{
+				{
+					Name: v1.SectionName("listener-1"),
+					SupportedKinds: []v1.RouteGroupKind{{
+						Group: (*v1.Group)(&v1.GroupVersion.Group),
+						Kind:  v1.Kind("HTTPRoute"),
+					}},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1.ListenerConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+						{
+							Type:   string(v1.ListenerConditionResolvedRefs),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+					},
+					AttachedRoutes: 2, // HTTPRoute specific-host-matches-listener-specific-host and wildcard-host-matches-listener-specific-host
+				},
+				{
+					Name: v1.SectionName("listener-2"),
+					SupportedKinds: []v1.RouteGroupKind{{
+						Group: (*v1.Group)(&v1.GroupVersion.Group),
+						Kind:  v1.Kind("HTTPRoute"),
+					}},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1.ListenerConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+						{
+							Type:   string(v1.ListenerConditionResolvedRefs),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+					},
+					AttachedRoutes: 1, // HTTPRoute wildcard-host-matches-listener-wildcard-host
+				},
+				{
+					Name: v1.SectionName("listener-3"),
+					SupportedKinds: []v1.RouteGroupKind{{
+						Group: (*v1.Group)(&v1.GroupVersion.Group),
+						Kind:  v1.Kind("HTTPRoute"),
+					}},
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(v1.ListenerConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+						{
+							Type:   string(v1.ListenerConditionResolvedRefs),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+					},
+					AttachedRoutes: 1, // HTTPRoute wildcard-host-matches-listener-wildcard-host
+				},
+			}
+
+			kubernetes.GatewayStatusMustHaveListeners(t, suite.Client, suite.TimeoutConfig, gwNN, listeners)
+		})
+
 		t.Run("HTTPRoutes intersects with an unspecified hostname listener", func(t *testing.T) {
 			routes := []types.NamespacedName{
 				{Namespace: ns, Name: "httproute-hostname-intersection-all"},


### PR DESCRIPTION
**What type of PR is this?**
/kind test

Optionally add one or more of the following kinds if applicable:
/area conformance-test


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #4341 


**Does this PR introduce a user-facing change?**:
```release-note
Add conformance test to check that only Accepted Routes are considered as attachedRoute on Gateway status
```
