### PR TITLE
propagate github token for the tag creation.

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -4,8 +4,8 @@ on:
   # TODO: Uncomment below code after we have released monthly couple of times.
   # Until then, we will manually trigger the workflow.
   # schedule:
-    # Run on the first day of every month at 00:00 UTC
-    # - cron: "0 0 1 * *"
+  # Run on the first day of every month at 00:00 UTC
+  # - cron: "0 0 1 * *"
   workflow_dispatch:
     # Allow manual triggering
     inputs:
@@ -69,6 +69,7 @@ jobs:
           git push origin "${STEPS_TAG_OUTPUTS_TAG}"
         env:
           STEPS_TAG_OUTPUTS_TAG: ${{ steps.tag.outputs.tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build monthly YAML
         env:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Otherwise monthly action run fails when attempting to push the git tag to the repository at line 69: git push origin "${STEPS_TAG_OUTPUTS_TAG}"

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
