### PR TITLE
conformance: implementations MAY support non-disruptive configuration

### DIFF
--- a/conformance/tests/httproute-nondisruptive-config.go
+++ b/conformance/tests/httproute-nondisruptive-config.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteNonDisruptiveConfig)
+}
+
+var HTTPRouteNonDisruptiveConfig = suite.ConformanceTest{
+	ShortName:   "HTTPRouteNonDisruptiveConfig",
+	Description: "Non-disruptive configuration changes for HTTPRoutes should not cause traffic disruption",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportGatewayNonDisruptiveConfig,
+	},
+	Manifests: []string{
+		"tests/httproute-nondisruptive-config.yaml",
+	},
+	Slow: true,
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, []string{ns})
+
+		gwNN := types.NamespacedName{Name: "nondisruptive-httproute", Namespace: ns}
+
+		t.Run("should change route backend without disrupting traffic", func(t *testing.T) {
+			routeNN := types.NamespacedName{Name: "nondisruptive-backend-change", Namespace: ns}
+
+			// Verify Gateway and route accepted
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, s.Client, s.TimeoutConfig, s.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+
+			// Verify initial traffic hits infra-backend-v1
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, s.TimeoutConfig, gwAddr, http.ExpectedResponse{
+				Request:   http.Request{Path: "/backend-change"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			})
+
+			// Start continuous traffic
+			stop := continuousTraffic(t, s.RoundTripper, gwAddr, "", "/backend-change")
+
+			// Patch HTTPRoute: change backendRef from infra-backend-v1 to infra-backend-v2
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.DefaultTestTimeout)
+			defer cancel()
+			original := &gatewayv1.HTTPRoute{}
+			err := s.Client.Get(ctx, routeNN, original)
+			require.NoErrorf(t, err, "error getting HTTPRoute")
+
+			mutate := original.DeepCopy()
+			require.GreaterOrEqual(t, len(mutate.Spec.Rules), 1, "expected at least one rule in HTTPRoute %s", routeNN.String())
+			require.GreaterOrEqual(t, len(mutate.Spec.Rules[0].BackendRefs), 1, "expected at least one backendRef in first rule of HTTPRoute %s", routeNN.String())
+			mutate.Spec.Rules[0].BackendRefs[0].Name = "infra-backend-v2"
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(original))
+			require.NoErrorf(t, err, "error patching HTTPRoute backendRef")
+
+			// Verify eventual consistency: traffic reaches infra-backend-v2
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, s.TimeoutConfig, gwAddr, http.ExpectedResponse{
+				Request:   http.Request{Path: "/backend-change"},
+				Backend:   "infra-backend-v2",
+				Namespace: ns,
+			})
+
+			// Post-mutation stability period
+			time.Sleep(2 * time.Second)
+
+			// Stop traffic and verify zero failures
+			result := stop()
+			tlog.Logf(t, "traffic results: total=%d failed=%d", result.TotalRequests, result.FailedRequests)
+			require.Positive(t, result.TotalRequests, "expected at least some traffic to have been sent")
+			require.Equal(t, int64(0), result.FailedRequests, "expected zero failed requests during backend change")
+		})
+
+		t.Run("should replace route without disrupting traffic", func(t *testing.T) {
+			routeANN := types.NamespacedName{Name: "nondisruptive-route-replace-a", Namespace: ns}
+
+			// Verify Gateway and route-A accepted
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, s.Client, s.TimeoutConfig, s.ControllerName, kubernetes.NewGatewayRef(gwNN), routeANN)
+
+			// Verify initial traffic hits infra-backend-v1
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, s.TimeoutConfig, gwAddr, http.ExpectedResponse{
+				Request:   http.Request{Path: "/route-replace"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			})
+
+			// Start continuous traffic
+			stop := continuousTraffic(t, s.RoundTripper, gwAddr, "", "/route-replace")
+
+			// Create HTTPRoute-B programmatically
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.DefaultTestTimeout)
+			defer cancel()
+
+			routeB := &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nondisruptive-route-replace-b",
+					Namespace: ns,
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      gatewayv1.ObjectName(gwNN.Name),
+								Namespace: (*gatewayv1.Namespace)(&ns),
+							},
+						},
+					},
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							Matches: []gatewayv1.HTTPRouteMatch{
+								{
+									Path: &gatewayv1.HTTPPathMatch{
+										Type:  ptr.To(gatewayv1.PathMatchPathPrefix),
+										Value: new("/route-replace"),
+									},
+								},
+							},
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: "infra-backend-v2",
+											Port: ptr.To(gatewayv1.PortNumber(8080)),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := s.Client.Create(ctx, routeB)
+			require.NoErrorf(t, err, "error creating HTTPRoute-B")
+			t.Cleanup(func() {
+				if cleanupErr := s.Client.Delete(context.Background(), routeB); cleanupErr != nil {
+					tlog.Logf(t, "error cleaning up HTTPRoute-B: %v", cleanupErr)
+				}
+			})
+
+			// Verify route-B is accepted
+			routeBNN := types.NamespacedName{Name: "nondisruptive-route-replace-b", Namespace: ns}
+			kubernetes.HTTPRouteMustHaveParents(t, s.Client, s.TimeoutConfig, routeBNN, []gatewayv1.RouteParentStatus{
+				{
+					ParentRef: gatewayv1.ParentReference{
+						Name:      gatewayv1.ObjectName(gwNN.Name),
+						Namespace: (*gatewayv1.Namespace)(&ns),
+					},
+					ControllerName: gatewayv1.GatewayController(s.ControllerName),
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gatewayv1.RouteConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: string(gatewayv1.RouteReasonAccepted),
+						},
+					},
+				},
+			}, false)
+
+			// Delete route-A
+			routeA := &gatewayv1.HTTPRoute{}
+			err = s.Client.Get(ctx, routeANN, routeA)
+			require.NoErrorf(t, err, "error getting HTTPRoute-A")
+			err = s.Client.Delete(ctx, routeA)
+			require.NoErrorf(t, err, "error deleting HTTPRoute-A")
+
+			// Verify eventual consistency: traffic reaches infra-backend-v2
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, s.TimeoutConfig, gwAddr, http.ExpectedResponse{
+				Request:   http.Request{Path: "/route-replace"},
+				Backend:   "infra-backend-v2",
+				Namespace: ns,
+			})
+
+			// Post-mutation stability period
+			time.Sleep(2 * time.Second)
+
+			// Stop traffic and verify zero failures
+			result := stop()
+			tlog.Logf(t, "traffic results: total=%d failed=%d", result.TotalRequests, result.FailedRequests)
+			require.Positive(t, result.TotalRequests, "expected at least some traffic to have been sent")
+			require.Equal(t, int64(0), result.FailedRequests, "expected zero failed requests during route replacement")
+		})
+	},
+}

--- a/conformance/tests/httproute-nondisruptive-config.yaml
+++ b/conformance/tests/httproute-nondisruptive-config.yaml
@@ -1,0 +1,53 @@
+# Shared Gateway for HTTPRoute non-disruptive config tests
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: nondisruptive-httproute
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+# Test 3: Change route backend without disrupting traffic
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: nondisruptive-backend-change
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: nondisruptive-httproute
+    namespace: gateway-conformance-infra
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /backend-change
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+# Test 4: Replace route without disrupting traffic
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: nondisruptive-route-replace-a
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: nondisruptive-httproute
+    namespace: gateway-conformance-infra
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /route-replace
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/listenerset-nondisruptive-config.go
+++ b/conformance/tests/listenerset-nondisruptive-config.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, ListenerSetNonDisruptiveConfig)
+}
+
+var ListenerSetNonDisruptiveConfig = suite.ConformanceTest{
+	ShortName:   "ListenerSetNonDisruptiveConfig",
+	Description: "Non-disruptive configuration changes for ListenerSets should not cause traffic disruption",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportListenerSet,
+		features.SupportGatewayNonDisruptiveConfig,
+	},
+	Manifests: []string{
+		"tests/listenerset-nondisruptive-config.yaml",
+	},
+	Slow: true,
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, []string{ns})
+
+		listenerSetGK := schema.GroupKind{
+			Group: gatewayv1.GroupVersion.Group,
+			Kind:  "ListenerSet",
+		}
+
+		t.Run("should delete conflicted ListenerSet without disrupting traffic", func(t *testing.T) {
+			gwNN := types.NamespacedName{Name: "nondisruptive-listenerset-conflict", Namespace: ns}
+			lsAlphaNN := types.NamespacedName{Name: "nondisruptive-ls-alpha", Namespace: ns}
+			lsBetaNN := types.NamespacedName{Name: "nondisruptive-ls-beta", Namespace: ns}
+			routeNN := types.NamespacedName{Name: "nondisruptive-conflict-route", Namespace: ns}
+
+			// Verify the Gateway is accepted
+			kubernetes.GatewayMustHaveCondition(t, s.Client, s.TimeoutConfig, gwNN, metav1.Condition{
+				Type:   string(gatewayv1.GatewayConditionAccepted),
+				Status: metav1.ConditionTrue,
+			})
+
+			// Get gateway address (route is attached to ListenerSets, not Gateway directly)
+			gwAddr, err := kubernetes.WaitForGatewayAddress(t, s.Client, s.TimeoutConfig, kubernetes.NewGatewayRef(gwNN))
+			require.NoErrorf(t, err, "error waiting for Gateway address")
+
+			// Verify nondisruptive-ls-alpha is accepted with listeners accepted
+			kubernetes.ListenerSetMustHaveCondition(t, s.Client, s.TimeoutConfig, lsAlphaNN, metav1.Condition{
+				Type:   string(gatewayv1.ListenerSetConditionAccepted),
+				Status: metav1.ConditionTrue,
+				Reason: string(gatewayv1.ListenerSetReasonAccepted),
+			})
+			kubernetes.ListenerSetListenersMustHaveConditions(t, s.Client, s.TimeoutConfig, lsAlphaNN, generateAcceptedListenerConditions(), "shared-listener")
+
+			// Verify nondisruptive-ls-beta listener has Conflicted=True
+			kubernetes.ListenerSetListenersMustHaveConditions(t, s.Client, s.TimeoutConfig, lsBetaNN, []metav1.Condition{
+				{
+					Type:   string(gatewayv1.ListenerConditionConflicted),
+					Status: metav1.ConditionTrue,
+					Reason: string(gatewayv1.ListenerReasonHostnameConflict),
+				},
+			}, "shared-listener")
+
+			// Verify route is accepted by nondisruptive-ls-alpha
+			kubernetes.RoutesAndParentMustBeAccepted(t, s.Client, s.TimeoutConfig, s.ControllerName, kubernetes.NewResourceRef(listenerSetGK, lsAlphaNN), &gatewayv1.HTTPRoute{}, routeNN)
+
+			// Verify initial traffic works
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, s.TimeoutConfig, gwAddr, http.ExpectedResponse{
+				Request:   http.Request{Host: "nondisruptive-shared.example.com", Path: "/test"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			})
+
+			// Start continuous traffic
+			stop := continuousTraffic(t, s.RoundTripper, gwAddr, "nondisruptive-shared.example.com", "/test")
+
+			// Delete the winning (alpha) ListenerSet
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.DefaultTestTimeout)
+			defer cancel()
+			lsAlpha := &gatewayv1.ListenerSet{}
+			err = s.Client.Get(ctx, lsAlphaNN, lsAlpha)
+			require.NoErrorf(t, err, "error getting ListenerSet nondisruptive-ls-alpha")
+			err = s.Client.Delete(ctx, lsAlpha)
+			require.NoErrorf(t, err, "error deleting ListenerSet nondisruptive-ls-alpha")
+
+			// Verify nondisruptive-ls-beta listener becomes accepted (conflict resolved)
+			kubernetes.ListenerSetListenersMustHaveConditions(t, s.Client, s.TimeoutConfig, lsBetaNN, generateAcceptedListenerConditions(), "shared-listener")
+
+			// Verify route is now accepted by nondisruptive-ls-beta
+			kubernetes.RoutesAndParentMustBeAccepted(t, s.Client, s.TimeoutConfig, s.ControllerName, kubernetes.NewResourceRef(listenerSetGK, lsBetaNN), &gatewayv1.HTTPRoute{}, routeNN)
+
+			// Post-mutation stability period
+			time.Sleep(2 * time.Second)
+
+			// Stop traffic and verify zero failures
+			result := stop()
+			tlog.Logf(t, "traffic results: total=%d failed=%d", result.TotalRequests, result.FailedRequests)
+			require.Positive(t, result.TotalRequests, "expected at least some traffic to have been sent")
+			require.Equal(t, int64(0), result.FailedRequests, "expected zero failed requests during non-disruptive config change")
+		})
+
+		t.Run("should migrate route from Gateway to ListenerSet without disrupting traffic", func(t *testing.T) {
+			gwNN := types.NamespacedName{Name: "nondisruptive-route-migration", Namespace: ns}
+			lsNN := types.NamespacedName{Name: "nondisruptive-migration-ls", Namespace: ns}
+			routeNN := types.NamespacedName{Name: "nondisruptive-migration-route", Namespace: ns}
+
+			// Verify Gateway and route accepted (no ListenerSet deployed yet)
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, s.Client, s.TimeoutConfig, s.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+
+			// Verify initial traffic works via Gateway wildcard listener
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, s.RoundTripper, s.TimeoutConfig, gwAddr, http.ExpectedResponse{
+				Request:   http.Request{Host: "something.nondisruptive-app.example.com", Path: "/test"},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			})
+
+			// Start continuous traffic
+			stop := continuousTraffic(t, s.RoundTripper, gwAddr, "something.nondisruptive-app.example.com", "/test")
+
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.DefaultTestTimeout)
+			defer cancel()
+
+			// Step 1: Add ListenerSet as a second parentRef on the route.
+			// The ListenerSet doesn't exist yet, so this parentRef is pending but harmless.
+			// This ensures the route will be attached to the ListenerSet the moment it appears.
+			original := &gatewayv1.HTTPRoute{}
+			err := s.Client.Get(ctx, routeNN, original)
+			require.NoErrorf(t, err, "error getting HTTPRoute")
+
+			lsGroup := gatewayv1.Group(gatewayv1.GroupVersion.Group)
+			lsKind := gatewayv1.Kind("ListenerSet")
+			lsNamespace := gatewayv1.Namespace(ns)
+			lsParentRef := gatewayv1.ParentReference{
+				Group:     &lsGroup,
+				Kind:      &lsKind,
+				Name:      gatewayv1.ObjectName(lsNN.Name),
+				Namespace: &lsNamespace,
+			}
+
+			mutate := original.DeepCopy()
+			mutate.Spec.ParentRefs = append(mutate.Spec.ParentRefs, lsParentRef)
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(original))
+			require.NoErrorf(t, err, "error adding ListenerSet parentRef to HTTPRoute")
+
+			// Step 2: Create the ListenerSet with an exact hostname.
+			// The exact hostname is more specific than the Gateway wildcard, so
+			// it takes precedence for routing. Because the route already has a
+			// ListenerSet parentRef (from Step 1), traffic continues uninterrupted.
+			ls := &gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      lsNN.Name,
+					Namespace: lsNN.Namespace,
+				},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{
+						Group:     new(gatewayv1.Group(gatewayv1.GroupVersion.Group)),
+						Kind:      ptr.To(gatewayv1.Kind("Gateway")),
+						Name:      gatewayv1.ObjectName(gwNN.Name),
+						Namespace: new(gatewayv1.Namespace(gwNN.Namespace)),
+					},
+					Listeners: []gatewayv1.ListenerEntry{
+						{
+							Name:     "specific-listener",
+							Port:     80,
+							Protocol: gatewayv1.HTTPProtocolType,
+							Hostname: ptr.To(gatewayv1.Hostname("something.nondisruptive-app.example.com")),
+							AllowedRoutes: &gatewayv1.AllowedRoutes{
+								Namespaces: &gatewayv1.RouteNamespaces{
+									From: ptr.To(gatewayv1.NamespacesFromAll),
+								},
+							},
+						},
+					},
+				},
+			}
+			err = s.Client.Create(ctx, ls)
+			require.NoErrorf(t, err, "error creating ListenerSet")
+			t.Cleanup(func() {
+				if cleanupErr := s.Client.Delete(context.Background(), ls); cleanupErr != nil {
+					tlog.Logf(t, "error cleaning up ListenerSet: %v", cleanupErr)
+				}
+			})
+
+			// Wait for ListenerSet to be accepted and programmed
+			kubernetes.ListenerSetMustHaveCondition(t, s.Client, s.TimeoutConfig, lsNN, metav1.Condition{
+				Type:   string(gatewayv1.ListenerSetConditionAccepted),
+				Status: metav1.ConditionTrue,
+				Reason: string(gatewayv1.ListenerSetReasonAccepted),
+			})
+			kubernetes.ListenerSetListenersMustHaveConditions(t, s.Client, s.TimeoutConfig, lsNN, generateAcceptedListenerConditions(), "specific-listener")
+
+			// Verify route is accepted by the ListenerSet
+			kubernetes.RoutesAndParentMustBeAccepted(t, s.Client, s.TimeoutConfig, s.ControllerName, kubernetes.NewResourceRef(listenerSetGK, lsNN), &gatewayv1.HTTPRoute{}, routeNN)
+
+			// Step 3: Remove the Gateway parentRef, completing the migration.
+			// Traffic is already flowing through the ListenerSet's exact listener,
+			// so this is a no-op from the data-plane perspective.
+			updated := &gatewayv1.HTTPRoute{}
+			err = s.Client.Get(ctx, routeNN, updated)
+			require.NoErrorf(t, err, "error getting HTTPRoute for final patch")
+
+			mutate = updated.DeepCopy()
+			mutate.Spec.ParentRefs = []gatewayv1.ParentReference{lsParentRef}
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(updated))
+			require.NoErrorf(t, err, "error removing Gateway parentRef from HTTPRoute")
+
+			// Post-mutation stability period
+			time.Sleep(2 * time.Second)
+
+			// Stop traffic and verify zero failures
+			result := stop()
+			tlog.Logf(t, "traffic results: total=%d failed=%d", result.TotalRequests, result.FailedRequests)
+			require.Positive(t, result.TotalRequests, "expected at least some traffic to have been sent")
+			require.Equal(t, int64(0), result.FailedRequests, "expected zero failed requests during route migration")
+		})
+	},
+}

--- a/conformance/tests/listenerset-nondisruptive-config.yaml
+++ b/conformance/tests/listenerset-nondisruptive-config.yaml
@@ -1,0 +1,127 @@
+# Test 1: Delete conflicted ListenerSet without disrupting traffic
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: nondisruptive-listenerset-conflict
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: gateway-listener
+    port: 80
+    protocol: HTTP
+    hostname: "nondisruptive-conflict.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+  allowedListeners:
+    namespaces:
+      from: Same
+---
+# This ListenerSet wins the hostname conflict by alphabetical precedence (alpha < beta)
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: nondisruptive-ls-alpha
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    kind: Gateway
+    group: gateway.networking.k8s.io
+    name: nondisruptive-listenerset-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+  - name: shared-listener
+    port: 80
+    protocol: HTTP
+    hostname: "nondisruptive-shared.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+# This ListenerSet is conflicted because it shares the same hostname as nondisruptive-ls-alpha
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: nondisruptive-ls-beta
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    kind: Gateway
+    group: gateway.networking.k8s.io
+    name: nondisruptive-listenerset-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+  - name: shared-listener
+    port: 80
+    protocol: HTTP
+    hostname: "nondisruptive-shared.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+# Route attached to both ListenerSets
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: nondisruptive-conflict-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - kind: ListenerSet
+    group: gateway.networking.k8s.io
+    name: nondisruptive-ls-alpha
+    namespace: gateway-conformance-infra
+  - kind: ListenerSet
+    group: gateway.networking.k8s.io
+    name: nondisruptive-ls-beta
+    namespace: gateway-conformance-infra
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /test
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+# Test 2: Migrate route from Gateway to ListenerSet without disrupting traffic
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: nondisruptive-route-migration
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: wildcard-listener
+    port: 80
+    protocol: HTTP
+    hostname: "*.nondisruptive-app.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+  allowedListeners:
+    namespaces:
+      from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: nondisruptive-migration-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - kind: Gateway
+    name: nondisruptive-route-migration
+    namespace: gateway-conformance-infra
+  hostnames:
+  - "something.nondisruptive-app.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /test
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/nondisruptive-traffic-helper.go
+++ b/conformance/tests/nondisruptive-traffic-helper.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
+)
+
+// trafficResult holds the results of a continuous traffic test.
+type trafficResult struct {
+	TotalRequests  int64
+	FailedRequests int64
+}
+
+// continuousTraffic starts a goroutine that sends HTTP requests as fast as possible.
+// Returns a stop function; calling it stops the goroutine and returns the results.
+// Counts any err != nil or StatusCode != 200 as a failed request.
+func continuousTraffic(
+	t *testing.T,
+	rt roundtripper.RoundTripper,
+	gwAddr, host, path string,
+) (stop func() trafficResult) {
+	t.Helper()
+
+	var totalRequests atomic.Int64
+	var failedRequests atomic.Int64
+	stopCh := make(chan struct{})
+	var once sync.Once
+	var res trafficResult
+
+	expected := http.ExpectedResponse{
+		Request: http.Request{
+			Host: host,
+			Path: path,
+		},
+		Response: http.Response{
+			StatusCode: 200,
+		},
+	}
+	req := http.MakeRequest(t, &expected, gwAddr, "HTTP", "http")
+
+	go func() {
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				totalRequests.Add(1)
+				_, cRes, err := rt.CaptureRoundTrip(req)
+				if err != nil {
+					failedRequests.Add(1)
+					tlog.Logf(t, "continuous traffic request failed: %v", err)
+					continue
+				}
+				if cRes.StatusCode != 200 {
+					failedRequests.Add(1)
+					tlog.Logf(t, "continuous traffic request returned status %d", cRes.StatusCode)
+				}
+			}
+		}
+	}()
+
+	stopFn := func() trafficResult {
+		once.Do(func() {
+			close(stopCh)
+			res = trafficResult{
+				TotalRequests:  totalRequests.Load(),
+				FailedRequests: failedRequests.Load(),
+			}
+		})
+		return res
+	}
+
+	// Ensure we never leak the goroutine even if the test bails out early.
+	t.Cleanup(func() { stopFn() })
+	return stopFn
+}

--- a/pkg/features/gateway.go
+++ b/pkg/features/gateway.go
@@ -74,6 +74,11 @@ const (
 	// with ListenerSets
 	SupportListenerSet FeatureName = "ListenerSet"
 
+	// SupportGatewayNonDisruptiveConfig option indicates support for
+	// non-disruptive configuration changes, such as migrating routes between
+	// listeners/ListenerSets or changing route backends without traffic disruption.
+	SupportGatewayNonDisruptiveConfig FeatureName = "GatewayNonDisruptiveConfig"
+
 	// SupportGatewayBackendClientCertificate option indicates support for
 	// specifying client certificates when the Gateway originates the connection
 	// to the backend.
@@ -127,6 +132,12 @@ var (
 		Channel: FeatureChannelStandard,
 	}
 
+	// GatewayNonDisruptiveConfigFeature contains metadata for the SupportGatewayNonDisruptiveConfig feature.
+	GatewayNonDisruptiveConfigFeature = Feature{
+		Name:    SupportGatewayNonDisruptiveConfig,
+		Channel: FeatureChannelStandard,
+	}
+
 	// GatewayBackendClientCertificateFeature contains metadata for the SupportGatewayBackendClientCertificate feature.
 	GatewayBackendClientCertificateFeature = Feature{
 		Name:    SupportGatewayBackendClientCertificate,
@@ -154,6 +165,7 @@ var GatewayExtendedFeatures = sets.New(
 	GatewayHTTPSListenerDetectMisdirectedRequestsFeature,
 	GatewayInfrastructurePropagationFeature,
 	GatewayEmptyAddressFeature,
+	GatewayNonDisruptiveConfigFeature,
 	GatewayBackendClientCertificateFeature,
 	GatewayFrontendClientCertificateValidationFeature,
 	GatewayFrontendClientCertificateValidationInsecureFallbackFeature,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**

Add one of the following kinds:
/kind test
/area conformance-test


**What this PR does / why we need it**:

This PR adds two new conformance tests (HTTPRouteNonDisruptiveConfig and ListenerSetNonDisruptiveConfig) gated behind a new GatewayNonDisruptiveConfig extended feature, verifying that implementations MAY support non-disruptive configuration changes — specifically, migrating an HTTPRoute's parentRef from a Gateway listener to a ListenerSet without dropping in-flight traffic (Test 2 from #4342), and deleting a conflicted ListenerSet so that traffic  seamlessly fails over to the remaining one (Test 1 from #4342). A shared traffic helper sends continuous requests throughout each reconfiguration and asserts zero request failures.    
  
The PR is tested as of now (2026-04-23) against the following implementations: Istio, Envoy Gateway, Cilium and Airlock with these results https://gist.github.com/davidesalerno/6bb4d575dff3c6f6711ebb261310da14

**Which issue(s) this PR fixes**:
This change will verify if an implementation is supporting non-disruptive configuration

Fixes #4342 

**Does this PR introduce a user-facing change?**:

```release-note
 New conformance test to verify if implementations MAY support non-disruptive configuration
```
