### PR TITLE
conformance: added tests for invalid backend TLS configuration

### DIFF
--- a/conformance/tests/gateway-invalid-tls-backend-configuration.go
+++ b/conformance/tests/gateway-invalid-tls-backend-configuration.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayInvalidTLSBackendConfiguration)
+}
+
+var GatewayInvalidTLSBackendConfiguration = suite.ConformanceTest{
+	ShortName:   "GatewayInvalidTLSBackendConfiguration",
+	Description: "A Gateway should have ResolvedRefs condition set false if the Gateway has an invalid backend TLS configuration",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportGatewayTLSBackendClientCertificate,
+		features.SupportHTTPRoute,
+		features.SupportBackendTLSPolicy,
+	},
+	Manifests: []string{"tests/gateway-invalid-tls-backend-configuration.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		testCases := []struct {
+			name                  string
+			gatewayNamespacedName types.NamespacedName
+			resolveRefsReason     gatewayv1.GatewayConditionReason
+		}{
+			{
+				name:                  "Nonexistent secret referenced as ClientCertificateRef in Gateway backend TLS configuration",
+				gatewayNamespacedName: types.NamespacedName{Name: "gateway-client-certificate-nonexistent-secret", Namespace: "gateway-conformance-infra"},
+				resolveRefsReason:     gatewayv1.GatewayReasonInvalidClientCertificateRef,
+			},
+			{
+				name:                  "Unsupported group resource referenced as ClientCertificateRef in Gateway backend TLS configuration",
+				gatewayNamespacedName: types.NamespacedName{Name: "gateway-client-certificate-unsupported-group", Namespace: "gateway-conformance-infra"},
+				resolveRefsReason:     gatewayv1.GatewayReasonInvalidClientCertificateRef,
+			},
+			{
+				name:                  "Unsupported kind resource referenced as ClientCertificateRef inGateway backend TLS configuration",
+				gatewayNamespacedName: types.NamespacedName{Name: "gateway-client-certificate-unsupported-kind", Namespace: "gateway-conformance-infra"},
+				resolveRefsReason:     gatewayv1.GatewayReasonInvalidClientCertificateRef,
+			},
+			{
+				name:                  "Malformed secret referenced as ClientCertificateRef in Gateway backend TLS configuration",
+				gatewayNamespacedName: types.NamespacedName{Name: "gateway-client-certificate-malformed-secret", Namespace: "gateway-conformance-infra"},
+				resolveRefsReason:     gatewayv1.GatewayReasonInvalidClientCertificateRef,
+			},
+			{
+				name:                  "Secret referenced from another namespace without any ReferenceGrant as ClientCertificateRef in Gateway backend TLS configuration",
+				gatewayNamespacedName: types.NamespacedName{Name: "gateway-client-certificate-missing-reference-grant", Namespace: "gateway-conformance-infra"},
+				resolveRefsReason:     gatewayv1.GatewayReasonRefNotPermitted,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, tc.gatewayNamespacedName)
+
+				kubernetes.GatewayMustHaveCondition(t, s.Client, s.TimeoutConfig, tc.gatewayNamespacedName, metav1.Condition{
+					Type:   string(gatewayv1.GatewayConditionResolvedRefs),
+					Status: metav1.ConditionFalse,
+					Reason: string(tc.resolveRefsReason),
+				})
+
+				kubernetes.GatewayMustHaveCondition(t, s.Client, s.TimeoutConfig, tc.gatewayNamespacedName, metav1.Condition{
+					Type:   string(gatewayv1.GatewayConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: string(gatewayv1.GatewayReasonAccepted),
+				})
+			})
+		}
+	},
+}

--- a/conformance/tests/gateway-invalid-tls-backend-configuration.yaml
+++ b/conformance/tests/gateway-invalid-tls-backend-configuration.yaml
@@ -1,0 +1,115 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-client-certificate-nonexistent-secret
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+  tls:
+    backend:
+      clientCertificateRef:
+        group: ""
+        kind: Secret
+        name: nonexistent-certificate
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-client-certificate-unsupported-group
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+  tls:
+    backend:
+      clientCertificateRef:
+        group: wrong.group.company.io
+        kind: Secret
+        name: tls-validity-checks-certificate
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-client-certificate-unsupported-kind
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+  tls:
+    backend:
+      clientCertificateRef:
+        group: ""
+        kind: WrongKind
+        name: tls-validity-checks-certificate
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-client-certificate-malformed-secret
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+  tls:
+    backend:
+      clientCertificateRef:
+        group: ""
+        kind: Secret
+        name: malformed-client-certificate
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: malformed-client-certificate
+  namespace: gateway-conformance-infra
+# this certificate is invalid because it does not contain the keys
+# named tls.crt and tls.key
+data: {}
+type: Opaque
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-client-certificate-missing-reference-grant
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+  tls:
+    backend:
+      clientCertificateRef:
+        group: ""
+        kind: Secret
+        name: certificate
+        namespace: gateway-conformance-web-backend

--- a/conformance/tests/gateway-tls-backend-client-certificate.go
+++ b/conformance/tests/gateway-tls-backend-client-certificate.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -53,6 +54,12 @@ var GatewayTLSBackendClientCertificate = suite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gatewayv1.HTTPRoute{}, false, routeNN)
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 		kubernetes.BackendTLSPolicyMustHaveAcceptedConditionTrue(t, suite.Client, suite.TimeoutConfig, policyNN, gwNN)
+
+		kubernetes.GatewayMustHaveCondition(t, suite.Client, suite.TimeoutConfig, gwNN, metav1.Condition{
+			Type:   string(gatewayv1.GatewayConditionResolvedRefs),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.GatewayReasonResolvedRefs),
+		})
 
 		t.Run("HTTP request sent to Service using TLS should succeed and the configured client certificate should be presented.", func(t *testing.T) {
 			expectedClientCert, _, err := GetTLSSecret(suite.Client, types.NamespacedName{Name: "tls-checks-client-certificate", Namespace: ns})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind test
/area conformance-test

**What this PR does / why we need it**:
This PR follows up on #4195 and #4123 by implementing conformance tests that validate the behavior of an invalid `ClientCertificateRef` and the `ResolvedRefs` condition on the `Gateway`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Added conformance tests for invalid backend TLS configurations and the Gateway ResolvedRefs condition
```
