### PR TITLE
conformance: GRPCRoute - Add all zero weight backend tests

### DIFF
--- a/conformance/tests/grpcroute-all-backends-weight-zero.go
+++ b/conformance/tests/grpcroute-all-backends-weight-zero.go
@@ -1,0 +1,62 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	pb "sigs.k8s.io/gateway-api/conformance/echo-basic/grpcechoserver"
+	"sigs.k8s.io/gateway-api/conformance/utils/grpc"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GRPCRouteAllBackendsWeightZero)
+}
+
+var GRPCRouteAllBackendsWeightZero = confsuite.ConformanceTest{
+	ShortName:   "GRPCRouteAllBackendsWeightZero",
+	Description: "A GRPCRoute with all backend weights set to 0 returns UNAVAILABLE",
+	Manifests:   []string{"tests/grpcroute-all-backends-weight-zero.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportGRPCRoute,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		var (
+			ns      = confsuite.InfrastructureNamespace
+			routeNN = types.NamespacedName{Name: "all-backends-weight-zero", Namespace: ns}
+			gwNN    = types.NamespacedName{Name: "same-namespace", Namespace: ns}
+			gwAddr  = kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &v1.GRPCRoute{}, true, routeNN)
+		)
+
+		t.Run("Requests should return UNAVAILABLE when all backend weights are 0", func(t *testing.T) {
+			grpc.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.GRPCClient, suite.TimeoutConfig, gwAddr, grpc.ExpectedResponse{
+				EchoRequest: &pb.EchoRequest{},
+				Response: grpc.Response{
+					Code: codes.Unavailable,
+				},
+			})
+		})
+	},
+}

--- a/conformance/tests/grpcroute-all-backends-weight-zero.yaml
+++ b/conformance/tests/grpcroute-all-backends-weight-zero.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: all-backends-weight-zero
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: grpc-infra-backend-v1
+      port: 8080
+      weight: 0
+    - name: grpc-infra-backend-v2
+      port: 8080
+      weight: 0

--- a/conformance/tests/httproute-all-backends-weight-zero.go
+++ b/conformance/tests/httproute-all-backends-weight-zero.go
@@ -1,0 +1,61 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteAllBackendsWeightZero)
+}
+
+var HTTPRouteAllBackendsWeightZero = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteAllBackendsWeightZero",
+	Description: "An HTTPRoute with all backend weights set to 0 returns 500",
+	Manifests:   []string{"tests/httproute-all-backends-weight-zero.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		var (
+			ns      = confsuite.InfrastructureNamespace
+			routeNN = types.NamespacedName{Name: "all-backends-weight-zero", Namespace: ns}
+			gwNN    = types.NamespacedName{Name: "same-namespace", Namespace: ns}
+			gwAddr  = kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		)
+
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		t.Run("Requests should return 500 when all backend weights are 0", func(t *testing.T) {
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
+				Request: http.Request{Path: "/"},
+				Response: http.Response{
+					StatusCode: 500,
+				},
+			})
+		})
+	},
+}

--- a/conformance/tests/httproute-all-backends-weight-zero.yaml
+++ b/conformance/tests/httproute-all-backends-weight-zero.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: all-backends-weight-zero
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      weight: 0
+    - name: infra-backend-v2
+      port: 8080
+      weight: 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind test
/area conformance-test

**What this PR does / why we need it**:
Tests alternate case where _all_ backends have 0 weight.
While not explicitly defined, it's implied that these should also return 500/Unavailable.

Discussed originally here: https://github.com/kubernetes-sigs/gateway-api/pull/4750#discussion_r3079792385

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
