### PR TITLE
conformance: make weight test 100x faster

### DIFF
--- a/conformance/utils/weight/weight.go
+++ b/conformance/utils/weight/weight.go
@@ -210,7 +210,7 @@ func TestWeightedDistributionBatch(sender BatchRequestSender, expectedWeights ma
 
 // Entropy utilities
 
-// AddRandomEntropy randomly chooses to add delay, random value, or both
+// AddRandomEntropy randomly chooses to add a random value.
 // The addRandomValue function should be provided by the caller to handle
 // protocol-specific ways of adding the random value (HTTP headers, gRPC metadata, etc.)
 func AddRandomEntropy(addRandomValue func(string) error) error {

--- a/conformance/utils/weight/weight.go
+++ b/conformance/utils/weight/weight.go
@@ -27,7 +27,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -211,42 +210,21 @@ func TestWeightedDistributionBatch(sender BatchRequestSender, expectedWeights ma
 
 // Entropy utilities
 
-// addRandomDelay adds a random delay up to the specified limit in milliseconds
-func addRandomDelay(limit int) {
-	n, err := rand.Int(rand.Reader, big.NewInt(int64(limit)))
-	if err != nil {
-		// Fallback to no delay if crypto/rand fails
-		return
-	}
-	randomSleepDuration := n.Int64()
-	time.Sleep(time.Duration(randomSleepDuration) * time.Millisecond)
-}
-
 // AddRandomEntropy randomly chooses to add delay, random value, or both
 // The addRandomValue function should be provided by the caller to handle
 // protocol-specific ways of adding the random value (HTTP headers, gRPC metadata, etc.)
 func AddRandomEntropy(addRandomValue func(string) error) error {
-	n, err := rand.Int(rand.Reader, big.NewInt(3))
+	n, err := rand.Int(rand.Reader, big.NewInt(2))
 	if err != nil {
-		// Fallback to case 0 if crypto/rand fails
-		addRandomDelay(1000)
 		return err
 	}
 	random := n.Int64()
 
 	switch random {
 	case 0:
-		addRandomDelay(1000)
+		// Do nothing
 		return nil
 	case 1:
-		valueN, err := rand.Int(rand.Reader, big.NewInt(10000))
-		if err != nil {
-			return fmt.Errorf("failed to generate random value: %w", err)
-		}
-		randomValue := valueN.Int64()
-		return addRandomValue(strconv.FormatInt(randomValue, 10))
-	case 2:
-		addRandomDelay(1000)
 		valueN, err := rand.Int(rand.Reader, big.NewInt(10000))
 		if err != nil {
 			return fmt.Errorf("failed to generate random value: %w", err)


### PR DESCRIPTION

**What type of PR is this?**

/area conformance-machinery

**What this PR does / why we need it**:
The current test takes 17s due to randomly injected sleep across 500 requests. This happens twice (HTTP and GRPC) for a total of 34s for these 2 tests.

With this PR, the test takes <1s for me.

For context, our entire e2e suite outside of gateway-api conformance takes 27s, so this 1 test is more than doubling our test times.

The original context for this was
https://github.com/kubernetes-sigs/gateway-api/pull/3827#discussion_r2123121430. I don't think this is needed for the test; if an implementation requires the entropy to properly distribute weight then it is broken and *should* fail. And I am not sure of any possible implementation that would only work *with* entropy; however, I did leave the randomized payload part of the suggestion (the original suggestion was to add *something* not necesarily sleeping).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
