### PR TITLE
Implement TCPServer for tests

### DIFF
--- a/conformance/echo-basic/echo-basic.go
+++ b/conformance/echo-basic/echo-basic.go
@@ -35,6 +35,7 @@ import (
 	"golang.org/x/net/websocket"
 
 	g "sigs.k8s.io/gateway-api/conformance/echo-basic/grpc"
+	t "sigs.k8s.io/gateway-api/conformance/echo-basic/tcpserver"
 )
 
 // RequestAssertions contains information about the request and the Ingress
@@ -85,6 +86,11 @@ var (
 func main() {
 	if os.Getenv("GRPC_ECHO_SERVER") != "" {
 		g.Main()
+		return
+	}
+
+	if os.Getenv("TCP_ECHO_SERVER") != "" {
+		t.Main()
 		return
 	}
 

--- a/conformance/echo-basic/tcpserver/tcpserver.go
+++ b/conformance/echo-basic/tcpserver/tcpserver.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tcpserver
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"strconv"
+)
+
+const (
+	WelcomeMessage = "Gateway API Test TCP Server\n"
+)
+
+// Context contains the Pod context, to be used on the echo response
+type Context struct {
+	Namespace string `json:"namespace"`
+	Ingress   string `json:"ingress"`
+	Service   string `json:"service"`
+	Pod       string `json:"pod"`
+	TCPPort   string `json:"tcpport"`
+	TLSPort   string `json:"tlsport,omitempty,omitzero"`
+}
+
+// TLSAssertions contains information about the TLS connection.
+type TLSAssertions struct {
+	Version            string `json:"version"`
+	ServerName         string `json:"serverName"`
+	NegotiatedProtocol string `json:"negotiatedProtocol,omitempty,omitzero"`
+	Curves             string `json:"curves,omitempty,omitzero"`
+	CipherSuite        string `json:"cipherSuite"`
+}
+
+// TCPAssertions is the union of Pod context, TLSAssertions and a flag exposing
+// if the request came via TLS
+type TCPAssertions struct {
+	Context      `json:",inline"`
+	IsTLS        bool           `json:"isTLS"`
+	TLSAssertion *TLSAssertions `json:"tls,omitempty,omitzero"`
+}
+
+type tcpServer struct {
+	tcpPort   string
+	tlsPort   string
+	tlsConfig *tls.Config
+}
+
+var podContext Context
+
+func Main() {
+	ctx := context.Background()
+	// We pass the errchan externally, so it can be used to close/stop the server (by unit tests)
+	errchan := make(chan error)
+	runServer(ctx, errchan)
+}
+
+func runServer(ctx context.Context, errchan chan error) {
+	podContext = Context{
+		Namespace: os.Getenv("NAMESPACE"),
+		Ingress:   os.Getenv("INGRESS_NAME"),
+		Service:   os.Getenv("SERVICE_NAME"),
+		Pod:       os.Getenv("POD_NAME"),
+	}
+
+	var err error
+	tcpPort := os.Getenv("TCP_PORT")
+
+	if tcpPort == "" {
+		tcpPort = "3000"
+	} else {
+		_, err = strconv.Atoi(tcpPort)
+		if err != nil {
+			errchan <- fmt.Errorf("non-integer value in TCP_PORT: %s. Error: %w", tcpPort, err)
+			return
+		}
+	}
+
+	podContext.TCPPort = tcpPort
+
+	tlsPort := os.Getenv("TLS_PORT")
+	if tlsPort == "" {
+		tlsPort = "8443"
+	} else {
+		_, err = strconv.Atoi(tlsPort)
+		if err != nil {
+			errchan <- fmt.Errorf("non-integer value in TLS_PORT: %s. Error: %w", tlsPort, err)
+			return
+		}
+	}
+	podContext.TLSPort = tlsPort
+
+	tlsConfig, err := newTLSConfig(os.Getenv("TLS_SERVER_CERT"), os.Getenv("TLS_SERVER_PRIV_KEY"))
+	if err != nil {
+		errchan <- err
+		return
+	}
+
+	server := tcpServer{
+		tcpPort:   tcpPort,
+		tlsPort:   tlsPort,
+		tlsConfig: tlsConfig,
+	}
+
+	go func() {
+		slog.Info("Starting server (tcp)", "protocol", "tcp", "port", tcpPort)
+		err := server.startListener(ctx, false) //nolint:gosec
+		if err != nil {
+			errchan <- err
+		}
+	}()
+
+	if tlsConfig != nil {
+		go func() {
+			slog.Info("Starting server (tcp)", "protocol", "tls", "port", tlsPort)
+			err := server.startListener(ctx, true) //nolint:gosec
+			if err != nil {
+				errchan <- err
+			}
+		}()
+	}
+	if err := <-errchan; err != nil {
+		panic(fmt.Sprintf("Failed to start tcp server: %s\n", err.Error()))
+	}
+}
+
+// start one listener at a time.
+func (s *tcpServer) startListener(ctx context.Context, tlsListener bool) error {
+	var listener net.Listener
+	var err error
+	if tlsListener {
+		listener, err = tls.Listen("tcp", fmt.Sprintf(":%s", s.tlsPort), s.tlsConfig)
+	} else {
+		listener, err = (&net.ListenConfig{}).Listen(ctx, "tcp", fmt.Sprintf(":%s", s.tcpPort))
+	}
+
+	if err != nil {
+		return err
+	}
+
+	defer listener.Close()
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			slog.Error("Accept error", "error", err)
+			continue
+		}
+		go handleConnection(ctx, conn)
+	}
+}
+
+func newTLSConfig(serverCertificate, serverPrivateKey string) (*tls.Config, error) {
+	// Ignore cases where a cert or key are not set
+	if serverCertificate == "" || serverPrivateKey == "" {
+		return nil, nil
+	}
+
+	certPEM, err := os.ReadFile(serverCertificate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read certificate %s: %w", serverCertificate, err)
+	}
+	keyPEM, err := os.ReadFile(serverPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read private key %s: %w", serverPrivateKey, err)
+	}
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing key pair: %w", err)
+	}
+	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
+	return tlsConfig, nil
+}
+
+// handleConnection will receive a new TCP connection and verify its properties +
+// the user request, providing a proper answer that can be asserted by the client
+func handleConnection(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+
+	assertions := &TCPAssertions{
+		Context: podContext,
+	}
+
+	tlsConn, isTLS := conn.(*tls.Conn)
+	// set additional TLS context
+	if isTLS {
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			slog.Error("TLS Handshake failed", "error", err)
+			return
+		}
+
+		state := tlsConn.ConnectionState()
+		assertions.TLSAssertion = &TLSAssertions{
+			NegotiatedProtocol: state.NegotiatedProtocol,
+			ServerName:         state.ServerName,
+			Version:            tls.VersionName(state.Version),
+			CipherSuite:        tls.CipherSuiteName(state.CipherSuite),
+			Curves:             state.CurveID.String(),
+		}
+	}
+
+	assertions.IsTLS = isTLS
+	fmt.Fprint(conn, (WelcomeMessage))
+
+	testPayload, err := json.Marshal(assertions)
+	if err != nil {
+		slog.Error("error encoding tcp response", "error", err)
+		return
+	}
+
+	// Echo Loop
+	scanner := bufio.NewScanner(conn)
+	for scanner.Scan() {
+		text := scanner.Text()
+		switch text {
+		// If the client sends a TEST message, answer with the echo-basic payload
+		case "TEST":
+			fmt.Fprintf(conn, "%s\n", string(testPayload))
+		// IS_TLS simple returns a true/false if the connection was made via TLS
+		case "IS_TLS":
+			fmt.Fprintf(conn, "%t\n", isTLS)
+		// PING can be used for simple tests that needs to check the connection state
+		case "PING":
+			fmt.Fprintf(conn, "PONG\n")
+		}
+	}
+}

--- a/conformance/echo-basic/tcpserver/tcpserver_test.go
+++ b/conformance/echo-basic/tcpserver/tcpserver_test.go
@@ -1,0 +1,287 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tcpserver
+
+import (
+	"bufio"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	namespace = "test-ns"
+	ingress   = "test-ingress"
+	service   = "test-service"
+	pod       = "test-pod"
+)
+
+func TestTCPEchoServer(t *testing.T) {
+	t.Setenv("NAMESPACE", namespace)
+	t.Setenv("INGRESS_NAME", ingress)
+	t.Setenv("SERVICE_NAME", service)
+	t.Setenv("POD_NAME", pod)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	t.Run("with TCP Server only when there is no TLS certificate", func(t *testing.T) {
+		tcpPort, err := getFreePort(ctx)
+		require.NoError(t, err, "error allocating TCP Port for test")
+
+		t.Logf("Using %d as TCP Port", tcpPort)
+		t.Setenv("TCP_PORT", strconv.Itoa(tcpPort))
+
+		tlsPort, err := getFreePort(ctx)
+		require.NoError(t, err, "error allocating TLS Port for test")
+
+		t.Logf("Using %d as TLS Port", tlsPort)
+		t.Setenv("TLS_PORT", strconv.Itoa(tlsPort))
+		errCh := make(chan error)
+		go runServer(ctx, errCh)
+		t.Cleanup(func() { close(errCh) })
+		waitForListener(ctx, t, strconv.Itoa(tcpPort))
+
+		dialer := &net.Dialer{}
+		_, err = dialer.DialContext(ctx, "tcp", fmt.Sprintf("localhost:%s", strconv.Itoa(tlsPort)))
+		require.Error(t, err, "trying to connect to an echo server without TLS enabled should fail")
+
+		tcpClient, err := dialer.DialContext(ctx, "tcp", fmt.Sprintf("localhost:%s", strconv.Itoa(tcpPort)))
+		require.NoError(t, err, "got an error while trying to connect to tcpserver")
+
+		t.Cleanup(func() {
+			tcpClient.Close() //nolint: errcheck
+		})
+		t.Run("check against the TCP server", func(t *testing.T) {
+			message, err := bufio.NewReader(tcpClient).ReadString('\n')
+			require.NoError(t, err, "error reading message response")
+			assert.Equal(t, "Gateway API Test TCP Server\n", message)
+
+			fmt.Fprintf(tcpClient, "PING\n")
+			message, err = bufio.NewReader(tcpClient).ReadString('\n')
+			require.NoError(t, err, "error reading message response")
+			assert.Equal(t, "PONG\n", message)
+
+			fmt.Fprintf(tcpClient, "IS_TLS\n")
+			message, err = bufio.NewReader(tcpClient).ReadString('\n')
+			require.NoError(t, err, "error reading message response")
+			assert.Equal(t, "false\n", message)
+
+			fmt.Fprintf(tcpClient, "TEST\n")
+			message, err = bufio.NewReader(tcpClient).ReadString('\n')
+			require.NoError(t, err, "error reading message response")
+			payload := &TCPAssertions{}
+			require.NoError(t, json.Unmarshal([]byte(message), payload))
+			assertTestMessage(t, payload, nil)
+		})
+	})
+
+	t.Run("with tls listener enabled", func(t *testing.T) {
+		tcpPort, err := getFreePort(ctx)
+		require.NoError(t, err, "error getting a port fot tcp server")
+
+		t.Logf("Using %d as TCP Port", tcpPort)
+		t.Setenv("TCP_PORT", strconv.Itoa(tcpPort))
+
+		tlsPort, err := getFreePort(ctx)
+		require.NoError(t, err, "error getting a random port fot tls server")
+		t.Logf("Using %d as TLS Port", tlsPort)
+		t.Setenv("TLS_PORT", strconv.Itoa(tlsPort))
+
+		key, cert := generateSelfSignedKeypairForTests(t)
+		t.Setenv("TLS_SERVER_PRIV_KEY", key)
+		t.Setenv("TLS_SERVER_CERT", cert)
+
+		errCh := make(chan error)
+		go runServer(ctx, errCh)
+		t.Cleanup(func() { close(errCh) })
+		waitForListener(ctx, t, strconv.Itoa(tcpPort))
+		waitForListener(ctx, t, strconv.Itoa(tlsPort))
+		dialer := &net.Dialer{}
+
+		t.Run("check against the TCP server", func(t *testing.T) {
+			tcpClient, err := dialer.DialContext(ctx, "tcp", fmt.Sprintf("localhost:%s", strconv.Itoa(tcpPort)))
+			require.NoError(t, err)
+
+			t.Cleanup(func() {
+				tcpClient.Close() //nolint: errcheck
+			})
+
+			t.Run("check the TCP server", func(t *testing.T) {
+				message, err := bufio.NewReader(tcpClient).ReadString('\n')
+				require.NoError(t, err, "error reading message response")
+				assert.Equal(t, "Gateway API Test TCP Server\n", message)
+
+				fmt.Fprintf(tcpClient, "PING\n")
+				message, err = bufio.NewReader(tcpClient).ReadString('\n')
+				require.NoError(t, err, "error reading message response")
+				assert.Equal(t, "PONG\n", message)
+
+				fmt.Fprintf(tcpClient, "IS_TLS\n")
+				message, err = bufio.NewReader(tcpClient).ReadString('\n')
+				require.NoError(t, err, "error reading message response")
+				assert.Equal(t, "false\n", message)
+
+				fmt.Fprintf(tcpClient, "TEST\n")
+				message, err = bufio.NewReader(tcpClient).ReadString('\n')
+				require.NoError(t, err, "error reading message response")
+				payload := &TCPAssertions{}
+				require.NoError(t, json.Unmarshal([]byte(message), payload))
+				assertTestMessage(t, payload, nil)
+			})
+		})
+
+		t.Run("check against a TLS server", func(t *testing.T) {
+			cert, err := os.ReadFile(cert)
+			require.NoError(t, err)
+			certPool := x509.NewCertPool()
+			require.True(t, certPool.AppendCertsFromPEM(cert))
+			conf := &tls.Config{
+				ServerName: "test.example.com",
+				RootCAs:    certPool,
+				MinVersion: tls.VersionTLS12,
+			}
+
+			tlsClient, err := (&tls.Dialer{
+				Config: conf,
+			}).DialContext(ctx, "tcp", fmt.Sprintf("localhost:%s", strconv.Itoa(tlsPort)))
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				tlsClient.Close() //nolint: errcheck
+			})
+
+			message, err := bufio.NewReader(tlsClient).ReadString('\n')
+			require.NoError(t, err, "error reading message response")
+			assert.Equal(t, "Gateway API Test TCP Server\n", message)
+
+			fmt.Fprintf(tlsClient, "PING\n")
+			message, err = bufio.NewReader(tlsClient).ReadString('\n')
+			require.NoError(t, err, "error reading message response")
+			assert.Equal(t, "PONG\n", message)
+
+			fmt.Fprintf(tlsClient, "IS_TLS\n")
+			message, err = bufio.NewReader(tlsClient).ReadString('\n')
+			require.NoError(t, err, "error reading message response")
+			assert.Equal(t, "true\n", message)
+
+			fmt.Fprintf(tlsClient, "TEST\n")
+			message, err = bufio.NewReader(tlsClient).ReadString('\n')
+			require.NoError(t, err, "error reading message response")
+			payload := &TCPAssertions{}
+			require.NoError(t, json.Unmarshal([]byte(message), payload))
+			expectedTLS := &TLSAssertions{
+				ServerName:  "test.example.com",
+				Version:     "TLS 1.3",
+				Curves:      "X25519MLKEM768",
+				CipherSuite: "TLS_AES_128_GCM_SHA256",
+			}
+			assertTestMessage(t, payload, expectedTLS)
+		})
+	})
+}
+
+func waitForListener(ctx context.Context, t *testing.T, port string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		tcpClient, err := (&net.Dialer{}).DialContext(ctx, "tcp", fmt.Sprintf("localhost:%s", port))
+		if err != nil {
+			t.Logf("got an error while trying to connect to tcpserver: %s, will retry", err)
+			return false
+		}
+		require.NoError(t, tcpClient.Close())
+		return true
+	}, 5*time.Second, time.Second, "error waiting the server listener to be ready")
+}
+
+func assertTestMessage(t *testing.T, payload *TCPAssertions, expectedTLS *TLSAssertions) {
+	t.Helper()
+	require.NotNil(t, payload)
+	assert.Equal(t, namespace, payload.Namespace, "namespace does not match")
+	assert.Equal(t, service, payload.Service, "service does not match")
+	assert.Equal(t, ingress, payload.Ingress, "ingress does not match")
+	assert.Equal(t, pod, payload.Pod, "pod name does not match")
+
+	assert.Equal(t, expectedTLS != nil, payload.IsTLS)
+	assert.Equal(t, expectedTLS, payload.TLSAssertion)
+}
+
+func getFreePort(ctx context.Context) (int, error) {
+	l, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// This function generates a keypair on a temporary directory, and returns the key and cert path to be used on tests
+func generateSelfSignedKeypairForTests(t *testing.T) (string, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err, "error generating private key")
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Minute),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost", "test.example.com"},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, pub, priv)
+	require.NoError(t, err, "error generating self signed certificate keypair for test")
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: derBytes,
+	})
+
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err, "error encoding privatekey")
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: privBytes,
+	})
+
+	tmpDir, err := os.MkdirTemp("", "")
+	require.NoError(t, err, "error creating temporary directory")
+
+	keyPath := filepath.Join(tmpDir, "tls.key")
+	crtPath := filepath.Join(tmpDir, "tls.crt")
+
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600), "error creating temporary private key file")
+	require.NoError(t, os.WriteFile(crtPath, certPEM, 0o600), "error creating temporary certificate file")
+
+	return keyPath, crtPath
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
On non-HTTP tests (TLSRoute, TCPRoute) we may need a tcp server. Originally we did the implementation with mqtt, but the usage of mosquitto library is not authorized on Kubernetes repo due to restrictions with the Eclipse license.

This way, this PR implements a simple TCPServer to be used later on Conformance tests that may need it, also supporting the creation of an extra TLS listener


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4414

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
