### PR TITLE
Bump tested Kubernetes versions to 1.35

### DIFF
--- a/.github/workflows/crd-validation.yml
+++ b/.github/workflows/crd-validation.yml
@@ -15,7 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         # Available versions at https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/HEAD/envtest-releases.yaml
-        k8s_version: [v1.34.0, v1.33.0, v1.32.0, v1.31.0, v1.30.3]
+        # Our goal is to cover the most recent 5 minor versions, even if the oldest one is EOL.
+        k8s_version: [v1.35.0, v1.34.1, v1.33.0, v1.32.0, v1.31.0]
         crd_channel: [standard, experimental]
     steps:
       - name: Checkout code

--- a/tests/cel/gateway_experimental_test.go
+++ b/tests/cel/gateway_experimental_test.go
@@ -98,7 +98,7 @@ func TestGatewayInfrastructureLabels(t *testing.T) {
 			labels: map[gatewayv1.LabelKey]gatewayv1.LabelValue{
 				"key": gatewayv1.LabelValue(strings.Repeat("a", 64)),
 			},
-			wantErrors: []string{"Too long: may not be longer than 63"},
+			wantErrors: []string{"Too long: may not be more than 63"},
 		},
 		{
 			name: "invalid label value with invalid characters",

--- a/tests/cel/gateway_test.go
+++ b/tests/cel/gateway_test.go
@@ -558,7 +558,7 @@ func TestValidateGateway(t *testing.T) {
 					},
 				}
 			},
-			wantErrors: []string{"Invalid value: \"1.2.3.4:8080\": status.addresses[0].value in body must be of type ipv4"},
+			wantErrors: []string{"Invalid value: \"1.2.3.4:8080\": addresses[0].value in body must be of type ipv4"},
 		},
 		{
 			desc: "duplicate ip address or hostname",

--- a/tests/cel/httproute_experimental_test.go
+++ b/tests/cel/httproute_experimental_test.go
@@ -476,7 +476,7 @@ func TestHTTPRouteTimeouts(t *testing.T) {
 		},
 		{
 			name:       "invalid timeout request 200ms less than backendRequest 1s",
-			wantErrors: []string{"Invalid value: \"object\": backendRequest timeout cannot be longer than request timeout"},
+			wantErrors: []string{"backendRequest timeout cannot be longer than request timeout"},
 			rules: []gatewayv1.HTTPRouteRule{
 				{
 					Timeouts: &gatewayv1.HTTPRouteTimeouts{

--- a/tests/cel/httproute_test.go
+++ b/tests/cel/httproute_test.go
@@ -74,7 +74,7 @@ func TestHTTPPathMatch(t *testing.T) {
 		},
 		{
 			name:       "invalid type",
-			wantErrors: []string{"must be one of ['Exact', 'PathPrefix', 'RegularExpression']"},
+			wantErrors: []string{"supported values: \"Exact\", \"PathPrefix\", \"RegularExpression\""},
 			path: &gatewayv1.HTTPPathMatch{
 				Type:  ptrTo(gatewayv1.PathMatchType("FooBar")),
 				Value: ptrTo("/path"),

--- a/tests/cel/main_test.go
+++ b/tests/cel/main_test.go
@@ -114,29 +114,8 @@ func ptrTo[T any](a T) *T {
 }
 
 func celErrorStringMatches(got, want string) bool {
-	gotL := strings.ToLower(got)
-	wantL := strings.ToLower(want)
-
 	// Starting in k8s v1.32, some CEL error messages changed to use "more" instead of "longer"
-	alternativeWantL := strings.ReplaceAll(wantL, "longer", "more")
+	alternativeWant := strings.ReplaceAll(want, "more", "longer")
 
-	// Starting in k8s v1.28, CEL error messages stopped adding spec and status prefixes to path names
-	wantLAdjusted := strings.ReplaceAll(wantL, "spec.", "")
-	wantLAdjusted = strings.ReplaceAll(wantLAdjusted, "status.", "")
-	alternativeWantL = strings.ReplaceAll(alternativeWantL, "spec.", "")
-	alternativeWantL = strings.ReplaceAll(alternativeWantL, "status.", "")
-
-	// Enum validation messages changed in k8s v1.28:
-	// Before: must be one of ['Exact', 'PathPrefix', 'RegularExpression']
-	// After: supported values: "Exact", "PathPrefix", "RegularExpression"
-	if strings.Contains(wantLAdjusted, "must be one of") {
-		r := strings.NewReplacer(
-			"must be one of", "supported values:",
-			"[", "",
-			"]", "",
-			"'", "\"",
-		)
-		wantLAdjusted = r.Replace(wantLAdjusted)
-	}
-	return strings.Contains(gotL, wantL) || strings.Contains(gotL, wantLAdjusted) || strings.Contains(gotL, alternativeWantL)
+	return strings.Contains(got, want) || strings.Contains(got, alternativeWant)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind test

**What this PR does / why we need it**:

Motivated by https://github.com/kubernetes-sigs/gateway-api/pull/4376#discussion_r2661907581. Adding tests on envtest 1.35.0 requires some minor changes, as error messages have been improved in K8s 1.35. I made an attempt to use pattern-based matching, ref. https://github.com/kubernetes-sigs/gateway-api/pull/4376#discussion_r2664038666, but I don't think it's worth the effort. Quite a few assert error messages contain text that needs to be escaped if using regex. So I went for the simplest solution with minimal changes.

Removed testing for Kubernetes versions that are EOL now. And cleaned up obsolete workarounds in the CEL error assert helper.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
