### PR TITLE
fix: add group to parentRef in HTTPRoute for XListenerSet

### DIFF
--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -485,6 +485,7 @@ spec:
   parentRefs:
   - name: second-workload-listeners
     kind: XListenerSet
+    group: gateway.networking.x-k8s.io
     sectionName: second
 ```
 
@@ -499,6 +500,7 @@ spec:
   parentRefs:
   - name: second-workload-listeners
     kind: XListenerSet
+    group: gateway.networking.x-k8s.io
     sectionName: second
   - name: parent-gateway
     kind: Gateway


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**

/kind gep

**What this PR does / why we need it**:

The examples shown for using an XListenerSet as parent to an HTTPRoute are not correct because the parentRef in the HTTPRoute does not use the correct group.
If no group is specified the default `gateway.networking.k8s.io` is inferred instead of `gateway.networking.x-k8s.io`. ([docs](https://gateway-api.sigs.k8s.io/reference/spec/#parentreference)

**Which issue(s) this PR fixes**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
