### PR TITLE
Promote client-certificate validation features to Standard

### DIFF
--- a/pkg/features/gateway.go
+++ b/pkg/features/gateway.go
@@ -126,12 +126,12 @@ var (
 	// GatewayBackendClientCertificateFeature contains metadata for the SupportGatewayBackendClientCertificate feature.
 	GatewayBackendClientCertificateFeature = Feature{
 		Name:    SupportGatewayBackendClientCertificate,
-		Channel: FeatureChannelExperimental,
+		Channel: FeatureChannelStandard,
 	}
 	// GatewayFrontendClientCertificateValidationFeature contains metadata for the GatewayFrontendClientCertificateValidation feature.
 	GatewayFrontendClientCertificateValidationFeature = Feature{
 		Name:    SupportGatewayFrontendClientCertificateValidation,
-		Channel: FeatureChannelExperimental,
+		Channel: FeatureChannelStandard,
 	}
 )
 


### PR DESCRIPTION
We promoted the client-certificate validation API changes to Standard, but we need to promote the features too.

Signed-off-by: Flynn <emissary@flynn.kodachi.com>

/kind cleanup

-->
```release-note
NONE
```
