### PR TITLE
Clarify at least 3 implementations must upload their report to appear

### DIFF
--- a/hack/mkdocs-generate-conformance.py
+++ b/hack/mkdocs-generate-conformance.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+###
+# Note: At least 3 implementations have to upload their report under a version folder in order for the table to be generated
+###
+
 import logging
 from io import StringIO
 from mkdocs import plugins

--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -79,7 +79,7 @@ other functions (like managing DNS or creating certificates).
 
 !!! info "Compare extended supported features across implementations"
 
-    [View a table to quickly compare supported features of projects](implementations/v1.4.md). These outline Gateway controller implementations that have passed core conformance tests, and focus on extended conformance features that they have implemented.
+    [View a table to quickly compare supported features of projects](implementations/v1.4.md). These outline Gateway controller implementations that have passed core conformance tests, and focus on extended conformance features that they have implemented. These tables will be generated and uploaded to the site once at least 3 implementations have uploaded their conformance reports under the [conformance reports](https://github.com/kubernetes-sigs/gateway-api/tree/main/conformance/reports).
 
 ## Gateway Controller Implementation Status <a name="gateways"></a>
 


### PR DESCRIPTION
Adding into the docs that _at least_ 3 conformance reports must be uploaded in a version folder in order for a table to be generated. Also in a comment in the `mkdocs_generate_conformance.py`

**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
