### PR TITLE
Fix protocoltype case 3184

### DIFF
--- a/apis/v1/gateway_types.go
+++ b/apis/v1/gateway_types.go
@@ -241,10 +241,10 @@ type GatewaySpec struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64
-	// +kubebuilder:validation:XValidation:message="tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']",rule="self.all(l, l.protocol in ['HTTP', 'TCP', 'UDP'] ? !has(l.tls) : true)"
-	// +kubebuilder:validation:XValidation:message="tls mode must be Terminate for protocol HTTPS",rule="self.all(l, (l.protocol == 'HTTPS' && has(l.tls)) ? (l.tls.mode == '' || l.tls.mode == 'Terminate') : true)"
-	// +kubebuilder:validation:XValidation:message="tls mode must be set for protocol TLS",rule="self.all(l, (l.protocol == 'TLS' ? has(l.tls) && has(l.tls.mode) && l.tls.mode != '' : true))"
-	// +kubebuilder:validation:XValidation:message="hostname must not be specified for protocols ['TCP', 'UDP']",rule="self.all(l, l.protocol in ['TCP', 'UDP']  ? (!has(l.hostname) || l.hostname == '') : true)"
+	// +kubebuilder:validation:XValidation:message="tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']",rule="self.all(l, l.protocol.matches('(?i)^(HTTP|TCP|UDP)$') ? !has(l.tls) : true)"
+	// +kubebuilder:validation:XValidation:message="tls mode must be Terminate for protocol HTTPS",rule="self.all(l, (l.protocol.matches('(?i)^HTTPS$') && has(l.tls)) ? (l.tls.mode == '' || l.tls.mode == 'Terminate') : true)"
+	// +kubebuilder:validation:XValidation:message="tls mode must be set for protocol TLS",rule="self.all(l, (l.protocol.matches('(?i)^TLS$') ? has(l.tls) && has(l.tls.mode) && l.tls.mode != '' : true))"
+	// +kubebuilder:validation:XValidation:message="hostname must not be specified for protocols ['TCP', 'UDP']",rule="self.all(l, l.protocol.matches('(?i)^(TCP|UDP)$')  ? (!has(l.hostname) || l.hostname == '') : true)"
 	// +kubebuilder:validation:XValidation:message="Listener name must be unique within the Gateway",rule="self.all(l1, self.exists_one(l2, l1.name == l2.name))"
 	// +kubebuilder:validation:XValidation:message="Combination of port, protocol and hostname must be unique for each listener",rule="self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))"
 	// +required
@@ -485,7 +485,9 @@ type Listener struct {
 // "Accepted" condition to False for the affected Listener with a reason of
 // "UnsupportedProtocol".
 //
-// Core ProtocolType values are listed in the table below.
+// Core ProtocolType values are listed in the table below. All Core ProtocolType values MUST be
+// treated case-insensitively by implementations. For example, "HTTP", "http", and "hTtP" are all
+// equivalent, but uppercase is recommended for consistency.
 //
 // Implementations can define their own protocols if a core ProtocolType does not
 // exist. Such definitions must use prefixed name, such as

--- a/apis/v1/gateway_types.go
+++ b/apis/v1/gateway_types.go
@@ -246,7 +246,7 @@ type GatewaySpec struct {
 	// +kubebuilder:validation:XValidation:message="tls mode must be set for protocol TLS",rule="self.all(l, (l.protocol.matches('(?i)^TLS$') ? has(l.tls) && has(l.tls.mode) && l.tls.mode != '' : true))"
 	// +kubebuilder:validation:XValidation:message="hostname must not be specified for protocols ['TCP', 'UDP']",rule="self.all(l, l.protocol.matches('(?i)^(TCP|UDP)$')  ? (!has(l.hostname) || l.hostname == '') : true)"
 	// +kubebuilder:validation:XValidation:message="Listener name must be unique within the Gateway",rule="self.all(l1, self.exists_one(l2, l1.name == l2.name))"
-	// +kubebuilder:validation:XValidation:message="Combination of port, protocol and hostname must be unique for each listener",rule="self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))"
+	// +kubebuilder:validation:XValidation:message="Combination of port, protocol and hostname must be unique for each listener",rule="self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol.lowerAscii() == l2.protocol.lowerAscii() && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))"
 	// +required
 	Listeners []Listener `json:"listeners"`
 

--- a/apis/v1/gateway_types.go
+++ b/apis/v1/gateway_types.go
@@ -241,12 +241,12 @@ type GatewaySpec struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64
-	// +kubebuilder:validation:XValidation:message="tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']",rule="self.all(l, l.protocol.matches('(?i)^(HTTP|TCP|UDP)$') ? !has(l.tls) : true)"
-	// +kubebuilder:validation:XValidation:message="tls mode must be Terminate for protocol HTTPS",rule="self.all(l, (l.protocol.matches('(?i)^HTTPS$') && has(l.tls)) ? (l.tls.mode == '' || l.tls.mode == 'Terminate') : true)"
-	// +kubebuilder:validation:XValidation:message="tls mode must be set for protocol TLS",rule="self.all(l, (l.protocol.matches('(?i)^TLS$') ? has(l.tls) && has(l.tls.mode) && l.tls.mode != '' : true))"
-	// +kubebuilder:validation:XValidation:message="hostname must not be specified for protocols ['TCP', 'UDP']",rule="self.all(l, l.protocol.matches('(?i)^(TCP|UDP)$')  ? (!has(l.hostname) || l.hostname == '') : true)"
+	// +kubebuilder:validation:XValidation:message="tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']",rule="self.all(l, l.protocol.upperAscii() in ['HTTP', 'TCP', 'UDP'] ? !has(l.tls) : true)"
+	// +kubebuilder:validation:XValidation:message="tls mode must be Terminate for protocol HTTPS",rule="self.all(l, (l.protocol.upperAscii() == 'HTTPS' && has(l.tls)) ? (l.tls.mode == '' || l.tls.mode == 'Terminate') : true)"
+	// +kubebuilder:validation:XValidation:message="tls mode must be set for protocol TLS",rule="self.all(l, (l.protocol.upperAscii() == 'TLS' ? has(l.tls) && has(l.tls.mode) && l.tls.mode != '' : true))"
+	// +kubebuilder:validation:XValidation:message="hostname must not be specified for protocols ['TCP', 'UDP']",rule="self.all(l, l.protocol.upperAscii() in ['TCP', 'UDP']  ? (!has(l.hostname) || l.hostname == '') : true)"
 	// +kubebuilder:validation:XValidation:message="Listener name must be unique within the Gateway",rule="self.all(l1, self.exists_one(l2, l1.name == l2.name))"
-	// +kubebuilder:validation:XValidation:message="Combination of port, protocol and hostname must be unique for each listener",rule="self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol.lowerAscii() == l2.protocol.lowerAscii() && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))"
+	// +kubebuilder:validation:XValidation:message="Combination of port, protocol and hostname must be unique for each listener",rule="self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol.upperAscii() == l2.protocol.upperAscii() && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))"
 	// +required
 	Listeners []Listener `json:"listeners"`
 

--- a/apis/v1/listenerset_types.go
+++ b/apis/v1/listenerset_types.go
@@ -110,12 +110,12 @@ type ListenerSetSpec struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64
-	// +kubebuilder:validation:XValidation:message="tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']",rule="self.all(l, l.protocol.matches('(?i)^(HTTP|TCP|UDP)$') ? !has(l.tls) : true)"
-	// +kubebuilder:validation:XValidation:message="tls mode must be Terminate for protocol HTTPS",rule="self.all(l, (l.protocol.matches('(?i)^HTTPS$') && has(l.tls)) ? (l.tls.mode == '' || l.tls.mode == 'Terminate') : true)"
-	// +kubebuilder:validation:XValidation:message="tls mode must be set for protocol TLS",rule="self.all(l, (l.protocol.matches('(?i)^TLS$') ? has(l.tls) && has(l.tls.mode) && l.tls.mode != '' : true))"
-	// +kubebuilder:validation:XValidation:message="hostname must not be specified for protocols ['TCP', 'UDP']",rule="self.all(l, l.protocol.matches('(?i)^(TCP|UDP)$')  ? (!has(l.hostname) || l.hostname == '') : true)"
+	// +kubebuilder:validation:XValidation:message="tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']",rule="self.all(l, l.protocol.upperAscii() in ['HTTP', 'TCP', 'UDP'] ? !has(l.tls) : true)"
+	// +kubebuilder:validation:XValidation:message="tls mode must be Terminate for protocol HTTPS",rule="self.all(l, (l.protocol.upperAscii() == 'HTTPS' && has(l.tls)) ? (l.tls.mode == '' || l.tls.mode == 'Terminate') : true)"
+	// +kubebuilder:validation:XValidation:message="tls mode must be set for protocol TLS",rule="self.all(l, (l.protocol.upperAscii() == 'TLS' ? has(l.tls) && has(l.tls.mode) && l.tls.mode != '' : true))"
+	// +kubebuilder:validation:XValidation:message="hostname must not be specified for protocols ['TCP', 'UDP']",rule="self.all(l, l.protocol.upperAscii() in ['TCP', 'UDP']  ? (!has(l.hostname) || l.hostname == '') : true)"
 	// +kubebuilder:validation:XValidation:message="Listener name must be unique within the Gateway",rule="self.all(l1, self.exists_one(l2, l1.name == l2.name))"
-	// +kubebuilder:validation:XValidation:message="Combination of port, protocol and hostname must be unique for each listener",rule="self.all(l1, !has(l1.port) || self.exists_one(l2, has(l2.port) && l1.port == l2.port && l1.protocol.lowerAscii() == l2.protocol.lowerAscii() && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))"
+	// +kubebuilder:validation:XValidation:message="Combination of port, protocol and hostname must be unique for each listener",rule="self.all(l1, !has(l1.port) || self.exists_one(l2, has(l2.port) && l1.port == l2.port && l1.protocol.upperAscii() == l2.protocol.upperAscii() && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))"
 	// +required
 	Listeners []ListenerEntry `json:"listeners,omitempty"`
 }

--- a/apis/v1/listenerset_types.go
+++ b/apis/v1/listenerset_types.go
@@ -110,12 +110,12 @@ type ListenerSetSpec struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64
-	// +kubebuilder:validation:XValidation:message="tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']",rule="self.all(l, l.protocol in ['HTTP', 'TCP', 'UDP'] ? !has(l.tls) : true)"
-	// +kubebuilder:validation:XValidation:message="tls mode must be Terminate for protocol HTTPS",rule="self.all(l, (l.protocol == 'HTTPS' && has(l.tls)) ? (l.tls.mode == '' || l.tls.mode == 'Terminate') : true)"
-	// +kubebuilder:validation:XValidation:message="tls mode must be set for protocol TLS",rule="self.all(l, (l.protocol == 'TLS' ? has(l.tls) && has(l.tls.mode) && l.tls.mode != '' : true))"
-	// +kubebuilder:validation:XValidation:message="hostname must not be specified for protocols ['TCP', 'UDP']",rule="self.all(l, l.protocol in ['TCP', 'UDP']  ? (!has(l.hostname) || l.hostname == '') : true)"
+	// +kubebuilder:validation:XValidation:message="tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']",rule="self.all(l, l.protocol.matches('(?i)^(HTTP|TCP|UDP)$') ? !has(l.tls) : true)"
+	// +kubebuilder:validation:XValidation:message="tls mode must be Terminate for protocol HTTPS",rule="self.all(l, (l.protocol.matches('(?i)^HTTPS$') && has(l.tls)) ? (l.tls.mode == '' || l.tls.mode == 'Terminate') : true)"
+	// +kubebuilder:validation:XValidation:message="tls mode must be set for protocol TLS",rule="self.all(l, (l.protocol.matches('(?i)^TLS$') ? has(l.tls) && has(l.tls.mode) && l.tls.mode != '' : true))"
+	// +kubebuilder:validation:XValidation:message="hostname must not be specified for protocols ['TCP', 'UDP']",rule="self.all(l, l.protocol.matches('(?i)^(TCP|UDP)$')  ? (!has(l.hostname) || l.hostname == '') : true)"
 	// +kubebuilder:validation:XValidation:message="Listener name must be unique within the Gateway",rule="self.all(l1, self.exists_one(l2, l1.name == l2.name))"
-	// +kubebuilder:validation:XValidation:message="Combination of port, protocol and hostname must be unique for each listener",rule="self.all(l1, !has(l1.port) || self.exists_one(l2, has(l2.port) && l1.port == l2.port && l1.protocol == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))"
+	// +kubebuilder:validation:XValidation:message="Combination of port, protocol and hostname must be unique for each listener",rule="self.all(l1, !has(l1.port) || self.exists_one(l2, has(l2.port) && l1.port == l2.port && l1.protocol.lowerAscii() == l2.protocol.lowerAscii() && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))"
 	// +required
 	Listeners []ListenerEntry `json:"listeners,omitempty"`
 }

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -919,16 +919,16 @@ spec:
                 x-kubernetes-validations:
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
-                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
-                    !has(l.tls) : true)'
+                  rule: 'self.all(l, l.protocol.matches(''(?i)^(HTTP|TCP|UDP)$'')
+                    ? !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
-                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                  rule: 'self.all(l, (l.protocol.matches(''(?i)^HTTPS$'') && has(l.tls))
+                    ? (l.tls.mode == '''' || l.tls.mode == ''Terminate'') : true)'
                 - message: tls mode must be set for protocol TLS
-                  rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
-                    && l.tls.mode != '''' : true))'
+                  rule: 'self.all(l, (l.protocol.matches(''(?i)^TLS$'') ? has(l.tls)
+                    && has(l.tls.mode) && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
-                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                  rule: 'self.all(l, l.protocol.matches(''(?i)^(TCP|UDP)$'')  ? (!has(l.hostname)
                     || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
@@ -2576,16 +2576,16 @@ spec:
                 x-kubernetes-validations:
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
-                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
-                    !has(l.tls) : true)'
+                  rule: 'self.all(l, l.protocol.matches(''(?i)^(HTTP|TCP|UDP)$'')
+                    ? !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
-                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                  rule: 'self.all(l, (l.protocol.matches(''(?i)^HTTPS$'') && has(l.tls))
+                    ? (l.tls.mode == '''' || l.tls.mode == ''Terminate'') : true)'
                 - message: tls mode must be set for protocol TLS
-                  rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
-                    && l.tls.mode != '''' : true))'
+                  rule: 'self.all(l, (l.protocol.matches(''(?i)^TLS$'') ? has(l.tls)
+                    && has(l.tls.mode) && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
-                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                  rule: 'self.all(l, l.protocol.matches(''(?i)^(TCP|UDP)$'')  ? (!has(l.hostname)
                     || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -934,9 +934,9 @@ spec:
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
                 - message: Combination of port, protocol and hostname must be unique
                     for each listener
-                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
-                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
-                    == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol.lowerAscii()
+                    == l2.protocol.lowerAscii() && (has(l1.hostname) && has(l2.hostname)
+                    ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
               tls:
                 description: |-
                   TLS specifies frontend and backend tls configuration for entire gateway.
@@ -2591,9 +2591,9 @@ spec:
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
                 - message: Combination of port, protocol and hostname must be unique
                     for each listener
-                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
-                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
-                    == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol.lowerAscii()
+                    == l2.protocol.lowerAscii() && (has(l1.hostname) && has(l2.hostname)
+                    ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
               tls:
                 description: |-
                   TLS specifies frontend and backend tls configuration for entire gateway.

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -919,23 +919,23 @@ spec:
                 x-kubernetes-validations:
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
-                  rule: 'self.all(l, l.protocol.matches(''(?i)^(HTTP|TCP|UDP)$'')
-                    ? !has(l.tls) : true)'
+                  rule: 'self.all(l, l.protocol.upperAscii() in [''HTTP'', ''TCP'',
+                    ''UDP''] ? !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol.matches(''(?i)^HTTPS$'') && has(l.tls))
+                  rule: 'self.all(l, (l.protocol.upperAscii() == ''HTTPS'' && has(l.tls))
                     ? (l.tls.mode == '''' || l.tls.mode == ''Terminate'') : true)'
                 - message: tls mode must be set for protocol TLS
-                  rule: 'self.all(l, (l.protocol.matches(''(?i)^TLS$'') ? has(l.tls)
+                  rule: 'self.all(l, (l.protocol.upperAscii() == ''TLS'' ? has(l.tls)
                     && has(l.tls.mode) && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
-                  rule: 'self.all(l, l.protocol.matches(''(?i)^(TCP|UDP)$'')  ? (!has(l.hostname)
-                    || l.hostname == '''') : true)'
+                  rule: 'self.all(l, l.protocol.upperAscii() in [''TCP'', ''UDP'']  ?
+                    (!has(l.hostname) || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
                 - message: Combination of port, protocol and hostname must be unique
                     for each listener
-                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol.lowerAscii()
-                    == l2.protocol.lowerAscii() && (has(l1.hostname) && has(l2.hostname)
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol.upperAscii()
+                    == l2.protocol.upperAscii() && (has(l1.hostname) && has(l2.hostname)
                     ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
               tls:
                 description: |-
@@ -2576,23 +2576,23 @@ spec:
                 x-kubernetes-validations:
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
-                  rule: 'self.all(l, l.protocol.matches(''(?i)^(HTTP|TCP|UDP)$'')
-                    ? !has(l.tls) : true)'
+                  rule: 'self.all(l, l.protocol.upperAscii() in [''HTTP'', ''TCP'',
+                    ''UDP''] ? !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol.matches(''(?i)^HTTPS$'') && has(l.tls))
+                  rule: 'self.all(l, (l.protocol.upperAscii() == ''HTTPS'' && has(l.tls))
                     ? (l.tls.mode == '''' || l.tls.mode == ''Terminate'') : true)'
                 - message: tls mode must be set for protocol TLS
-                  rule: 'self.all(l, (l.protocol.matches(''(?i)^TLS$'') ? has(l.tls)
+                  rule: 'self.all(l, (l.protocol.upperAscii() == ''TLS'' ? has(l.tls)
                     && has(l.tls.mode) && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
-                  rule: 'self.all(l, l.protocol.matches(''(?i)^(TCP|UDP)$'')  ? (!has(l.hostname)
-                    || l.hostname == '''') : true)'
+                  rule: 'self.all(l, l.protocol.upperAscii() in [''TCP'', ''UDP'']  ?
+                    (!has(l.hostname) || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
                 - message: Combination of port, protocol and hostname must be unique
                     for each listener
-                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol.lowerAscii()
-                    == l2.protocol.lowerAscii() && (has(l1.hostname) && has(l2.hostname)
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol.upperAscii()
+                    == l2.protocol.upperAscii() && (has(l1.hostname) && has(l2.hostname)
                     ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
               tls:
                 description: |-

--- a/config/crd/experimental/gateway.networking.k8s.io_listenersets.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_listenersets.yaml
@@ -466,23 +466,23 @@ spec:
                 x-kubernetes-validations:
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
-                  rule: 'self.all(l, l.protocol.matches(''(?i)^(HTTP|TCP|UDP)$'')
-                    ? !has(l.tls) : true)'
+                  rule: 'self.all(l, l.protocol.upperAscii() in [''HTTP'', ''TCP'',
+                    ''UDP''] ? !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol.matches(''(?i)^HTTPS$'') && has(l.tls))
+                  rule: 'self.all(l, (l.protocol.upperAscii() == ''HTTPS'' && has(l.tls))
                     ? (l.tls.mode == '''' || l.tls.mode == ''Terminate'') : true)'
                 - message: tls mode must be set for protocol TLS
-                  rule: 'self.all(l, (l.protocol.matches(''(?i)^TLS$'') ? has(l.tls)
+                  rule: 'self.all(l, (l.protocol.upperAscii() == ''TLS'' ? has(l.tls)
                     && has(l.tls.mode) && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
-                  rule: 'self.all(l, l.protocol.matches(''(?i)^(TCP|UDP)$'')  ? (!has(l.hostname)
-                    || l.hostname == '''') : true)'
+                  rule: 'self.all(l, l.protocol.upperAscii() in [''TCP'', ''UDP'']  ?
+                    (!has(l.hostname) || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
                 - message: Combination of port, protocol and hostname must be unique
                     for each listener
                   rule: 'self.all(l1, !has(l1.port) || self.exists_one(l2, has(l2.port)
-                    && l1.port == l2.port && l1.protocol.lowerAscii() == l2.protocol.lowerAscii()
+                    && l1.port == l2.port && l1.protocol.upperAscii() == l2.protocol.upperAscii()
                     && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname
                     : !has(l1.hostname) && !has(l2.hostname))))'
               parentRef:

--- a/config/crd/experimental/gateway.networking.k8s.io_listenersets.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_listenersets.yaml
@@ -466,25 +466,25 @@ spec:
                 x-kubernetes-validations:
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
-                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
-                    !has(l.tls) : true)'
+                  rule: 'self.all(l, l.protocol.matches(''(?i)^(HTTP|TCP|UDP)$'')
+                    ? !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
-                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                  rule: 'self.all(l, (l.protocol.matches(''(?i)^HTTPS$'') && has(l.tls))
+                    ? (l.tls.mode == '''' || l.tls.mode == ''Terminate'') : true)'
                 - message: tls mode must be set for protocol TLS
-                  rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
-                    && l.tls.mode != '''' : true))'
+                  rule: 'self.all(l, (l.protocol.matches(''(?i)^TLS$'') ? has(l.tls)
+                    && has(l.tls.mode) && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
-                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                  rule: 'self.all(l, l.protocol.matches(''(?i)^(TCP|UDP)$'')  ? (!has(l.hostname)
                     || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
                 - message: Combination of port, protocol and hostname must be unique
                     for each listener
                   rule: 'self.all(l1, !has(l1.port) || self.exists_one(l2, has(l2.port)
-                    && l1.port == l2.port && l1.protocol == l2.protocol && (has(l1.hostname)
-                    && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname)
-                    && !has(l2.hostname))))'
+                    && l1.port == l2.port && l1.protocol.lowerAscii() == l2.protocol.lowerAscii()
+                    && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname
+                    : !has(l1.hostname) && !has(l2.hostname))))'
               parentRef:
                 description: ParentRef references the Gateway that the listeners are
                   attached to.

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -911,9 +911,9 @@ spec:
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
                 - message: Combination of port, protocol and hostname must be unique
                     for each listener
-                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
-                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
-                    == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol.lowerAscii()
+                    == l2.protocol.lowerAscii() && (has(l1.hostname) && has(l2.hostname)
+                    ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
               tls:
                 description: |-
                   TLS specifies frontend and backend tls configuration for entire gateway.
@@ -2545,9 +2545,9 @@ spec:
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
                 - message: Combination of port, protocol and hostname must be unique
                     for each listener
-                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
-                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
-                    == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol.lowerAscii()
+                    == l2.protocol.lowerAscii() && (has(l1.hostname) && has(l2.hostname)
+                    ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
               tls:
                 description: |-
                   TLS specifies frontend and backend tls configuration for entire gateway.

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -896,23 +896,23 @@ spec:
                 x-kubernetes-validations:
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
-                  rule: 'self.all(l, l.protocol.matches(''(?i)^(HTTP|TCP|UDP)$'')
-                    ? !has(l.tls) : true)'
+                  rule: 'self.all(l, l.protocol.upperAscii() in [''HTTP'', ''TCP'',
+                    ''UDP''] ? !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol.matches(''(?i)^HTTPS$'') && has(l.tls))
+                  rule: 'self.all(l, (l.protocol.upperAscii() == ''HTTPS'' && has(l.tls))
                     ? (l.tls.mode == '''' || l.tls.mode == ''Terminate'') : true)'
                 - message: tls mode must be set for protocol TLS
-                  rule: 'self.all(l, (l.protocol.matches(''(?i)^TLS$'') ? has(l.tls)
+                  rule: 'self.all(l, (l.protocol.upperAscii() == ''TLS'' ? has(l.tls)
                     && has(l.tls.mode) && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
-                  rule: 'self.all(l, l.protocol.matches(''(?i)^(TCP|UDP)$'')  ? (!has(l.hostname)
-                    || l.hostname == '''') : true)'
+                  rule: 'self.all(l, l.protocol.upperAscii() in [''TCP'', ''UDP'']  ?
+                    (!has(l.hostname) || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
                 - message: Combination of port, protocol and hostname must be unique
                     for each listener
-                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol.lowerAscii()
-                    == l2.protocol.lowerAscii() && (has(l1.hostname) && has(l2.hostname)
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol.upperAscii()
+                    == l2.protocol.upperAscii() && (has(l1.hostname) && has(l2.hostname)
                     ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
               tls:
                 description: |-
@@ -2530,23 +2530,23 @@ spec:
                 x-kubernetes-validations:
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
-                  rule: 'self.all(l, l.protocol.matches(''(?i)^(HTTP|TCP|UDP)$'')
-                    ? !has(l.tls) : true)'
+                  rule: 'self.all(l, l.protocol.upperAscii() in [''HTTP'', ''TCP'',
+                    ''UDP''] ? !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol.matches(''(?i)^HTTPS$'') && has(l.tls))
+                  rule: 'self.all(l, (l.protocol.upperAscii() == ''HTTPS'' && has(l.tls))
                     ? (l.tls.mode == '''' || l.tls.mode == ''Terminate'') : true)'
                 - message: tls mode must be set for protocol TLS
-                  rule: 'self.all(l, (l.protocol.matches(''(?i)^TLS$'') ? has(l.tls)
+                  rule: 'self.all(l, (l.protocol.upperAscii() == ''TLS'' ? has(l.tls)
                     && has(l.tls.mode) && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
-                  rule: 'self.all(l, l.protocol.matches(''(?i)^(TCP|UDP)$'')  ? (!has(l.hostname)
-                    || l.hostname == '''') : true)'
+                  rule: 'self.all(l, l.protocol.upperAscii() in [''TCP'', ''UDP'']  ?
+                    (!has(l.hostname) || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
                 - message: Combination of port, protocol and hostname must be unique
                     for each listener
-                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol.lowerAscii()
-                    == l2.protocol.lowerAscii() && (has(l1.hostname) && has(l2.hostname)
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol.upperAscii()
+                    == l2.protocol.upperAscii() && (has(l1.hostname) && has(l2.hostname)
                     ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
               tls:
                 description: |-

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -896,16 +896,16 @@ spec:
                 x-kubernetes-validations:
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
-                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
-                    !has(l.tls) : true)'
+                  rule: 'self.all(l, l.protocol.matches(''(?i)^(HTTP|TCP|UDP)$'')
+                    ? !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
-                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                  rule: 'self.all(l, (l.protocol.matches(''(?i)^HTTPS$'') && has(l.tls))
+                    ? (l.tls.mode == '''' || l.tls.mode == ''Terminate'') : true)'
                 - message: tls mode must be set for protocol TLS
-                  rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
-                    && l.tls.mode != '''' : true))'
+                  rule: 'self.all(l, (l.protocol.matches(''(?i)^TLS$'') ? has(l.tls)
+                    && has(l.tls.mode) && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
-                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                  rule: 'self.all(l, l.protocol.matches(''(?i)^(TCP|UDP)$'')  ? (!has(l.hostname)
                     || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
@@ -2530,16 +2530,16 @@ spec:
                 x-kubernetes-validations:
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
-                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
-                    !has(l.tls) : true)'
+                  rule: 'self.all(l, l.protocol.matches(''(?i)^(HTTP|TCP|UDP)$'')
+                    ? !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
-                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                  rule: 'self.all(l, (l.protocol.matches(''(?i)^HTTPS$'') && has(l.tls))
+                    ? (l.tls.mode == '''' || l.tls.mode == ''Terminate'') : true)'
                 - message: tls mode must be set for protocol TLS
-                  rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
-                    && l.tls.mode != '''' : true))'
+                  rule: 'self.all(l, (l.protocol.matches(''(?i)^TLS$'') ? has(l.tls)
+                    && has(l.tls.mode) && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
-                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                  rule: 'self.all(l, l.protocol.matches(''(?i)^(TCP|UDP)$'')  ? (!has(l.hostname)
                     || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))

--- a/config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
@@ -466,23 +466,23 @@ spec:
                 x-kubernetes-validations:
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
-                  rule: 'self.all(l, l.protocol.matches(''(?i)^(HTTP|TCP|UDP)$'')
-                    ? !has(l.tls) : true)'
+                  rule: 'self.all(l, l.protocol.upperAscii() in [''HTTP'', ''TCP'',
+                    ''UDP''] ? !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol.matches(''(?i)^HTTPS$'') && has(l.tls))
+                  rule: 'self.all(l, (l.protocol.upperAscii() == ''HTTPS'' && has(l.tls))
                     ? (l.tls.mode == '''' || l.tls.mode == ''Terminate'') : true)'
                 - message: tls mode must be set for protocol TLS
-                  rule: 'self.all(l, (l.protocol.matches(''(?i)^TLS$'') ? has(l.tls)
+                  rule: 'self.all(l, (l.protocol.upperAscii() == ''TLS'' ? has(l.tls)
                     && has(l.tls.mode) && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
-                  rule: 'self.all(l, l.protocol.matches(''(?i)^(TCP|UDP)$'')  ? (!has(l.hostname)
-                    || l.hostname == '''') : true)'
+                  rule: 'self.all(l, l.protocol.upperAscii() in [''TCP'', ''UDP'']  ?
+                    (!has(l.hostname) || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
                 - message: Combination of port, protocol and hostname must be unique
                     for each listener
                   rule: 'self.all(l1, !has(l1.port) || self.exists_one(l2, has(l2.port)
-                    && l1.port == l2.port && l1.protocol.lowerAscii() == l2.protocol.lowerAscii()
+                    && l1.port == l2.port && l1.protocol.upperAscii() == l2.protocol.upperAscii()
                     && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname
                     : !has(l1.hostname) && !has(l2.hostname))))'
               parentRef:

--- a/config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
@@ -466,25 +466,25 @@ spec:
                 x-kubernetes-validations:
                 - message: tls must not be specified for protocols ['HTTP', 'TCP',
                     'UDP']
-                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
-                    !has(l.tls) : true)'
+                  rule: 'self.all(l, l.protocol.matches(''(?i)^(HTTP|TCP|UDP)$'')
+                    ? !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
-                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                  rule: 'self.all(l, (l.protocol.matches(''(?i)^HTTPS$'') && has(l.tls))
+                    ? (l.tls.mode == '''' || l.tls.mode == ''Terminate'') : true)'
                 - message: tls mode must be set for protocol TLS
-                  rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
-                    && l.tls.mode != '''' : true))'
+                  rule: 'self.all(l, (l.protocol.matches(''(?i)^TLS$'') ? has(l.tls)
+                    && has(l.tls.mode) && l.tls.mode != '''' : true))'
                 - message: hostname must not be specified for protocols ['TCP', 'UDP']
-                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                  rule: 'self.all(l, l.protocol.matches(''(?i)^(TCP|UDP)$'')  ? (!has(l.hostname)
                     || l.hostname == '''') : true)'
                 - message: Listener name must be unique within the Gateway
                   rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
                 - message: Combination of port, protocol and hostname must be unique
                     for each listener
                   rule: 'self.all(l1, !has(l1.port) || self.exists_one(l2, has(l2.port)
-                    && l1.port == l2.port && l1.protocol == l2.protocol && (has(l1.hostname)
-                    && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname)
-                    && !has(l2.hostname))))'
+                    && l1.port == l2.port && l1.protocol.lowerAscii() == l2.protocol.lowerAscii()
+                    && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname
+                    : !has(l1.hostname) && !has(l2.hostname))))'
               parentRef:
                 description: ParentRef references the Gateway that the listeners are
                   attached to.

--- a/tests/cel/gateway_test.go
+++ b/tests/cel/gateway_test.go
@@ -67,6 +67,36 @@ func TestValidateGateway(t *testing.T) {
 			wantErrors: []string{"tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']"},
 		},
 		{
+			desc: "tls config present with lowercase http protocol",
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("http"),
+						Protocol: gatewayv1.ProtocolType("http"),
+						Port:     gatewayv1.PortNumber(8080),
+						TLS:      &gatewayv1.ListenerTLSConfig{},
+					},
+				}
+			},
+			wantErrors: []string{"tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']"},
+		},
+		{
+			desc: "lowercase https protocol with Passthrough tls mode",
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("https"),
+						Protocol: gatewayv1.ProtocolType("https"),
+						Port:     gatewayv1.PortNumber(8080),
+						TLS: &gatewayv1.ListenerTLSConfig{
+							Mode: ptrTo(gatewayv1.TLSModeType("Passthrough")),
+						},
+					},
+				}
+			},
+			wantErrors: []string{"tls mode must be Terminate for protocol HTTPS"},
+		},
+		{
 			desc: "https protocol with Passthrough tls mode",
 			mutate: func(gw *gatewayv1.Gateway) {
 				gw.Spec.Listeners = []gatewayv1.Listener{

--- a/tests/cel/gateway_test.go
+++ b/tests/cel/gateway_test.go
@@ -81,6 +81,48 @@ func TestValidateGateway(t *testing.T) {
 			wantErrors: []string{"tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']"},
 		},
 		{
+			desc: "tls config present with mixed-case Http protocol",
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("http"),
+						Protocol: gatewayv1.ProtocolType("Http"),
+						Port:     gatewayv1.PortNumber(8080),
+						TLS:      &gatewayv1.ListenerTLSConfig{},
+					},
+				}
+			},
+			wantErrors: []string{"tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']"},
+		},
+		{
+			desc: "tls config present with lowercase tcp protocol",
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("tcp"),
+						Protocol: gatewayv1.ProtocolType("tcp"),
+						Port:     gatewayv1.PortNumber(8080),
+						TLS:      &gatewayv1.ListenerTLSConfig{},
+					},
+				}
+			},
+			wantErrors: []string{"tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']"},
+		},
+		{
+			desc: "tls config present with lowercase udp protocol",
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("udp"),
+						Protocol: gatewayv1.ProtocolType("udp"),
+						Port:     gatewayv1.PortNumber(8080),
+						TLS:      &gatewayv1.ListenerTLSConfig{},
+					},
+				}
+			},
+			wantErrors: []string{"tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']"},
+		},
+		{
 			desc: "lowercase https protocol with Passthrough tls mode",
 			mutate: func(gw *gatewayv1.Gateway) {
 				gw.Spec.Listeners = []gatewayv1.Listener{
@@ -95,6 +137,108 @@ func TestValidateGateway(t *testing.T) {
 				}
 			},
 			wantErrors: []string{"tls mode must be Terminate for protocol HTTPS"},
+		},
+		{
+			desc: "mixed-case hTtPs protocol with Passthrough tls mode",
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("https"),
+						Protocol: gatewayv1.ProtocolType("hTtPs"),
+						Port:     gatewayv1.PortNumber(8080),
+						TLS: &gatewayv1.ListenerTLSConfig{
+							Mode: ptrTo(gatewayv1.TLSModeType("Passthrough")),
+						},
+					},
+				}
+			},
+			wantErrors: []string{"tls mode must be Terminate for protocol HTTPS"},
+		},
+		{
+			desc: "lowercase tls protocol requires tls mode to be set",
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("tls"),
+						Protocol: gatewayv1.ProtocolType("tls"),
+						Port:     gatewayv1.PortNumber(8443),
+					},
+				}
+			},
+			wantErrors: []string{"tls mode must be set for protocol TLS"},
+		},
+		{
+			desc: "mixed-case Tls protocol requires tls mode to be set",
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("tls"),
+						Protocol: gatewayv1.ProtocolType("Tls"),
+						Port:     gatewayv1.PortNumber(8443),
+					},
+				}
+			},
+			wantErrors: []string{"tls mode must be set for protocol TLS"},
+		},
+		{
+			desc: "hostname present with lowercase tcp protocol",
+			mutate: func(gw *gatewayv1.Gateway) {
+				hostname := gatewayv1.Hostname("foo")
+				gw.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("tcp"),
+						Protocol: gatewayv1.ProtocolType("tcp"),
+						Port:     gatewayv1.PortNumber(8080),
+						Hostname: &hostname,
+					},
+				}
+			},
+			wantErrors: []string{"hostname must not be specified for protocols ['TCP', 'UDP']"},
+		},
+		{
+			desc: "hostname present with lowercase udp protocol",
+			mutate: func(gw *gatewayv1.Gateway) {
+				hostname := gatewayv1.Hostname("foo")
+				gw.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("udp"),
+						Protocol: gatewayv1.ProtocolType("udp"),
+						Port:     gatewayv1.PortNumber(8080),
+						Hostname: &hostname,
+					},
+				}
+			},
+			wantErrors: []string{"hostname must not be specified for protocols ['TCP', 'UDP']"},
+		},
+		{
+			desc: "lowercase http protocol without tls is valid",
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("http"),
+						Protocol: gatewayv1.ProtocolType("http"),
+						Port:     gatewayv1.PortNumber(8080),
+					},
+				}
+			},
+		},
+		{
+			desc: "duplicate listeners with different-case protocols should conflict",
+			mutate: func(gw *gatewayv1.Gateway) {
+				gw.Spec.Listeners = []gatewayv1.Listener{
+					{
+						Name:     gatewayv1.SectionName("http1"),
+						Protocol: gatewayv1.ProtocolType("HTTP"),
+						Port:     gatewayv1.PortNumber(8080),
+					},
+					{
+						Name:     gatewayv1.SectionName("http2"),
+						Protocol: gatewayv1.ProtocolType("http"),
+						Port:     gatewayv1.PortNumber(8080),
+					},
+				}
+			},
+			wantErrors: []string{"Combination of port, protocol and hostname must be unique for each listener"},
 		},
 		{
 			desc: "https protocol with Passthrough tls mode",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR enforces that `ProtocolType` validations are formally treated case-insensitively. This solves an issue where valid configurations (e.g., `protocol: "tcp"`) previously circumvented `Gateway` Listener validation checks that strictly required `l.protocol == 'TCP'`. This aligns the API mathematically with the decision to handle standard Core protocols with case-insensitive flexibility while treating Uppercase strings as standard/recommended. 
- The CEL rules in `apis/v1/gateway_types.go` have been converted from strict equality checks to case-insensitive regex pattern validations (e.g. `(?i)^(HTTP|TCP|UDP)$`).
- Corresponding API documentation updates were applied.
- Additional test coverage was added in `tests/cel/gateway_test.go` to explicitly verify lowercase and mixed-case validation bounds scenarios.

**Which issue(s) this PR fixes**:
Fixes #3184

**Does this PR introduce a user-facing change?**:

```release-note
ProtocolType validations now accurately match mixed-case or lowercase ProtocolType configurations (e.g. "tcp") without bypassing HTTP/TCP/TLS constraints. Action required from implementation owners: Support mixed case for Protocol.
```