### PR TITLE
Add cloud-provider-kind conformance for 1.4.1

### DIFF
--- a/conformance/reports/v1.4.1/cloud-provider-kind/README.md
+++ b/conformance/reports/v1.4.1/cloud-provider-kind/README.md
@@ -1,0 +1,33 @@
+# Cloud Provider KIND
+
+## Table of Contents
+
+|API channel|Implementation version|Mode|Report|
+|-----------|----------------------|----|------|
+|standard|[v0.10.0]|default|[report](./standard-v0.10.0-default-report.yaml)|
+
+## Reproduce
+
+1. `[Install `cloud-provider-kind`](https://github.com/kubernetes-sigs/cloud-provider-kind/tree/v0.10.0?tab=readme-ov-file#install)
+
+2. [Run a `KIND` cluster](https://kind.sigs.k8s.io/docs/user/quick-start/)
+
+3. [Start the `cloud-provider-kind`](https://github.com/kubernetes-sigs/cloud-provider-kind/tree/v0.10.0?tab=readme-ov-file#gateway-api-support-alpha)
+
+4. Run the conformance tests:
+
+```sh
+go test -timeout 30m ./conformance -run TestConformance \
+  --report-output /tmp/report.yaml \
+  --organization=sigs.k8s.io \
+  --project=cloud-provider-kind \
+  --url=https://github.com/kubernetes-sigs/cloud-provider-kind \
+  --version=v0.10.0 \
+  --contact=https://github.com/kubernetes-sigs/cloud-provider-kind/issues/new \
+  --gateway-class=cloud-provider-kind \
+  --conformance-profiles GATEWAY-HTTP \
+  --all-features \
+  --allow-crds-mismatch \
+  --cleanup-base-resources=false \
+  --exempt-features=Mesh,BackendTLSPolicy
+```

--- a/conformance/reports/v1.4.1/cloud-provider-kind/standard-v0.10.0-default-report.yaml
+++ b/conformance/reports/v1.4.1/cloud-provider-kind/standard-v0.10.0-default-report.yaml
@@ -1,0 +1,89 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-01-05T16:40:26-03:00"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.4.1
+implementation:
+  contact:
+  - https://github.com/kubernetes-sigs/cloud-provider-kind/issues/new
+  organization: sigs.k8s.io
+  project: cloud-provider-kind
+  url: https://github.com/kubernetes-sigs/cloud-provider-kind
+  version: v0.10.0
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 33
+      Skipped: 0
+  extended:
+    failedTests:
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructure
+    - GatewayStaticAddresses
+    - HTTPRoute303Redirect
+    - HTTPRoute307Redirect
+    - HTTPRoute308Redirect
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendRequestHeaderModifier
+    - HTTPRouteCORSAllowCredentialsBehavior
+    - HTTPRouteMethodMatching
+    - HTTPRouteRedirectPath
+    - HTTPRouteRedirectPort
+    - HTTPRouteRedirectPortAndScheme
+    - HTTPRouteRedirectScheme
+    - HTTPRouteRequestHeaderModifierBackendWeights
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestPercentageMirror
+    - HTTPRouteResponseHeaderModifier
+    - HTTPRouteRewriteHost
+    - HTTPRouteRewritePath
+    - HTTPRouteTimeoutBackendRequest
+    - HTTPRouteTimeoutRequest
+    result: failure
+    statistics:
+      Failed: 24
+      Passed: 7
+      Skipped: 0
+    supportedFeatures:
+    - BackendTLSPolicySANValidation
+    - GatewayAddressEmpty
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructurePropagation
+    - GatewayPort8080
+    - GatewayStaticAddresses
+    - GatewayTLSBackendClientCertificate
+    - HTTPRoute303RedirectStatusCode
+    - HTTPRoute307RedirectStatusCode
+    - HTTPRoute308RedirectStatusCode
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteCORS
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRouteNamedRouteRule
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRedirect
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestPercentageMirror
+    - HTTPRouteRequestTimeout
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    unsupportedFeatures:
+    - BackendTLSPolicy
+  name: GATEWAY-HTTP
+  summary: Core tests succeeded. Extended tests failed with 24 test failures.
+succeededProvisionalTests:
+- GatewayOptionalAddressValue
+- HTTPRouteNamedRule


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Adds conformance test for cloud-provider-kind v0.10.0 and GW API 1.4.1


**Which issue(s) this PR fixes**:
Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
