### PR TITLE
[docs] Clarification on inter Gateway listener conflicts in documentation

### DIFF
--- a/apis/v1/gateway_types.go
+++ b/apis/v1/gateway_types.go
@@ -75,15 +75,18 @@ type GatewaySpec struct {
 	//
 	// ## Distinct Listeners
 	//
-	// Each Listener in a set of Listeners (for example, in a single Gateway)
-	// MUST be _distinct_, in that a traffic flow MUST be able to be assigned to
-	// exactly one listener. (This section uses "set of Listeners" rather than
-	// "Listeners in a single Gateway" because implementations MAY merge configuration
-	// from multiple Gateways onto a single data plane, and these rules _also_
-	// apply in that case).
+	// Each Listener in a Gateway's set of Listeners MUST be _distinct_, in that a
+	// traffic flow MUST be able to be assigned to exactly one listener.
 	//
-	// Practically, this means that each listener in a set MUST have a unique
+	// Practically, this means that each listener within a Gateway MUST have a unique
 	// combination of Port, Protocol, and, if supported by the protocol, Hostname.
+	//
+	// Separate Gateways MAY define identical or conflicting Listeners because each
+	// Gateway is an independent instance. Implementations that merge multiple
+	// Gateways onto a single data plane SHOULD implement listener isolation
+	// internally. If an implementation cannot isolate listener binds when merging
+	// Gateways, it MUST set an implementation-specific condition on the affected
+	// Gateway(s) explaining the conflict.
 	//
 	// Some combinations of port, protocol, and TLS settings are considered
 	// Core support and MUST be supported by implementations based on the objects
@@ -1440,9 +1443,9 @@ type ListenerConditionReason string
 
 const (
 	// This condition indicates that the controller was unable to resolve
-	// conflicting specification requirements for this Listener. If a
-	// Listener is conflicted, its network port should not be configured
-	// on any network elements.
+	// conflicting specification requirements for this Listener within the
+	// Gateway. If a Listener is conflicted, its network port should not be
+	// configured on any network elements.
 	//
 	// Possible reasons for this condition to be true are:
 	//

--- a/site-src/api-types/gateway.md
+++ b/site-src/api-types/gateway.md
@@ -24,6 +24,20 @@ The `Gateway` spec defines the following:
 If the desired configuration specified in Gateway spec cannot be achieved, the
 Gateway will be in an error state with details provided by status conditions.
 
+### Listener conflicts across Gateways
+
+Listener distinctness rules apply within a single `Gateway`. Two distinct
+`Gateway` resources MAY define identical or conflicting listeners because each
+Gateway represents an independent instance.
+
+Implementations that merge multiple Gateways onto a shared data plane SHOULD
+provide listener isolation internally so overlapping listeners do not conflict.
+If an implementation cannot isolate listener binds when merging Gateways, it
+MUST set an implementation-specific condition on the affected Gateway(s) or
+Listeners explaining the conflict. For example, setting `Programmed` or 
+`Accepted` to `False` with a reason like `Conflicted` or a custom 
+implementation-prefixed reason.
+
 ### Deployment models
 
 Depending on the `GatewayClass`, the creation of a `Gateway` could do any of


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind documentation

**What this PR does / why we need it**:
Added clarification on behavior and handling of inter Gateway listener conflicts.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4161

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
