### PR TITLE
allow absent conflict condition for non-conflicted listeners

### DIFF
--- a/conformance/tests/listenerset-allowed-namespace-same.go
+++ b/conformance/tests/listenerset-allowed-namespace-same.go
@@ -104,10 +104,5 @@ func generateAcceptedListenerConditions() []metav1.Condition {
 			Status: metav1.ConditionTrue,
 			Reason: "", // any reason
 		},
-		{
-			Type:   string(gatewayv1.ListenerConditionConflicted),
-			Status: metav1.ConditionFalse,
-			Reason: "", // any reason
-		},
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind test
/area conformance-test

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4618 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
The `conflicted=false` condition is not required anymore in the listener status for non-conflicted listeners.
```
