### PR TITLE
conformance: add Amazon VPC Lattice Gateway API Controller v2.0.1 report

### DIFF
--- a/conformance/reports/v1.4.0/aws-aws-application-networking-k8s/README.md
+++ b/conformance/reports/v1.4.0/aws-aws-application-networking-k8s/README.md
@@ -1,0 +1,15 @@
+# Amazon VPC Lattice Gateway API Controller
+
+The [Amazon VPC Lattice Gateway API Controller](https://github.com/aws/aws-application-networking-k8s) is an implementation of the Kubernetes Gateway API that orchestrates AWS VPC Lattice resources using Kubernetes Custom Resource Definitions like Gateway and HTTPRoute.
+
+## Table of contents
+
+| API channel  | Implementation version | Mode    | Report |
+|--------------|------------------------|---------|--------|
+| experimental | [v2.0.1](https://github.com/aws/aws-application-networking-k8s/releases/tag/v2.0.1) | default | [v2.0.1 report](./experimental-v2.0.1-default-report.yaml) |
+
+## Reproduce
+
+1. Create an EKS cluster with VPC Lattice configured in the same VPC.
+2. Install the Amazon VPC Lattice Gateway API Controller v2.0.1.
+3. Follow the conformance test instructions in the [controller documentation](https://github.com/aws/aws-application-networking-k8s/blob/main/docs/conformance-test.md).

--- a/conformance/reports/v1.4.0/aws-aws-application-networking-k8s/experimental-v2.0.1-default-report.yaml
+++ b/conformance/reports/v1.4.0/aws-aws-application-networking-k8s/experimental-v2.0.1-default-report.yaml
@@ -1,0 +1,46 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-02-27T04:11:24Z"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.4.0
+implementation:
+  contact:
+  - https://github.com/aws/aws-application-networking-k8s/issues
+  organization: aws
+  project: aws-application-networking-k8s
+  url: https://github.com/aws/aws-application-networking-k8s
+  version: v2.0.1
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: partial
+    skippedTests:
+    - GatewayInvalidTLSConfiguration
+    - GatewaySecretInvalidReferenceGrant
+    - GatewaySecretMissingReferenceGrant
+    - GatewayWithAttachedRoutes
+    - HTTPRouteHTTPSListener
+    - HTTPRouteHeaderMatching
+    - HTTPRouteHostnameIntersection
+    - HTTPRouteInvalidBackendRefUnknownKind
+    - HTTPRouteInvalidCrossNamespaceBackendRef
+    - HTTPRouteInvalidNonExistentBackendRef
+    - HTTPRouteInvalidReferenceGrant
+    - HTTPRouteListenerHostnameMatching
+    - HTTPRouteMatching
+    - HTTPRouteMatchingAcrossRoutes
+    - HTTPRouteObservedGenerationBump
+    - HTTPRoutePartiallyInvalidViaInvalidReferenceGrant
+    - HTTPRoutePathMatchOrder
+    - HTTPRouteRedirectHostAndStatus
+    - HTTPRouteReferenceGrant
+    - HTTPRouteRequestHeaderModifier
+    - HTTPRouteServiceTypes
+    - HTTPRouteSimpleSameNamespace
+    - HTTPRouteWeight
+    statistics:
+      Failed: 0
+      Passed: 10
+      Skipped: 23
+  name: GATEWAY-HTTP
+  summary: Core tests partially succeeded with 23 test skips.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it:**
Submit new conformance report for Amazon VPC Lattice Gateway API Controller [v2.0.1](https://github.com/aws/aws-application-networking-k8s/releases/tag/v2.0.1).

**Which issue(s) this PR fixes:**
NONE

**Does this PR introduce a user-facing change?:**

```release-note
NONE
```