### PR TITLE
Add 204 as a possible cors preflight response code

### DIFF
--- a/conformance/tests/httproute-cors.go
+++ b/conformance/tests/httproute-cors.go
@@ -127,7 +127,7 @@ var HTTPRouteCORS = suite.ConformanceTest{
 				},
 				Namespace: "",
 				Response: http.Response{
-					StatusCode: 200,
+					StatusCodes: []int{200, 204},
 					ValidHeaderValues: map[string][]string{
 						"access-control-allow-origin": {"https://www.bar.com"},
 						"access-control-allow-methods": {
@@ -175,7 +175,7 @@ var HTTPRouteCORS = suite.ConformanceTest{
 				},
 				Namespace: "",
 				Response: http.Response{
-					StatusCode: 200,
+					StatusCodes: []int{200, 204},
 					ValidHeaderValues: map[string][]string{
 						"access-control-allow-origin": {"https://xpto.www.bar.com"},
 						"access-control-allow-methods": {
@@ -241,7 +241,7 @@ var HTTPRouteCORS = suite.ConformanceTest{
 					},
 				},
 				Response: http.Response{
-					StatusCodes: []int{200, 204},
+					StatusCode: 200,
 					Headers: map[string]string{
 						"access-control-allow-origin": "https://www.foo.com",
 					},
@@ -260,7 +260,7 @@ var HTTPRouteCORS = suite.ConformanceTest{
 					},
 				},
 				Response: http.Response{
-					StatusCodes: []int{200, 204},
+					StatusCode: 200,
 					Headers: map[string]string{
 						"access-control-allow-origin": "https://www.bar.com",
 					},
@@ -341,6 +341,7 @@ var HTTPRouteCORS = suite.ConformanceTest{
 				},
 				Namespace: "",
 				Response: http.Response{
+					StatusCodes:   []int{200, 204},
 					AbsentHeaders: []string{"Access-Control-Allow-Credentials"},
 				},
 			},
@@ -424,7 +425,7 @@ var HTTPRouteCORS = suite.ConformanceTest{
 					},
 				},
 				Response: http.Response{
-					StatusCodes: []int{200},
+					StatusCode: 200,
 					ValidHeaderValues: map[string][]string{
 						// The access-control-allow-origin for a wildcard domain depends on the implementation.
 						// Envoy enforces the return of the same requested Origin, while NGINX an others may return a "*"
@@ -448,7 +449,7 @@ var HTTPRouteCORS = suite.ConformanceTest{
 					},
 				},
 				Response: http.Response{
-					StatusCodes: []int{200, 204},
+					StatusCode: 200,
 					ValidHeaderValues: map[string][]string{
 						// The access-control-allow-origin for a wildcard domain depends on the implementation.
 						// Envoy enforces the return of the same requested Origin, while NGINX an others may return a "*"
@@ -488,7 +489,7 @@ var HTTPRouteCORS = suite.ConformanceTest{
 				},
 				Namespace: "",
 				Response: http.Response{
-					StatusCode: 200,
+					StatusCodes: []int{200, 204},
 					ValidHeaderValues: map[string][]string{
 						"access-control-allow-origin":  {"https://other.foo.com"},
 						"access-control-allow-methods": {"PUT"},
@@ -528,7 +529,7 @@ var HTTPRouteCORS = suite.ConformanceTest{
 				},
 				Namespace: "",
 				Response: http.Response{
-					StatusCode: 200,
+					StatusCodes: []int{200, 204},
 					ValidHeaderValues: map[string][]string{
 						"access-control-allow-origin": {"https://other.foo.com", "*"},
 						"access-control-allow-methods": {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

Optionally add one or more of the following kinds if applicable:
/area conformance-test

**What this PR does / why we need it**:

A CORS preflight response has only headers, and some implementations use 204 No Content as the response code. This update adds 204 along with 200 as valid response codes for preflight requests.

Change also regular (non preflight) responses to status code 200 only, since this is a response of a test backend configured by the conformance test.

**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
