### PR TITLE
Minute clean-ups in conformance tests for CORS

### DIFF
--- a/conformance/tests/httproute-cors.go
+++ b/conformance/tests/httproute-cors.go
@@ -550,13 +550,13 @@ var HTTPRouteCORS = suite.ConformanceTest{
 				},
 			},
 			{
-				TestCaseName: "Simple request with credentials auth should be allowed and always echo the origin",
+				TestCaseName: "CORS request with credentials auth should be allowed and always echo the origin",
 				Request: http.Request{
 					Path:   "/cors-wildcard-methods-headers",
 					Method: "GET",
 					Headers: map[string]string{
-						"Origin":        "https://other.foo.com",
-						"Authorization": "Bearer test",
+						"Origin": "https://other.foo.com",
+						"Cookie": "foo=bar", // Cookie is a credential.
 					},
 				},
 				Namespace: ns,
@@ -569,13 +569,13 @@ var HTTPRouteCORS = suite.ConformanceTest{
 				},
 			},
 			{
-				TestCaseName: "Simple request with credentials should hide auth headers on unauth path",
+				TestCaseName: "CORS request with credentials should hide auth headers on unauth path",
 				Request: http.Request{
 					Path:   "/cors-wildcard-methods-headers-unauth",
 					Method: "GET",
 					Headers: map[string]string{
-						"Origin":        "https://other.foo.com",
-						"Authorization": "Bearer test",
+						"Origin": "https://other.foo.com",
+						"Cookie": "foo=bar", // Cookie is a credential.
 					},
 				},
 				Namespace: ns,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind cleanup
/area conformance-test


**What this PR does / why we need it**:

1. Not all non-preflight CORS requests [are simple](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS#simple_requests). Let's rename the corresponding test cases from `Simple request...` to `CORS request...`.

2. It turns out the `Authorization` header [does not count](https://github.com/kubernetes-sigs/gateway-api/issues/3861#issuecomment-3990452266) as a credential, so let's use Cookies as in the GEP instead https://github.com/kubernetes-sigs/gateway-api/blob/b91ed0cec9be54d022ab6822c37b5740eb15eab9/geps/gep-1767/index.md?plain=1#L257-L267

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
