### PR TITLE
TLSRoute: Add conformance test TCPRoute being invalide for TLS listener

### DIFF
--- a/conformance/tests/gateway-invalid-route-kind.go
+++ b/conformance/tests/gateway-invalid-route-kind.go
@@ -56,32 +56,13 @@ var GatewayInvalidRouteKind = suite.ConformanceTest{
 			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
 		})
 
-		t.Run("Gateway HTTP listener should have a false ResolvedRefs condition with reason InvalidRouteKinds and HTTPRoute must be put in the supportedKinds", func(t *testing.T) {
-			gwNN := types.NamespacedName{Name: "gateway-http-supported-and-invalid-route-kind", Namespace: "gateway-conformance-infra"}
+		t.Run("Gateway listener should have a false ResolvedRefs condition with reason InvalidRouteKinds and HTTPRoute must be put in the supportedKinds", func(t *testing.T) {
+			gwNN := types.NamespacedName{Name: "gateway-supported-and-invalid-route-kind", Namespace: "gateway-conformance-infra"}
 			listeners := []v1.ListenerStatus{{
 				Name: v1.SectionName("http"),
 				SupportedKinds: []v1.RouteGroupKind{{
 					Group: (*v1.Group)(&v1.GroupVersion.Group),
 					Kind:  v1.Kind("HTTPRoute"),
-				}},
-				Conditions: []metav1.Condition{{
-					Type:   string(v1.ListenerConditionResolvedRefs),
-					Status: metav1.ConditionFalse,
-					Reason: string(v1.ListenerReasonInvalidRouteKinds),
-				}},
-				AttachedRoutes: 0,
-			}}
-
-			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, listeners)
-		})
-
-		t.Run("Gateway TLS listener should have a false ResolvedRefs condition with reason InvalidRouteKinds and TLSRoute must be put in the supportedKinds", func(t *testing.T) {
-			gwNN := types.NamespacedName{Name: "gateway-tls-supported-and-invalid-route-kind", Namespace: "gateway-conformance-infra"}
-			listeners := []v1.ListenerStatus{{
-				Name: v1.SectionName("tls"),
-				SupportedKinds: []v1.RouteGroupKind{{
-					Group: (*v1.Group)(&v1.GroupVersion.Group),
-					Kind:  v1.Kind("TLSRoute"),
 				}},
 				Conditions: []metav1.Condition{{
 					Type:   string(v1.ListenerConditionResolvedRefs),

--- a/conformance/tests/gateway-invalid-route-kind.yaml
+++ b/conformance/tests/gateway-invalid-route-kind.yaml
@@ -18,7 +18,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: gateway-http-supported-and-invalid-route-kind
+  name: gateway-supported-and-invalid-route-kind
   namespace: gateway-conformance-infra
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
@@ -32,23 +32,3 @@ spec:
         kinds:
           - kind: InvalidRoute
           - kind: HTTPRoute
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: gateway-tls-supported-and-invalid-route-kind
-  namespace: gateway-conformance-infra
-spec:
-  gatewayClassName: "{GATEWAY_CLASS_NAME}"
-  listeners:
-    - name: tls
-      port: 443
-      protocol: TLS
-      allowedRoutes:
-        namespaces:
-          from: All
-        kinds:
-          - kind: TCPRoute
-          - kind: TLSRoute
-      tls:
-        mode: Passthrough

--- a/conformance/tests/tlsroute-listener-passthrough-supported-kinds.go
+++ b/conformance/tests/tlsroute-listener-passthrough-supported-kinds.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, TLSRouteListenerPassthroughSupportedKinds)
+}
+
+var TLSRouteListenerPassthroughSupportedKinds = suite.ConformanceTest{
+	ShortName:   "TLSRouteListenerPassthroughSupportedKinds",
+	Description: "A Gateway Listener with TLS mode Passthrough MUST include TLSRoute in SupportedKinds",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportTLSRoute,
+	},
+	Manifests: []string{"tests/tlsroute-listener-passthrough-supported-kinds.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		gwNN := types.NamespacedName{Name: "gateway-tlsroute-passthrough-supported-kind", Namespace: "gateway-conformance-infra"}
+
+		t.Run("TLS listener should have a false ResolvedRefs condition with reason InvalidRouteKinds for TCPRoute, and TLSRoute must be put in the supportedKinds", func(t *testing.T) {
+			listeners := []v1.ListenerStatus{{
+				Name: v1.SectionName("tls-passthrough"),
+				SupportedKinds: []v1.RouteGroupKind{{
+					Group: (*v1.Group)(&v1.GroupVersion.Group),
+					Kind:  v1.Kind("TLSRoute"),
+				}},
+				Conditions: []metav1.Condition{{
+					Type:   string(v1.ListenerConditionResolvedRefs),
+					Status: metav1.ConditionFalse,
+					Reason: string(v1.ListenerReasonInvalidRouteKinds),
+				}},
+				AttachedRoutes: 0,
+			}}
+			kubernetes.GatewayStatusMustHaveListeners(t, suite.Client, suite.TimeoutConfig, gwNN, listeners)
+		})
+	},
+}

--- a/conformance/tests/tlsroute-listener-passthrough-supported-kinds.yaml
+++ b/conformance/tests/tlsroute-listener-passthrough-supported-kinds.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tlsroute-passthrough-supported-kind
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: tls-passthrough
+      port: 443
+      protocol: TLS
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TCPRoute
+          - kind: TLSRoute
+      tls:
+        mode: Passthrough


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind test
/area conformance-test

**What this PR does / why we need it**:

This PR checks that TCPRoute is not supported for TLS listener (kind must be TLSRoute) as per #4427 and removes the tests using TCPRoute for TLS listener. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

Part of #1579

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
