### PR TITLE
Clarify gep-1713 language to make it clear ListenerSet to Gateway is 1:1

### DIFF
--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -47,7 +47,7 @@ The feature will be part of the experimental channel, which implementations can 
 
 ## API
 
-This proposal introduces a new `ListenerSet` resource that has the ability to attach a set of listeners to multiple parent `Gateways`.
+This proposal introduces a new `ListenerSet` resource that has the ability to attach a set of listeners to a parent `Gateway`.
 
 **Note**: While this API is experimental, its `Kind` will be `XListenerSet` and 
 once the API is gratuated to stable it will be renamed to `ListenerSet`.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Clarify ListenerSet GEP as there is contradicting statements. ListenerSet is meant to attach to one Gateway.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
