### PR TITLE
TLSRoute: Add conformance test TCPRoute being invalid for TLS listener with mode Terminate

### DIFF
--- a/conformance/tests/tlsroute-listener-terminate-supported-kinds.go
+++ b/conformance/tests/tlsroute-listener-terminate-supported-kinds.go
@@ -44,22 +44,20 @@ var TLSRouteListenerTerminateSupportedKinds = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "gateway-tlsroute-terminate-supported", Namespace: "gateway-conformance-infra"}
 
-		t.Run("Listener with mode Terminate must have TLSRoute in SupportedKinds", func(t *testing.T) {
-			listeners := []v1.ListenerStatus{
-				{
-					Name: v1.SectionName("tls-terminate"),
-					SupportedKinds: []v1.RouteGroupKind{{
-						Group: (*v1.Group)(&v1.GroupVersion.Group),
-						Kind:  v1.Kind("TLSRoute"),
-					}},
-					Conditions: []metav1.Condition{{
-						Type:   string(v1.ListenerConditionAccepted),
-						Status: metav1.ConditionTrue,
-						Reason: string(v1.ListenerReasonAccepted),
-					}},
-					AttachedRoutes: 0,
-				},
-			}
+		t.Run("TLS listener with mode Terminate should have a false ResolvedRefs condition with reason InvalidRouteKinds for TCPRoute, and TLSRoute must be put in the supportedKinds", func(t *testing.T) {
+			listeners := []v1.ListenerStatus{{
+				Name: v1.SectionName("tls-terminate"),
+				SupportedKinds: []v1.RouteGroupKind{{
+					Group: (*v1.Group)(&v1.GroupVersion.Group),
+					Kind:  v1.Kind("TLSRoute"),
+				}},
+				Conditions: []metav1.Condition{{
+					Type:   string(v1.ListenerConditionResolvedRefs),
+					Status: metav1.ConditionFalse,
+					Reason: string(v1.ListenerReasonInvalidRouteKinds),
+				}},
+				AttachedRoutes: 0,
+			}}
 			kubernetes.GatewayStatusMustHaveListeners(t, suite.Client, suite.TimeoutConfig, gwNN, listeners)
 		})
 	},

--- a/conformance/tests/tlsroute-listener-terminate-supported-kinds.yaml
+++ b/conformance/tests/tlsroute-listener-terminate-supported-kinds.yaml
@@ -15,6 +15,7 @@ spec:
         namespaces:
           from: Same
         kinds:
+          - kind: TCPRoute
           - kind: TLSRoute
       tls:
         mode: Terminate


### PR DESCRIPTION
…er with mode Terminate

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind test
/area conformance-test

**What this PR does / why we need it**:

This PR checks that TCPRoute is not supported for TLS listener with mode Terminate (kind must be TLSRoute) as per https://github.com/kubernetes-sigs/gateway-api/pull/4427. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

Part of #1579

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
