### PR TITLE
grpc: do not require unique hostnames with http

### DIFF
--- a/site-src/api-types/grpcroute.md
+++ b/site-src/api-types/grpcroute.md
@@ -40,20 +40,19 @@ gRPC meets all of these criteria, so the decision was made to include `GRPCRoute
 
 ### Cross Serving
 
-Implementations that support GRPCRoute must enforce uniqueness of
-hostnames between `GRPCRoute`s and `HTTPRoute`s. If a route (A) of type `HTTPRoute` or
-`GRPCRoute` is attached to a Listener and that listener already has another Route (B) of
-the other type attached and the intersection of the hostnames of A and B is
-non-empty, then the implementation must reject Route A. That is, the
-implementation must raise an 'Accepted' condition with a status of 'False' in
-the corresponding RouteParentStatus.
-
 In general, it is recommended that separate hostnames be used for gRPC and
 non-gRPC HTTP traffic. This aligns with standard practice in the gRPC community.
-If however, it is a necessity to serve HTTP and gRPC on the same hostname with
-the only differentiator being URI, the user should use `HTTPRoute` resources for
-both gRPC and HTTP. This will come at the cost of the improved UX of the
-`GRPCRoute` resource.
+
+Implementations that support GRPCRoute may enforce uniqueness of
+hostnames between `GRPCRoute`s and `HTTPRoute`s. That is, if a route (A) of type `HTTPRoute` or
+`GRPCRoute` is attached to a Listener and that listener already has another Route (B) of
+the other type attached and the intersection of the hostnames of A and B is
+non-empty, then the implementation may reject Route A and raise an 'Accepted' condition with a status of 'False' in
+the corresponding RouteParentStatus.
+
+If there is a necessity to serve HTTP and gRPC on the same hostname with
+the only differentiator being URI, and the implementation enforces uniqueness, the user should use `HTTPRoute` resources 
+for both gRPC and HTTP. This will come at the cost of the improved UX of the `GRPCRoute` resource.
 
 ## When to Use GRPCRoute
 


### PR DESCRIPTION
This part of the spec is not implemented by a large number of implementations. That I know of:
* Istio
* Kgateway
* Envoy Gateway
* Contour
* Agentgateway

I can only speak for the ones I am involved in, but this is not an accident; this was an intentional diversion from the recommendation here, as this does not meet users needs. HTTP and gRPC are entirely compatible to be on the same hostname, and quite common to do so even if the gRPC maintainers does not consider it a best practice (I am not sure how this is even true, given this opinion comes from Google who hosts HTTP and gRPC on the same `googleapis.com`?? maybe I am missing something). Instead, this forces users into an arbitrary restriction and then forces them to rewrite all of their routes from GRPCRoute to HTTPRoute which is a regression in usability.

The original GEP:

```
If at some point in the future, demand for this use case increases and we have
reason to believe that the feasibility of implementation has improved, this
would be a backward compatible change.
```

Given the reality of the current state of implementations, I believe the demand for this has been met to change the spec.

See also https://kubernetes.slack.com/archives/CR0H13KGA/p1770320071586889

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Previously, implementations were required to reject GRPCRoute and HTTPRoutes on the same hostname (however, few implementations did this). Now, implementations may optionally do this, or allow them to coincide.
```
