### PR TITLE
conformance: relax ListenerSet conflict tests reasons

### DIFF
--- a/conformance/tests/listenerset-hostname-conflict.go
+++ b/conformance/tests/listenerset-hostname-conflict.go
@@ -46,16 +46,18 @@ var ListenerSetHostnameConflict = confsuite.ConformanceTest{
 		ns := confsuite.InfrastructureNamespace
 		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
 
+		// GEP-1713 requires conflicted listeners to report Conflicted=True, but
+		// does not normatively require a specific reason for Accepted/Programmed.
 		hostnameConflictedListenerConditions := []metav1.Condition{
 			{
 				Type:   string(gatewayv1.ListenerConditionAccepted),
 				Status: metav1.ConditionFalse,
-				Reason: string(gatewayv1.ListenerReasonHostnameConflict),
+				Reason: "", // any reason
 			},
 			{
 				Type:   string(gatewayv1.ListenerConditionProgrammed),
 				Status: metav1.ConditionFalse,
-				Reason: string(gatewayv1.ListenerReasonHostnameConflict),
+				Reason: "", // any reason
 			},
 			{
 				Type:   string(gatewayv1.ListenerConditionConflicted),

--- a/conformance/tests/listenerset-protocol-conflict.go
+++ b/conformance/tests/listenerset-protocol-conflict.go
@@ -46,16 +46,18 @@ var ListenerSetProtocolConflict = confsuite.ConformanceTest{
 		ns := confsuite.InfrastructureNamespace
 		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
 
+		// GEP-1713 requires conflicted listeners to report Conflicted=True, but
+		// does not normatively require a specific reason for Accepted/Programmed.
 		protocolConflictedListenerConditions := []metav1.Condition{
 			{
 				Type:   string(gatewayv1.ListenerConditionAccepted),
 				Status: metav1.ConditionFalse,
-				Reason: string(gatewayv1.ListenerReasonProtocolConflict),
+				Reason: "", // any reason
 			},
 			{
 				Type:   string(gatewayv1.ListenerConditionProgrammed),
 				Status: metav1.ConditionFalse,
-				Reason: string(gatewayv1.ListenerReasonProtocolConflict),
+				Reason: "", // any reason
 			},
 			{
 				Type:   string(gatewayv1.ListenerConditionConflicted),


### PR DESCRIPTION

**What type of PR is this?**

/area conformance-test


**What this PR does / why we need it**:

### What

Relax the ListenerSet hostname and protocol conflict conformance tests so that losing listeners must still report:

- `Accepted=False`
- `Programmed=False`
- `Conflicted=True`, with the specific conflict reason (`HostnameConflict` or `ProtocolConflict`)

but do not need to use a specific `Reason` for `Accepted` or `Programmed`.

### Why

GEP-1713 requires conflicted listeners to surface conflicts via `Conflicted=True`, but it does not normatively require a specific reason on `Accepted=False` or `Programmed=False`.

The previous tests required `HostnameConflict` or `ProtocolConflict` as the reason for `Accepted`, `Programmed`, and `Conflicted`. That is stricter than the GEP text and conflates broader summary conditions with the conflict-specific condition.

`Accepted` and `Programmed` describe broader listener state and may be `False` for reasons other than the specific conflict reason. `Conflicted` is the condition that specifically captures hostname or protocol conflicts. This change keeps the test focused on the normative requirement that conflicted listeners report `Conflicted=True` with the appropriate conflict reason, without over-constraining the reason used for `Accepted=False` or `Programmed=False`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```

cc @davidjumani @rikatz
