### PR TITLE
conformance: Move Inference Extension conformance helper functions to gateway-api/conformance

### DIFF
--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -32,8 +32,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/conformance/utils/kubernetes/helpers_test.go
+++ b/conformance/utils/kubernetes/helpers_test.go
@@ -17,18 +17,25 @@ limitations under the License.
 package kubernetes
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/gateway-api/conformance/utils/config"
 )
 
 // -----------------------------------------------------------------------------
@@ -132,6 +139,62 @@ func TestVerifyConditionsMatchGeneration(t *testing.T) {
 			assert.Equal(t, test.expected, err)
 		})
 	}
+}
+
+func TestHTTPRouteMustBeAcceptedAndResolved(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, InstallGatewayV1(scheme))
+
+	routeNN := types.NamespacedName{Name: "test-route", Namespace: "default"}
+	gatewayNN := types.NamespacedName{Name: "test-gateway", Namespace: "default"}
+
+	gwNamespace := v1.Namespace(gatewayNN.Namespace)
+	route := &v1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeNN.Name,
+			Namespace: routeNN.Namespace,
+		},
+		Status: v1.HTTPRouteStatus{
+			RouteStatus: v1.RouteStatus{
+				Parents: []v1.RouteParentStatus{
+					{
+						ParentRef: v1.ParentReference{
+							Name:      v1.ObjectName(gatewayNN.Name),
+							Namespace: &gwNamespace,
+						},
+						Conditions: []metav1.Condition{
+							{
+								Type:               string(v1.RouteConditionAccepted),
+								Status:             metav1.ConditionTrue,
+								Reason:             string(v1.RouteReasonAccepted),
+								LastTransitionTime: metav1.Now(),
+							},
+							{
+								Type:               string(v1.RouteConditionResolvedRefs),
+								Status:             metav1.ConditionTrue,
+								Reason:             string(v1.RouteReasonResolvedRefs),
+								LastTransitionTime: metav1.Now(),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(route).Build()
+
+	timeoutConfig := config.TimeoutConfig{
+		HTTPRouteMustHaveCondition: 5 * time.Second,
+		DefaultPollInterval:        100 * time.Millisecond,
+	}
+
+	HTTPRouteMustBeAcceptedAndResolved(t, c, timeoutConfig, routeNN, gatewayNN)
+
+	DeleteHTTPRoute(t, c, routeNN)
+
+	err := c.Get(context.TODO(), routeNN, &v1.HTTPRoute{})
+	assert.True(t, apierrors.IsNotFound(err))
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/area conformance-machinery

**What this PR does / why we need it**:

Moving code from gateway-api-inference-extension/conformance that relies on importing Gateway API CRD types (mostly used there for checking status of Gateways when running conformance tests).

Part of an effort to improve conformance and circular dependency issues for projects that import both gateway-api/conformance and gateway-api-inference-extension/conformance: https://github.com/kubernetes-sigs/gateway-api/issues/4478

PR in gateway-api-inference-extension to be merged after this: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2433

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
