### PR TITLE
Remove TCPRoute support from TLS listeners

### DIFF
--- a/apis/v1alpha2/tlsroute_types.go
+++ b/apis/v1alpha2/tlsroute_types.go
@@ -29,9 +29,6 @@ import (
 // The TLSRoute resource is similar to TCPRoute, but can be configured
 // to match against TLS-specific metadata. This allows more flexibility
 // in matching streams for a given TLS listener.
-//
-// If you need to forward traffic to a single target for a TLS listener, you
-// could choose to use a TCPRoute with a TLS listener.
 type TLSRoute struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/applyconfiguration/apis/v1alpha2/tlsroute.go
+++ b/applyconfiguration/apis/v1alpha2/tlsroute.go
@@ -33,9 +33,6 @@ import (
 // The TLSRoute resource is similar to TCPRoute, but can be configured
 // to match against TLS-specific metadata. This allows more flexibility
 // in matching streams for a given TLS listener.
-//
-// If you need to forward traffic to a single target for a TLS listener, you
-// could choose to use a TCPRoute with a TLS listener.
 type TLSRouteApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -28,9 +28,6 @@ spec:
           The TLSRoute resource is similar to TCPRoute, but can be configured
           to match against TLS-specific metadata. This allows more flexibility
           in matching streams for a given TLS listener.
-
-          If you need to forward traffic to a single target for a TLS listener, you
-          could choose to use a TCPRoute with a TLS listener.
         properties:
           apiVersion:
             description: |-

--- a/geps/gep-2643/index.md
+++ b/geps/gep-2643/index.md
@@ -540,7 +540,7 @@ be at least one intersecting hostname for the `TLSRoute` to be attached to the
 | A Gateway with \*.example.tld on a TLS listener MUST allow a TLSRoute with hostname some.example.tld to be attached to it (and the same, but with a non wildcard hostname) <br/> Issue: [TLSRoute conformance] | TLSRoute MUST be able to attach to the Gateway using the matching hostname, a request MUST succeed | TLSRoute  |
 | Expose support for TLSRoute termination <br/> Issue: [Termination] | For a [Listener] setting mode: "terminate", TLSRoute MUST be present in [ListenerStatus.SupportedKinds] in case TLSRoute termination is supported | TLSRouteTermination |
 | Explicitly expose that TLSRoute termination is not supported. <br/> Issue: [Termination] | For a [Listener] setting mode: "terminate" and not being supported, the Listener entry MUST NOT be Accepted containing the condition `Accepted: False` and `Reason: UnsupportedValue`. | TLSRoute + !TLSRouteTermination |
-| Explicitly expose that tls listener accepts termination for TCPRoute only. | For a [Listener] setting mode: "terminate" that supports only `TCPRoute`, a Listener entry MUST exist but only TCPRoute MUST be present in [ListenerStatus.SupportedKinds]. | TLSRoute + !TLSRouteTermination |
+
 
 [Simple]: https://github.com/kubernetes-sigs/gateway-api/blob/edd7cbeac3ff1458c75ed21636af52ba1536b73a/conformance/tests/tlsroute-simple-same-namespace.go
 [ReferenceGrant]: https://github.com/kubernetes-sigs/gateway-api/blob/edd7cbeac3ff1458c75ed21636af52ba1536b73a/conformance/tests/tlsroute-invalid-reference-grant.go

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -7473,7 +7473,7 @@ func schema_sigsk8sio_gateway_api_apis_v1alpha2_TLSRoute(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "The TLSRoute resource is similar to TCPRoute, but can be configured to match against TLS-specific metadata. This allows more flexibility in matching streams for a given TLS listener.\n\nIf you need to forward traffic to a single target for a TLS listener, you could choose to use a TCPRoute with a TLS listener.",
+				Description: "The TLSRoute resource is similar to TCPRoute, but can be configured to match against TLS-specific metadata. This allows more flexibility in matching streams for a given TLS listener.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {

--- a/site-src/guides/tls.md
+++ b/site-src/guides/tls.md
@@ -35,7 +35,6 @@ For downstream connections, depending on the Listener Protocol, different TLS mo
 |-------------------|-------------|---------------------|
 | TLS               | Passthrough | TLSRoute            |
 | TLS               | Terminate   | TLSRoute (extended) |
-| TLS               | Terminate   | TCPRoute            |
 | HTTPS             | Terminate   | HTTPRoute           |
 | GRPC              | Terminate   | GRPCRoute           |
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Based on the discussion from Gateway API meeting on 14/Jan/2026, we are removing TCPRoute from TLS listeners, as the TLS listener discriminator is hostname/sni.

TCPRoutes are intended to be attached on a 1:1 relation between a listener port and a route, and we plan to address it again once TCPRoute is promoted


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Remove TCPRoute support from TLS listeners
```
