### PR TITLE
Gravitee Kubernetes Operator 4.10.3 conformance report for 1.4.0

### DIFF
--- a/conformance/reports/v1.4.0/gravitee/README.md
+++ b/conformance/reports/v1.4.0/gravitee/README.md
@@ -1,0 +1,67 @@
+# Gravitee
+
+## Table of Contents
+
+| API channel  | Implementation version                    | Mode    | Report                                                 |
+|--------------|-------------------------------------------|---------|--------------------------------------------------------|
+| standard     | [version-4.10.3](https://github.com/gravitee-io/gravitee-kubernetes-operator/releases/tag/4.10.3) | default | [version-4.10.3 report](./standard-4.10.3-default-report.yaml) |
+
+> The Gravitee Kubernetes Operator provides partial conformance for Gateway - HTTP features in version 4.10.3. It does not support matching rules across routes. These feature will be introduced in a future release.
+
+## Prerequisites
+
+The following binaries are assumed to be installed on your device
+  
+  - [docker](https://docs.docker.com/get-started/get-docker/)
+  - [kubectl](https://kubernetes.io/docs/tasks/tools/)
+  - [kind](https://github.com/kubernetes-sigs/kind)
+  - [go](https://go.dev/learn/)
+
+The reproducer has been tested on macOS and Linux only.
+
+## Reproducer
+
+1. Clone the Gravitee Kubernetes Operator repository
+
+```bash
+git clone --depth 1 --branch 4.10.3 https://github.com/gravitee-io/gravitee-kubernetes-operator.git
+```
+
+2. Start the Kubernetes cluster
+
+```bash
+make start-conformance-cluster
+```
+
+3. Run a local Load Balancer Service
+
+> The make target runs [cloud-provider-kind](https://kind.sigs.k8s.io/docs/user/loadbalancer). If you are reproducing on a macOS device, the binary requires `sudo` privileges and you will be prompted for a password. For Linux devices, cloud-provider-kind will be run using Docker compose.
+
+```bash
+make cloud-lb
+```
+
+4. Run the operator
+
+```bash
+make run
+```
+
+5. Install the Gravitee GatewayClass
+
+```bash
+kubectl apply -f ./test/conformance/gateway-class-parameters.report.yaml -f ./test/conformance/gateway-class.yaml
+```
+
+6. Run the conformance tests
+
+```bash
+make conformance
+```
+
+7. Print report
+
+```bash
+cat test/conformance/kubernetes.io/gateway-api/report/standard-4.10.3-default-report.yaml
+```
+

--- a/conformance/reports/v1.4.0/gravitee/standard-4.10.3-default-report.yaml
+++ b/conformance/reports/v1.4.0/gravitee/standard-4.10.3-default-report.yaml
@@ -1,0 +1,57 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-01-30T13:31:15-06:00"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.4.0
+implementation:
+  contact:
+  - team-devex@graviteesource.com
+  organization: gravitee.io
+  project: gravitee-kubernetes-operator
+  url: https://github.com/gravitee-io/gravitee-kubernetes-operator
+  version: 4.10.3
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: partial
+    skippedTests:
+    - HTTPRouteMatchingAcrossRoutes
+    statistics:
+      Failed: 0
+      Passed: 32
+      Skipped: 1
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 7
+      Skipped: 0
+    supportedFeatures:
+    - GatewayPort8080
+    - HTTPRoutePathRedirect
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    unsupportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteCORS
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRouteNamedRouteRule
+    - HTTPRouteParentRefPort
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestPercentageMirror
+    - HTTPRouteRequestTimeout
+  name: GATEWAY-HTTP
+  summary: Core tests partially succeeded with 1 test skips. Extended tests succeeded.

--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -446,11 +446,11 @@ v1.4.0 release for the GATEWAY_HTTP conformance profile except `HTTPRouteHostnam
 
 ### Gravitee Kubernetes Operator
 
-[![Conformance](https://img.shields.io/badge/Gateway%20API%20Partial%20Conformance%20v1.3.0-Gravitee%20Kubernetes%20Operator-orange)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.3.0/gravitee)
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Partial%20Conformance%20v1.4.0-Gravitee%20Kubernetes%20Operator-orange)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.4.0/gravitee)
 
 The [Gravitee Kubernetes Operator](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko) (GKO) lets you manage [Gravitee](https://www.gravitee.io/) APIs, applications, and other assets in a Kubernetes-native and declarative way.
 
-The Gravitee Kubernetes Operator provides partial conformance for Gateway - HTTP features in version 4.8.5. It does not support matching rules across routes or defining services of a type other than Kubernetes Core v1 services. These features will be introduced in a future release.
+The Gravitee Kubernetes Operator provides partial conformance for Gateway - HTTP features in version 4.10.3. It does not support matching rules across routes. These feature will be introduced in a future release.
 
 For support, feedback, or to engage in a discussion about the Gravitee Kubernetes Operator, please feel free to submit an [issue](https://github.com/gravitee-io/issues/issues) or visit our community [forum](https://community.gravitee.io/c/support/gravitee-kubernetes-operator-gko/26).
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
/area conformance-test


**What this PR does / why we need it**:

Adds Gravitee Kubernetes Operator version 4.10.3 conformance report for gateway API 1.4.0

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```