### PR TITLE
Remove broken link from security guide

### DIFF
--- a/site-src/concepts/security.md
+++ b/site-src/concepts/security.md
@@ -310,8 +310,7 @@ spec:
 ReferenceGrant owners should ensure that the reference permissions being granted are as minimal as possible.
 
 * Specify `to` targets in all possible ways (`group`, `kind`, **and** `name`)  
-  * In particular, DO NOT leave `name` unspecified, even though it is optional, without a *very* good reason, as that is granting a blanket 
-
+* In particular, DO NOT leave `name` unspecified, even though it is optional, without a *very* good reason, as that is granting a blanket 
 
 ### Proper definition of Roles and RoleBinding
 
@@ -324,8 +323,6 @@ that reflect proper user permissions.
 
 Additionally, it is highly recommended that the strict permissions are given, not
 allowing regular users to modify a Gateway API status.
-
-For more information about the security model of Gateway API, check [Security Model](security-model.md)
 
 ### Usage and limit of GatewayClass
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
During the migration of security guide a leading broken link and some extra spaces were left behind. This PR fixes these mistakes

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
