### PR TITLE
docs: fix mkdocs redirects warning 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,7 @@ plugins:
   - redirects:
       redirect_maps:
         'guides/index.md': 'guides/getting-started/index.md'
-        'ingress-nginx': 'guides/getting-started/migrating-from-ingress-nginx.md'
+        'ingress-nginx.md': 'guides/getting-started/migrating-from-ingress-nginx.md'
         'concepts/gamma.md': 'mesh/index.md'
         'concepts/service-facets.md': 'mesh/service-facets.md'
         'concepts/guidelines.md': 'guides/api-design.md'


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it:**

The ingress-nginx source key in mkdocs.yml's redirect_maps is missing the .md extension.
This causes the mkdocs redirects plugin to emit a warning about an invalid markdown file path when running mkdocs serve. This PR adds the .md extension to fix the warning.

**Which issue(s) this PR fixes:**

Fixes #4679 

  **Does this PR introduce a user-facing change?**:

```release-note
NONE
```