### PR TITLE
conformance: invalid client certificate validation

### DIFF
--- a/conformance/tests/gateway-with-invalid-clientcertificate-validation.go
+++ b/conformance/tests/gateway-with-invalid-clientcertificate-validation.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayInvalidFrontendClientCertificateValidation)
+}
+
+var GatewayInvalidFrontendClientCertificateValidation = suite.ConformanceTest{
+	ShortName:   "GatewayInvalidFrontendClientCertificateValidation",
+	Description: "Gateway's should reject invalid Client Certificate Validation Config",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportReferenceGrant,
+		features.SupportGatewayFrontendClientCertificateValidation,
+	},
+	Manifests: []string{"tests/gateway-with-invalid-clientcertificate-validation.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		// Validate that invalid configuration for Default and PerPort client certificate validation
+		// impacts only status of affected Listener.
+		t.Run("Validate status for invalid client certificate configuration", func(t *testing.T) {
+			gwNN := types.NamespacedName{Name: "gateway-with-invalid-client-cert-validation", Namespace: "gateway-conformance-infra"}
+			cases := []struct {
+				name               string
+				lName              string
+				expectedConditions []metav1.Condition
+			}{
+				{
+					name:  "default valid configuration",
+					lName: "https",
+					expectedConditions: []metav1.Condition{
+						{
+							Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+						{
+							Type:   string(gatewayv1.ListenerConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+						{
+							Type:   string(gatewayv1.ListenerConditionProgrammed),
+							Status: metav1.ConditionTrue,
+							Reason: "", // any reason
+						},
+					},
+				},
+				{
+					name:  "unresolved reference",
+					lName: "https-unresolved",
+					expectedConditions: []metav1.Condition{
+						{
+							Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+							Status: metav1.ConditionFalse,
+							Reason: string(gatewayv1.ListenerReasonInvalidCACertificateRef),
+						},
+						{
+							Type:   string(gatewayv1.ListenerConditionAccepted),
+							Status: metav1.ConditionFalse,
+							Reason: string(gatewayv1.ListenerReasonNoValidCACertificate),
+						},
+						{
+							Type:   string(gatewayv1.ListenerConditionProgrammed),
+							Status: metav1.ConditionFalse,
+							Reason: "", // any reason
+						},
+					},
+				},
+				{
+					name:  "invalid kind",
+					lName: "https-invalid-kind",
+					expectedConditions: []metav1.Condition{
+						{
+							Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+							Status: metav1.ConditionFalse,
+							Reason: string(gatewayv1.ListenerReasonInvalidCACertificateKind),
+						},
+						{
+							Type:   string(gatewayv1.ListenerConditionAccepted),
+							Status: metav1.ConditionFalse,
+							Reason: string(gatewayv1.ListenerReasonNoValidCACertificate),
+						},
+						{
+							Type:   string(gatewayv1.ListenerConditionProgrammed),
+							Status: metav1.ConditionFalse,
+							Reason: "", // any reason
+						},
+					},
+				},
+				{
+					name:  "reference grant missing",
+					lName: "https-grant-missing",
+					expectedConditions: []metav1.Condition{
+						{
+							Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+							Status: metav1.ConditionFalse,
+							Reason: string(gatewayv1.ListenerReasonRefNotPermitted),
+						},
+						{
+							Type:   string(gatewayv1.ListenerConditionAccepted),
+							Status: metav1.ConditionFalse,
+							Reason: string(gatewayv1.ListenerReasonNoValidCACertificate),
+						},
+						{
+							Type:   string(gatewayv1.ListenerConditionProgrammed),
+							Status: metav1.ConditionFalse,
+							Reason: "", // any reason
+						},
+					},
+				},
+			}
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					kubernetes.GatewayListenerMustHaveConditions(t, suite.Client, suite.TimeoutConfig, gwNN, tc.lName, tc.expectedConditions)
+				})
+			}
+		})
+	},
+}

--- a/conformance/tests/gateway-with-invalid-clientcertificate-validation.yaml
+++ b/conformance/tests/gateway-with-invalid-clientcertificate-validation.yaml
@@ -1,0 +1,105 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-with-invalid-client-cert-validation
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  tls:
+    frontend:
+      default:
+        validation:
+          caCertificateRefs:
+          - kind: ConfigMap
+            group: ""
+            name: tls-validity-checks-ca-certificate
+      perPort:
+      - port: 7443
+        tls:
+          validation:
+            caCertificateRefs:
+            - kind: ConfigMap
+              group: ""
+              name: non-exisitng-cm
+      - port: 8443
+        tls:
+          validation:
+            caCertificateRefs:
+            - kind: Service
+              group: ""
+              name: infra-backend-v2
+      - port: 6443
+        tls:
+          validation:
+            caCertificateRefs:
+            - kind: ConfigMap
+              group: ""
+              name: gateway-conformance-web-backend
+              namespace: web-backend-cm
+  listeners:
+  - name: https
+    port: 443
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: Same
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: tls-validity-checks-certificate
+        namespace: gateway-conformance-infra
+  - name: https-unresolved
+    port: 7443
+    hostname: first-example.org
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: Same
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: tls-validity-checks-certificate
+        namespace: gateway-conformance-infra
+  - name: https-invalid-kind
+    port: 8443
+    hostname: second-example.org
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: Same
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: tls-validity-checks-certificate
+        namespace: gateway-conformance-infra
+  - name: https-grant-missing
+    port: 6443
+    hostname: fourth-example.org
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: Same
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: tls-validity-checks-certificate
+        namespace: gateway-conformance-infra
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: misconfigured-client-certificate-validation-https-test
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: client-validation-invalid
+  hostnames:
+  - example.org
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -375,6 +375,8 @@ func (suite *ConformanceTestSuite) Setup(t *testing.T, tests []ConformanceTest) 
 		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{secret}, suite.Cleanup)
 		secret = kubernetes.MustCreateSelfSignedCertSecret(t, "gateway-conformance-infra", "tls-validity-checks-certificate", []string{"*", "*.org"})
 		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{secret}, suite.Cleanup)
+		configMap, _, _ := kubernetes.MustCreateCACertConfigMap(t, "gateway-conformance-web-backend", "web-backend-cm")
+		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{configMap}, suite.Cleanup)
 
 		// secrets for client certificates validation tests
 		caConfigMap, ca, caPrivKey := kubernetes.MustCreateCACertConfigMap(t, "gateway-conformance-infra", "tls-validity-checks-ca-certificate")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind test
/area conformance-test
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Relates to https://github.com/kubernetes-sigs/gateway-api/issues/4250

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
