### PR TITLE
Update HTTPRoute BackendRefs public docs to match API spec.

### DIFF
--- a/site-src/api-types/httproute.md
+++ b/site-src/api-types/httproute.md
@@ -208,7 +208,7 @@ this configuration error.
 
 BackendRefs defines API objects where matching requests should be sent. If
 unspecified, the rule performs no forwarding. If unspecified and no filters
-are specified that would result in a response being sent, a 404 error code
+are specified that would result in a response being sent, a 500 error code
 is returned.
 
 The following example forwards HTTP requests for path prefix `/bar` to service


### PR DESCRIPTION
*  The return code of 404 was added to the public docs page and API spec in [May 2022](https://github.com/kubernetes-sigs/gateway-api/commit/2696d45d98ae3f6d22d61c0d6436a1fd35ce8666).
*  The API spec was [updated to 500](https://github.com/kubernetes-sigs/gateway-api/commit/cb7de00ee93c0f11ad9873a1efe2e506bf130a91)) but the public docs were not updated accordingly.
*  The ["no backendRefs" language was later removed](https://github.com/kubernetes-sigs/gateway-api/commit/30f2983e9f01368adff82772c4d9178fcdb26344) without updating the public docs as well.

/kind documentation

**What this PR does / why we need it**:

Docs mismatch API spec.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
