### PR TITLE
conformance: fix ListenerSetAllowedRoutesSupportedKinds flaking

### DIFF
--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -1172,11 +1172,13 @@ func ListenerSetListenersMustHaveConditions(t *testing.T, client client.Client, 
 	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.ListenerSetListenersMustHaveConditions, true, func(ctx context.Context) (bool, error) {
 		var parent gatewayv1.ListenerSet
 		if err := client.Get(ctx, lsName, &parent); err != nil {
-			return false, fmt.Errorf("error fetching Gateway: %w", err)
+			tlog.Logf(t, "error fetching Gateway: %v", err)
+			return false, nil
 		}
 
 		if err := ConditionsHaveLatestObservedGeneration(&parent, parent.Status.Conditions); err != nil {
-			return false, err
+			tlog.Logf(t, "condition not yet at observed generation: %v", err)
+			return false, nil
 		}
 
 		for _, condition := range conditions {


### PR DESCRIPTION

**What type of PR is this?**

/area conformance-machinery

**What this PR does / why we need it**:
This does not properly retry due to incorrect usage of PollUntilContextTimeout.

Given we have had like 10 of these same bugs, maybe we should consider not using PollUntilContextTimeout and making our own helpers that are easier to use properly.

I would love to backport this as it makes our CI unreliable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
