### PR TITLE
GEP-1619: Remove idleTimeout from SessionPersistence API

### DIFF
--- a/apis/v1/shared_types.go
+++ b/apis/v1/shared_types.go
@@ -935,15 +935,6 @@ type SessionPersistence struct {
 	// +optional
 	AbsoluteTimeout *Duration `json:"absoluteTimeout,omitempty"`
 
-	// IdleTimeout defines the idle timeout of the persistent session.
-	// Once the session has been idle for more than the specified
-	// IdleTimeout duration, the session becomes invalid.
-	//
-	// Support: Extended
-	//
-	// +optional
-	IdleTimeout *Duration `json:"idleTimeout,omitempty"`
-
 	// Type defines the type of session persistence such as through
 	// the use of a header or cookie. Defaults to cookie based session
 	// persistence.

--- a/apis/v1/zz_generated.deepcopy.go
+++ b/apis/v1/zz_generated.deepcopy.go
@@ -2482,11 +2482,6 @@ func (in *SessionPersistence) DeepCopyInto(out *SessionPersistence) {
 		*out = new(Duration)
 		**out = **in
 	}
-	if in.IdleTimeout != nil {
-		in, out := &in.IdleTimeout, &out.IdleTimeout
-		*out = new(Duration)
-		**out = **in
-	}
 	if in.Type != nil {
 		in, out := &in.Type, &out.Type
 		*out = new(SessionPersistenceType)

--- a/applyconfiguration/apis/v1/sessionpersistence.go
+++ b/applyconfiguration/apis/v1/sessionpersistence.go
@@ -40,12 +40,6 @@ type SessionPersistenceApplyConfiguration struct {
 	//
 	// Support: Extended
 	AbsoluteTimeout *apisv1.Duration `json:"absoluteTimeout,omitempty"`
-	// IdleTimeout defines the idle timeout of the persistent session.
-	// Once the session has been idle for more than the specified
-	// IdleTimeout duration, the session becomes invalid.
-	//
-	// Support: Extended
-	IdleTimeout *apisv1.Duration `json:"idleTimeout,omitempty"`
 	// Type defines the type of session persistence such as through
 	// the use of a header or cookie. Defaults to cookie based session
 	// persistence.
@@ -80,14 +74,6 @@ func (b *SessionPersistenceApplyConfiguration) WithSessionName(value string) *Se
 // If called multiple times, the AbsoluteTimeout field is set to the value of the last call.
 func (b *SessionPersistenceApplyConfiguration) WithAbsoluteTimeout(value apisv1.Duration) *SessionPersistenceApplyConfiguration {
 	b.AbsoluteTimeout = &value
-	return b
-}
-
-// WithIdleTimeout sets the IdleTimeout field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the IdleTimeout field is set to the value of the last call.
-func (b *SessionPersistenceApplyConfiguration) WithIdleTimeout(value apisv1.Duration) *SessionPersistenceApplyConfiguration {
-	b.IdleTimeout = &value
 	return b
 }
 

--- a/applyconfiguration/internal/internal.go
+++ b/applyconfiguration/internal/internal.go
@@ -1609,9 +1609,6 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: cookieConfig
       type:
         namedType: io.k8s.sigs.gateway-api.apis.v1.CookieConfig
-    - name: idleTimeout
-      type:
-        scalar: string
     - name: sessionName
       type:
         scalar: string

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -1911,15 +1911,6 @@ spec:
                               - Session
                               type: string
                           type: object
-                        idleTimeout:
-                          description: |-
-                            IdleTimeout defines the idle timeout of the persistent session.
-                            Once the session has been idle for more than the specified
-                            IdleTimeout duration, the session becomes invalid.
-
-                            Support: Extended
-                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                          type: string
                         sessionName:
                           description: |-
                             SessionName defines the name of the persistent session token

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -3815,15 +3815,6 @@ spec:
                               - Session
                               type: string
                           type: object
-                        idleTimeout:
-                          description: |-
-                            IdleTimeout defines the idle timeout of the persistent session.
-                            Once the session has been idle for more than the specified
-                            IdleTimeout duration, the session becomes invalid.
-
-                            Support: Extended
-                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                          type: string
                         sessionName:
                           description: |-
                             SessionName defines the name of the persistent session token
@@ -8078,15 +8069,6 @@ spec:
                               - Session
                               type: string
                           type: object
-                        idleTimeout:
-                          description: |-
-                            IdleTimeout defines the idle timeout of the persistent session.
-                            Once the session has been idle for more than the specified
-                            IdleTimeout duration, the session becomes invalid.
-
-                            Support: Extended
-                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                          type: string
                         sessionName:
                           description: |-
                             SessionName defines the name of the persistent session token

--- a/config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
+++ b/config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
@@ -205,15 +205,6 @@ spec:
                         - Session
                         type: string
                     type: object
-                  idleTimeout:
-                    description: |-
-                      IdleTimeout defines the idle timeout of the persistent session.
-                      Once the session has been idle for more than the specified
-                      IdleTimeout duration, the session becomes invalid.
-
-                      Support: Extended
-                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                    type: string
                   sessionName:
                     description: |-
                       SessionName defines the name of the persistent session token

--- a/geps/gep-1619/index.md
+++ b/geps/gep-1619/index.md
@@ -509,15 +509,6 @@ type SessionPersistence struct {
     // +optional
     AbsoluteTimeout *Duration `json:"absoluteTimeout,omitempty"`
 
-    // IdleTimeout defines the idle timeout of the persistent session.
-    // Once the session has been idle for more than the specified
-    // IdleTimeout duration, the session becomes invalid.
-    //
-    // Support: Extended
-    //
-    // +optional
-    IdleTimeout *Duration `json:"idleTimeout,omitempty"`
-
     // Type defines the type of session persistence such as through
     // the use of a header or cookie. Defaults to cookie based session
     // persistence.
@@ -1093,6 +1084,19 @@ configuration via a warning status or log.
     - This might require addressing as part of an update to [GEP-2648](../gep-2648/index.md).
 
 ## Alternatives
+
+### IdleTimeout
+
+The `idleTimeout` field was originally included in the SessionPersistence API but
+was removed because no Gateway API implementation has implemented it and no
+implementation has requested it. HTTP cookies have no native idle timeout
+mechanism — `Max-Age`/`Expires` are absolute, not idle-based. Implementing idle
+timeout requires server-side session state tracking (e.g., HAProxy's `maxidle` or
+NGINX's `sticky learn` with `timeout=`), which is additional complexity beyond
+what the current cookie-based model requires. Some dataplanes have no mechanism
+for idle timeout at all, making it unimplementable for those controllers. This
+field could be re-introduced in a future GEP if implementations demonstrate
+viable approaches and express interest.
 
 ### SessionPersistence API Alternative
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -7275,13 +7275,6 @@ func schema_sigsk8sio_gateway_api_apis_v1_SessionPersistence(ref common.Referenc
 							Format:      "",
 						},
 					},
-					"idleTimeout": {
-						SchemaProps: spec.SchemaProps{
-							Description: "IdleTimeout defines the idle timeout of the persistent session. Once the session has been idle for more than the specified IdleTimeout duration, the session becomes invalid.\n\nSupport: Extended",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Type defines the type of session persistence such as through the use of a header or cookie. Defaults to cookie based session persistence.\n\nSupport: Core for \"Cookie\" type\n\nSupport: Extended for \"Header\" type",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Remove the idleTimeout field from the SessionPersistence API. No Gateway API implementation has implemented this field and no implementation has requested it. HTTP cookies have no native idle timeout mechanism, and implementing it requires server-side session state tracking which is additional complexity beyond what the current cookie-based model requires.

The field is documented in the GEP-1619 Alternatives section so it can be re-introduced in a future GEP if implementations demonstrate viable approaches and express interest.

**Which issue(s) this PR fixes**:
Fixes #4770

**Does this PR introduce a user-facing change?**:
```release-note
Remove the idleTimeout field from the experimental SessionPersistence API.
```
