### PR TITLE
Revise GEP-1713: Allow only static ports for ListenerSets

### DIFF
--- a/apisx/v1alpha1/shared_types.go
+++ b/apisx/v1alpha1/shared_types.go
@@ -37,22 +37,8 @@ type (
 	SessionPersistence         = v1.SessionPersistence
 )
 
-// PortNumberWith0 defines a network port that allows 0 to indicate dynamic
-// port assignment. This type should only be used in spec fields where port 0
-// has the special meaning of "auto-assign a port". In most cases,
-// StatusPortNumber (which excludes 0) should be preferred.
-//
-// +kubebuilder:validation:Minimum=0
-// +kubebuilder:validation:Maximum=65535
-type PortNumberWith0 int32
-
-// StatusPortNumber defines a network port in status fields.
-// Unlike PortNumberWith0, this does not allow 0 since status fields
-// reflect actual assigned ports.
-//
-// +kubebuilder:validation:Minimum=1
-// +kubebuilder:validation:Maximum=65535
-type StatusPortNumber int32
+// PortNumber defines a network port.
+type PortNumber int32
 
 // ParentGatewayReference identifies an API object including its namespace,
 // defaulting to Gateway.

--- a/apisx/v1alpha1/xlistenerset_types.go
+++ b/apisx/v1alpha1/xlistenerset_types.go
@@ -160,15 +160,11 @@ type ListenerEntry struct {
 	// Port is the network port. Multiple listeners may use the
 	// same port, subject to the Listener compatibility rules.
 	//
-	// If the port is not set or specified as zero, the implementation will assign
-	// a unique port. If the implementation does not support dynamic port
-	// assignment, it MUST set `Accepted` condition to `False` with the
-	// `UnsupportedPort` reason.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
 	//
-	// +optional
-	//
-	// +kubebuilder:default=0
-	Port PortNumberWith0 `json:"port,omitempty"`
+	// +required
+	Port PortNumber `json:"port"`
 
 	// Protocol specifies the network protocol this listener expects to receive.
 	// +required
@@ -249,11 +245,6 @@ type ListenerEntryStatus struct {
 	// Name is the name of the Listener that this status corresponds to.
 	// +required
 	Name SectionName `json:"name"`
-
-	// Port is the network port the listener is configured to listen on.
-	//
-	// +required
-	Port StatusPortNumber `json:"port"`
 
 	// SupportedKinds is the list indicating the Kinds supported by this
 	// listener. This MUST represent the kinds supported by an implementation for

--- a/applyconfiguration/apisx/v1alpha1/listenerentry.go
+++ b/applyconfiguration/apisx/v1alpha1/listenerentry.go
@@ -61,12 +61,7 @@ type ListenerEntryApplyConfiguration struct {
 	Hostname *v1.Hostname `json:"hostname,omitempty"`
 	// Port is the network port. Multiple listeners may use the
 	// same port, subject to the Listener compatibility rules.
-	//
-	// If the port is not set or specified as zero, the implementation will assign
-	// a unique port. If the implementation does not support dynamic port
-	// assignment, it MUST set `Accepted` condition to `False` with the
-	// `UnsupportedPort` reason.
-	Port *apisxv1alpha1.PortNumberWith0 `json:"port,omitempty"`
+	Port *apisxv1alpha1.PortNumber `json:"port,omitempty"`
 	// Protocol specifies the network protocol this listener expects to receive.
 	Protocol *v1.ProtocolType `json:"protocol,omitempty"`
 	// TLS is the TLS configuration for the Listener. This field is required if
@@ -129,7 +124,7 @@ func (b *ListenerEntryApplyConfiguration) WithHostname(value v1.Hostname) *Liste
 // WithPort sets the Port field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Port field is set to the value of the last call.
-func (b *ListenerEntryApplyConfiguration) WithPort(value apisxv1alpha1.PortNumberWith0) *ListenerEntryApplyConfiguration {
+func (b *ListenerEntryApplyConfiguration) WithPort(value apisxv1alpha1.PortNumber) *ListenerEntryApplyConfiguration {
 	b.Port = &value
 	return b
 }

--- a/applyconfiguration/apisx/v1alpha1/listenerentrystatus.go
+++ b/applyconfiguration/apisx/v1alpha1/listenerentrystatus.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
-	apisxv1alpha1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
 	apisv1 "sigs.k8s.io/gateway-api/applyconfiguration/apis/v1"
 )
 
@@ -32,8 +31,6 @@ import (
 type ListenerEntryStatusApplyConfiguration struct {
 	// Name is the name of the Listener that this status corresponds to.
 	Name *v1.SectionName `json:"name,omitempty"`
-	// Port is the network port the listener is configured to listen on.
-	Port *apisxv1alpha1.StatusPortNumber `json:"port,omitempty"`
 	// SupportedKinds is the list indicating the Kinds supported by this
 	// listener. This MUST represent the kinds supported by an implementation for
 	// that Listener configuration.
@@ -80,14 +77,6 @@ func ListenerEntryStatus() *ListenerEntryStatusApplyConfiguration {
 // If called multiple times, the Name field is set to the value of the last call.
 func (b *ListenerEntryStatusApplyConfiguration) WithName(value v1.SectionName) *ListenerEntryStatusApplyConfiguration {
 	b.Name = &value
-	return b
-}
-
-// WithPort sets the Port field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the Port field is set to the value of the last call.
-func (b *ListenerEntryStatusApplyConfiguration) WithPort(value apisxv1alpha1.StatusPortNumber) *ListenerEntryStatusApplyConfiguration {
-	b.Port = &value
 	return b
 }
 

--- a/applyconfiguration/internal/internal.go
+++ b/applyconfiguration/internal/internal.go
@@ -1936,6 +1936,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: port
       type:
         scalar: numeric
+      default: 0
     - name: protocol
       type:
         scalar: string
@@ -1962,10 +1963,6 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
-    - name: port
-      type:
-        scalar: numeric
-      default: 0
     - name: supportedKinds
       type:
         list:

--- a/config/crd/experimental/gateway.networking.x-k8s.io_xlistenersets.yaml
+++ b/config/crd/experimental/gateway.networking.x-k8s.io_xlistenersets.yaml
@@ -297,18 +297,12 @@ spec:
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     port:
-                      default: 0
                       description: |-
                         Port is the network port. Multiple listeners may use the
                         same port, subject to the Listener compatibility rules.
-
-                        If the port is not set or specified as zero, the implementation will assign
-                        a unique port. If the implementation does not support dynamic port
-                        assignment, it MUST set `Accepted` condition to `False` with the
-                        `UnsupportedPort` reason.
                       format: int32
                       maximum: 65535
-                      minimum: 0
+                      minimum: 1
                       type: integer
                     protocol:
                       description: Protocol specifies the network protocol this listener
@@ -460,6 +454,7 @@ spec:
                           > 0 || size(self.options) > 0 : true'
                   required:
                   - name
+                  - port
                   - protocol
                   type: object
                 maxItems: 64
@@ -723,13 +718,6 @@ spec:
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
-                    port:
-                      description: Port is the network port the listener is configured
-                        to listen on.
-                      format: int32
-                      maximum: 65535
-                      minimum: 1
-                      type: integer
                     supportedKinds:
                       description: |-
                         SupportedKinds is the list indicating the Kinds supported by this
@@ -767,7 +755,6 @@ spec:
                   - attachedRoutes
                   - conditions
                   - name
-                  - port
                   - supportedKinds
                   type: object
                 maxItems: 64

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -204,18 +204,11 @@ type ListenerEntry struct {
 	// Port is the network port. Multiple listeners may use the
 	// same port, subject to the Listener compatibility rules.
 	//
-	// If the port is not set, the implementation will assign
-	// a unique port. If the implementation does not support dynamic port
-	// assignment, it MUST set `Accepted` condition to `False` with the
-	// `UnsupportedPort` reason.
-	//
-	// Support: Core
-	//
-	// +optional
-	//
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
-	Port *PortNumber `json:"port,omitempty"`
+	//
+	// +required
+	Port PortNumber `json:"port"`
 
 	// Protocol specifies the network protocol this listener expects to receive.
 	//
@@ -435,11 +428,7 @@ spec:
 ```
 ### ListenerEntry
 
-`ListenerEntry` is currently a copy of the `Listener` struct with some changes noted in the below sections
-
-#### Port
-
-`Port` is now optional to allow for dynamic port assignment.  If the port is unspecified or set to zero, the implementation will assign a unique port. If the implementation does not support dynamic port assignment, it MUST set `Accepted` condition to `False` with the `UnsupportedPort` reason.
+`ListenerEntry` is currently a copy of the `Listener` struct.
 
 ## Semantics
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -8859,7 +8859,8 @@ func schema_sigsk8sio_gateway_api_apisx_v1alpha1_ListenerEntry(ref common.Refere
 					},
 					"port": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules.\n\nIf the port is not set or specified as zero, the implementation will assign a unique port. If the implementation does not support dynamic port assignment, it MUST set `Accepted` condition to `False` with the `UnsupportedPort` reason.",
+							Description: "Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -8885,7 +8886,7 @@ func schema_sigsk8sio_gateway_api_apisx_v1alpha1_ListenerEntry(ref common.Refere
 						},
 					},
 				},
-				Required: []string{"name", "protocol"},
+				Required: []string{"name", "port", "protocol"},
 			},
 		},
 		Dependencies: []string{
@@ -8906,14 +8907,6 @@ func schema_sigsk8sio_gateway_api_apisx_v1alpha1_ListenerEntryStatus(ref common.
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
-						},
-					},
-					"port": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Port is the network port the listener is configured to listen on.",
-							Default:     0,
-							Type:        []string{"integer"},
-							Format:      "int32",
 						},
 					},
 					"supportedKinds": {
@@ -8966,7 +8959,7 @@ func schema_sigsk8sio_gateway_api_apisx_v1alpha1_ListenerEntryStatus(ref common.
 						},
 					},
 				},
-				Required: []string{"name", "port", "supportedKinds", "attachedRoutes", "conditions"},
+				Required: []string{"name", "supportedKinds", "attachedRoutes", "conditions"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
Add one of the following kinds:
/kind gep


**What this PR does / why we need it**:
This PR allows only static ports for ListenerSets, as per the community meeting on 13 January 2026. Support for dynamic port allocation can be added in the future


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Allow only static port ports for listenerSets
```
