### PR TITLE
conformance: add TLSRoute termination feature exposure tests

### DIFF
--- a/apis/v1/gateway_types.go
+++ b/apis/v1/gateway_types.go
@@ -1507,6 +1507,7 @@ const (
 	// * "PortUnavailable"
 	// * "UnsupportedProtocol"
 	// * "NoValidCACertificate"
+	// * "UnsupportedValue"
 	//
 	// Possible reasons for this condition to be Unknown are:
 	//
@@ -1547,6 +1548,11 @@ const (
 	// Listener could not resolve the references to any CACertificate used
 	// to configure Gateway's Client Certificate Validation
 	ListenerReasonNoValidCACertificate ListenerConditionReason = "NoValidCACertificate"
+
+	// This reason is used with the "Accepted" condition when the
+	// Listener uses a value for a field that is not supported by the
+	// implementation
+	ListenerReasonUnsupportedValue ListenerConditionReason = "UnsupportedValue"
 )
 
 const (

--- a/conformance/tests/tlsroute-listener-terminate-not-supported.go
+++ b/conformance/tests/tlsroute-listener-terminate-not-supported.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, TLSRouteListenerTerminateNotSupported)
+}
+
+var TLSRouteListenerTerminateNotSupported = suite.ConformanceTest{
+	ShortName:   "TLSRouteListenerTerminateNotSupported",
+	Description: "When TLSRoute termination is NOT supported, a Gateway Listener with TLS mode Terminate MUST have Accepted=False with Reason=UnsupportedValue",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportTLSRoute,
+	},
+	Manifests: []string{"tests/tlsroute-listener-terminate-not-supported.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		if suite.SupportedFeatures.Has(features.SupportTLSRouteModeTerminate) {
+			return
+		}
+		gwNN := types.NamespacedName{Name: "gateway-tlsroute-terminate-unsupported", Namespace: "gateway-conformance-infra"}
+
+		t.Run("Listener with unsupported mode Terminate must have Accepted=False with Reason=UnsupportedValue", func(t *testing.T) {
+			listeners := []v1.ListenerStatus{
+				{
+					Name: v1.SectionName("tls-terminate"),
+					Conditions: []metav1.Condition{{
+						Type:   string(v1.ListenerConditionAccepted),
+						Status: metav1.ConditionFalse,
+						Reason: string(v1.ListenerReasonUnsupportedValue),
+					}},
+					AttachedRoutes: 0,
+				},
+			}
+			kubernetes.GatewayStatusMustHaveListeners(t, suite.Client, suite.TimeoutConfig, gwNN, listeners)
+		})
+	},
+}

--- a/conformance/tests/tlsroute-listener-terminate-not-supported.yaml
+++ b/conformance/tests/tlsroute-listener-terminate-not-supported.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tlsroute-terminate-unsupported
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: tls-terminate
+      port: 8443
+      protocol: TLS
+      hostname: terminate.example.com
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: tls-terminate-checks-certificate

--- a/conformance/tests/tlsroute-listener-terminate-supported-kinds.go
+++ b/conformance/tests/tlsroute-listener-terminate-supported-kinds.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, TLSRouteListenerTerminateSupportedKinds)
+}
+
+var TLSRouteListenerTerminateSupportedKinds = suite.ConformanceTest{
+	ShortName:   "TLSRouteListenerTerminateSupportedKinds",
+	Description: "A Gateway Listener with TLS mode Terminate MUST include TLSRoute in SupportedKinds when termination is supported",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportTLSRoute,
+		features.SupportTLSRouteModeTerminate,
+	},
+	Manifests: []string{"tests/tlsroute-listener-terminate-supported-kinds.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		gwNN := types.NamespacedName{Name: "gateway-tlsroute-terminate-supported", Namespace: "gateway-conformance-infra"}
+
+		t.Run("Listener with mode Terminate must have TLSRoute in SupportedKinds", func(t *testing.T) {
+			listeners := []v1.ListenerStatus{
+				{
+					Name: v1.SectionName("tls-terminate"),
+					SupportedKinds: []v1.RouteGroupKind{{
+						Group: (*v1.Group)(&v1.GroupVersion.Group),
+						Kind:  v1.Kind("TLSRoute"),
+					}},
+					Conditions: []metav1.Condition{{
+						Type:   string(v1.ListenerConditionAccepted),
+						Status: metav1.ConditionTrue,
+						Reason: string(v1.ListenerReasonAccepted),
+					}},
+					AttachedRoutes: 0,
+				},
+			}
+			kubernetes.GatewayStatusMustHaveListeners(t, suite.Client, suite.TimeoutConfig, gwNN, listeners)
+		})
+	},
+}

--- a/conformance/tests/tlsroute-listener-terminate-supported-kinds.yaml
+++ b/conformance/tests/tlsroute-listener-terminate-supported-kinds.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tlsroute-terminate-supported
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: tls-terminate
+      port: 8443
+      protocol: TLS
+      hostname: terminate.example.com
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: tls-terminate-checks-certificate


### PR DESCRIPTION
Adds tests to verify Gateway ListenerStatus correctly exposes TLSRoute termination support. Includes ExcludedFeatures field in ConformanceTest for negative feature testing and ListenerReasonUnsupportedValue constant.

**What type of PR is this?**
/kind test
/area conformance-test

**What this PR does / why we need it**:

Adds tests to verify Gateway ListenerStatus correctly exposes TLSRoute termination support. Includes ExcludedFeatures field in ConformanceTest for negative feature testing and ListenerReasonUnsupportedValue constant.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
