### PR TITLE
Docs: Remove deprecated copy_on_write option

### DIFF
--- a/hack/mkdocs-generate-conformance.py
+++ b/hack/mkdocs-generate-conformance.py
@@ -111,8 +111,6 @@ warning_text = """
 
 def generate_conformance_tables(reports, currVersion, mkdocsConfig):
 
-    # Enable Pandas copy-on-write
-    pandas.options.mode.copy_on_write = True
 
     gateway_tls_table = pandas.DataFrame()
     gateway_grpc_table = pandas.DataFrame()

--- a/hack/mkdocs/image/requirements.txt
+++ b/hack/mkdocs/image/requirements.txt
@@ -13,7 +13,7 @@ mkdocs-macros-plugin==1.5.0
 mkdocs-material==9.7.4
 mkdocs-redirects==1.2.2
 mkdocs-mermaid2-plugin==1.2.3
-pandas>=2.0.3
+pandas>=3.0.0
 pep562==1.1
 Pygments==2.19.2
 pymdown-extensions==10.21


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind deprecation
**What this PR does / why we need it**:

Remove the `pandas.options.mode.copy_on_write = True` setting in `hack/mkdocs-generate-conformance.py`.

In Pandas 2.x, `copy_on_write` was an opt-in experimental feature that required explicitly enabling it. Starting with Pandas 3.0, Copy-on-Write became the default behavior, making this option unnecessary. Setting this option in Pandas 3.0+ triggers a `Pandas4Warning` during `mkdocs serve`.

**Which issue(s) this PR fixes**:

Fixes #4677 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
