### PR TITLE
cleanup: fix docs build variable mismatch and script error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ build-docs: install-deps update-geps api-ref-docs wizard-wasm wizard-data confor
 
 .PHONY: verify-docs
 verify-docs: build-docs
-	docker run --init --rm -w /input -v ${PWD}:/input $(DOCS_VERIFY_CONTAINER_IMAGE) --root-dir /input/site/public --include "sigs.k8s.io" --accept 200 --max-concurrency 10 --include-fragments --cache $(VALIDATE_DOCS_EXTRA_ARGS) /input/site/public/**/*.html
+	docker run --init --rm -w /input -v ${PWD}:/input $(DOCS_VERIFY_CONTAINER_IMAGE) --root-dir /input/site/public --include "sigs.k8s.io" --accept 200 --max-concurrency 10 --include-fragments --cache $(VALIDATE_DOCS_EXTRA_FLAGS) /input/site/public/**/*.html
 
 .PHONY: build-docs-netlify
 build-docs-netlify: install-deps update-geps api-ref-docs wizard-wasm wizard-data conformance-data

--- a/hack/docsy/generate.sh
+++ b/hack/docsy/generate.sh
@@ -51,7 +51,7 @@ for i in "${arr[@]}"; do
         echo "Branch ${i} not found on ${REMOTE}. Try: REMOTE=upstream $0"
         exit 1
     }
-    git archive "${REMOTE}/${i}" apis apisx | tar -x -C "${tmpdir}"
+    git archive --format=tar FETCH_HEAD apis apisx | tar -x -C "${tmpdir}"
 
     # Start removing any "release-" prefix from docpath
     docpath=${i#"release-"}

--- a/hack/docsy/generate.sh
+++ b/hack/docsy/generate.sh
@@ -47,9 +47,11 @@ link_title_specx="Experimental"
 for i in "${arr[@]}"; do
     tmpdir=$(mktemp -d --tmpdir=${PWD}/tmp)
 
-    git fetch ${REMOTE} ${i} ||
-	    echo "You need a git remote pointing to upstream for API Ref generation. To solve this issue locally, execute 'git remote add upstream git@github.com:kubernetes-sigs/gateway-api.git' and then call the script again with 'REMOTE=upstream <command>'"
-    git --work-tree=${tmpdir} checkout ${REMOTE}/${i} -- apis apisx
+    git fetch "${REMOTE}" "${i}" || {
+        echo "Branch ${i} not found on ${REMOTE}. Try: REMOTE=upstream $0"
+        exit 1
+    }
+    git archive "${REMOTE}/${i}" apis apisx | tar -x -C "${tmpdir}"
 
     # Start removing any "release-" prefix from docpath
     docpath=${i#"release-"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind cleanup

**What this PR does / why we need it**:

Fix docs build tooling bugs.

* `VALIDATE_DOCS_EXTRA_ARGS` in verify-docs target doesn't match the `VALIDATE_DOCS_EXTRA_FLAGS` variable definition.
* `generate.sh` uses `git checkout --work-tree` which pollutes the repository index, replaced with `git archive | tar`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
