### PR TITLE
Add provisional GEP-4747: L7 Reverse-Proxy Egress Gateway Support

### DIFF
--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -57,7 +57,6 @@ argues that no new Gateway-level resource is required.
 
 * Establish egress as a first-class usage pattern of Gateway API
 * Define how Gateway + HTTPRoute + Backend ([PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)) compose for egress
-* Provide an `Egress` conformance profile so implementations can declare support
 * Document egress-specific guidance for listeners, routes, and policy scoping
 * Define Endpoint routing mode (direct to external destination); gateway chaining
   is covered in [GEP-4751]
@@ -259,25 +258,6 @@ enforcement mechanisms (like NetworkPolicy, sidecar configuration, or
 CNI-level controls). This GEP does not define enforcement mechanisms -- it defines what the
 Gateway does once traffic arrives.
 
-## Conformance
-
-### Egress Conformance Profile
-
-This GEP defines an `Egress` conformance profile. Implementations declare
-egress support by passing egress conformance tests.
-
-**Core egress conformance** (required for profile):
-
-- Gateway accepts and routes egress traffic
-- HTTPRoute attached to egress Gateway routes to Backend ([PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488))
-- Policy conflict resolution follows specificity precedence
-
-**Extended egress conformance**:
-
-- Multi-backend weighted routing and failover
-- Backend TLS origination (Simple, Mutual) -- via [PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488) conformance
-- Cross-namespace Backend references with ReferenceGrant
-
 ## Security Considerations
 
 ### Egress-Specific Risks
@@ -306,17 +286,12 @@ dedicated `EgressGateway` resource as an alternative. Community input is
 needed to decide which approach to pursue. See
 [Alternatives Considered](#alternatives-considered).
 
-### 2. Egress Conformance Profile Shape
-
-Should egress conformance be a standalone profile (like [`Mesh`](../gep-1709/index.md)) or a feature
-within the existing `HTTP` profile?
-
-### 3. Listener Hostname Guidance
+### 2. Listener Hostname Guidance
 
 Should the GEP recommend specific listener configurations for egress (e.g.,
 "use a single wildcard listener") or leave this entirely to implementations?
 
-### 4. Mixed Ingress/Egress Gateways
+### 3. Mixed Ingress/Egress Gateways
 
 Should a single Gateway be allowed to serve both ingress and egress traffic
 (via multiple listeners)?
@@ -375,23 +350,21 @@ Dynamic routing to arbitrary hostnames (forward proxy) is out of scope. See
 - [ ] Community decision on Gateway reuse (this GEP) vs EgressGateway ([GEP-4748])
 - [ ] [PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488) (Backend) reaches at least Provisional status
 - [ ] Open questions resolved
-- [ ] Egress conformance profile defined in detail
 
 ### Alpha (Experimental)
 
-- [ ] Egress conformance tests implemented
-- [ ] At least one implementation passes egress conformance
+- [ ] At least one implementation supports egress usage pattern
 - [ ] Documentation for egress usage patterns
 
 ### Beta
 
-- [ ] At least two implementations pass egress conformance
+- [ ] At least two implementations support egress usage pattern
 - [ ] Production usage reports from 2+ organizations
 - [ ] Gateway Routability (#1651) resolved or workaround documented
 
 ### GA (Standard)
 
-- [ ] Three implementations passing extended egress conformance
+- [ ] Three implementations supporting egress usage pattern
 - [ ] No API-level changes needed for 6+ months
 - [ ] Security review complete
 

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -179,10 +179,9 @@ spec:
 - Egress gateways typically use a single listener with no hostname filter
   (accepting all destinations), though setting `hostname` to filter by
   destination IS valid and means "only accept requests going to this host."
-- `listeners[].tls` is the server-side TLS config presented to workloads
-  connecting to the gateway. The TLS configuration structure is identical to
-  ingress; only the client/server roles are reversed. Client-side TLS to external
-  destinations is configured on the Backend resource ([PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)).
+- `listeners[].tls` configures TLS for workloads connecting to the gateway.
+  The TLS configuration is identical to ingress. TLS to external destinations
+  is configured on the Backend resource ([PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)).
 
 ### Egress Routing
 
@@ -207,10 +206,9 @@ spec:
       name: openai-backend
 ```
 
-`hostnames` on an egress HTTPRoute means "match requests whose destination
-Host header is one of these values." The matching behavior is identical to ingress,
-though the semantic intent differs: ingress routes serve requests TO these hostnames,
-while egress routes forward requests GOING TO these external hostnames.
+`hostnames` on an egress HTTPRoute matches requests whose destination
+Host header is one of these values. The matching behavior is identical
+to ingress.
 
 ### Routing Modes
 
@@ -291,7 +289,6 @@ egress support by passing egress conformance tests.
 
 - Gateway with egress GatewayClass accepts and routes traffic
 - HTTPRoute attached to egress Gateway routes to Backend ([PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488))
-- `hostnames` on HTTPRoute correctly matches destination Host headers
 - Policy conflict resolution follows specificity precedence
 
 **Extended egress conformance**:

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -267,7 +267,7 @@ is resolved, workloads connect to the egress gateway via an implementation-manag
 Gateway API implementations already create a Service for each Gateway; for egress, this Service
 SHOULD be of type `ClusterIP` (not `LoadBalancer`).
 
-Implementations supporting the Egress conformance profile SHOULD:
+Implementations should:
 
 - Automatically create a ClusterIP Service for egress Gateways
 - Report the Service's ClusterIP in `gateway.status.addresses`

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -22,6 +22,8 @@ only when, they appear in all capitals, as shown here.
 > `EgressGateway` resource. Community feedback on both approaches is
 > explicitly requested.
 
+[GEP-91]: ../gep-91/index.md
+[GEP-2907]: ../gep-2907/index.md
 [GEP-4748]: ../gep-4748/index.md
 [GEP-4751]: https://github.com/kubernetes-sigs/gateway-api/issues/4751
 
@@ -101,6 +103,8 @@ semantically valuable within both contexts:
 | `listeners[].port` | Port to accept incoming traffic | Port to accept outbound traffic from workloads |
 | `listeners[].hostname` | Virtual host to match (SNI/Host header) | Filter workload requests by SNI/Host header |
 | `listeners[].tls` | Cert presented to external clients (server TLS) | Cert presented to internal workloads (server TLS) |
+| `tls.frontend` | Client cert validation for external clients ([GEP-91]) | Client cert validation for internal workloads ([GEP-91]) |
+| `tls.backend` | Gateway's client cert for mTLS to internal backends ([GEP-2907]) | Gateway's client cert for mTLS to external destinations ([GEP-2907]) |
 
 The difference between ingress and egress is an emergent property of:
 
@@ -336,6 +340,7 @@ Dynamic routing to arbitrary hostnames (forward proxy) is out of scope. See
 
 * [WG AI Gateway egress proposal](https://github.com/kubernetes-sigs/wg-ai-gateway/blob/main/proposals/10-egress-gateways.md)
 * [GEP-4488: Backend Resource](https://github.com/kubernetes-sigs/gateway-api/pull/4488)
+* [GEP-91: Client Certificate Validation](../gep-91/index.md)
 * [GEP-1897: BackendTLSPolicy](../gep-1897/index.md)
 * [GEP-2907: TLS Terminology](../gep-2907/index.md)
 * [Issue #1651: Gateway Routability](https://github.com/kubernetes-sigs/gateway-api/issues/1651)

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -222,7 +222,7 @@ Traffic flows directly from egress gateway to external destination:
 Workload --> Egress Gateway --> External API (Backend)
 ```
 
-The gateway applies policies, resolves the Backend destination, originates
+The gateway applies policies, resolves the Backend destination, (optionally) originates
 TLS to the external endpoint, and forwards the request.
 
 #### Parent Mode (Gateway Chaining)

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -272,9 +272,10 @@ Implementations should:
 
 ### Traffic Enforcement
 
-Operators MUST use enforcement mechanisms (like NetworkPolicy, sidecar
-configuration, or CNI-level controls) to deny direct egress from workloads
-and force outbound traffic through the Gateway. This GEP does not define enforcement mechanisms -- it defines what the
+For egress gateways to be effective, operators should deny direct egress
+from workloads and force outbound traffic through the Gateway using
+enforcement mechanisms (like NetworkPolicy, sidecar configuration, or
+CNI-level controls). This GEP does not define enforcement mechanisms -- it defines what the
 Gateway does once traffic arrives.
 
 ## Conformance

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -287,7 +287,7 @@ egress support by passing egress conformance tests.
 
 **Core egress conformance** (required for profile):
 
-- Gateway with egress GatewayClass accepts and routes traffic
+- Gateway accepts and routes egress traffic
 - HTTPRoute attached to egress Gateway routes to Backend ([PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488))
 - Policy conflict resolution follows specificity precedence
 

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -261,14 +261,13 @@ MUST surface conflicts in status conditions.
 ### Workload-to-Gateway Addressing (Interim)
 
 Until Gateway Routability ([#1651](https://github.com/kubernetes-sigs/gateway-api/issues/1651))
-is resolved, workloads connect to the egress gateway via an implementation-managed Service. Most
-Gateway API implementations already create a Service for each Gateway; for egress, this Service
-SHOULD be of type `ClusterIP` (not `LoadBalancer`).
+is resolved, workloads connect to the egress gateway via an implementation-managed
+address reachable only within the cluster (often a ClusterIP Service).
 
 Implementations should:
 
-- Automatically create a ClusterIP Service for egress Gateways
-- Report the Service's ClusterIP in `gateway.status.addresses`
+- Expose an internally-reachable address for egress Gateways
+- Report this address in `gateway.status.addresses`
 - Use a stable DNS name (e.g., `<gateway-name>.<namespace>.svc.cluster.local`)
 
 ### Traffic Enforcement

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -1,4 +1,4 @@
-# GEP-4747: Egress Gateway Support
+# GEP-4747: L7 Reverse-Proxy Egress Gateway
 
 * Issue: [#4747](https://github.com/kubernetes-sigs/gateway-api/issues/4747)
 * Status: Provisional

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -275,9 +275,9 @@ Implementations should:
 
 ### Traffic Enforcement
 
-Operators MUST use NetworkPolicy, sidecar configuration, or CNI-level controls
-to deny direct egress from workloads and force outbound traffic through the
-Gateway. This GEP does not define enforcement mechanisms -- it defines what the
+Operators MUST use enforcement mechanisms (like NetworkPolicy, sidecar
+configuration, or CNI-level controls) to deny direct egress from workloads
+and force outbound traffic through the Gateway. This GEP does not define enforcement mechanisms -- it defines what the
 Gateway does once traffic arrives.
 
 ## Conformance

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -23,6 +23,7 @@ only when, they appear in all capitals, as shown here.
 > explicitly requested.
 
 [GEP-4748]: ../gep-4748/index.md
+[GEP-4751]: https://github.com/kubernetes-sigs/gateway-api/issues/4751
 
 ## TLDR
 
@@ -58,7 +59,8 @@ argues that no new Gateway-level resource is required.
 * Define how Gateway + HTTPRoute + Backend ([PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)) compose for egress
 * Provide an `Egress` conformance profile so implementations can declare support
 * Document egress-specific guidance for listeners, routes, and policy scoping
-* Support two routing modes: Endpoint (direct) and Parent (gateway chaining)
+* Define Endpoint routing mode (direct to external destination); gateway chaining
+  is covered in [GEP-4751]
 
 ## Non-Goals
 
@@ -223,27 +225,6 @@ Workload --> Egress Gateway --> External API (Backend)
 The gateway applies policies, resolves the Backend destination, (optionally) originates
 TLS to the external endpoint, and forwards the request.
 
-#### Parent Mode (Gateway Chaining)
-
-Traffic flows through a local egress gateway to an upstream gateway:
-
-```
-Workload --> Local Egress GW --> Upstream GW --> External API
-```
-
-Use cases:
-
-- Multi-cluster: local cluster routes through a central egress cluster
-- Multi-zone: regional gateways route through a global exit point
-- Compliance: all traffic exits through an audited chokepoint
-
-Requirements:
-
-- Local retries MUST be limited to establishing the upstream connection
-- Request-level retries MUST be performed by the upstream gateway
-- Implementations MUST tag forwarded requests (e.g., via header) to prevent
-  retry loops between chained gateways
-
 ### Policy Application Scopes
 
 Egress policies apply at three levels:
@@ -293,7 +274,6 @@ egress support by passing egress conformance tests.
 
 **Extended egress conformance**:
 
-- Parent mode (gateway chaining)
 - Multi-backend weighted routing and failover
 - Backend TLS origination (Simple, Mutual) -- via [PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488) conformance
 - Cross-namespace Backend references with ReferenceGrant
@@ -336,12 +316,7 @@ within the existing `HTTP` profile?
 Should the GEP recommend specific listener configurations for egress (e.g.,
 "use a single wildcard listener") or leave this entirely to implementations?
 
-### 4. Parent Mode Standardization
-
-Is Parent Mode (gateway chaining) common enough to warrant conformance tests,
-or should it be Implementation-Specific?
-
-### 5. Mixed Ingress/Egress Gateways
+### 4. Mixed Ingress/Egress Gateways
 
 Should a single Gateway be allowed to serve both ingress and egress traffic
 (via multiple listeners)?

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -1,0 +1,425 @@
+# GEP-4747: Egress Gateway Support
+
+* Issue: [#4747](https://github.com/kubernetes-sigs/gateway-api/issues/4747)
+* Status: Provisional
+
+(See [status definitions](../overview.md#gep-states).)
+
+[Chihiro]: https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas
+[Ian]: https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas
+[Ana]: https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in BCP 14 ([RFC8174]) when, and
+only when, they appear in all capitals, as shown here.
+
+[RFC8174]: https://www.rfc-editor.org/rfc/rfc8174
+
+> **Note**: This GEP is Provisional. It proposes that existing Gateway API
+> resources are sufficient for L7 reverse-proxy egress. A companion GEP
+> ([GEP-4748]) explores an alternative approach using a dedicated
+> `EgressGateway` resource. Community feedback on both approaches is
+> explicitly requested.
+
+[GEP-4748]: ../gep-4748/index.md
+
+## TLDR
+
+Define how Gateway API resources compose for L7 reverse-proxy egress: routing
+traffic from in-cluster workloads to external destinations through a Gateway,
+using HTTPRoute for routing and the Backend resource
+([PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)) for destination representation. This GEP
+argues that no new Gateway-level resource is required.
+
+## User Stories
+
+### Platform Operator
+
+> **[Ian] needs to provide workloads access to external AI services (OpenAI,
+> Vertex AI, Bedrock) with centralized credential management, TLS policy,
+> and observability -- without distributing API keys to individual workloads.**
+
+### Application Developer
+
+> **[Ana] needs her application to call external inference APIs through a
+> managed gateway, with automatic failover between providers when the primary
+> is unavailable.**
+
+### Cluster Administrator
+
+> **[Chihiro] needs to enforce that all outbound traffic to third-party
+> services passes through a policy-enforced gateway, with per-namespace
+> rate limiting and regulatory region locks.**
+
+## Goals
+
+* Establish egress as a first-class usage pattern of Gateway API
+* Define how Gateway + HTTPRoute + Backend ([PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)) compose for egress
+* Provide an `Egress` conformance profile so implementations can declare support
+* Document egress-specific guidance for listeners, routes, and policy scoping
+* Support two routing modes: Endpoint (direct) and Parent (gateway chaining)
+
+## Non-Goals
+
+* Introduce a new `EgressGateway` resource (see [GEP-4748] and
+  [Alternatives Considered](#alternatives-considered))
+* Define the Backend resource (see [PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488))
+* Address forward-proxy egress with dynamic routing
+  (see [#4704](https://github.com/kubernetes-sigs/gateway-api/issues/4704))
+* Address L3/L4 network-level egress
+* Address mesh-attached egress (sidecar/waypoint enforcement without Gateway)
+* Solve workload-to-Gateway addressing
+  (see [#1651](https://github.com/kubernetes-sigs/gateway-api/issues/1651))
+
+## Introduction
+
+### The Problem
+
+Applications increasingly need managed access to services outside the cluster:
+cloud AI APIs, cross-cluster inference endpoints, third-party services.
+Kubernetes currently lacks standardized APIs for routing this traffic through a
+policy-enforced Gateway. Workarounds include:
+
+- **Synthetic ExternalName Services**: Subject to confused deputy attacks
+  ([CVE-2021-25740](https://github.com/kubernetes/kubernetes/issues/103675)),
+  break SNI/Host alignment, and cannot carry per-destination TLS policy.
+- **Implementation-specific resources**: Istio `ServiceEntry`, Linkerd
+  `EgressNetwork`, Cilium `CiliumEgressGatewayPolicy` -- each with different
+  models, none standardized.
+
+### Why No New Resource
+
+A field-by-field analysis of the Gateway resource shows that some fields carry different meanings
+depending on ingress or egress use cases: listeners, addresses, TLS, allowedRoutes. However, they remain
+semantically valuable within both contexts:
+
+| Field | Ingress Meaning | Egress Meaning |
+|-------|----------------|----------------|
+| `addresses` | How external clients reach the gateway | How internal workloads reach the gateway |
+| `listeners[].port` | Port to accept incoming traffic | Port to accept outbound traffic from workloads |
+| `listeners[].hostname` | Virtual host to match (SNI/Host header) | Filter workload requests by SNI/Host header |
+| `listeners[].tls` | Cert presented to external clients (server TLS) | Cert presented to internal workloads (server TLS) |
+
+The difference between ingress and egress is an emergent property of:
+
+1. **Where the Gateway is deployed** (facing internal workloads, not the
+   internet)
+2. **What backends routes reference** (external Backend resources, not internal
+   Services)
+
+Both are already expressible in Gateway API. GatewayClass can provide a
+mechanism for implementations to distinguish egress controllers from ingress
+controllers.
+
+### Prior Art
+
+| Implementation | Egress Model | Separate Resource? |
+|---|---|---|
+| Istio | [Same `Gateway` resource](https://istio.io/latest/docs/tasks/traffic-management/egress/egress-gateway/) | No |
+| Linkerd | [`EgressNetwork`](https://linkerd.io/2-edge/reference/egress-network/) (classifies traffic, not a Gateway) | Different model |
+| Cilium | `CiliumEgressGatewayPolicy` (L3/L4) | Different layer |
+
+Implementations that use Gateway API's Gateway resource for egress do NOT
+require a separate resource type.
+
+## API
+
+### No New API Types
+
+This GEP does not introduce new API types. It defines how existing types
+compose for egress:
+
+```
+                     parentRef              backendRef
+Workload --> Gateway <-------- HTTPRoute ----------> Backend (PR #4488)
+              |                   |                     |
+         GatewayClass        hostnames:            destination:
+         (egress)          ["*.openai.com"]       type: Hostname
+                                                  hostname:
+                                                    address: api.openai.com
+                                                  ports:
+                                                  - number: 443
+                                                    tls: ...
+```
+
+### Egress Gateway Configuration
+
+An egress gateway is a `Gateway`. An egress-specific `GatewayClass` MAY be
+used to apply egress-specific validation, defaults, and to denote that the
+Gateway is being used for egress:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: egress
+spec:
+  controllerName: example.com/egress-gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: egress-gateway
+  namespace: gateway-system
+spec:
+  gatewayClassName: egress
+  listeners:
+  - name: https
+    port: 8443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: egress-gw-cert
+```
+
+**Listener guidance for egress**:
+
+- Egress gateways typically use a single listener with no hostname filter
+  (accepting all destinations), though setting `hostname` to filter by
+  destination IS valid and means "only accept requests going to this host."
+- `listeners[].tls` is the server-side TLS config presented to workloads
+  connecting to the gateway. The TLS configuration structure is identical to
+  ingress; only the client/server roles are reversed. Client-side TLS to external
+  destinations is configured on the Backend resource ([PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)).
+
+### Egress Routing
+
+HTTPRoute attaches to the egress Gateway and references Backend resources:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: openai-route
+  namespace: app-team
+spec:
+  parentRefs:
+  - name: egress-gateway
+    namespace: gateway-system
+  hostnames:
+  - "api.openai.com"
+  rules:
+  - backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: Backend
+      name: openai-backend
+```
+
+`hostnames` on an egress HTTPRoute means "match requests whose destination
+Host header is one of these values." The matching behavior is identical to ingress,
+though the semantic intent differs: ingress routes serve requests TO these hostnames,
+while egress routes forward requests GOING TO these external hostnames.
+
+### Routing Modes
+
+#### Endpoint Mode
+
+Traffic flows directly from egress gateway to external destination:
+
+```
+Workload --> Egress Gateway --> External API (Backend)
+```
+
+The gateway applies policies, resolves the Backend destination, originates
+TLS to the external endpoint, and forwards the request.
+
+#### Parent Mode (Gateway Chaining)
+
+Traffic flows through a local egress gateway to an upstream gateway:
+
+```
+Workload --> Local Egress GW --> Upstream GW --> External API
+```
+
+Use cases:
+
+- Multi-cluster: local cluster routes through a central egress cluster
+- Multi-zone: regional gateways route through a global exit point
+- Compliance: all traffic exits through an audited chokepoint
+
+Requirements:
+
+- Local retries MUST be limited to establishing the upstream connection
+- Request-level retries MUST be performed by the upstream gateway
+- Implementations MUST tag forwarded requests (e.g., via header) to prevent
+  retry loops between chained gateways
+
+### Policy Application Scopes
+
+Egress policies apply at three levels:
+
+| Scope | Mechanism | Egress Examples |
+|-------|-----------|-----------------|
+| **Gateway** | Policy attachment to Gateway | CIDR deny lists, global rate limits, default deny |
+| **Route** | HTTPRoute filters, ExtensionRef | Payload transforms, compliance checks, guardrails |
+| **Backend** | Backend.spec.tls, Backend.spec.filters [PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488) | Per-destination TLS, credential injection |
+
+**Conflict resolution**: Route > Backend > Gateway (most specific wins).
+Same-level ties: oldest resource by `creationTimestamp` wins. Implementations
+MUST surface conflicts in status conditions.
+
+### Workload-to-Gateway Addressing (Interim)
+
+Until Gateway Routability ([#1651](https://github.com/kubernetes-sigs/gateway-api/issues/1651))
+is resolved, workloads connect to the egress gateway via an implementation-managed Service. Most
+Gateway API implementations already create a Service for each Gateway; for egress, this Service
+SHOULD be of type `ClusterIP` (not `LoadBalancer`).
+
+Implementations supporting the Egress conformance profile SHOULD:
+
+- Automatically create a ClusterIP Service for egress Gateways
+- Report the Service's ClusterIP in `gateway.status.addresses`
+- Use a stable DNS name (e.g., `<gateway-name>.<namespace>.svc.cluster.local`)
+
+### Traffic Enforcement
+
+Operators MUST use NetworkPolicy, sidecar configuration, or CNI-level controls
+to deny direct egress from workloads and force outbound traffic through the
+Gateway. This GEP does not define enforcement mechanisms -- it defines what the
+Gateway does once traffic arrives.
+
+## Conformance
+
+### Egress Conformance Profile
+
+This GEP defines an `Egress` conformance profile. Implementations declare
+egress support by passing egress conformance tests.
+
+**Core egress conformance** (required for profile):
+
+- Gateway with egress GatewayClass accepts and routes traffic
+- HTTPRoute attached to egress Gateway routes to Backend ([PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488))
+- `hostnames` on HTTPRoute correctly matches destination Host headers
+- Policy conflict resolution follows specificity precedence
+
+**Extended egress conformance**:
+
+- Parent mode (gateway chaining)
+- Multi-backend weighted routing and failover
+- Backend TLS origination (Simple, Mutual) -- via [PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488) conformance
+- Cross-namespace Backend references with ReferenceGrant
+
+## Security Considerations
+
+### Egress-Specific Risks
+
+1. **Data exfiltration**: A compromised workload could use the egress gateway
+   to send data to attacker-controlled endpoints. Mitigation: restrict Backend
+   creation via RBAC, use NetworkPolicy to limit which namespaces can reach the
+   gateway.
+
+2. **Credential exposure**: Backend extensions may inject credentials into
+   requests. The egress gateway becomes a high-value target. Mitigation:
+   standard Kubernetes secrets RBAC, audit logging.
+
+3. **Gateway bypass**: Workloads with direct internet access bypass all egress
+   policy. NetworkPolicy enforcement may be used to mitigate this.
+
+## Open Questions
+
+> These are explicitly marked as open for community feedback during
+> Provisional status.
+
+### 1. Gateway Reuse vs EgressGateway Resource
+
+This GEP argues that no new resource is needed. [GEP-4748] proposes a
+dedicated `EgressGateway` resource as an alternative. Community input is
+needed to decide which approach to pursue. See
+[Alternatives Considered](#alternatives-considered).
+
+### 2. Egress Conformance Profile Shape
+
+Should egress conformance be a standalone profile (like [`Mesh`](../gep-1709/index.md)) or a feature
+within the existing `HTTP` profile?
+
+### 3. Listener Hostname Guidance
+
+Should the GEP recommend specific listener configurations for egress (e.g.,
+"use a single wildcard listener") or leave this entirely to implementations?
+
+### 4. Parent Mode Standardization
+
+Is Parent Mode (gateway chaining) common enough to warrant conformance tests,
+or should it be Implementation-Specific?
+
+### 5. Mixed Ingress/Egress Gateways
+
+Should a single Gateway be allowed to serve both ingress and egress traffic
+(via multiple listeners)?
+
+## Alternatives Considered
+
+### New EgressGateway Resource (GEP-4748)
+
+A dedicated `EgressGateway` resource was prototyped
+([wg-ai-gateway PR #45](https://github.com/kubernetes-sigs/wg-ai-gateway/pull/45))
+and is proposed in companion [GEP-4748].
+
+**Arguments for**: User clarity, prevents accidental misuse, access controls, reserves design
+space for egress-specific fields.
+
+**Arguments against**: Zero UX differences at the Gateway level, API
+fragmentation, precedent risk, may introduce confusion when paired with mixed-mode
+architectures (using Gateway).
+
+See [GEP-4748] for the full proposal.
+
+### EgressRoute (Prior GEP #1971)
+
+A [previous attempt](https://github.com/kubernetes-sigs/gateway-api/pull/1971)
+proposed an `EgressRoute` resource. It was closed without merge. This GEP
+takes a different approach: egress routing uses existing HTTPRoute with Backend
+as the destination type.
+
+### Forward Proxy Model
+
+Dynamic routing to arbitrary hostnames (forward proxy) is out of scope. See
+[#4704](https://github.com/kubernetes-sigs/gateway-api/issues/4704).
+
+## Dependencies
+
+| Dependency | Status | Impact |
+|---|---|---|
+| [PR #4488: Backend Resource](https://github.com/kubernetes-sigs/gateway-api/pull/4488) | PR open | Required -- egress routes need Backend destinations |
+| [#1651: Gateway Routability](https://github.com/kubernetes-sigs/gateway-api/issues/1651) | Issue open | Nice-to-have -- defines how workloads address gateways |
+
+## References
+
+* [WG AI Gateway egress proposal](https://github.com/kubernetes-sigs/wg-ai-gateway/blob/main/proposals/10-egress-gateways.md)
+* [GEP-4488: Backend Resource](https://github.com/kubernetes-sigs/gateway-api/pull/4488)
+* [GEP-1897: BackendTLSPolicy](../gep-1897/index.md)
+* [GEP-2907: TLS Terminology](../gep-2907/index.md)
+* [Issue #1651: Gateway Routability](https://github.com/kubernetes-sigs/gateway-api/issues/1651)
+* [Issue #4704: Forward Proxy Egress](https://github.com/kubernetes-sigs/gateway-api/issues/4704)
+* [PR #1971: Prior Egress GEP](https://github.com/kubernetes-sigs/gateway-api/pull/1971)
+* [CVE-2021-25740](https://github.com/kubernetes/kubernetes/issues/103675)
+
+## Graduation Criteria
+
+### Provisional -> Implementable
+
+- [ ] Community decision on Gateway reuse (this GEP) vs EgressGateway ([GEP-4748])
+- [ ] [PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488) (Backend) reaches at least Provisional status
+- [ ] Open questions resolved
+- [ ] Egress conformance profile defined in detail
+
+### Alpha (Experimental)
+
+- [ ] Egress conformance tests implemented
+- [ ] At least one implementation passes egress conformance
+- [ ] Documentation for egress usage patterns
+
+### Beta
+
+- [ ] At least two implementations pass egress conformance
+- [ ] Production usage reports from 2+ organizations
+- [ ] Gateway Routability (#1651) resolved or workaround documented
+
+### GA (Standard)
+
+- [ ] Three implementations passing extended egress conformance
+- [ ] No API-level changes needed for 6+ months
+- [ ] Security review complete
+

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -112,9 +112,10 @@ semantically valuable within both contexts:
 
 The difference between ingress and egress is an emergent property of:
 
-1. **Where the Gateway is deployed** (facing internal workloads, not the
-   internet)
-2. **What backends routes reference** (external Backend resources, not internal
+1. **The reachability of the Gateway's addresses** (typically internal
+   workloads, though externally-reachable Gateways targeting external
+   backends are also valid)
+2. **What backends routes reference** (external Backend resources, not just internal
    Services)
 
 Both are already expressible in Gateway API. GatewayClass can provide a

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -189,12 +189,16 @@ The `type` field is a list of one or more values:
   `Egress` in its type MUST support Backend as a backendRef target and MUST
   provision a cluster-reachable address.
 
-Implementations MUST enforce the declared type. A Gateway whose type does not
-include `Egress` MUST reject routes with Backend backendRefs. This prevents
-existing Gateways from being used as open proxies when Backend support is
-introduced. Routes attached to an egress Gateway MAY reference both Backend
-resources and internal Services (e.g., routing some traffic to a local cache
-and other traffic to external APIs).
+Implementations MUST enforce the declared type. When a Route references a
+Backend that targets an external destination and is parented to a Gateway
+whose type does not include `Egress`, the implementation MUST set
+`ResolvedRefs` to `False` with reason `RefNotPermitted` and MUST NOT program
+the backendRef. The mechanism for distinguishing external from internal
+Backend destinations is defined by the Backend resource
+([PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)).
+Backends that reference internal destinations are permitted regardless of
+Gateway type. Routes attached to an egress Gateway MAY reference both Backend
+resources and internal Services.
 
 ### Egress Gateway Configuration
 

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -76,6 +76,7 @@ argues that no new Gateway-level resource is required.
   (see [#1651](https://github.com/kubernetes-sigs/gateway-api/issues/1651))
 * Define or introduce traffic redirection mechanisms (e.g., transparent
   interception of egress traffic)
+* Define mixed-mode (combined ingress/egress) Gateway semantics
 
 ## Introduction
 
@@ -118,6 +119,12 @@ The difference between ingress and egress is an emergent property of:
 Both are already expressible in Gateway API. GatewayClass can provide a
 mechanism for implementations to distinguish egress controllers from ingress
 controllers.
+
+A single Gateway MAY serve both ingress and egress if the implementation
+supports it. However, this GEP does not define a mechanism for distinguishing
+ingress and egress listeners or routes on a shared Gateway. Implementations
+that support mixed-mode gateways would need to surface direction at the
+Listener or Route level; defining such a mechanism is left to a future GEP.
 
 ### Prior Art
 

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -280,6 +280,12 @@ Gateway does once traffic arrives.
 3. **Gateway bypass**: Workloads with direct internet access bypass all egress
    policy. NetworkPolicy enforcement may be used to mitigate this.
 
+4. **Outbound abuse**: An actor who can create Routes or Backends may use the
+   egress gateway to launch attacks (e.g., denial-of-service, port scanning)
+   against external targets, with traffic appearing to originate from the
+   cluster's egress IP. Mitigation: restrict Route and Backend creation via
+   RBAC, enforce allowlisted destinations, and apply rate-limiting policies.
+
 ## Open Questions
 
 > These are explicitly marked as open for community feedback during

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -74,6 +74,8 @@ argues that no new Gateway-level resource is required.
 * Address mesh-attached egress (sidecar/waypoint enforcement without Gateway)
 * Solve workload-to-Gateway addressing
   (see [#1651](https://github.com/kubernetes-sigs/gateway-api/issues/1651))
+* Define or introduce traffic redirection mechanisms (e.g., transparent
+  interception of egress traffic)
 
 ## Introduction
 

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -77,7 +77,6 @@ argues that no new Gateway-level resource is required.
   (see [#1651](https://github.com/kubernetes-sigs/gateway-api/issues/1651))
 * Define or introduce traffic redirection mechanisms (e.g., transparent
   interception of egress traffic)
-* Define mixed-mode (combined ingress/egress) Gateway semantics
 
 ## Introduction
 
@@ -122,11 +121,9 @@ Both are already expressible in Gateway API. GatewayClass can provide a
 mechanism for implementations to distinguish egress controllers from ingress
 controllers.
 
-A single Gateway MAY serve both ingress and egress if the implementation
-supports it. However, this GEP does not define a mechanism for distinguishing
-ingress and egress listeners or routes on a shared Gateway. Implementations
-that support mixed-mode gateways would need to surface direction at the
-Listener or Route level; defining such a mechanism is left to a future GEP.
+A single Gateway MAY serve both ingress and egress by setting
+`type: [Ingress, Egress]`. See [Gateway Type Field](#gateway-type-field) for
+details.
 
 ### Prior Art
 
@@ -141,10 +138,11 @@ require a separate resource type.
 
 ## API
 
-### No New API Types
+### API Overview
 
-This GEP does not introduce new API types. It defines how existing types
-compose for egress:
+This GEP does not introduce new API resources. It extends the Gateway resource
+with a `type` field and a `ClusterIP` address type, and defines how existing
+types compose for egress:
 
 ```
                      parentRef              backendRef
@@ -164,11 +162,42 @@ target for egress routes, representing an external destination. The specific
 resource definition is being developed in
 [PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488).
 
+### Gateway Type Field
+
+This GEP introduces a `type` field on the Gateway spec to indicate whether
+the Gateway handles ingress traffic, egress traffic, or both:
+
+```yaml
+spec:
+  type: [Egress]            # egress only
+  type: [Ingress]           # ingress only (default)
+  type: [Ingress, Egress]   # mixed mode
+```
+
+The `type` field is a list of one or more values:
+
+- **`Ingress`**: The Gateway accepts traffic from external or cross-cluster
+  clients and routes it to backends. This is the default when `type` is unset.
+  Defaulting to `Ingress` prevents existing Gateways from being accidentally
+  configured as open proxies when Backend support is introduced.
+  Implementations that already use Gateway for egress will need to explicitly
+  set `type` to include `Egress`.
+- **`Egress`**: The Gateway accepts traffic from internal workloads and routes
+  it to destinations including external Backend resources. A Gateway with
+  `Egress` in its type MUST support Backend as a backendRef target and MUST
+  provision a cluster-reachable address.
+
+Implementations MUST enforce the declared type. A Gateway whose type does not
+include `Egress` MUST reject routes with Backend backendRefs. This prevents
+existing Gateways from being used as open proxies when Backend support is
+introduced. Routes attached to an egress Gateway MAY reference both Backend
+resources and internal Services (e.g., routing some traffic to a local cache
+and other traffic to external APIs).
+
 ### Egress Gateway Configuration
 
-An egress gateway is a `Gateway`. An egress-specific `GatewayClass` MAY be
-used to apply egress-specific validation, defaults, and to denote that the
-Gateway is being used for egress:
+An egress gateway is a `Gateway` with `type: [Egress]`. An egress-specific
+`GatewayClass` MAY be used to apply egress-specific validation and defaults:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -184,7 +213,10 @@ metadata:
   name: egress-gateway
   namespace: gateway-system
 spec:
+  type: [Egress]
   gatewayClassName: egress
+  addresses:
+  - type: ClusterIP
   listeners:
   - name: https
     port: 8443
@@ -327,11 +359,6 @@ needed to decide which approach to pursue. See
 
 Should the GEP recommend specific listener configurations for egress (e.g.,
 "use a single wildcard listener") or leave this entirely to implementations?
-
-### 3. Mixed Ingress/Egress Gateways
-
-Should a single Gateway be allowed to serve both ingress and egress traffic
-(via multiple listeners)?
 
 ## Alternatives Considered
 

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -133,7 +133,7 @@ Listener or Route level; defining such a mechanism is left to a future GEP.
 |---|---|---|
 | Istio | [Same `Gateway` resource](https://istio.io/latest/docs/tasks/traffic-management/egress/egress-gateway/) | No |
 | Linkerd | [`EgressNetwork`](https://linkerd.io/2-edge/reference/egress-network/) (classifies traffic, not a Gateway) | Different model |
-| Cilium | `CiliumEgressGatewayPolicy` (L3/L4) | Different layer |
+| Cilium | `CiliumEgressGatewayPolicy` (L3/L4); L7 policy via [`CiliumNetworkPolicy`](https://docs.cilium.io/en/stable/security/policy/layer7) | Different model |
 
 Implementations that use Gateway API's Gateway resource for egress do NOT
 require a separate resource type.

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -67,7 +67,8 @@ argues that no new Gateway-level resource is required.
 
 * Introduce a new `EgressGateway` resource (see [GEP-4748] and
   [Alternatives Considered](#alternatives-considered))
-* Define the Backend resource (see [PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488))
+* Define a specific Backend resource (for ongoing work see
+  [PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488))
 * Address forward-proxy egress with dynamic routing
   (see [#4704](https://github.com/kubernetes-sigs/gateway-api/issues/4704))
 * Address L3/L4 network-level egress
@@ -156,6 +157,11 @@ Workload --> Gateway <-------- HTTPRoute ----------> Backend (PR #4488)
                                                   - number: 443
                                                     tls: ...
 ```
+
+Throughout this GEP, **Backend** refers to a CRD that acts as a backendRef
+target for egress routes, representing an external destination. The specific
+resource definition is being developed in
+[PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488).
 
 ### Egress Gateway Configuration
 

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -249,6 +249,8 @@ MUST surface conflicts in status conditions.
 Until Gateway Routability ([#1651](https://github.com/kubernetes-sigs/gateway-api/issues/1651))
 is resolved, workloads connect to the egress gateway via an implementation-managed
 address reachable only within the cluster (often a ClusterIP Service).
+See also [PR #4767](https://github.com/kubernetes-sigs/gateway-api/pull/4767)
+for ongoing work on service scope and routability.
 
 Implementations should:
 

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -253,19 +253,33 @@ Route, and Backend-level policies are handled -- will be addressed as part of
 the Backend resource design
 ([PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)).
 
-### Workload-to-Gateway Addressing (Interim)
+### Workload-to-Gateway Addressing
 
-Until Gateway Routability ([#1651](https://github.com/kubernetes-sigs/gateway-api/issues/1651))
-is resolved, workloads connect to the egress gateway via an implementation-managed
-address reachable only within the cluster (often a ClusterIP Service).
-See also [PR #4767](https://github.com/kubernetes-sigs/gateway-api/pull/4767)
-for ongoing work on service scope and routability.
+Egress Gateways require an address reachable from within the cluster so that
+workloads can connect to them. Implementations MUST expose such an address and
+report it in `gateway.status.addresses`. Workloads typically reach the gateway
+via a stable DNS name (e.g., `<gateway-name>.<namespace>.svc.cluster.local`).
 
-Implementations should:
+This GEP introduces `ClusterIP` as a new `AddressType` for Gateway. Operators
+can request a cluster-internal-only address by specifying it in
+`gateway.spec.addresses`:
 
-- Expose an internally-reachable address for egress Gateways
-- Report this address in `gateway.status.addresses`
-- Use a stable DNS name (e.g., `<gateway-name>.<namespace>.svc.cluster.local`)
+```yaml
+spec:
+  addresses:
+  - type: ClusterIP
+    value: ""  # implementation-assigned
+```
+
+`ClusterIP` is already a well-understood concept from Kubernetes Services. When
+specified on a Gateway, the implementation MUST provision an address that is
+reachable only from within the cluster and report it in
+`gateway.status.addresses`. This address type has Extended support.
+
+See also [#1651](https://github.com/kubernetes-sigs/gateway-api/issues/1651)
+for prior discussion on cluster-local Gateway addresses and
+[PR #4767](https://github.com/kubernetes-sigs/gateway-api/pull/4767) for
+related work on service scope and routability.
 
 ### Traffic Enforcement
 
@@ -353,7 +367,7 @@ Dynamic routing to arbitrary hostnames (forward proxy) is out of scope. See
 | Dependency | Status | Impact |
 |---|---|---|
 | [PR #4488: Backend Resource](https://github.com/kubernetes-sigs/gateway-api/pull/4488) | PR open | Required -- egress routes need Backend destinations |
-| [#1651: Gateway Routability](https://github.com/kubernetes-sigs/gateway-api/issues/1651) | Issue open | Nice-to-have -- defines how workloads address gateways |
+| [#1651: Gateway Routability](https://github.com/kubernetes-sigs/gateway-api/issues/1651) | Issue open | Formalizes `ClusterIP` as a Gateway `AddressType`; implementations already provision ClusterIP Services for egress |
 
 ## References
 

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -177,7 +177,9 @@ spec:
 The `type` field is a list of one or more values:
 
 - **`Ingress`**: The Gateway accepts traffic from external or cross-cluster
-  clients and routes it to backends. This is the default when `type` is unset.
+  clients and routes it to backends. When `type` is unset or an empty list,
+  implementations MUST treat it as `[Ingress]` and surface that value in
+  the Gateway's status.
   Defaulting to `Ingress` prevents existing Gateways from being accidentally
   configured as open proxies when Backend support is introduced.
   Implementations that already use Gateway for egress will need to explicitly

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -158,8 +158,8 @@ Workload --> Gateway <-------- HTTPRoute ----------> Backend (PR #4488)
 ```
 
 Throughout this GEP, **Backend** refers to a CRD that acts as a backendRef
-target for egress routes, representing an external destination. The specific
-resource definition is being developed in
+target, representing a destination. The specific resource definition is being
+developed in
 [PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488).
 
 ### Gateway Type Field

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -417,7 +417,7 @@ Dynamic routing to arbitrary hostnames (forward proxy) is out of scope. See
 | Dependency | Status | Impact |
 |---|---|---|
 | [PR #4488: Backend Resource](https://github.com/kubernetes-sigs/gateway-api/pull/4488) | PR open | Required -- egress routes need Backend destinations |
-| [#1651: Gateway Routability](https://github.com/kubernetes-sigs/gateway-api/issues/1651) | Issue open | Formalizes `ClusterIP` as a Gateway `AddressType`; implementations already provision ClusterIP Services for egress |
+| [#1651: Gateway Routability](https://github.com/kubernetes-sigs/gateway-api/issues/1651) | Issue open | `ClusterIP` address type is proposed in this GEP, overlapping with #1651; broader routability concerns remain open there |
 
 ## References
 

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -147,14 +147,14 @@ types compose for egress:
 ```
                      parentRef              backendRef
 Workload --> Gateway <-------- HTTPRoute ----------> Backend (PR #4488)
-              |                   |                     |
-         GatewayClass        hostnames:            destination:
-         (egress)          ["*.openai.com"]       type: Hostname
-                                                  hostname:
-                                                    address: api.openai.com
-                                                  ports:
-                                                  - number: 443
-                                                    tls: ...
+                                  |                     |
+                              hostnames:            destination:
+                            ["*.openai.com"]       type: Hostname
+                                                   hostname:
+                                                     address: api.openai.com
+                                                   ports:
+                                                   - number: 443
+                                                     tls: ...
 ```
 
 Throughout this GEP, **Backend** refers to a CRD that acts as a backendRef

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -325,25 +325,42 @@ Gateway does once traffic arrives.
 
 ## Security Considerations
 
-### Egress-Specific Risks
+### Motivation
 
-1. **Data exfiltration**: A compromised workload could use the egress gateway
-   to send data to attacker-controlled endpoints. Mitigation: restrict Backend
-   creation via RBAC, use NetworkPolicy to limit which namespaces can reach the
-   gateway.
+A key motivation for adding explicit egress semantics to Gateway API is to
+support generative AI use cases, where gateways apply common policy
+(credential injection, rate limiting, observability) to inference requests
+destined for external model providers. This naturally makes egress gateways
+attractive targets for abuse: a gateway holding provider credentials becomes a
+high-value asset for attackers seeking unauthorized inference access. Recent
+incidents demonstrate active reconnaissance and exploitation of exposed LLM
+proxy infrastructure
+([GreyNoise, 2026](https://www.greynoise.io/blog/threat-actors-actively-targeting-llms);
+[Pillar Security, 2026](https://www.pillar.security/blog/operation-bizarre-bazaar-first-attributed-llmjacking-campaign-with-commercial-marketplace-monetization)).
 
-2. **Credential exposure**: Backend extensions may inject credentials into
-   requests. The egress gateway becomes a high-value target. Mitigation:
-   standard Kubernetes secrets RBAC, audit logging.
+### Open Relay Precedents
 
-3. **Gateway bypass**: Workloads with direct internet access bypass all egress
+The `type` field and its enforcement exist because permissive-by-default
+external routing has a long history of causing ecosystem-scale damage. The
+following table documents open relay precedents that motivate a default-closed
+posture for Hostname-type Backend routing:
+| Threat | Mechanism | Precedent | 
+|--------|-----------|-----------|
+| **Open relay** | Misconfigured gateway relays traffic to arbitrary external destinations | [Google SMTP relay abuse (2022)](https://www.bleepingcomputer.com/news/security/google-smtp-relay-service-abused-for-sending-phishing-emails/) |
+| **Traffic amplification** | Permissive default enables use as traffic amplifier | [Memcached UDP amplification (2018)](https://github.blog/news-insights/company-news/ddos-incident-report/) |
+| **Confused deputy** | Service-based egress workarounds route to unintended destinations | [CVE-2021-25740](https://github.com/kubernetes/kubernetes/issues/103675) |
+
+The `type` field is defense-in-depth, not the primary security control.
+The primary control is RBAC on Backend creation. What the `type` field
+provides is a stable, declared property on the Gateway that makes policy
+attachment, audit, and enforcement legible. Without it, determining whether
+a Gateway is egress-capable requires inferring it from route topology, which
+is racy and incomplete during reconciliation.
+
+### Additional Risks
+
+1. **Gateway bypass**: Workloads with direct internet access bypass all egress
    policy. NetworkPolicy enforcement may be used to mitigate this.
-
-4. **Outbound abuse**: An actor who can create Routes or Backends may use the
-   egress gateway to launch attacks (e.g., denial-of-service, port scanning)
-   against external targets, with traffic appearing to originate from the
-   cluster's egress IP. Mitigation: restrict Route and Backend creation via
-   RBAC, enforce allowlisted destinations, and apply rate-limiting policies.
 
 ## Open Questions
 

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -245,17 +245,12 @@ TLS to the external endpoint, and forwards the request.
 
 ### Policy Application Scopes
 
-Egress policies apply at three levels:
-
-| Scope | Mechanism | Egress Examples |
-|-------|-----------|-----------------|
-| **Gateway** | Policy attachment to Gateway | CIDR deny lists, global rate limits, default deny |
-| **Route** | HTTPRoute filters, ExtensionRef | Payload transforms, compliance checks, guardrails |
-| **Backend** | Backend.spec.tls, Backend.spec.filters [PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488) | Per-destination TLS, credential injection |
-
-**Conflict resolution**: Route > Backend > Gateway (most specific wins).
-Same-level ties: oldest resource by `creationTimestamp` wins. Implementations
-MUST surface conflicts in status conditions.
+Egress policies may apply at multiple levels (Gateway, Route, Backend). This
+GEP does not define conflict resolution or precedence ordering between these
+scopes. Policy resolution semantics -- including how conflicts between Gateway,
+Route, and Backend-level policies are handled -- will be addressed as part of
+the Backend resource design
+([PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)).
 
 ### Workload-to-Gateway Addressing (Interim)
 

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -121,10 +121,6 @@ Both are already expressible in Gateway API. GatewayClass can provide a
 mechanism for implementations to distinguish egress controllers from ingress
 controllers.
 
-A single Gateway MAY serve both ingress and egress by setting
-`type: [Ingress, Egress]`. See [Gateway Type Field](#gateway-type-field) for
-details.
-
 ### Prior Art
 
 | Implementation | Egress Model | Separate Resource? |
@@ -140,9 +136,9 @@ require a separate resource type.
 
 ### API Overview
 
-This GEP does not introduce new API resources. It extends the Gateway resource
-with a `type` field and a `ClusterIP` address type, and defines how existing
-types compose for egress:
+This GEP does not introduce new API resources. It introduces a `ClusterIP`
+address type for the Gateway resource and defines how existing types compose
+for egress:
 
 ```
                      parentRef              backendRef
@@ -162,48 +158,11 @@ target, representing a destination. The specific resource definition is being
 developed in
 [PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488).
 
-### Gateway Type Field
-
-This GEP introduces a `type` field on the Gateway spec to indicate whether
-the Gateway handles ingress traffic, egress traffic, or both:
-
-```yaml
-spec:
-  type: [Egress]            # egress only
-  type: [Ingress]           # ingress only (default)
-  type: [Ingress, Egress]   # mixed mode
-```
-
-The `type` field is a list of one or more values:
-
-- **`Ingress`**: The Gateway accepts traffic from external or cross-cluster
-  clients and routes it to backends. When `type` is unset or an empty list,
-  implementations MUST treat it as `[Ingress]` and surface that value in
-  the Gateway's status.
-  Defaulting to `Ingress` prevents existing Gateways from being accidentally
-  configured as open proxies when Backend support is introduced.
-  Implementations that already use Gateway for egress will need to explicitly
-  set `type` to include `Egress`.
-- **`Egress`**: The Gateway accepts traffic from internal workloads and routes
-  it to destinations including external Backend resources. A Gateway with
-  `Egress` in its type MUST support Backend as a backendRef target and MUST
-  provision a cluster-reachable address.
-
-Implementations MUST enforce the declared type. When a Route references a
-Backend that targets an external destination and is parented to a Gateway
-whose type does not include `Egress`, the implementation MUST set
-`ResolvedRefs` to `False` with reason `RefNotPermitted` and MUST NOT program
-the backendRef. The mechanism for distinguishing external from internal
-Backend destinations is defined by the Backend resource
-([PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)).
-Backends that reference internal destinations are permitted regardless of
-Gateway type. Routes attached to an egress Gateway MAY reference both Backend
-resources and internal Services.
-
 ### Egress Gateway Configuration
 
-An egress gateway is a `Gateway` with `type: [Egress]`. An egress-specific
-`GatewayClass` MAY be used to apply egress-specific validation and defaults:
+An egress gateway is a Gateway configured for outbound traffic. An
+egress-specific `GatewayClass` MAY be used to apply egress-specific
+validation and defaults:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -219,7 +178,6 @@ metadata:
   name: egress-gateway
   namespace: gateway-system
 spec:
-  type: [Egress]
   gatewayClassName: egress
   addresses:
   - type: ClusterIP
@@ -344,22 +302,17 @@ proxy infrastructure
 
 ### Open Relay Precedents
 
-The `type` field and its enforcement exist because permissive-by-default
-external routing has a long history of causing ecosystem-scale damage. The
-following table documents open relay precedents that motivate a default-closed
-posture for Hostname-type Backend routing:
+The following table documents open relay precedents relevant to external
+Backend routing:
 | Threat | Mechanism | Precedent | 
 |--------|-----------|-----------|
 | **Open relay** | Misconfigured gateway relays traffic to arbitrary external destinations | [Google SMTP relay abuse (2022)](https://www.bleepingcomputer.com/news/security/google-smtp-relay-service-abused-for-sending-phishing-emails/) |
 | **Traffic amplification** | Permissive default enables use as traffic amplifier | [Memcached UDP amplification (2018)](https://github.blog/news-insights/company-news/ddos-incident-report/) |
 | **Confused deputy** | Service-based egress workarounds route to unintended destinations | [CVE-2021-25740](https://github.com/kubernetes/kubernetes/issues/103675) |
 
-The `type` field is defense-in-depth, not the primary security control.
-The primary control is RBAC on Backend creation. What the `type` field
-provides is a stable, declared property on the Gateway that makes policy
-attachment, audit, and enforcement legible. Without it, determining whether
-a Gateway is egress-capable requires inferring it from route topology, which
-is racy and incomplete during reconciliation.
+The primary security control against open relays is RBAC on Backend creation.
+Whether additional Gateway-level controls are needed to prevent accidental
+open proxies is an open question deferred to a follow-up GEP.
 
 ### Additional Risks
 
@@ -382,6 +335,13 @@ needed to decide which approach to pursue. See
 
 Should the GEP recommend specific listener configurations for egress (e.g.,
 "use a single wildcard listener") or leave this entirely to implementations?
+
+### 3. Gateway-Level Controls for External Routing
+
+Whether the Gateway resource needs additional controls to prevent accidental
+open proxies -- and if so, what form they should take (e.g., a Gateway-level
+field, GatewayClass parameter, or other approach) -- is deferred to a
+follow-up GEP.
 
 ## Alternatives Considered
 

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -5,9 +5,9 @@
 
 (See [status definitions](../overview.md#gep-states).)
 
-[Chihiro]: https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas
-[Ian]: https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas
-[Ana]: https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas
+[Chihiro]: https://gateway-api.sigs.k8s.io/docs/concepts/roles-and-personas/#key-roles-and-personas
+[Ian]: https://gateway-api.sigs.k8s.io/docs/concepts/roles-and-personas/#key-roles-and-personas
+[Ana]: https://gateway-api.sigs.k8s.io/docs/concepts/roles-and-personas/#key-roles-and-personas
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this

--- a/geps/gep-4747/index.md
+++ b/geps/gep-4747/index.md
@@ -157,6 +157,10 @@ Throughout this GEP, **Backend** refers to a CRD that acts as a backendRef
 target, representing a destination. The specific resource definition is being
 developed in
 [PR #4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488).
+While this GEP concerns semantics for routing to external backends via a
+Backend resource, it does not preclude other egress mechanisms. Existing
+mechanisms such as ExternalName Services MAY also be used to reference
+external destinations.
 
 ### Egress Gateway Configuration
 

--- a/geps/gep-4747/metadata.yaml
+++ b/geps/gep-4747/metadata.yaml
@@ -1,0 +1,23 @@
+apiVersion: internal.gateway.networking.k8s.io/v1alpha1
+kind: GEPDetails
+number: 4747
+name: Egress Gateway Support
+status: Provisional
+authors:
+  - usize
+  - shaneutt
+  - keithmattix
+relationships:
+  obsoletes: []
+  obsoletedBy: []
+  extends: []
+  extendedBy: []
+  seeAlso:
+    - number: 4488
+      name: Backend Resource
+references:
+  - https://github.com/kubernetes-sigs/wg-ai-gateway/blob/main/proposals/10-egress-gateways.md
+  - https://github.com/kubernetes-sigs/gateway-api/issues/1651
+featureNames:
+  - EgressGateway
+changelog: []

--- a/geps/gep-4747/metadata.yaml
+++ b/geps/gep-4747/metadata.yaml
@@ -1,7 +1,7 @@
 apiVersion: internal.gateway.networking.k8s.io/v1alpha1
 kind: GEPDetails
 number: 4747
-name: Egress Gateway Support
+name: L7 Reverse-Proxy Egress Gateway
 status: Provisional
 authors:
   - usize


### PR DESCRIPTION
/kind gep

Provisional GEP for L7 reverse-proxy egress in Gateway API, focused on
**"What?"/"Why?"/"Who?"**.

**GEP-4747** proposes that existing Gateway API resources are sufficient
for egress — no new Gateway-level resource required. An egress-specific
`GatewayClass` MAY be used to apply validation, defaults, and to denote
egress usage.

A companion GEP proposing a dedicated `EgressGateway` resource will be
filed separately.

This GEP depends on the Backend resource (PR #4488) and originates from the
[WG AI Gateway egress proposal](https://github.com/kubernetes-sigs/wg-ai-gateway/blob/main/proposals/10-egress-gateways.md).

**What this PR does / why we need it**:
Adds a provisional GEP exploring egress gateway support for Gateway API.
Kubernetes lacks standardized APIs for routing outbound traffic through a
policy-enforced gateway.

**Which issue(s) this PR fixes**:
Fixes #4747

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```