### PR TITLE
docs: rename rogue listener.routes per ffd6005

### DIFF
--- a/site-src/guides/multiple-ns.md
+++ b/site-src/guides/multiple-ns.md
@@ -119,7 +119,7 @@ Gateway because the  attachment constraint (Namespace label) was not met.
 Note that attachment constraints on the Gateway are not required, but they are
 a best-practice if operating a cluster with many different teams and
 Namespaces. In environments where all apps in a cluster have permission to
-attach to a Gateway then the `listeners[].routes` field does not have to be
+attach to a Gateway then the `listeners[].allowedRoutes` field does not have to be
 configured and all Routes can freely use the Gateway.
 
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
`listener.routes` was renamed to `listener.allowedRoutes` after #796 was merged in, and I believe this was an instance missed.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
