### PR TITLE
Add conformance reports for haproxy ingress

### DIFF
--- a/conformance/reports/v1.4.1/haproxy-ingress/README.md
+++ b/conformance/reports/v1.4.1/haproxy-ingress/README.md
@@ -1,0 +1,70 @@
+# HAProxy Ingress
+
+## Table of contents
+
+| API channel | Implementation version | Mode | Report |
+|-------------|------------------------|------|--------|
+| experimental | [v0.17.0-alpha.1](https://github.com/jcmoraisjr/haproxy-ingress/releases/tag/v0.17.0-alpha.1) | default | [v0.17.0-alpha.1 report](./experimental-v0.17.0-alpha.1-default-report.yaml) |
+
+## Reproduce
+
+The following steps reproduce the HAProxy Ingress conformance test report.
+
+1. Create a kind cluster
+
+    ```yaml
+    # kind.yaml
+    kind: Cluster
+    apiVersion: kind.x-k8s.io/v1alpha4
+    nodes:
+    - role: control-plane
+      extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+      - containerPort: 443
+        hostPort: 443
+    ```
+
+    ```bash
+    kind create cluster --config kind.yaml
+    ```
+
+1. Deploy Gateway API CRDs
+
+    ```bash
+    kubectl create -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
+    ```
+
+1. Deploy HAProxy Ingress
+
+    ```bash
+    helm upgrade --install --create-namespace --namespace ingress-controller \
+      haproxy-ingress https://github.com/haproxy-ingress/charts/releases/download/0.17.0-alpha.1/haproxy-ingress-0.17.0-alpha.1.tgz \
+      --set controller.kind=DaemonSet \
+      --set controller.daemonset.useHostPort=true \
+      --set controller.service.type=ClusterIP \
+      --set controller.extraArgs.publish-address=127.0.0.1 \
+      --set controller.gatewayClassResource.enabled=true
+    ```
+    > Set only `gatewayClassResource` value above to expose controller via LoadBalancer service type instead.
+
+1. Run the conformance tests
+
+    ```bash
+    git clone https://github.com/kubernetes-sigs/gateway-api
+    cd gateway-api
+    git checkout v1.4.1
+    ```
+    
+    ```bash
+    go test ./conformance -run TestConformance -v -timeout=1h -args \
+      --project=haproxy-ingress \
+      --organization="HAProxy Ingress" \
+      --url=https://haproxy-ingress.github.io \
+      --version=v0.17.0-alpha.1 \
+      --contact=https://kubernetes.slack.com/channels/haproxy-ingress \
+      --gateway-class=haproxy \
+      --supported-features=Gateway,HTTPRoute,TLSRoute,GatewayAddressEmpty,GatewayPort8080,HTTPRouteBackendProtocolWebSocket,HTTPRouteCORS,HTTPRouteDestinationPortMatching,HTTPRouteNamedRouteRule,HTTPRouteResponseHeaderModification,HTTPRouteSchemeRedirect \
+      --conformance-profiles=GATEWAY-HTTP,GATEWAY-TLS \
+      --report-output=/tmp/experimental-report.yaml
+    ```

--- a/conformance/reports/v1.4.1/haproxy-ingress/experimental-v0.17.0-alpha.1-default-report.yaml
+++ b/conformance/reports/v1.4.1/haproxy-ingress/experimental-v0.17.0-alpha.1-default-report.yaml
@@ -1,0 +1,81 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-03-15T16:57:11-03:00"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.4.1
+implementation:
+  contact:
+  - https://kubernetes.slack.com/channels/haproxy-ingress
+  organization: HAProxy Ingress
+  project: haproxy-ingress
+  url: https://haproxy-ingress.github.io
+  version: v0.17.0-alpha.1
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 33
+      Skipped: 0
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 8
+      Skipped: 0
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayPort8080
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteCORS
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteNamedRouteRule
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    unsupportedFeatures:
+    - BackendTLSPolicy
+    - BackendTLSPolicySANValidation
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRedirect
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestPercentageMirror
+    - HTTPRouteRequestTimeout
+  name: GATEWAY-HTTP
+  summary: Core tests succeeded. Extended tests succeeded.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 11
+      Skipped: 0
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 1
+      Skipped: 0
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayPort8080
+    unsupportedFeatures:
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+  name: GATEWAY-TLS
+  summary: Core tests succeeded. Extended tests succeeded.
+succeededProvisionalTests:
+- GatewayOptionalAddressValue
+- HTTPRouteNamedRule

--- a/conformance/reports/v1.5.1/haproxy-ingress/README.md
+++ b/conformance/reports/v1.5.1/haproxy-ingress/README.md
@@ -1,0 +1,70 @@
+# HAProxy Ingress
+
+## Table of contents
+
+| API channel | Implementation version | Mode | Report |
+|-------------|------------------------|------|--------|
+| experimental | [v0.17.0-alpha.1](https://github.com/jcmoraisjr/haproxy-ingress/releases/tag/v0.17.0-alpha.1) | default | [v0.17.0-alpha.1 report](./experimental-v0.17.0-alpha.1-default-report.yaml) |
+
+## Reproduce
+
+The following steps reproduce the HAProxy Ingress conformance test report.
+
+1. Create a kind cluster
+
+    ```yaml
+    # kind.yaml
+    kind: Cluster
+    apiVersion: kind.x-k8s.io/v1alpha4
+    nodes:
+    - role: control-plane
+      extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+      - containerPort: 443
+        hostPort: 443
+    ```
+
+    ```bash
+    kind create cluster --config kind.yaml
+    ```
+
+1. Deploy Gateway API CRDs
+
+    ```bash
+    kubectl create -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
+    ```
+
+1. Deploy HAProxy Ingress
+
+    ```bash
+    helm upgrade --install --create-namespace --namespace ingress-controller \
+      haproxy-ingress https://github.com/haproxy-ingress/charts/releases/download/0.17.0-alpha.1/haproxy-ingress-0.17.0-alpha.1.tgz \
+      --set controller.kind=DaemonSet \
+      --set controller.daemonset.useHostPort=true \
+      --set controller.service.type=ClusterIP \
+      --set controller.extraArgs.publish-address=127.0.0.1 \
+      --set controller.gatewayClassResource.enabled=true
+    ```
+    > Set only `gatewayClassResource` value above to expose controller via LoadBalancer service type instead.
+
+1. Run the conformance tests
+
+    ```bash
+    git clone https://github.com/kubernetes-sigs/gateway-api
+    cd gateway-api
+    git checkout v1.5.1
+    ```
+    
+    ```bash
+    go test ./conformance -run TestConformance -v -timeout=1h -args \
+      --project=haproxy-ingress \
+      --organization="HAProxy Ingress" \
+      --url=https://haproxy-ingress.github.io \
+      --version=v0.17.0-alpha.1 \
+      --contact=https://kubernetes.slack.com/channels/haproxy-ingress \
+      --gateway-class=haproxy \
+      --supported-features=Gateway,HTTPRoute,GatewayAddressEmpty,GatewayPort8080,HTTPRouteBackendProtocolWebSocket,HTTPRouteCORS,HTTPRouteDestinationPortMatching,HTTPRouteNamedRouteRule,HTTPRouteResponseHeaderModification,HTTPRouteSchemeRedirect \
+      --conformance-profiles=GATEWAY-HTTP \
+      --report-output=/tmp/experimental-report.yaml
+    ```

--- a/conformance/reports/v1.5.1/haproxy-ingress/experimental-v0.17.0-alpha.1-default-report.yaml
+++ b/conformance/reports/v1.5.1/haproxy-ingress/experimental-v0.17.0-alpha.1-default-report.yaml
@@ -1,0 +1,68 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-03-20T09:29:21-03:00"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.5.1
+implementation:
+  contact:
+  - https://kubernetes.slack.com/channels/haproxy-ingress
+  organization: HAProxy Ingress
+  project: haproxy-ingress
+  url: https://haproxy-ingress.github.io
+  version: v0.17.0-alpha.1
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 33
+      Skipped: 0
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 9
+      Skipped: 0
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayPort8080
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteCORS
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteNamedRouteRule
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    unsupportedFeatures:
+    - BackendTLSPolicy
+    - BackendTLSPolicySANValidation
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPListenerIsolation
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - HTTPRoute303RedirectStatusCode
+    - HTTPRoute307RedirectStatusCode
+    - HTTPRoute308RedirectStatusCode
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRedirect
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestPercentageMirror
+    - HTTPRouteRequestTimeout
+    - ListenerSet
+  name: GATEWAY-HTTP
+  summary: Core tests succeeded. Extended tests succeeded.
+succeededProvisionalTests:
+- GatewayOptionalAddressValue
+- HTTPRouteNamedRule

--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -89,6 +89,7 @@ other functions (like managing DNS or creating certificates).
 - [Cilium][16]
 - [Envoy Gateway][18] (GA)
 - [Google Kubernetes Engine][6] (GA)
+- [HAProxy Ingress][7]
 - [Istio][9] (GA)
 - [kgateway][37] (GA)
 - [NGINX Gateway Fabric][12] (GA)
@@ -114,7 +115,6 @@ other functions (like managing DNS or creating certificates).
 - [Easegress][30] (GA)
 - [Emissary-Ingress (Ambassador API Gateway)][4] (alpha)
 - [Flomesh Service Mesh][17] (beta)
-- [HAProxy Ingress][7] (alpha)
 - [HAProxy Kubernetes Ingress Controller][32] (GA)
 - [HashiCorp Consul][8]
 - [Kuma][11] (GA)
@@ -457,12 +457,13 @@ For support, feedback, or to engage in a discussion about the Gravitee Kubernete
 
 ### HAProxy Ingress
 
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.5.1-HAProxy%20Ingress-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.5.1/haproxy-ingress)
+
 [HAProxy Ingress][h1] is a community driven ingress controller implementation for HAProxy.
 
-HAProxy Ingress v0.13 partially supports the Gateway API's v1alpha1 specification. See the [controller's Gateway API documentation][h2] to get informed about conformance and roadmap.
+HAProxy Ingress is a conformant Gateway API implementation since `v0.17`. It implements all core features from the standard channel, as well as TLSRoute and TCPRoute APIs from the experimental channel.
 
 [h1]:https://haproxy-ingress.github.io/
-[h2]:https://haproxy-ingress.github.io/docs/configuration/gateway-api/
 
 ### HAProxy Kubernetes Ingress Controller
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/area conformance-test

**What this PR does / why we need it**:

Adds conformance tests for HAProxy Ingress

**Which issue(s) this PR fixes**:

N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
