### PR TITLE
Bump golangci-lint to the latest version (v2)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,79 +1,115 @@
+version: "2"
 run:
-  timeout: 10m
+  modules-download-mode: readonly
   issues-exit-code: 1
   tests: true
-  modules-download-mode: readonly
   allow-parallel-runners: false
-
 linters:
-  fast: false
   enable:
-  - errcheck
-  - copyloopvar
-  - gocritic
-  - gofumpt
-  - goimports
-  - gomodguard
-  - gosec
-  - govet
-  - misspell
-  - revive
-  - unconvert
-  - unparam
-  - unused
-  - whitespace
-  disable-all: false
-  presets:
-  - bugs
-  - unused
-
-# all available settings of specific linters
-linters-settings:
-  gofmt:
-    # simplify code: gofmt with `-s` option, true by default
-    simplify: true
-  goimports:
-    local-prefixes: sigs.k8s.io/gateway-api
-  govet:
-    enable:
-      - shadow
-    settings:
-      shadow:
-        # Whether to be strict about shadowing; can be noisy.
-        strict: false
-  misspell:
-    locale: US
-    ignore-words: []
-  gomodguard:
-    blocked:
-    # List of blocked modules.
-      modules:
-        - io/ioutil:
-            recommendations:
-              - io
-              - os
-            reason: "Deprecation of package ioutil in Go 1.16."
-
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - copyloopvar
+    - durationcheck
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - gocritic
+    - gomodguard
+    - gosec
+    - gosmopolitan
+    - loggercheck
+    - makezero
+    - misspell
+    - musttag
+    - nilerr
+    - nilnesserr
+    - noctx
+    - protogetter
+    - reassign
+    - recvcheck
+    - revive
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
+    - testifylint
+    - unconvert
+    - unparam
+    - whitespace
+    - zerologlint
+  # all available settings of specific linters
+  settings:
+    gomodguard:
+      blocked:
+        # List of blocked modules.
+        modules:
+          - io/ioutil:
+              recommendations:
+                - io
+                - os
+              reason: Deprecation of package ioutil in Go 1.16.
+    govet:
+      enable:
+        - shadow
+      settings:
+        shadow:
+          # Whether to be strict about shadowing; can be noisy.
+          strict: false
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # Exclude some linters from running on tests files.
+      - linters:
+          - dupl
+          - errcheck
+          - gocyclo
+        path: _test\.go
+      # Too many false positives - for examples see: https://github.com/Antonboom/testifylint/issues/67
+      - linters:
+          - testifylint
+        text: require must only be used in the goroutine running the test function
+      - linters:
+          - testifylint
+        text: contains assertions that must only be used in the goroutine running the test function
+      # It is valid usage to wrap errors without using %w to not make them part of
+      # the API contract.
+      - linters:
+          - errorlint
+        text: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
+      - path: (.+)\.go$
+        text: Using the variable on range scope `tc` in function literal
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
-        - gocyclo
-        - errcheck
-        - dupl
-     # Too many false positives - for examples see: https://github.com/Antonboom/testifylint/issues/67
-    - linters:
-      - testifylint
-      text: "require must only be used in the goroutine running the test function"
-    - linters:
-      - testifylint
-      text: "contains assertions that must only be used in the goroutine running the test function"
-    # It is valid usage to wrap errors without using %w to not make them part of
-    # the API contract.
-    - linters: ["errorlint"]
-      text: "non-wrapping format verb for fmt.Errorf. Use `%w` to format errors"
-  exclude:
-    - Using the variable on range scope `tc` in function literal
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofmt:
+      # simplify code: gofmt with `-s` option, true by default
+      simplify: true
+    goimports:
+      local-prefixes:
+        - sigs.k8s.io/gateway-api
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/apis/v1/gateway_types.go
+++ b/apis/v1/gateway_types.go
@@ -1324,6 +1324,7 @@ const (
 	//
 	// Note: This condition is not really "deprecated", but rather "reserved"; however, deprecated triggers Go linters
 	// to alert about usage.
+	//
 	// Deprecated: Ready is reserved for future use
 	GatewayConditionReady GatewayConditionType = "Ready"
 

--- a/conformance/echo-basic/echo-basic_test.go
+++ b/conformance/echo-basic/echo-basic_test.go
@@ -171,8 +171,8 @@ func TestEchoHandler(t *testing.T) {
 
 	// Test RequestAssertions struct contains expected context namespace
 	expectedNamespace := context.Namespace
-	if responseAssertions.Context.Namespace != expectedNamespace {
-		t.Errorf("Expected X-Content-Type-Options header %s, but got %s", expectedNamespace, responseAssertions.Context.Namespace)
+	if responseAssertions.Namespace != expectedNamespace {
+		t.Errorf("Expected X-Content-Type-Options header %s, but got %s", expectedNamespace, responseAssertions.Namespace)
 	}
 }
 

--- a/conformance/echo-basic/grpc/grpcechoserver_test.go
+++ b/conformance/echo-basic/grpc/grpcechoserver_test.go
@@ -69,7 +69,7 @@ func clientAndServer(t *testing.T) (pb.GrpcEchoClient, serverConfig, string) {
 		HTTPPort:   ServerHTTPPort,
 		PodContext: podContext,
 	}
-	httpPort, _ := runServer(config)
+	httpPort, _ := runServer(t.Context(), config)
 
 	dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 

--- a/conformance/tests/httproute-request-percentage-mirror.go
+++ b/conformance/tests/httproute-request-percentage-mirror.go
@@ -145,8 +145,7 @@ var HTTPRouteRequestPercentageMirror = suite.ConformanceTest{
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expected)
 
 				// Override to not have more requests than expected
-				var dedicatedTimeoutConfig config.TimeoutConfig
-				dedicatedTimeoutConfig = suite.TimeoutConfig
+				dedicatedTimeoutConfig := suite.TimeoutConfig
 				dedicatedTimeoutConfig.RequiredConsecutiveSuccesses = 1
 				// used to limit number of parallel go routines
 				semaphore := make(chan struct{}, concurrentRequests)
@@ -225,7 +224,7 @@ func testMirroredRequestsDistribution(t *testing.T, suite *suite.ConformanceTest
 		tlog.Logf(t, "Pod: %s, Expected: %f (min: %f, max: %f), Actual: %f", mirrorPod.Name, expected, minExpected, maxExpected, actual)
 
 		if actual < minExpected || actual > maxExpected {
-			errs = append(errs, fmt.Errorf("Pod %s did not meet the mirroring percentage within tolerance. Expected between %f and %f, but got %f", mirrorPod.Name, minExpected, maxExpected, actual))
+			errs = append(errs, fmt.Errorf("pod %s did not meet the mirroring percentage within tolerance. Expected between %f and %f, but got %f", mirrorPod.Name, minExpected, maxExpected, actual))
 		}
 	}
 	if len(errs) > 0 {

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -242,7 +242,7 @@ func AwaitConvergence(t *testing.T, threshold int, maxTimeToConsistency time.Dur
 		default:
 		}
 
-		completed := fn(time.Now().Sub(start))
+		completed := fn(time.Since(start))
 		attempts++
 		if completed {
 			successes++

--- a/conformance/utils/http/mirror.go
+++ b/conformance/utils/http/mirror.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package http
+package http //nolint:revive
 
 import (
 	"fmt"

--- a/conformance/utils/kubernetes/apply_test.go
+++ b/conformance/utils/kubernetes/apply_test.go
@@ -179,7 +179,7 @@ spec:
 			resources, err := tc.applier.prepareResources(t, decoder)
 
 			require.NoError(t, err, "unexpected error preparing resources")
-			require.EqualValues(t, tc.expected, resources)
+			require.Equal(t, tc.expected, resources)
 		})
 	}
 }

--- a/conformance/utils/kubernetes/helpers_test.go
+++ b/conformance/utils/kubernetes/helpers_test.go
@@ -68,7 +68,7 @@ func TestNewGatewayRef(t *testing.T) {
 			require.IsType(t, GatewayRef{}, ref)
 			if test.listenerNames == nil {
 				require.Len(t, ref.listenerNames, 1)
-				assert.Equal(t, "", string(*ref.listenerNames[0]))
+				assert.Empty(t, string(*ref.listenerNames[0]))
 			} else {
 				require.Len(t, ref.listenerNames, len(test.listenerNames))
 				for i := 0; i < len(ref.listenerNames); i++ {

--- a/conformance/utils/suite/reports.go
+++ b/conformance/utils/suite/reports.go
@@ -66,9 +66,9 @@ func (p profileReportsMap) addTestResults(conformanceProfile ConformanceProfile,
 			if report.Extended == nil {
 				report.Extended = &confv1.ExtendedStatus{}
 			}
-			report.Extended.Statistics.Passed++
+			report.Extended.Passed++
 		} else {
-			report.Core.Statistics.Passed++
+			report.Core.Passed++
 		}
 	case testFailed:
 		if testIsExtended {
@@ -76,9 +76,9 @@ func (p profileReportsMap) addTestResults(conformanceProfile ConformanceProfile,
 				report.Extended = &confv1.ExtendedStatus{}
 			}
 			report.Extended.FailedTests = append(report.Extended.FailedTests, result.test.ShortName)
-			report.Extended.Statistics.Failed++
+			report.Extended.Failed++
 		} else {
-			report.Core.Statistics.Failed++
+			report.Core.Failed++
 			if report.Core.FailedTests == nil {
 				report.Core.FailedTests = []string{}
 			}
@@ -89,10 +89,10 @@ func (p profileReportsMap) addTestResults(conformanceProfile ConformanceProfile,
 			if report.Extended == nil {
 				report.Extended = &confv1.ExtendedStatus{}
 			}
-			report.Extended.Statistics.Skipped++
+			report.Extended.Skipped++
 			report.Extended.SkippedTests = append(report.Extended.SkippedTests, result.test.ShortName)
 		} else {
-			report.Core.Statistics.Skipped++
+			report.Core.Skipped++
 			report.Core.SkippedTests = append(report.Core.SkippedTests, result.test.ShortName)
 		}
 	}
@@ -196,9 +196,9 @@ func buildReportSummary(status confv1.Status) string {
 	case confv1.Success:
 		message = "succeeded"
 	case confv1.Partial:
-		message = fmt.Sprintf("partially succeeded with %d test skips", status.Statistics.Skipped)
+		message = fmt.Sprintf("partially succeeded with %d test skips", status.Skipped)
 	case confv1.Failure:
-		message = fmt.Sprintf("failed with %d test failures", status.Statistics.Failed)
+		message = fmt.Sprintf("failed with %d test failures", status.Failed)
 	}
 	return message
 }

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly VERSION="v1.64.8"
+readonly VERSION="v2.7.2"
 readonly KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 cd "${KUBE_ROOT}"

--- a/pkg/utils/duration.go
+++ b/pkg/utils/duration.go
@@ -38,7 +38,7 @@ func ParseDuration(s string) (*time.Duration, error) {
 		See https://gateway-api.sigs.k8s.io/geps/gep-2257/ for more details.
 	*/
 	if !re.MatchString(s) {
-		return nil, errors.New("Invalid duration format")
+		return nil, errors.New("invalid duration format")
 	}
 	parsedTime, err := time.ParseDuration(s)
 	if err != nil {
@@ -72,17 +72,17 @@ func FormatDuration(duration time.Duration) (string, error) {
 
 	// check if a negative value
 	if duration < 0 {
-		return "", errors.New("Invalid duration format. Cannot have negative durations")
+		return "", errors.New("invalid duration format. Cannot have negative durations")
 	}
 	// check for the maximum value allowed to be expressed
 	if duration > maxDuration {
-		return "", errors.New("Invalid duration format. Duration larger than maximum expression allowed in GEP-2257")
+		return "", errors.New("invalid duration format. Duration larger than maximum expression allowed in GEP-2257")
 	}
 	// time.Duration allows for floating point ms, which is not allowed in GEP-2257
 	durationMicroseconds := duration.Microseconds()
 
 	if durationMicroseconds%1000 != 0 {
-		return "", errors.New("Cannot express sub-milliseconds precision in GEP-2257")
+		return "", errors.New("cannot express sub-milliseconds precision in GEP-2257")
 	}
 
 	output := ""

--- a/tests/crd/crd_test.go
+++ b/tests/crd/crd_test.go
@@ -146,7 +146,7 @@ func executeKubectlCommand(t *testing.T, kubectl, kubeconfig string, args []stri
 	cacheDir := filepath.Dir(kubeconfig)
 	args = append([]string{"--cache-dir", cacheDir}, args...)
 
-	cmd := exec.Command(kubectl, args...)
+	cmd := exec.CommandContext(t.Context(), kubectl, args...)
 	cmd.Env = []string{
 		fmt.Sprintf("KUBECONFIG=%s", kubeconfig),
 	}

--- a/tools/generator/main.go
+++ b/tools/generator/main.go
@@ -117,12 +117,12 @@ func main() {
 			crdRaw := parser.CustomResourceDefinitions[groupKind]
 
 			// Inline version of "addAttribution(&crdRaw)" ...
-			if crdRaw.ObjectMeta.Annotations == nil {
-				crdRaw.ObjectMeta.Annotations = map[string]string{}
+			if crdRaw.Annotations == nil {
+				crdRaw.Annotations = map[string]string{}
 			}
-			crdRaw.ObjectMeta.Annotations[consts.BundleVersionAnnotation] = bundleVersion
-			crdRaw.ObjectMeta.Annotations[consts.ChannelAnnotation] = channel
-			crdRaw.ObjectMeta.Annotations[apiext.KubeAPIApprovedAnnotation] = consts.ApprovalLink
+			crdRaw.Annotations[consts.BundleVersionAnnotation] = bundleVersion
+			crdRaw.Annotations[consts.ChannelAnnotation] = channel
+			crdRaw.Annotations[apiext.KubeAPIApprovedAnnotation] = consts.ApprovalLink
 
 			// Prevent the top level metadata for the CRD to be generated regardless of the intention in the arguments
 			crd.FixTopLevelMetadata(crdRaw)
@@ -160,7 +160,7 @@ func main() {
 
 func gatewayTweaksMap(channel string, props map[string]apiext.JSONSchemaProps) map[string]apiext.JSONSchemaProps {
 	for name := range props {
-		jsonProps, _ := props[name]
+		jsonProps := props[name]
 		p := gatewayTweaks(channel, name, jsonProps)
 		if p == nil {
 			delete(props, name)

--- a/tools/modelschema/main.go
+++ b/tools/modelschema/main.go
@@ -34,7 +34,7 @@ import (
 func main() {
 	err := output()
 	if err != nil {
-		os.Stderr.WriteString(fmt.Sprintf("Failed: %v", err))
+		fmt.Fprintf(os.Stderr, "Failed: %v", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind cleanup

**What this PR does / why we need it**:

In https://github.com/kubernetes-sigs/gateway-api/pull/4376 it is required to bump the minimum Go version to Go 1.25, and golangci-lint v1 does not support Go 1.25.

I used `golangci-lint migrate` to migrate the golangci-lint configuration and manually ported the comments from the existing configuration, as the migration tool removes comments. Some new errors were introduced by v2, but were easy to fix.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
