### PR TITLE
Fix for release artifact validation CI

### DIFF
--- a/.github/workflows/verify-release-artifacts.yml
+++ b/.github/workflows/verify-release-artifacts.yml
@@ -1,11 +1,14 @@
 # Verify that release artifacts (standard-install.yaml) match the source at the release tag.
-# Catches cases where the release pipeline was run from a commit ahead of the tagged commit.
+# Runs when a new release is published (any tag). For release events, GitHub uses the workflow
+# from the default branch—ensure this file is on main (or your default branch).
+# For past releases that didn't trigger, run manually: Actions -> Verify Release Artifacts -> Run workflow.
 
 name: Verify Release Artifacts
 
 on:
   release:
-    types: [published]
+    types:
+      - published
   workflow_dispatch:
     inputs:
       tag:
@@ -20,8 +23,6 @@ jobs:
   verify-standard-install:
     name: standard-install.yaml matches source at tag
     runs-on: ubuntu-latest
-    # On release event: only SemVer tags; on manual run: always run (tag validated by input)
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     steps:
       - name: Set tag for verification
         id: set-tag
@@ -50,14 +51,16 @@ jobs:
           cd "$workdir"
 
           # A) Get standard-install.yaml from this release
+          echo "Downloading release assets."
           gh release download "$TAG" --repo "$REPO" --pattern "standard-install.yaml" --dir .
 
           # B) Get source tarball from release, or fall back to GitHub archive for this tag
+          echo "Downloading source tarball"
           curl -sSfL -o source.tar.gz "https://github.com/${REPO}/archive/refs/tags/${TAG}.tar.gz"
           tar --extract --gunzip --file $(ls *.tar.gz | head -1)
           cd gateway-api-*
           echo "Building standard-install.yaml from source at tag $TAG (same version)..."
-          make build-install-yaml
+          VERSION=$TAG make build-install-yaml 2>/dev/null || make build-install-yaml
 
           # C) Normalize build files
           sed 's/Copyright [0-9]\{4\}/Copyright YEAR/' ../standard-install.yaml > /tmp/release.yaml
@@ -66,8 +69,9 @@ jobs:
           echo ""
           echo "Diff: (A) release asset  vs  (B) built from source. Lines with - are in release, + are in built."
           if ! diff -u /tmp/release.yaml /tmp/built.yaml; then
-            echo ""
-            echo "::error::Release $TAG: standard-install.yaml in the release does not match the source."
-            exit 1
+              echo ""
+              echo "::error::Validation FAILED. The CRD logic in the release does not match the source code."
+              exit 1
           fi
-          echo "Release artifact matches source at tag $TAG. Verification passed."
+          echo ""
+          echo "Success! The manifest logic in the $TAG release matches the source code."


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Validation CI didn't trigger on the v1.5.0 release. When I ran it manually, the script failed to run the build script as it requires some env variables.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
