### PR TITLE
CORS conformance fixes regarding credentials and wildcards

### DIFF
--- a/conformance/tests/httproute-cors.go
+++ b/conformance/tests/httproute-cors.go
@@ -546,6 +546,46 @@ var HTTPRouteCORS = suite.ConformanceTest{
 					},
 				},
 			},
+			{
+				TestCaseName: "Simple request with credentials auth should be allowed and always echo the origin",
+				Request: http.Request{
+					Path:   "/cors-wildcard-methods-headers",
+					Method: "GET",
+					Headers: map[string]string{
+						"Origin":        "https://other.foo.com",
+						"Authorization": "Bearer test",
+					},
+				},
+				Namespace: ns,
+				Response: http.Response{
+					StatusCode: 200,
+					ValidHeaderValues: map[string][]string{
+						"access-control-allow-origin":      {"https://other.foo.com"},
+						"access-control-allow-credentials": {"true"},
+					},
+				},
+			},
+			{
+				TestCaseName: "Simple request with credentials should hide auth headers on unauth path",
+				Request: http.Request{
+					Path:   "/cors-wildcard-methods-headers-unauth",
+					Method: "GET",
+					Headers: map[string]string{
+						"Origin":        "https://other.foo.com",
+						"Authorization": "Bearer test",
+					},
+				},
+				Namespace: ns,
+				Response: http.Response{
+					StatusCode: 200,
+					ValidHeaderValues: map[string][]string{
+						"access-control-allow-origin": {"https://other.foo.com"},
+					},
+					AbsentHeaders: []string{
+						"access-control-allow-credentials",
+					},
+				},
+			},
 		}
 		for i := range testCases {
 			// Declare tc here to avoid loop variable


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind test
/area conformance-test

**What this PR does / why we need it**:

1. One test case verified gateway behavior with a requests not adhering to HTTP standards. The request is turned into a valid one in this PR.
2. The above test case verified the lack of wildcards in `access-control-allow-origin`, but not in `access-control-allow-methods`. Now, both are covered.
3. The next test case allowed wildcards in `access-control-allow-origin` and `access-control-allow-methods`, but not in `access-control-allow-headers`. Now, wildcards are allowed in all three.
4. The PR also adds test cases for simple credentialed requests as suggested by @snorwin via dm.

*More details can be found in the corresponding commit descriptions.*

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
