### PR TITLE
chore: add sigs.k8s.io to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
       k8s.io: # Group k8s.io golang dependencies updates
           patterns:
             - "k8s.io/*"
+            - "sigs.k8s.io/*"
     labels:
       - go
       - dependencies
@@ -28,6 +29,7 @@ updates:
       k8s.io: # Group k8s.io golang dependencies updates
         patterns:
           - "k8s.io/*"
+          - "sigs.k8s.io/*"
     labels:
       - go
       - dependencies


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:
Fix dependabot config to also group sigs.k8s.io dependencies. This is a cherry-pick from @mikemorris commit for it, because I just saw it was not pointing to main :( 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
