### PR TITLE
conformance: add Zentinel v0.6.1 report for Gateway API v1.4.1

### DIFF
--- a/conformance/reports/v1.4.1/zentinelproxy-zentinel/README.md
+++ b/conformance/reports/v1.4.1/zentinelproxy-zentinel/README.md
@@ -1,0 +1,22 @@
+# Zentinel
+
+[Zentinel](https://github.com/zentinelproxy/zentinel) is a security-first reverse proxy built on Cloudflare's Pingora framework. It emphasizes predictability, transparency, and operational simplicity.
+
+## Table of Contents
+
+| API channel | Implementation version                                                        | Mode    | Report                                                         |
+|-------------|-------------------------------------------------------------------------------|---------|----------------------------------------------------------------|
+| standard    | [v0.6.1](https://github.com/zentinelproxy/zentinel/releases/tag/v0.6.1)      | default | [v0.6.1 report](./standard-v0.6.1-default-report.yaml)        |
+
+## Reproduce
+
+Clone the Zentinel repository and run the conformance test script:
+
+```shell
+git clone https://github.com/zentinelproxy/zentinel.git && cd zentinel
+./scripts/conformance-test.sh --report
+```
+
+Prerequisites: Docker, kind, kubectl, helm, Go 1.22+.
+
+The script creates a kind cluster, builds the gateway controller and proxy images, installs Gateway API CRDs (v1.4.1), deploys Zentinel via Helm, and runs the official conformance suite. The report is written to `conformance/reports/standard-v0.6.1-default-report.yaml`.

--- a/conformance/reports/v1.4.1/zentinelproxy-zentinel/standard-v0.6.1-default-report.yaml
+++ b/conformance/reports/v1.4.1/zentinelproxy-zentinel/standard-v0.6.1-default-report.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-03-21T06:37:35-07:00"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.4.1
+implementation:
+  contact:
+  - '@zentinelproxy'
+  organization: zentinelproxy
+  project: zentinel
+  url: https://github.com/zentinelproxy/zentinel
+  version: 0.6.1
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 33
+      Skipped: 0
+  name: GATEWAY-HTTP
+  summary: Core tests succeeded.


### PR DESCRIPTION
## Summary

- Add conformance report for [Zentinel](https://github.com/zentinelproxy/zentinel) v0.6.1
- Gateway API version: v1.4.1
- Channel: standard
- Profile: GATEWAY-HTTP (core)
- Result: **33/33 passed**, 0 failed, 0 skipped

Zentinel is a security-first reverse proxy built on Cloudflare's Pingora framework. The gateway controller (`crates/gateway/`) translates Gateway API resources into Zentinel's native KDL configuration and runs alongside the proxy as a sidecar.

## Reproduce

```shell
git clone https://github.com/zentinelproxy/zentinel.git && cd zentinel
./scripts/conformance-test.sh --report
```

Requires: Docker, kind, kubectl, helm, Go 1.22+.