### PR TITLE
fix: use omitzero instead of omitempty for supportedKinds to ensure backward compatibility

### DIFF
--- a/apis/v1/gateway_types.go
+++ b/apis/v1/gateway_types.go
@@ -1365,7 +1365,7 @@ type ListenerStatus struct {
 	// +optional
 	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=8
-	SupportedKinds []RouteGroupKind `json:"supportedKinds,omitempty"`
+	SupportedKinds []RouteGroupKind `json:"supportedKinds,omitzero"`
 
 	// AttachedRoutes represents the total number of Routes that have been
 	// successfully attached to this Listener.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind bug

**What this PR does / why we need it**:
With the 1.5 release, the `supportedKinds` field in `ListenerStatus` was changed from `required` to `optional`, and `omitempty` was introduced.

While this appears to be a non-breaking API change, the addition of `omitempty` effectively breaks controllers reconciling older versions as soon as the dependency is updated to v1.5. Because the field is no longer explicitly set to an empty value, it may be omitted entirely from the status. However, certain conformance tests, e.g., `GatewayInvalidRouteKind`, still expect the field to be present, even if empty.

In our case, this resulted in the controller entering an endless reconcile loop with the following error:
```
"message":"failed to update status: Gateway.gateway.networking.k8s.io \"gateway-only-invalid-route-kind\" is invalid: [status.listeners[0].supportedKinds: Required value, <nil>: Invalid value: null: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]"
```

**1.4.1** 
```
	// +required
	// +listType=atomic
	// +kubebuilder:validation:MaxItems=8
	SupportedKinds []RouteGroupKind `json:"supportedKinds"`
```
https://github.com/kubernetes-sigs/gateway-api/blob/v1.4.1/apis/v1/gateway_types.go#L1310-L1313

**v1.5.0-rc.1**
```
	// +optional
	// +listType=atomic
	// +kubebuilder:validation:MaxItems=8
	SupportedKinds []RouteGroupKind `json:"supportedKinds,omitempty"`
```
https://github.com/kubernetes-sigs/gateway-api/blob/v1.5.0-rc.1/apis/v1/gateway_types.go#L1365-L1368

This PR ensures compatibility by preventing `supportedKinds` from being omitted in cases where it must be explicitly set empty.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Replace `omitempty` with `omitzero` for `supportedKinds` in ListenerStatus to preserve backward compatibility for controllers reconciling older Gateway API versions.
```
