### PR TITLE
conformance: invalid default client certificate validation config

### DIFF
--- a/conformance/tests/gateway-invalid-default-frontend-client-certificate-validation.go
+++ b/conformance/tests/gateway-invalid-default-frontend-client-certificate-validation.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tls"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayFrontendInvalidDefaultClientCertificateValidation)
+}
+
+var GatewayFrontendInvalidDefaultClientCertificateValidation = suite.ConformanceTest{
+	ShortName:   "GatewayFrontendInvalidDefaultClientCertificateValidation",
+	Description: "Invalid Gateway's default Client Certificate Validation Config should only affect HTTPS traffic",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportGatewayFrontendClientCertificateValidation,
+	},
+	Manifests: []string{"tests/gateway-invalid-default-frontend-client-certificate-validation.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+
+		gwNN := types.NamespacedName{Name: "invalid-default-client-validation-config", Namespace: ns}
+
+		// Wait for gateway address to be assigned. Do not check the Status it will be done per each Listener later.
+		gwAddr, err := kubernetes.WaitForGatewayAddress(t, suite.Client, suite.TimeoutConfig, kubernetes.NewGatewayRef(gwNN))
+		require.NoErrorf(t, err, "timed out waiting for Gateway address to be assigned")
+
+		// use gateway Adddress without port because we have 2 HTTPS listeners with different port
+		gwAddr, _, err = net.SplitHostPort(gwAddr)
+		require.NoErrorf(t, err, "Failed to split host port from gateway VIP: %v", gwAddr)
+
+		// Get Server certificate, this certificate is the same for both listeners
+		certNN := types.NamespacedName{Name: "tls-validity-checks-certificate", Namespace: ns}
+		serverCertPem, _, err := GetTLSSecret(suite.Client, certNN)
+		if err != nil {
+			t.Fatalf("unexpected error finding TLS secret: %v", err)
+		}
+
+		t.Run("Validate tls configuration does not impact HTTP listener", func(t *testing.T) {
+			expectedConditions := []metav1.Condition{
+				{
+					Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+					Status: metav1.ConditionTrue,
+					Reason: "", // any reason
+				},
+				{
+					Type:   string(gatewayv1.ListenerConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: "", // any reason
+				},
+				{
+					Type:   string(gatewayv1.ListenerConditionProgrammed),
+					Status: metav1.ConditionTrue,
+					Reason: "", // any reason
+				},
+			}
+			kubernetes.GatewayListenerMustHaveConditions(t, suite.Client, suite.TimeoutConfig, gwNN, "http", expectedConditions)
+
+			httpAddr := gwAddr + ":80"
+			expectedSuccess := http.ExpectedResponse{
+				Request:   http.Request{Host: "example.org", Path: "/"},
+				Response:  http.Response{StatusCode: 200},
+				Backend:   "infra-backend-v1",
+				Namespace: "gateway-conformance-infra",
+			}
+			// send request to the first listener and validate that it is passing
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, httpAddr, expectedSuccess)
+		})
+
+		t.Run("Validate that invalid default configuration is impacting HTTPS listener", func(t *testing.T) {
+			expectedConditions := []metav1.Condition{
+				{
+					Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+					Status: metav1.ConditionFalse,
+					Reason: string(gatewayv1.ListenerReasonInvalidCACertificateRef),
+				},
+				{
+					Type:   string(gatewayv1.ListenerConditionAccepted),
+					Status: metav1.ConditionFalse,
+					Reason: string(gatewayv1.ListenerReasonNoValidCACertificate),
+				},
+				{
+					Type:   string(gatewayv1.ListenerConditionProgrammed),
+					Status: metav1.ConditionFalse,
+					Reason: "", // any reason
+				},
+			}
+			kubernetes.GatewayListenerMustHaveConditions(t, suite.Client, suite.TimeoutConfig, gwNN, "https", expectedConditions)
+
+			httpsAddr := gwAddr + ":443"
+			expectedFailure := http.ExpectedResponse{
+				Request:   http.Request{Host: "example.org", Path: "/"},
+				Namespace: "gateway-conformance-infra",
+			}
+			// send request to the second listener and validate that it is failing
+			tls.MakeTLSRequestAndExpectFailureResponse(t, suite.RoundTripper, httpsAddr, serverCertPem, nil, nil, "example.org", expectedFailure)
+		})
+	},
+}

--- a/conformance/tests/gateway-invalid-default-frontend-client-certificate-validation.yaml
+++ b/conformance/tests/gateway-invalid-default-frontend-client-certificate-validation.yaml
@@ -1,0 +1,57 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: invalid-default-client-validation-config
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  tls:
+    frontend:
+      default:
+        validation:
+          caCertificateRefs:
+          - kind: ConfigMap
+            group: ""
+            name: does-not-exist
+      perPort:
+      - port: 80
+        tls:
+          validation:
+            caCertificateRefs:
+            - kind: ConfigMap
+              group: ""
+              name: tls-validity-checks-per-port-ca-certificate
+  listeners:
+  - name: https
+    port: 443
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: Same
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: tls-validity-checks-certificate
+        namespace: gateway-conformance-infra
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: invalid-default-client-validation-config
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: invalid-default-client-validation-config
+  hostnames:
+  - example.org
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/area conformance-test
/kind test
**What this PR does / why we need it**:
Conformance tests for invalid default client certificate validation 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Relates to https://github.com/kubernetes-sigs/gateway-api/issues/4250

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
