### PR TITLE
update conformance report of gke-gateway for v1.4.0

### DIFF
--- a/conformance/reports/v1.4.0/gke-gateway/README.md
+++ b/conformance/reports/v1.4.0/gke-gateway/README.md
@@ -4,7 +4,7 @@
 
 |API channel|Implementation version|Mode|Report|
 |-----------|----------------------|----|------|
-|standard|1.34.1-gke.1829001|gke-l7-regional-external-managed|[v1.34.1 rxlb report](./standard-1.43.1-rxlb-report.yaml)|
+|standard|1.34.4-gke.1047000|gke-l7-regional-external-managed|[v1.34.4 rxlb report](./standard-1.34.4-rxlb-report.yaml)|
 
 ## Reproduce
 
@@ -27,9 +27,8 @@ go test ./conformance -run TestConformance -v -timeout=3h -args \
     --organization=GKE \
     --project=gke-gateway \
     --url=https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api \
-    --version=1.34.1-gke.1829001 \
+    --version=1.34.4-gke.1047000 \
     --contact=gke-gateway-dev@google.com \
-    --skip-tests=HTTPRouteHostnameIntersection \
     --supported-features=Gateway,HTTPRoute,GatewayPort8080,HTTPRouteHostRewrite,HTTPRoutePathRedirect,HTTPRouteRequestMirror,HTTPRouteRequestPercentageMirror,HTTPRouteResponseHeaderModification,HTTPRouteSchemeRedirect \
     --report-output="/path/to/report"
 ```

--- a/conformance/reports/v1.4.0/gke-gateway/standard-1.34.4-rxlb-report.yaml
+++ b/conformance/reports/v1.4.0/gke-gateway/standard-1.34.4-rxlb-report.yaml
@@ -1,5 +1,5 @@
 apiVersion: gateway.networking.k8s.io/v1
-date: "2025-10-31T09:24:35Z"
+date: "2026-03-19T15:18:26Z"
 gatewayAPIChannel: standard
 gatewayAPIVersion: v1.4.0
 implementation:
@@ -8,18 +8,16 @@ implementation:
   organization: GKE
   project: gke-gateway
   url: https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api
-  version: 1.34.1-gke.1829001
+  version: 1.34.4-gke.1047000
 kind: ConformanceReport
 mode: default
 profiles:
 - core:
-    result: partial
-    skippedTests:
-    - HTTPRouteHostnameIntersection
+    result: success
     statistics:
       Failed: 0
-      Passed: 32
-      Skipped: 1
+      Passed: 33
+      Skipped: 0
   extended:
     result: success
     statistics:
@@ -57,6 +55,6 @@ profiles:
     - HTTPRouteRequestMultipleMirrors
     - HTTPRouteRequestTimeout
   name: GATEWAY-HTTP
-  summary: Core tests partially succeeded with 1 test skips. Extended tests succeeded.
+  summary: Core tests succeeded. Extended tests succeeded.
 succeededProvisionalTests:
 - HTTPRouteRequestPercentageMirror

--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -88,6 +88,7 @@ other functions (like managing DNS or creating certificates).
 - [Airlock Microgateway][34]
 - [Cilium][16]
 - [Envoy Gateway][18] (GA)
+- [Google Kubernetes Engine][6] (GA)
 - [Istio][9] (GA)
 - [kgateway][37] (GA)
 - [NGINX Gateway Fabric][12] (GA)
@@ -99,7 +100,6 @@ other functions (like managing DNS or creating certificates).
 - [Azure Application Gateway for Containers][27] (GA)
 - [Contour][3] (GA)
 - [Gloo Gateway][5] (GA)
-- [Google Kubernetes Engine][6] (GA)
 - [Gravitee Kubernetes Operator][42] (GA)
 - [Kong Ingress Controller][10] (GA)
 - [Kong Gateway Operator][35] (GA)
@@ -425,7 +425,7 @@ Google Cloud Service Mesh supports [Envoy-based sidecar mesh][envoy-sidecar-mesh
 
 ### Google Kubernetes Engine
 
-[![Conformance](https://img.shields.io/badge/Gateway_API_Partial_Conformance_v1.3.0-Google_Kubernetes_Engine-orange)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.4.0/gke-gateway)
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.4.0-Google_Kubernetes_Engine-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.4.0/gke-gateway)
 
 [Google Kubernetes Engine (GKE)][gke] is a managed Kubernetes platform offered
 by Google Cloud. GKE's implementation of the Gateway API is through the [GKE


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind test
/area conformance-test

**What this PR does / why we need it**:
This PR updates the GKE Gateway conformance report for Gateway API v1.4.0. The tests were run against GKE version `1.34.4-gke.1047000`.

This report reflects that the `HTTPRouteHostnameIntersection` test is now passing. 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
