### PR TITLE
docs: Add Signadot to implementations

### DIFF
--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -131,6 +131,7 @@ other functions (like managing DNS or creating certificates).
 - [Knative][24] (alpha)
 - [Kuadrant][26] (GA)
 - [kruise-rollouts][41] (alpha)
+- [Signadot][46] (alpha)
 
 [3]:#contour
 [5]:#gloo-gateway
@@ -161,6 +162,7 @@ other functions (like managing DNS or creating certificates).
 [43]:#alibaba-cloud-service-mesh
 [44]:#aws-load-balancer-controller
 [45]:#varnish-gateway
+[46]:#signadot
 
 
 [gamma]:mesh/index.md
@@ -548,6 +550,16 @@ For help and support with Kuadrant's implementation please feel free to [create 
 [kuadrant]:https://kuadrant.io/
 [kuadrant-issue-new]:https://github.com/Kuadrant/kuadrant-operator/issues/new
 [kuadrant-slack]:https://kubernetes.slack.com/archives/C05J0D0V525
+
+### Signadot
+
+[Signadot][signadot] is an ephemeral environments platform that integrates with the Gateway API to route requests to sandboxed workloads.
+When Gateway API routing is enabled, Signadot creates derived `HTTPRoute` and `GRPCRoute` resources that match on a routing key and send matching requests to sandbox backends while preserving baseline routing behavior.
+
+- [Gateway API request routing guide][signadot-gateway-api]
+
+[signadot]:https://www.signadot.com/
+[signadot-gateway-api]:https://signadot.com/docs/guides/request-routing/gateway-api
 
 ### OpenKruise Rollouts
 [OpenKruise Rollouts][kruise-rollouts] is a plugin-n-play progressive delivery controller for Kubernetes. It supports several advanced deployment methods such as blue/green and canaries. OpenKruise Rollouts has built-in support for the Gateway API.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

- Adds Signadot to the Gateway API Integrations list on the implementations page.
- Includes a short integration description and a link to Signadot’s Gateway API request routing guide.

**Which issue(s) this PR fixes**:

```
NONE
```

**Does this PR introduce a user-facing change?**:

```
Added Signadot to the Gateway API implementations page under Integrations.
```