### PR TITLE
Fix: Update HTTPHeader and HTTPHeaderFilter Docs

### DIFF
--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -1017,11 +1017,8 @@ type HTTPHeader struct {
 	// Name is the name of the HTTP Header to be matched. Name matching MUST be
 	// case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 	//
-	// If multiple entries specify equivalent header names, the first entry with
-	// an equivalent name MUST be considered for a match. Subsequent entries
-	// with an equivalent header name MUST be ignored. Due to the
-	// case-insensitivity of header names, "foo" and "Foo" are considered
-	// equivalent.
+	// Due to the case-insensitivity of header names, "foo" and "Foo" are
+	// considered equivalent.
 	// +required
 	Name HTTPHeaderName `json:"name"`
 
@@ -1048,6 +1045,10 @@ type HTTPHeaderFilter struct {
 	// Set overwrites the request with the given header (name, value)
 	// before the action.
 	//
+	// Only one action for a given header name is permitted. Filters
+	// specifying multiple actions of the same or different type for any
+	// one header name are invalid.
+	//
 	// Input:
 	//   GET /foo HTTP/1.1
 	//   my-header: foo
@@ -1070,6 +1071,10 @@ type HTTPHeaderFilter struct {
 	// Add adds the given header(s) (name, value) to the request
 	// before the action. It appends to any existing values associated
 	// with the header name.
+	//
+	// Only one action for a given header name is permitted. Filters
+	// specifying multiple actions of the same or different type for any
+	// one header name are invalid.
 	//
 	// Input:
 	//   GET /foo HTTP/1.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR updates the documentation for HTTPHeader and HTTPHeaderFilter which is outdated as of now.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/4480

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Docs: Clarify HTTP header modifier semantics in API reference

Updated the documentation for HTTPHeader and HTTPHeaderFilter:                                          
- Removed the "multiple entries" matching semantics from HTTPHeader.Name.
- Added an explicit note to HTTPHeaderFilter.Set and HTTPHeaderFilter.Add stating that only one action per header name is permitted, and filters specifying multiple actions of the same or different type for a given header name are invalid.
```
