### PR TITLE
Add AWS Load Balancer Controller conformance results for v1.5.0 Gateway API

### DIFF
--- a/conformance/reports/v1.5.0/aws-load-balancer-controller/README.md
+++ b/conformance/reports/v1.5.0/aws-load-balancer-controller/README.md
@@ -1,0 +1,17 @@
+# AWS Load Balancer Controller
+
+The AWS Load Balancer Controller manages AWS Elastic Load Balancers for a Kubernetes cluster. The controller provisions AWS Application Load Balancers (ALB) when you create a Kubernetes Ingress and AWS Network Load Balancers (NLB) when you create a Kubernetes Service of type LoadBalancer.
+
+We also released AWS Load Balancer Controller Gateway API support for both Layer 4 (L4) and Layer 7 (L7) routing. This highly anticipated feature enables customers to provision and manage AWS Network Load Balancers (NLBs) and Application Load Balancers (ALBs) directly from Kubernetes clusters using the extensible Gateway API, providing a modern alternative to traditional Ingress and Service resources.
+
+## Table of contents
+
+| API channel | Implementation version                                                                        | Mode | Report                                                 |
+|-------------|-----------------------------------------------------------------------------------------------|------|--------------------------------------------------------|
+| standard | [v3.2.0](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v3.2.0) | default | [v3.2.0 report](conformance-report.yaml) |
+
+## Reproduce
+
+To reproduce the conformance test results for AWS Load Balancer Controller v3.2.0:
+
+For detailed instructions, refer to the [AWS Load Balancer Controller - Conformance Test Instruction](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/conformance/README.md).

--- a/conformance/reports/v1.5.0/aws-load-balancer-controller/conformance-report.yaml
+++ b/conformance/reports/v1.5.0/aws-load-balancer-controller/conformance-report.yaml
@@ -1,0 +1,79 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-04-01T12:23:28-07:00"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.5.0
+implementation:
+  contact:
+  - https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/OWNERS#L6
+  organization: aws
+  project: aws-load-balancer-controller
+  url: https://github.com/kubernetes-sigs/aws-load-balancer-controller
+  version: v3.2.0
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: partial
+    skippedTests:
+    - GatewayInvalidTLSConfiguration
+    - GatewaySecretInvalidReferenceGrant
+    - GatewaySecretMissingReferenceGrant
+    - GatewaySecretReferenceGrantAllInNamespace
+    - GatewaySecretReferenceGrantSpecific
+    - GatewayWithAttachedRoutes
+    - HTTPRouteHTTPSListener
+    - HTTPRouteHostnameIntersection
+    - HTTPRouteRequestHeaderModifier
+    - HTTPRouteServiceTypes
+    statistics:
+      Failed: 0
+      Passed: 23
+      Skipped: 10
+  extended:
+    result: partial
+    skippedTests:
+    - ListenerSetReferenceGrant
+    statistics:
+      Failed: 0
+      Passed: 13
+      Skipped: 1
+    supportedFeatures:
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteMethodMatching
+    - HTTPRouteParentRefPort
+    - HTTPRoutePortRedirect
+    - ListenerSet
+    unsupportedFeatures:
+    - BackendTLSPolicy
+    - BackendTLSPolicySANValidation
+    - GatewayAddressEmpty
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPListenerIsolation
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
+    - GatewayPort8080
+    - GatewayStaticAddresses
+    - HTTPRoute303RedirectStatusCode
+    - HTTPRoute307RedirectStatusCode
+    - HTTPRoute308RedirectStatusCode
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteCORS
+    - HTTPRouteHostRewrite
+    - HTTPRouteNamedRouteRule
+    - HTTPRoutePathRedirect
+    - HTTPRoutePathRewrite
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestPercentageMirror
+    - HTTPRouteRequestTimeout
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+  name: GATEWAY-HTTP
+  summary: Core tests partially succeeded with 10 test skips. Extended tests partially
+    succeeded with 1 test skips.

--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -265,7 +265,7 @@ APISIX currently supports Gateway API `v1beta1` version of the specification for
 
 ### AWS Load Balancer Controller
 
-[![Conformance](https://img.shields.io/badge/Gateway%20API%20Partial%20Conformance%20v1.3.0-AWS%20Load%20Balancer%20Controller-orange)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.3.0/aws-load-balancer-controller)
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Partial%20Conformance%20v1.5.0-AWS%20Load%20Balancer%20Controller-orange)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.5.0/aws-load-balancer-controller)
 
 [AWS Load Balancer Controller][aws-lbc] manages AWS Elastic Load Balancers for Kubernetes clusters. The controller provisions AWS Application Load Balancers (ALB) when you create a Kubernetes Ingress and AWS Network Load Balancers (NLB) when you create a Kubernetes Service of type LoadBalancer.
 


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind documentation
/area conformance-test

**What this PR does / why we need it**:

Adds conformance test results for https://github.com/kubernetes-sigs/aws-load-balancer-controller.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Add AWS Load Balancer Controller conformance results for v1.5.0 Gateway API
```
