### PR TITLE
Add conformance for tlsroute mixed listeners

### DIFF
--- a/conformance/tests/tlsroute-listener-mixed-termination-not-supported.go
+++ b/conformance/tests/tlsroute-listener-mixed-termination-not-supported.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, TLSRouteListenerMixedTerminationNotSupported)
+}
+
+var TLSRouteListenerMixedTerminationNotSupported = suite.ConformanceTest{
+	ShortName:   "TLSRouteListenerMixedTerminationNotSupported",
+	Description: "When TLSRoute mixed termination/passthrough listener is NOT supported, a Gateway Listener with 2 distinct TLS modes on the same port MUST have Accepted=False with Reason=ProtocolConflict",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportTLSRoute,
+		features.SupportTLSRouteModeTerminate,
+	},
+	Manifests: []string{"tests/tlsroute-listener-mixed-termination-not-supported.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		if suite.SupportedFeatures.Has(features.SupportTLSRouteModeMixed) {
+			t.Log("TLSRouteListenerMixedTerminationNotSupported is not executed when an implementation claims to support mixed termination")
+			return
+		}
+		gwNN := types.NamespacedName{Name: "gateway-tlsroute-mixed-termination-not-supported", Namespace: "gateway-conformance-infra"}
+
+		t.Run("Listener with unsupported mixed Terminate/Passthrough must have Accepted=False with Reason=ProtocolConflict", func(t *testing.T) {
+			listeners := []v1.ListenerStatus{
+				{
+					Name: v1.SectionName("tls-terminate"),
+					Conditions: []metav1.Condition{{
+						Type:   string(v1.ListenerConditionAccepted),
+						Status: metav1.ConditionFalse,
+						Reason: string(v1.ListenerReasonProtocolConflict),
+					}},
+					AttachedRoutes: 0,
+				},
+				{
+					Name: v1.SectionName("tls-passthrough"),
+					Conditions: []metav1.Condition{{
+						Type:   string(v1.ListenerConditionAccepted),
+						Status: metav1.ConditionFalse,
+						Reason: string(v1.ListenerReasonProtocolConflict),
+					}},
+					AttachedRoutes: 0,
+				},
+			}
+			kubernetes.GatewayStatusMustHaveListeners(t, suite.Client, suite.TimeoutConfig, gwNN, listeners)
+		})
+	},
+}

--- a/conformance/tests/tlsroute-listener-mixed-termination-not-supported.yaml
+++ b/conformance/tests/tlsroute-listener-mixed-termination-not-supported.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tlsroute-mixed-termination-not-supported
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: tls-terminate
+      port: 8443
+      protocol: TLS
+      hostname: terminate.example.com
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: tls-terminate-checks-certificate
+    - name: tls-passthrough
+      port: 8443
+      protocol: TLS
+      hostname: passthrough.example.com
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+      tls:
+        mode: Passthrough

--- a/conformance/tests/tlsroute-mixed-termination-same-namespace.go
+++ b/conformance/tests/tlsroute-mixed-termination-same-namespace.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	tlsutils "sigs.k8s.io/gateway-api/conformance/utils/tls"
+	"sigs.k8s.io/gateway-api/pkg/features"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, TLSRouteMixedTerminationSameNamespace)
+}
+
+var TLSRouteMixedTerminationSameNamespace = suite.ConformanceTest{
+	ShortName:   "TLSRouteMixedTerminationSameNamespace",
+	Description: "A Gateway with 2 TLS Listeners on different modes, on the same port must route the traffic correctly",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportTLSRoute,
+		features.SupportTLSRouteModeTerminate,
+		features.SupportTLSRouteModeMixed,
+	},
+	Provisional: true,
+	Manifests:   []string{"tests/tlsroute-mixed-termination-same-namespace.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeTerminateNN := types.NamespacedName{Name: "gateway-conformance-mixed-terminateroute", Namespace: ns}
+		routePassthroughNN := types.NamespacedName{Name: "gateway-conformance-mixed-passthroughroute", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "gateway-tlsroute-mixed", Namespace: ns}
+		caCertNN := types.NamespacedName{Name: "tls-checks-ca-certificate", Namespace: ns}
+		certNN := types.NamespacedName{Name: "tls-checks-certificate", Namespace: ns}
+
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+
+		gwAddr, hostnamesPassthrough := kubernetes.GatewayAndTLSRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName,
+			kubernetes.NewGatewayRef(gwNN), routePassthroughNN)
+
+		listeners := []v1.ListenerStatus{
+			{
+				Name: v1.SectionName("tls-terminate"),
+				SupportedKinds: []v1.RouteGroupKind{{
+					Group: (*v1.Group)(&v1.GroupVersion.Group),
+					Kind:  v1.Kind("TLSRoute"),
+				}},
+				Conditions: []metav1.Condition{{
+					Type:   string(v1.ListenerConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: string(v1.ListenerReasonAccepted),
+				}},
+				AttachedRoutes: 1,
+			},
+			{
+				Name: v1.SectionName("tls-passthrough"),
+				SupportedKinds: []v1.RouteGroupKind{{
+					Group: (*v1.Group)(&v1.GroupVersion.Group),
+					Kind:  v1.Kind("TLSRoute"),
+				}},
+				Conditions: []metav1.Condition{{
+					Type:   string(v1.ListenerConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: string(v1.ListenerReasonAccepted),
+				}},
+				AttachedRoutes: 1,
+			},
+		}
+		kubernetes.GatewayStatusMustHaveListeners(t, suite.Client, suite.TimeoutConfig, gwNN, listeners)
+
+		if len(hostnamesPassthrough) != 1 {
+			t.Fatalf("unexpected error in test configuration, found %d passthrough hostnames", len(hostnamesPassthrough))
+		}
+		serverStrPassthrough := string(hostnamesPassthrough[0])
+
+		_, hostnamesTerminate := kubernetes.GatewayAndTLSRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName,
+			kubernetes.NewGatewayRef(gwNN), routeTerminateNN)
+
+		if len(hostnamesTerminate) != 1 {
+			t.Fatalf("unexpected error in test configuration, found %d terminate hostnames", len(hostnamesTerminate))
+		}
+		serverStrTerminate := string(hostnamesTerminate[0])
+
+		caConfigMap, err := kubernetes.GetConfigMapData(suite.Client, suite.TimeoutConfig, caCertNN)
+		if err != nil {
+			t.Fatalf("unexpected error finding TLS secret: %v", err)
+		}
+		caString, ok := caConfigMap["ca.crt"]
+		if !ok {
+			t.Fatalf("ca.crt not found in configmap: %s/%s", caCertNN.Namespace, caCertNN.Name)
+		}
+
+		serverCertPem, _, err := GetTLSSecret(suite.Client, certNN)
+		if err != nil {
+			t.Fatalf("unexpected error finding TLS secret: %v", err)
+		}
+
+		t.Run("Simple MQTT TLS request matching TLSRoute should reach mqtt-backend", func(t *testing.T) {
+			t.Parallel()
+
+			// Using the gwAddrPassthrough as it should be the same for both listeners
+			t.Logf("Establishing MQTT connection to host %s via %s", serverStrTerminate, gwAddr)
+
+			certpool := x509.NewCertPool()
+			if !certpool.AppendCertsFromPEM([]byte(caString)) {
+				t.Fatal("Failed to append CA certificate")
+			}
+
+			opts := mqtt.NewClientOptions()
+			opts.AddBroker(fmt.Sprintf("tls://%s", gwAddr))
+			opts.SetTLSConfig(&tls.Config{
+				RootCAs:    certpool,
+				ServerName: serverStrTerminate,
+				MinVersion: tls.VersionTLS13,
+			})
+
+			msgChan := make(chan string)
+
+			topic := "test/tlsroute-terminate"
+			message := "Hello TLSRoute Terminate MQTT!"
+
+			c := mqtt.NewClient(opts)
+			if token := c.Connect(); !token.WaitTimeout(suite.TimeoutConfig.DefaultTestTimeout) || token.Error() != nil {
+				t.Fatalf("Connection failed or timed out: %v", token.Error())
+			}
+
+			if token := c.Publish(topic, 0, true, message); !token.WaitTimeout(suite.TimeoutConfig.DefaultTestTimeout) || token.Error() != nil {
+				t.Fatalf("Failed to publish or timeout: %v", token.Error())
+			}
+
+			if token := c.Subscribe(topic, 0, func(_ mqtt.Client, msg mqtt.Message) {
+				t.Logf("Received message: %s\n", string(msg.Payload()))
+				msgChan <- string(msg.Payload())
+			}); token.WaitTimeout(suite.TimeoutConfig.DefaultTestTimeout) && token.Error() != nil {
+				t.Fatalf("Failed to subscribe or timeout: %v", token.Error())
+			}
+
+			select {
+			case msg := <-msgChan:
+				if msg != message {
+					t.Fatalf("Expected message %s does not match the received message %s", msg, message)
+				}
+				t.Log("Round-trip test succeeded")
+			case <-time.After(suite.TimeoutConfig.DefaultTestTimeout):
+				t.Fatal("Timed out waiting for message")
+			}
+		})
+
+		t.Run("Simple TLS request matching TLSRoute Passthrough should reach infra-backend", func(t *testing.T) {
+			t.Parallel()
+			tlsutils.MakeTLSRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, serverCertPem, nil, nil, serverStrPassthrough,
+				http.ExpectedResponse{
+					Request:   http.Request{Host: serverStrPassthrough, Path: "/"},
+					Backend:   "tls-backend",
+					Namespace: "gateway-conformance-infra",
+				})
+		})
+	},
+}

--- a/conformance/tests/tlsroute-mixed-termination-same-namespace.yaml
+++ b/conformance/tests/tlsroute-mixed-termination-same-namespace.yaml
@@ -1,0 +1,125 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tlsroute-mixed-termination
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: tls-terminate
+    port: 8883
+    protocol: TLS
+    hostname: tls.example.com # This is the valid cert SAN
+    allowedRoutes:
+      namespaces:
+        from: Same
+      kinds:
+      - kind: TLSRoute
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: tls-terminate-checks-certificate
+  - name: tls-passthrough
+    port: 8883
+    protocol: TLS
+    hostname: abc.example.com # This is the valid cert on backend
+    allowedRoutes:
+      namespaces:
+        from: Same
+      kinds:
+      - kind: TLSRoute
+    tls:
+      mode: Passthrough
+---
+# Route for Passthrough
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: TLSRoute
+metadata:
+  name: gateway-conformance-mixed-passthroughroute
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: gateway-tlsroute-mixed-termination
+    namespace: gateway-conformance-infra
+  hostnames:
+  - abc.example.com
+  rules:
+  - backendRefs:
+    - name: tls-backend
+      port: 443
+---
+# TLSRoute and service for the terminated MQTT service
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: TLSRoute
+metadata:
+  name: gateway-conformance-mixed-terminateroute
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: gateway-tlsroute-mixed-termination
+    namespace: gateway-conformance-infra
+  hostnames:
+  - tls.example.com
+  rules:
+  - backendRefs:
+    - name: mqtt-backend
+      port: 1883
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mqtt-backend
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: mqtt-backend
+  ports:
+  - protocol: TCP
+    port: 1883
+    targetPort: 1883
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mqtt-backend
+  namespace: gateway-conformance-infra
+  labels:
+    app: mqtt-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mqtt-backend
+  template:
+    metadata:
+      labels:
+        app: mqtt-backend
+    spec:
+      containers:
+      - name: mqtt-backend
+        # https://hub.docker.com/_/eclipse-mosquitto
+        image: docker.io/eclipse-mosquitto:2
+        volumeMounts:
+        - name: config
+          mountPath: /mosquitto/config/mosquitto.conf
+          subPath: mosquitto.conf
+        ports:
+        - containerPort: 1883
+        resources:
+          requests:
+            cpu: 10m
+      volumes:
+      - name: config
+        configMap:
+          name: mosquitto-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mosquitto-config
+  namespace: gateway-conformance-infra
+data:
+  mosquitto.conf: |
+    listener 1883
+    allow_anonymous true
+---

--- a/pkg/features/tlsroute.go
+++ b/pkg/features/tlsroute.go
@@ -28,6 +28,9 @@ const (
 
 	// This option indicates support for TLSRoute mode Terminate (extended conformance)
 	SupportTLSRouteModeTerminate FeatureName = "TLSRouteModeTerminate"
+
+	// This option indicates support for TLSRoute mode Mixed (extended conformance)
+	SupportTLSRouteModeMixed FeatureName = "TLSRouteModeMixed"
 )
 
 var (
@@ -39,6 +42,12 @@ var (
 	// TLSRouteModeTerminate contains metadata for the TLSRouteModeTerminate feature.
 	TLSRouteModeTerminateFeature = Feature{
 		Name:    SupportTLSRouteModeTerminate,
+		Channel: FeatureChannelExperimental,
+	}
+
+	// TLSRouteModeTerminate contains metadata for the TLSRouteModeTerminate feature.
+	TLSRouteModeMixedFeature = Feature{
+		Name:    SupportTLSRouteModeMixed,
 		Channel: FeatureChannelExperimental,
 	}
 )
@@ -54,4 +63,5 @@ var TLSRouteCoreFeatures = sets.New(
 // This does not include any Core Features.
 var TLSRouteExtendedFeatures = sets.New(
 	TLSRouteModeTerminateFeature,
+	TLSRouteModeMixedFeature,
 )


### PR DESCRIPTION
**What type of PR is this?**
/area conformance-test

**What this PR does / why we need it**:
Last mile on conformance tests for TLSRoute: adding the case for TLSRouteModeMixed

In this case, an implementation supports a Gateway that has 2 listeners of type TLS, but one is terminated and the other is passthrough. 

It must forward the traffic correctly.

Additionally, another conformance test is added here so implementations must report when the combination of listeners is not supported

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```


This PR was tested on Istio with the patch of https://github.com/istio/istio/pull/58638
