### PR TITLE
docs: Add guidance preferring GRPCRoute for gRPC

### DIFF
--- a/site-src/api-types/grpcroute.md
+++ b/site-src/api-types/grpcroute.md
@@ -6,6 +6,11 @@
     `v1.1.0`. For more information on release channels, refer to our [versioning
     guide](../concepts/versioning.md).
 
+!!! note
+    If you know you're working with gRPC, prefer using a `GRPCRoute`. An `HTTPRoute` may be sufficient
+    for basic routing and load balancing, but `GRPCRoute` makes the intent clearer and can unlock
+    more gRPC-specific functionality. See [When to Use GRPCRoute](#when-to-use-grpcroute).
+
 [GRPCRoute][grpcroute] is a Gateway API type for specifying routing behavior
 of gRPC requests from a Gateway listener to an API object, i.e. Service.
 


### PR DESCRIPTION
/kind documentation

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
- Adds a short note at the top of the `GRPCRoute` documentation clarifying that if you know you’re working with gRPC, you should prefer using a `GRPCRoute`.
- Notes that an `HTTPRoute` may be sufficient for basic routing/load balancing, but `GRPCRoute` makes intent clearer and can enable more gRPC-specific functionality (with a link to the detailed guidance section).

**Which issue(s) this PR fixes**:
None

**Does this PR introduce a user-facing change?**:
No

```release-note
Added documentation guidance recommending GRPCRoute for gRPC traffic.
```
