### PR TITLE
Update HTTPRoute timeouts channel information

### DIFF
--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -237,9 +237,9 @@ on `weight` and other fields.
 
 #### Timeouts (optional)
 
-??? example "Experimental Channel since v1.0.0"
+??? success "Standard Channel since v1.2.0"
 
-    HTTPRoute timeouts have been part of the Experimental Channel since `v1.0.0`.
+    HTTPRoute timeouts have been part of the Standard Channel since `v1.2.0`.
     For more information on release channels, refer to our
     [versioning guide](../concepts/versioning.md).
 


### PR DESCRIPTION
Updated the documentation to reflect that HTTPRoute timeouts are now part of the Standard Channel since v1.2.0.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
Add one of the following kinds:
/kind documentation


**What this PR does / why we need it**:
Timeouts feature in HTTPRoutes were moved to Standard channel in version 1.2.0: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.2.0
Fixed docs to reflect that.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
