### PR TITLE
conformance: tune and allow configuring polling interval

### DIFF
--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -107,6 +107,9 @@ type TimeoutConfig struct {
 	// DefaultTestTimeout is the default amount of time to wait for a test to complete
 	DefaultTestTimeout time.Duration
 
+	// DefaultPollInterval is the default amount of time to poll for status checks.
+	DefaultPollInterval time.Duration
+
 	// RequiredConsecutiveSuccesses is the number of requests that must succeed in a row
 	// to consider a response "consistent" before making additional assertions on the response body.
 	// If this number is not reached within MaxTimeToConsistency, the test will fail.
@@ -136,6 +139,7 @@ func DefaultTimeoutConfig() TimeoutConfig {
 		RequestTimeout:                         10 * time.Second,
 		LatestObservedGenerationSet:            60 * time.Second,
 		DefaultTestTimeout:                     60 * time.Second,
+		DefaultPollInterval:                    time.Millisecond * 100,
 		RequiredConsecutiveSuccesses:           3,
 	}
 }

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -120,7 +120,7 @@ func gwcMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.Timeo
 	t.Helper()
 
 	var controllerName string
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.GWCMustBeAccepted, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.GWCMustBeAccepted, true, func(ctx context.Context) (bool, error) {
 		gwc := &gatewayv1.GatewayClass{}
 		err := c.Get(ctx, types.NamespacedName{Name: gwcName}, gwc)
 		if err != nil {
@@ -147,7 +147,7 @@ func gwcMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.Timeo
 func GatewayMustHaveLatestConditions(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, gwNN types.NamespacedName) {
 	t.Helper()
 
-	waitErr := wait.PollUntilContextTimeout(t.Context(), 1*time.Second, timeoutConfig.LatestObservedGenerationSet, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(t.Context(), timeoutConfig.DefaultPollInterval, timeoutConfig.LatestObservedGenerationSet, true, func(ctx context.Context) (bool, error) {
 		gw := &gatewayv1.Gateway{}
 		err := c.Get(ctx, gwNN, gw)
 		if err != nil {
@@ -170,7 +170,7 @@ func GatewayMustHaveLatestConditions(t *testing.T, c client.Client, timeoutConfi
 func GatewayClassMustHaveLatestConditions(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, gwcNN types.NamespacedName) {
 	t.Helper()
 
-	waitErr := wait.PollUntilContextTimeout(t.Context(), 1*time.Second, timeoutConfig.LatestObservedGenerationSet, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(t.Context(), timeoutConfig.DefaultPollInterval, timeoutConfig.LatestObservedGenerationSet, true, func(ctx context.Context) (bool, error) {
 		gwc := &gatewayv1.GatewayClass{}
 		err := c.Get(ctx, gwcNN, gwc)
 		if err != nil {
@@ -193,7 +193,7 @@ func GatewayClassMustHaveLatestConditions(t *testing.T, c client.Client, timeout
 func HTTPRouteMustHaveLatestConditions(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, rNN types.NamespacedName) {
 	t.Helper()
 
-	waitErr := wait.PollUntilContextTimeout(t.Context(), 1*time.Second, timeoutConfig.LatestObservedGenerationSet, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(t.Context(), timeoutConfig.DefaultPollInterval, timeoutConfig.LatestObservedGenerationSet, true, func(ctx context.Context) (bool, error) {
 		r := &gatewayv1.HTTPRoute{}
 		err := c.Get(ctx, rNN, r)
 		if err != nil {
@@ -254,7 +254,7 @@ func FilterStaleConditions(obj metav1.Object, conditions []metav1.Condition) []m
 func NamespacesMustBeReady(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, namespaces []string) {
 	t.Helper()
 
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.NamespacesMustBeReady, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.NamespacesMustBeReady, true, func(ctx context.Context) (bool, error) {
 		for _, ns := range namespaces {
 			gwList := &gatewayv1.GatewayList{}
 			err := c.List(ctx, gwList, client.InNamespace(ns))
@@ -320,7 +320,7 @@ func GatewayMustHaveCondition(
 
 	waitErr := wait.PollUntilContextTimeout(
 		context.Background(),
-		1*time.Second,
+		timeoutConfig.DefaultPollInterval,
 		timeoutConfig.GatewayMustHaveCondition,
 		true,
 		func(ctx context.Context) (bool, error) {
@@ -354,11 +354,14 @@ func GatewayMustHaveCondition(
 func GatewayMustHaveAttachedListeners(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, gwName types.NamespacedName, count int32) {
 	var gotStatus *gatewayv1.GatewayStatus
 
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.GatewayStatusMustHaveListeners, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.GatewayStatusMustHaveListeners, true, func(ctx context.Context) (bool, error) {
 		gw := &gatewayv1.Gateway{}
 
 		err := client.Get(ctx, gwName, gw)
-		require.NoError(t, err, "error fetching Gateway")
+		if err != nil {
+			tlog.Log(t, "failed to get gateway ", err)
+			return false, nil
+		}
 
 		if err := ConditionsHaveLatestObservedGeneration(gw, gw.Status.Conditions); err != nil {
 			tlog.Log(t, "Gateway ", err)
@@ -387,7 +390,7 @@ func ListenerSetMustHaveCondition(
 
 	waitErr := wait.PollUntilContextTimeout(
 		context.Background(),
-		1*time.Second,
+		timeoutConfig.DefaultPollInterval,
 		timeoutConfig.ListenerSetMustHaveCondition,
 		true,
 		func(ctx context.Context) (bool, error) {
@@ -425,7 +428,7 @@ func ListenerSetMustHaveCondition(
 func MeshNamespacesMustBeReady(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, namespaces []string) {
 	t.Helper()
 
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.NamespacesMustBeReady, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.NamespacesMustBeReady, true, func(ctx context.Context) (bool, error) {
 		for _, ns := range namespaces {
 			podList := &v1.PodList{}
 			err := c.List(ctx, podList, client.InNamespace(ns))
@@ -507,7 +510,7 @@ func WaitForGatewayAddress(t *testing.T, client client.Client, timeoutConfig con
 	t.Helper()
 
 	var ipAddr, port string
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.GatewayMustHaveAddress, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.GatewayMustHaveAddress, true, func(ctx context.Context) (bool, error) {
 		gw, err := getGatewayStatus(ctx, t, client, gwRef)
 		if gw == nil {
 			// The returned error is nil if the Gateway conditions don't have the latest observed generation.
@@ -566,7 +569,7 @@ func GatewayListenersMustHaveConditions(t *testing.T, client client.Client, time
 		}
 	}
 
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.GatewayListenersMustHaveConditions, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.GatewayListenersMustHaveConditions, true, func(ctx context.Context) (bool, error) {
 		var gw gatewayv1.Gateway
 		if err := client.Get(ctx, gwName, &gw); err != nil {
 			return false, fmt.Errorf("error fetching Gateway: %w", err)
@@ -603,7 +606,7 @@ func GatewayListenersMustHaveConditions(t *testing.T, client client.Client, time
 func GatewayListenerMustHaveConditions(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, gwName types.NamespacedName, lName string, conditions []metav1.Condition) {
 	t.Helper()
 
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.GatewayListenersMustHaveConditions, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.GatewayListenersMustHaveConditions, true, func(ctx context.Context) (bool, error) {
 		var gw gatewayv1.Gateway
 		if err := client.Get(ctx, gwName, &gw); err != nil {
 			return false, fmt.Errorf("error fetching Gateway: %w", err)
@@ -633,7 +636,7 @@ func GatewayListenerMustHaveConditions(t *testing.T, client client.Client, timeo
 func GatewayMustHaveZeroRoutes(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, gwName types.NamespacedName) {
 	var gotStatus *gatewayv1.GatewayStatus
 
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.GatewayStatusMustHaveListeners, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.GatewayStatusMustHaveListeners, true, func(ctx context.Context) (bool, error) {
 		gw := &gatewayv1.Gateway{}
 
 		err := client.Get(ctx, gwName, gw)
@@ -670,6 +673,7 @@ func HTTPRouteMustHaveNoAcceptedParents(t *testing.T, client client.Client, time
 
 	var actual []gatewayv1.RouteParentStatus
 	emptyChecked := false
+	// Note: explicitly do not use timeoutConfig.DefaultPollInterval here as we are doing a negative test
 	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.HTTPRouteMustNotHaveParents, true, func(ctx context.Context) (bool, error) {
 		route := &gatewayv1.HTTPRoute{}
 		err := client.Get(ctx, routeName, route)
@@ -681,7 +685,7 @@ func HTTPRouteMustHaveNoAcceptedParents(t *testing.T, client client.Client, time
 
 		if len(actual) == 0 {
 			// For empty status, we need to distinguish between "correctly did not set" and "hasn't set yet"
-			// Ensure we iterate at least two times (taking advantage of the 1s poll delay) to give it some time.
+			// Ensure we iterate at least two times to give it some time.
 			if !emptyChecked {
 				emptyChecked = true
 				return false, nil
@@ -715,6 +719,7 @@ func TLSRouteMustHaveNoAcceptedParents(t *testing.T, client client.Client, timeo
 
 	var actual []gatewayv1.RouteParentStatus
 	emptyChecked := false
+	// We explicitly do not use timeoutConfig.DefaultPollInterval here since we are doing negative testing
 	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.HTTPRouteMustNotHaveParents, true, func(ctx context.Context) (bool, error) {
 		route := &gatewayv1.TLSRoute{}
 		err := client.Get(ctx, routeName, route)
@@ -726,7 +731,7 @@ func TLSRouteMustHaveNoAcceptedParents(t *testing.T, client client.Client, timeo
 
 		if len(actual) == 0 {
 			// For empty status, we need to distinguish between "correctly did not set" and "hasn't set yet"
-			// Ensure we iterate at least two times (taking advantage of the 1s poll delay) to give it some time.
+			// Ensure we iterate at least two times to give it some time.
 			if !emptyChecked {
 				emptyChecked = true
 				return false, nil
@@ -785,7 +790,7 @@ func RouteMustHaveParents(t *testing.T, cli client.Client, timeoutConfig config.
 	require.True(t, ok, "error converting %v to metav1.Object", routeType)
 
 	var actual []gatewayv1.RouteParentStatus
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.RouteMustHaveParents, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.RouteMustHaveParents, true, func(ctx context.Context) (bool, error) {
 		err := cli.Get(ctx, routeName, cliObj)
 		if err != nil {
 			return false, fmt.Errorf("error fetching %s: %w", routeTypeName, err)
@@ -827,7 +832,7 @@ func TLSRouteMustHaveParents(t *testing.T, client client.Client, timeoutConfig c
 	var actual []gatewayv1.RouteParentStatus
 	var route gatewayv1.TLSRoute
 
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.RouteMustHaveParents, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.RouteMustHaveParents, true, func(ctx context.Context) (bool, error) {
 		err := client.Get(ctx, routeName, &route)
 		if err != nil {
 			return false, fmt.Errorf("error fetching TLSRoute: %w", err)
@@ -891,7 +896,7 @@ func GatewayStatusMustHaveListeners(t *testing.T, cl client.Client, timeoutConfi
 	t.Helper()
 
 	var actual []gatewayv1.ListenerStatus
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.GatewayStatusMustHaveListeners, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.GatewayStatusMustHaveListeners, true, func(ctx context.Context) (bool, error) {
 		gw := &gatewayv1.Gateway{}
 		err := cl.Get(ctx, gwNN, gw)
 		if err != nil {
@@ -916,7 +921,7 @@ func ListenerSetStatusMustHaveListeners(t *testing.T, cl client.Client, timeoutC
 	t.Helper()
 
 	var actual []gatewayv1.ListenerEntryStatus
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.ListenerSetListenersMustHaveConditions, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.ListenerSetListenersMustHaveConditions, true, func(ctx context.Context) (bool, error) {
 		gw := &gatewayv1.ListenerSet{}
 		err := cl.Get(ctx, lsNN, gw)
 		if err != nil {
@@ -939,7 +944,7 @@ func ListenerSetStatusMustHaveListeners(t *testing.T, cl client.Client, timeoutC
 func HTTPRouteMustHaveCondition(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, routeNN types.NamespacedName, gwNN types.NamespacedName, condition metav1.Condition) {
 	t.Helper()
 
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.HTTPRouteMustHaveCondition, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.HTTPRouteMustHaveCondition, true, func(ctx context.Context) (bool, error) {
 		route := &gatewayv1.HTTPRoute{}
 		err := client.Get(ctx, routeNN, route)
 		if err != nil {
@@ -1039,7 +1044,7 @@ func GatewayAndTLSRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutCon
 func TLSRouteMustHaveCondition(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, routeNN types.NamespacedName, gwNN types.NamespacedName, condition metav1.Condition) {
 	t.Helper()
 
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.TLSRouteMustHaveCondition, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.TLSRouteMustHaveCondition, true, func(ctx context.Context) (bool, error) {
 		route := &gatewayv1.TLSRoute{}
 		err := client.Get(ctx, routeNN, route)
 		if err != nil {
@@ -1159,7 +1164,7 @@ func ListenerSetListenersMustHaveConditions(t *testing.T, client client.Client, 
 		}
 	}
 
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.ListenerSetListenersMustHaveConditions, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.ListenerSetListenersMustHaveConditions, true, func(ctx context.Context) (bool, error) {
 		var parent gatewayv1.ListenerSet
 		if err := client.Get(ctx, lsName, &parent); err != nil {
 			return false, fmt.Errorf("error fetching Gateway: %w", err)
@@ -1401,7 +1406,7 @@ func findPodConditionInList(t *testing.T, conditions []v1.PodCondition, condName
 // halting after the specified timeout is exceeded.
 func BackendTLSPolicyMustHaveCondition(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, policyNN, gwNN types.NamespacedName, condition metav1.Condition) {
 	t.Helper()
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.HTTPRouteMustHaveCondition, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.HTTPRouteMustHaveCondition, true, func(ctx context.Context) (bool, error) {
 		policy := &gatewayv1.BackendTLSPolicy{}
 		err := client.Get(ctx, policyNN, policy)
 		if err != nil {


### PR DESCRIPTION
Much of the time for conformance is spent waiting on the 1s timer to trigger. These checks are very cheap in-memory checks, so no reason to wait so long. This drops the time down and makes it configurable

**What type of PR is this?**
/area conformance-machinery


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The default polling interval for conformance tests has been decreased. This can be modified by the new DefaultPollInterval.
```
