### PR TITLE
generator: omit top-level CRD status from manifests

### DIFF
--- a/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -1410,9 +1410,3 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -507,9 +507,3 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -3333,9 +3333,3 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -2271,9 +2271,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -8527,9 +8527,3 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/experimental/gateway.networking.k8s.io_listenersets.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_listenersets.yaml
@@ -772,9 +772,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
@@ -345,9 +345,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -748,9 +748,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -2362,9 +2362,3 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -748,9 +748,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
+++ b/config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
@@ -600,9 +600,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/experimental/gateway.networking.x-k8s.io_xmeshes.yaml
+++ b/config/crd/experimental/gateway.networking.x-k8s.io_xmeshes.yaml
@@ -240,9 +240,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -1374,9 +1374,3 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -507,9 +507,3 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -3287,9 +3287,3 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
@@ -2062,9 +2062,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -6901,9 +6901,3 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
@@ -772,9 +772,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
@@ -345,9 +345,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
@@ -2106,9 +2106,3 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/tools/generator/main.go
+++ b/tools/generator/main.go
@@ -26,6 +26,7 @@ import (
 
 	"golang.org/x/tools/go/packages"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-tools/pkg/crd"
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
@@ -33,6 +34,12 @@ import (
 
 	"sigs.k8s.io/gateway-api/pkg/consts"
 )
+
+type customResourceDefinitionManifest struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              apiext.CustomResourceDefinitionSpec `json:"spec"`
+}
 
 var standardKinds = map[string]bool{
 	"GatewayClass":     true,
@@ -137,12 +144,17 @@ func main() {
 				version.Schema.OpenAPIV3Schema.Properties = gatewayTweaksMap(channel, version.Schema.OpenAPIV3Schema.Properties)
 			}
 
-			conv, err := crd.AsVersion(*channelCrd, apiext.SchemeGroupVersion)
+			convObj, err := crd.AsVersion(*channelCrd, apiext.SchemeGroupVersion)
 			if err != nil {
 				log.Fatalf("failed to convert CRD: %s", err)
 			}
 
-			out, err := yaml.Marshal(conv)
+			conv, ok := convObj.(*apiext.CustomResourceDefinition)
+			if !ok {
+				log.Fatalf("failed to convert CRD: unexpected type %T", convObj)
+			}
+
+			out, err := marshalCRDManifest(*conv)
 			if err != nil {
 				log.Fatalf("failed to marshal CRD: %s", err)
 			}
@@ -158,6 +170,15 @@ func main() {
 	if loader.PrintErrors(roots, packages.TypeError) {
 		log.Fatalf("not all generators ran successfully")
 	}
+}
+
+func marshalCRDManifest(customResourceDefinition apiext.CustomResourceDefinition) ([]byte, error) {
+	manifest := customResourceDefinitionManifest{
+		TypeMeta:   customResourceDefinition.TypeMeta,
+		ObjectMeta: customResourceDefinition.ObjectMeta,
+		Spec:       customResourceDefinition.Spec,
+	}
+	return yaml.Marshal(manifest)
 }
 
 func gatewayTweaksMap(channel string, props map[string]apiext.JSONSchemaProps) map[string]apiext.JSONSchemaProps {

--- a/tools/generator/main_test.go
+++ b/tools/generator/main_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMarshalCRDManifestOmitsTopLevelStatus(t *testing.T) {
+	t.Parallel()
+
+	crd := apiext.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiext.SchemeGroupVersion.String(),
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "httproutes.gateway.networking.k8s.io",
+		},
+		Spec: apiext.CustomResourceDefinitionSpec{
+			Group: "gateway.networking.k8s.io",
+			Names: apiext.CustomResourceDefinitionNames{
+				Plural: "httproutes",
+				Kind:   "HTTPRoute",
+			},
+			Scope: "Namespaced",
+		},
+		Status: apiext.CustomResourceDefinitionStatus{
+			Conditions:     nil,
+			StoredVersions: nil,
+		},
+	}
+
+	out, err := marshalCRDManifest(crd)
+	if err != nil {
+		t.Fatalf("marshalCRDManifest returned error: %v", err)
+	}
+
+	yaml := string(out)
+	if strings.Contains(yaml, "\nstatus:\n") || strings.HasPrefix(yaml, "status:\n") {
+		t.Fatalf("expected top-level status to be omitted, got:\n%s", yaml)
+	}
+	if strings.Contains(yaml, "\nTypeMeta:\n") || strings.HasPrefix(yaml, "TypeMeta:\n") {
+		t.Fatalf("expected type metadata to stay inlined, got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n") {
+		t.Fatalf("expected top-level apiVersion/kind metadata, got:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, "\nspec:\n") {
+		t.Fatalf("expected spec to be present, got:\n%s", yaml)
+	}
+}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -19,6 +19,7 @@ tool (
 require (
 	golang.org/x/tools v0.43.0
 	k8s.io/apiextensions-apiserver v0.35.3
+	k8s.io/apimachinery v0.35.3
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912
 	sigs.k8s.io/controller-tools v0.20.1
 	sigs.k8s.io/gateway-api v0.0.0
@@ -76,7 +77,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.35.3 // indirect
-	k8s.io/apimachinery v0.35.3 // indirect
 	k8s.io/code-generator v0.35.3 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind bug

**What this PR does / why we need it**:
This PR fixes how CRD files are generated.

Right now, the generated install YAML includes a top-level `status` field in `CustomResourceDefinition` objects. That field contains invalid `null` values, which causes tools like `kubeconform` to fail. Since `status` is filled in by Kubernetes, it should not be in static install files.

This change removes that field from generated manifests and regenerates the CRDs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4402

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Generated Gateway API CRD install manifests no longer include top-level CustomResourceDefinition status fields with invalid null values, fixing strict schema validation failures in tools such as kubeconform.
```
