### PR TITLE
2734 - update gateway infrastructure annotations to 16

### DIFF
--- a/apis/v1/gateway_types.go
+++ b/apis/v1/gateway_types.go
@@ -1071,7 +1071,7 @@ type GatewayInfrastructure struct {
 	// Support: Extended
 	//
 	// +optional
-	// +kubebuilder:validation:MaxProperties=8
+	// +kubebuilder:validation:MaxProperties=16
 	// +kubebuilder:validation:XValidation:message="Annotation keys must be in the form of an optional DNS subdomain prefix followed by a required name segment of up to 63 characters.",rule="self.all(key, key.matches(r\"\"\"^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$\"\"\"))"
 	// +kubebuilder:validation:XValidation:message="If specified, the annotation key's prefix must be a DNS subdomain not longer than 253 characters in total.",rule="self.all(key, key.split(\"/\")[0].size() < 253)"
 	Annotations map[AnnotationKey]AnnotationValue `json:"annotations,omitempty"`

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -271,7 +271,7 @@ spec:
                       An implementation may chose to add additional implementation-specific annotations as they see fit.
 
                       Support: Extended
-                    maxProperties: 8
+                    maxProperties: 16
                     type: object
                     x-kubernetes-validations:
                     - message: Annotation keys must be in the form of an optional
@@ -1928,7 +1928,7 @@ spec:
                       An implementation may chose to add additional implementation-specific annotations as they see fit.
 
                       Support: Extended
-                    maxProperties: 8
+                    maxProperties: 16
                     type: object
                     x-kubernetes-validations:
                     - message: Annotation keys must be in the form of an optional

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -248,7 +248,7 @@ spec:
                       An implementation may chose to add additional implementation-specific annotations as they see fit.
 
                       Support: Extended
-                    maxProperties: 8
+                    maxProperties: 16
                     type: object
                     x-kubernetes-validations:
                     - message: Annotation keys must be in the form of an optional
@@ -1882,7 +1882,7 @@ spec:
                       An implementation may chose to add additional implementation-specific annotations as they see fit.
 
                       Support: Extended
-                    maxProperties: 8
+                    maxProperties: 16
                     type: object
                     x-kubernetes-validations:
                     - message: Annotation keys must be in the form of an optional


### PR DESCRIPTION
Fixes #2734 

/kind feature

**What this PR does / why we need it**:
update to increase the number of annotations within the gateway infrastructure to 16.
When using the AWS LoadBalancerController there are a number of annotations that must be applied when the LoadBalancer is created, adding the annotations after the load balancer is created (or the request to create the LoadBalancer is sent results in the changes not being applied). Such changes are the Subnets to be attached, SSL Policy, scheme and a number of others. You will often find that you reach the limit of 8 annotations on the infrastructure very quickly, applying the annotations through the config map is too late and the changes wont be applied. This is more a sequencing issue with the LoadBalanceController however until AWS upgrades how this works we require a way to create the NLB with our specified requirements.

**Which issue(s) this PR fixes**:
Fixes #2734

**Does this PR introduce a user-facing change?**:
```release-note
Yes, it will allow the usage of up to 16 annotations on the gateway infrastructure object.
```
