### PR TITLE
docs: fix broken links from security-model rename

### DIFF
--- a/geps/gep-1294/index.md
+++ b/geps/gep-1294/index.md
@@ -11,7 +11,7 @@ This GEP is intended to establish an implementable, but experimental, baseline f
 
 ## Personas
 
-This GEP uses the [roles and personas](../../concepts/security-model.md#roles-and-personas) defined in the Gateway API security model, and the service "producer" and "consumer" roles defined in [GEP-1324: Service Mesh in Gateway API](../gep-1324/index.md#producer-and-consumer).
+This GEP uses the [roles and personas](../../concepts/security.md#roles-and-personas) defined in the Gateway API security model, and the service "producer" and "consumer" roles defined in [GEP-1324: Service Mesh in Gateway API](../gep-1324/index.md#producer-and-consumer).
 
 ## Goals
 

--- a/geps/gep-1619/index.md
+++ b/geps/gep-1619/index.md
@@ -661,7 +661,7 @@ their preferred form of session persistence if desired.
 
 ### Target Persona
 
-Referring to the [Gateway API Security Model](../../concepts/security-model.md#roles-and-personas),
+Referring to the [Gateway API Security Model](../../concepts/security.md#roles-and-personas),
 the target kubernetes role/persona for session persistence are application developers, as mentioned in the [When does an application require session persistence?](#when-does-an-application-require-session-persistence)
 section. It is the responsibility of the application developers to adjust the persistence configuration to ensure the
 functionality of their applications.

--- a/site-src/api-types/referencegrant.md
+++ b/site-src/api-types/referencegrant.md
@@ -29,7 +29,7 @@ ReferenceGrant, a cross namespace reference is invalid.
 It is recommended that `ReferenceGrants` are used with caution, and that validations
 and limits are applied by cluster admins to guarantee the proper usage of this resource.
 
-Please refer to [Security Considerations](../concepts/security-considerations.md#limiting-cross-namespace-references)
+Please refer to [Security Considerations](../concepts/security.md#limiting-cross-namespace-references)
 for more details.
 
 ## Structure
@@ -116,7 +116,7 @@ No hints should be provided about whether or not the referenced resource exists.
 Cross namespace Route -> Gateway binding follows a slightly different pattern
 where the handshake mechanism is built into the Gateway resource. For more
 information on that approach, refer to the relevant [Security Model
-documentation](../concepts/security-model.md). Although conceptually similar to
+documentation](../concepts/security.md). Although conceptually similar to
 ReferenceGrant, this configuration is built directly into Gateway Listeners,
 and allows for fine-grained per Listener configuration that would not be
 possible with ReferenceGrant.

--- a/site-src/concepts/roles-and-personas.md
+++ b/site-src/concepts/roles-and-personas.md
@@ -77,4 +77,4 @@ system and will define resource model responsibility and separation.
 
 RBAC is discussed further in the [Security Model] description.
 
-[Security Model]: security-model.md#rbac
+[Security Model]: security.md#rbac

--- a/site-src/guides/getting-started/migrating-from-ingress.md
+++ b/site-src/guides/getting-started/migrating-from-ingress.md
@@ -73,7 +73,7 @@ resource, the infrastructure provider and cluster operator became the owners of
 that resource, and thus, explicit personas of the Ingress API.
 
 Gateway API
-includes [four explicit personas](../../concepts/security-model.md#roles-and-personas):
+includes [four explicit personas](../../concepts/security.md#roles-and-personas):
 the application developer, the application admin, the cluster operator, and the
 infrastructure providers. This allows you to break away from the self-service
 model by splitting the responsibilities of the user persona across those


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind documentation

**What this PR does / why we need it**:
Fixes some broken links found by lychee while I was testing #4657. Not sure why the [mkdocs redirect](https://github.com/kubernetes-sigs/gateway-api/blob/877cd09f5d131716a3f04426a297d80660f5ccf3/mkdocs.yml#L58) didn't fix them. I thought it might be a bug related to fragments, but I found [this case](https://github.com/kubernetes-sigs/gateway-api/blob/877cd09f5d131716a3f04426a297d80660f5ccf3/site-src/api-types/referencegrant.md?plain=1#L119) which is broken without a fragment.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
