### PR TITLE
fix: correct syntax error in HTTPRouteMatch, GRPCRouteMatch examples

### DIFF
--- a/apis/v1/grpcroute_types.go
+++ b/apis/v1/grpcroute_types.go
@@ -302,13 +302,14 @@ type GRPCRouteRule struct {
 // is `foo` AND it contains the `version: v1` header:
 //
 // ```
-// matches:
-//   - method:
-//     type: Exact
-//     service: "foo"
-//   - headers:
-//     name: "version"
-//     value "v1"
+//
+//	matches:
+//	- method:
+//	    type: Exact
+//	    service: "foo"
+//	  headers:
+//	  - name: "version"
+//	    value: "v1"
 //
 // ```
 type GRPCRouteMatch struct {

--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -754,7 +754,7 @@ const (
 //	  value: "/foo"
 //	headers:
 //	- name: "version"
-//	  value "v1"
+//	  value: "v1"
 //
 // ```
 type HTTPRouteMatch struct {

--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -755,7 +755,7 @@ const (
 //	  value: "/foo"
 //	headers:
 //	- name: "version"
-//	  value "v1"
+//	  value: "v1"
 //
 // ```
 type HTTPRouteMatch struct {

--- a/applyconfiguration/apis/v1/grpcroutematch.go
+++ b/applyconfiguration/apis/v1/grpcroutematch.go
@@ -29,13 +29,14 @@ package v1
 // is `foo` AND it contains the `version: v1` header:
 //
 // ```
+//
 // matches:
 // - method:
 // type: Exact
 // service: "foo"
-// - headers:
-// name: "version"
-// value "v1"
+// headers:
+// - name: "version"
+// value: "v1"
 //
 // ```
 type GRPCRouteMatchApplyConfiguration struct {

--- a/applyconfiguration/apis/v1/httproutematch.go
+++ b/applyconfiguration/apis/v1/httproutematch.go
@@ -39,7 +39,7 @@ import (
 // value: "/foo"
 // headers:
 // - name: "version"
-// value "v1"
+// value: "v1"
 //
 // ```
 type HTTPRouteMatchApplyConfiguration struct {

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -1733,24 +1733,14 @@ spec:
                         matching precedence MUST be granted to the first matching rule meeting
                         the above criteria.
                       items:
-                        description: |-
-                          GRPCRouteMatch defines the predicate used to match requests to a given
-                          action. Multiple match types are ANDed together, i.e. the match will
-                          evaluate to true only if all conditions are satisfied.
-
-                          For example, the match below will match a gRPC request only if its service
-                          is `foo` AND it contains the `version: v1` header:
-
-                          ```
-                          matches:
-                            - method:
-                              type: Exact
-                              service: "foo"
-                            - headers:
-                              name: "version"
-                              value "v1"
-
-                          ```
+                        description: "GRPCRouteMatch defines the predicate used to
+                          match requests to a given\naction. Multiple match types
+                          are ANDed together, i.e. the match will\nevaluate to true
+                          only if all conditions are satisfied.\n\nFor example, the
+                          match below will match a gRPC request only if its service\nis
+                          `foo` AND it contains the `version: v1` header:\n\n```\n\n\tmatches:\n\t-
+                          method:\n\t    type: Exact\n\t    service: \"foo\"\n\t  headers:\n\t
+                          \ - name: \"version\"\n\t    value: \"v1\"\n\n```"
                         properties:
                           headers:
                             description: |-

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -3438,7 +3438,7 @@ spec:
                           match below will match a HTTP request only if its path\nstarts
                           with `/foo` AND it contains the `version: v1` header:\n\n```\nmatch:\n\n\tpath:\n\t
                           \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
-                          \ value \"v1\"\n\n```"
+                          \ value: \"v1\"\n\n```"
                         properties:
                           headers:
                             description: |-
@@ -7701,7 +7701,7 @@ spec:
                           match below will match a HTTP request only if its path\nstarts
                           with `/foo` AND it contains the `version: v1` header:\n\n```\nmatch:\n\n\tpath:\n\t
                           \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
-                          \ value \"v1\"\n\n```"
+                          \ value: \"v1\"\n\n```"
                         properties:
                           headers:
                             description: |-

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -3438,7 +3438,7 @@ spec:
                           match below will match a HTTP request only if its path\nstarts
                           with `/foo` AND it contains the `version: v1` header:\n\n```\nmatch:\n\n\tpath:\n\t
                           \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
-                          \ value \"v1\"\n\n```"
+                          \ value: \"v1\"\n\n```"
                         properties:
                           headers:
                             description: |-
@@ -7693,7 +7693,7 @@ spec:
                           match below will match a HTTP request only if its path\nstarts
                           with `/foo` AND it contains the `version: v1` header:\n\n```\nmatch:\n\n\tpath:\n\t
                           \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
-                          \ value \"v1\"\n\n```"
+                          \ value: \"v1\"\n\n```"
                         properties:
                           headers:
                             description: |-

--- a/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
@@ -1654,24 +1654,14 @@ spec:
                         matching precedence MUST be granted to the first matching rule meeting
                         the above criteria.
                       items:
-                        description: |-
-                          GRPCRouteMatch defines the predicate used to match requests to a given
-                          action. Multiple match types are ANDed together, i.e. the match will
-                          evaluate to true only if all conditions are satisfied.
-
-                          For example, the match below will match a gRPC request only if its service
-                          is `foo` AND it contains the `version: v1` header:
-
-                          ```
-                          matches:
-                            - method:
-                              type: Exact
-                              service: "foo"
-                            - headers:
-                              name: "version"
-                              value "v1"
-
-                          ```
+                        description: "GRPCRouteMatch defines the predicate used to
+                          match requests to a given\naction. Multiple match types
+                          are ANDed together, i.e. the match will\nevaluate to true
+                          only if all conditions are satisfied.\n\nFor example, the
+                          match below will match a gRPC request only if its service\nis
+                          `foo` AND it contains the `version: v1` header:\n\n```\n\n\tmatches:\n\t-
+                          method:\n\t    type: Exact\n\t    service: \"foo\"\n\t  headers:\n\t
+                          \ - name: \"version\"\n\t    value: \"v1\"\n\n```"
                         properties:
                           headers:
                             description: |-

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -2847,7 +2847,7 @@ spec:
                           match below will match a HTTP request only if its path\nstarts
                           with `/foo` AND it contains the `version: v1` header:\n\n```\nmatch:\n\n\tpath:\n\t
                           \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
-                          \ value \"v1\"\n\n```"
+                          \ value: \"v1\"\n\n```"
                         properties:
                           headers:
                             description: |-
@@ -6297,7 +6297,7 @@ spec:
                           match below will match a HTTP request only if its path\nstarts
                           with `/foo` AND it contains the `version: v1` header:\n\n```\nmatch:\n\n\tpath:\n\t
                           \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
-                          \ value \"v1\"\n\n```"
+                          \ value: \"v1\"\n\n```"
                         properties:
                           headers:
                             description: |-

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3774,7 +3774,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_GRPCRouteMatch(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "GRPCRouteMatch defines the predicate used to match requests to a given action. Multiple match types are ANDed together, i.e. the match will evaluate to true only if all conditions are satisfied.\n\nFor example, the match below will match a gRPC request only if its service is `foo` AND it contains the `version: v1` header:\n\n``` matches:\n  - method:\n    type: Exact\n    service: \"foo\"\n  - headers:\n    name: \"version\"\n    value \"v1\"\n\n```",
+				Description: "GRPCRouteMatch defines the predicate used to match requests to a given action. Multiple match types are ANDed together, i.e. the match will evaluate to true only if all conditions are satisfied.\n\nFor example, the match below will match a gRPC request only if its service is `foo` AND it contains the `version: v1` header:\n\n```\n\n\tmatches:\n\t- method:\n\t    type: Exact\n\t    service: \"foo\"\n\t  headers:\n\t  - name: \"version\"\n\t    value: \"v1\"\n\n```",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"method": {
@@ -5437,7 +5437,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_HTTPRouteMatch(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "HTTPRouteMatch defines the predicate used to match requests to a given action. Multiple match types are ANDed together, i.e. the match will evaluate to true only if all conditions are satisfied.\n\nFor example, the match below will match a HTTP request only if its path starts with `/foo` AND it contains the `version: v1` header:\n\n``` match:\n\n\tpath:\n\t  value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t  value \"v1\"\n\n```",
+				Description: "HTTPRouteMatch defines the predicate used to match requests to a given action. Multiple match types are ANDed together, i.e. the match will evaluate to true only if all conditions are satisfied.\n\nFor example, the match below will match a HTTP request only if its path starts with `/foo` AND it contains the `version: v1` header:\n\n``` match:\n\n\tpath:\n\t  value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t  value: \"v1\"\n\n```",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"path": {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3830,7 +3830,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_GRPCRouteMatch(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "GRPCRouteMatch defines the predicate used to match requests to a given action. Multiple match types are ANDed together, i.e. the match will evaluate to true only if all conditions are satisfied.\n\nFor example, the match below will match a gRPC request only if its service is `foo` AND it contains the `version: v1` header:\n\n``` matches:\n  - method:\n    type: Exact\n    service: \"foo\"\n  - headers:\n    name: \"version\"\n    value \"v1\"\n\n```",
+				Description: "GRPCRouteMatch defines the predicate used to match requests to a given action. Multiple match types are ANDed together, i.e. the match will evaluate to true only if all conditions are satisfied.\n\nFor example, the match below will match a gRPC request only if its service is `foo` AND it contains the `version: v1` header:\n\n```\n\n\tmatches:\n\t- method:\n\t    type: Exact\n\t    service: \"foo\"\n\t  headers:\n\t  - name: \"version\"\n\t    value: \"v1\"\n\n```",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"method": {
@@ -5493,7 +5493,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_HTTPRouteMatch(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "HTTPRouteMatch defines the predicate used to match requests to a given action. Multiple match types are ANDed together, i.e. the match will evaluate to true only if all conditions are satisfied.\n\nFor example, the match below will match a HTTP request only if its path starts with `/foo` AND it contains the `version: v1` header:\n\n``` match:\n\n\tpath:\n\t  value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t  value \"v1\"\n\n```",
+				Description: "HTTPRouteMatch defines the predicate used to match requests to a given action. Multiple match types are ANDed together, i.e. the match will evaluate to true only if all conditions are satisfied.\n\nFor example, the match below will match a HTTP request only if its path starts with `/foo` AND it contains the `version: v1` header:\n\n``` match:\n\n\tpath:\n\t  value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t  value: \"v1\"\n\n```",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"path": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind documentation

**What this PR does / why we need it**:

Fix syntax errors in HTTPRouteMatch, GRPCRouteMatch examples.

Change:
- apis/v1/httproute_types.go
  - value "v1" → value: "v1"
- apis/v1/grpcroute_types.go
  - value "v1" → value: "v1"
  - fix yaml indentation & list formatting

P.S.
Update grpcroute example yaml formatting (indentation) based on apis/v1/httproute_types.go (lines 750–759) to pass make verify.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
