### PR TITLE
fix redirect for the old security-model link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ plugins:
         'concepts/gamma.md': 'mesh/index.md'
         'concepts/service-facets.md': 'mesh/service-facets.md'
         'concepts/guidelines.md': 'guides/api-design.md'
+        'concepts/security-model.md': 'concepts/security.md'
         'contributing/community.md': 'contributing/index.md'
         'contributing/gamma.md': 'mesh/index.md#contributing'
         'reference/implementers-guide.md': 'guides/implementers.md'


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
When moving the security guide to a new location I didn't considered that some folks would be pointing to the old guide.

This PR fixes it, adding the proper redirection from the old link

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
