### PR TITLE
docs: clarify RequestHeaderModifier set behavior

### DIFF
--- a/site-src/guides/http-header-modifier.md
+++ b/site-src/guides/http-header-modifier.md
@@ -19,7 +19,7 @@ To add a header to an HTTP request, use a filter of the type `RequestHeaderModif
 {% include 'standard/http-request-header-add.yaml' %}
 ```
 
-To edit an existing header, use the `set` action and specify the value of the header to be modified and the new header value to be set.
+To unconditionally set the value of a header, use `set`. It will override the value of a header with the provided value if the header is already present, or set it to the provided value if the header does not exist.
 
 ```yaml
     filters:


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation


**What this PR does / why we need it**:
Clarifies the `RequestHeaderModifier` guide to match the documented behavior of `set`, as agreed in https://github.com/kubernetes-sigs/gateway-api/issues/3314#issuecomment-2363858052

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3314

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
