### PR TITLE
cleanup-test-resources option

### DIFF
--- a/conformance/conformance.go
+++ b/conformance/conformance.go
@@ -93,6 +93,7 @@ func DefaultOptions(t *testing.T) suite.ConformanceOptions {
 	return suite.ConformanceOptions{
 		AllowCRDsMismatch:          *flags.AllowCRDsMismatch,
 		CleanupBaseResources:       *flags.CleanupBaseResources,
+		CleanupTestResources:       *flags.CleanupTestResources,
 		Client:                     client,
 		ClientOptions:              clientOptions,
 		Clientset:                  clientset,
@@ -171,7 +172,8 @@ func RunConformanceWithOptions(t *testing.T, opts suite.ConformanceOptions) {
 
 func logOptions(t *testing.T, opts suite.ConformanceOptions) {
 	t.Logf("  GatewayClass: %s", opts.GatewayClassName)
-	t.Logf("  Cleanup Resources: %t", opts.CleanupBaseResources)
+	t.Logf("  Cleanup Base Resources: %t", opts.CleanupBaseResources)
+	t.Logf("  Cleanup Test Resources: %t", opts.CleanupTestResources)
 	t.Logf("  Debug: %t", opts.Debug)
 	t.Logf("  Enable All Features: %t", opts.EnableAllSupportedFeatures)
 	t.Logf("  Supported Features: %v", opts.SupportedFeatures.UnsortedList())

--- a/conformance/utils/flags/flags.go
+++ b/conformance/utils/flags/flags.go
@@ -35,6 +35,7 @@ var (
 	MeshName                   = flag.String("mesh-name", "", "Name of Mesh to use for tests")
 	ShowDebug                  = flag.Bool("debug", false, "Whether to print debug logs")
 	CleanupBaseResources       = flag.Bool("cleanup-base-resources", true, "Whether to cleanup base test resources after the run")
+	CleanupTestResources       = flag.Bool("cleanup-test-resources", true, "Whether to cleanup test-specific resources after each test")
 	SupportedFeatures          = flag.String("supported-features", "", "Supported features included in conformance tests suites")
 	SkipTests                  = flag.String("skip-tests", "", "Comma-separated list of tests to skip")
 	RunTest                    = flag.String("run-test", "", "Name of a single test to run, instead of the whole suite")

--- a/conformance/utils/suite/conformance.go
+++ b/conformance/utils/suite/conformance.go
@@ -68,7 +68,7 @@ func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) {
 
 	for _, manifestLocation := range test.Manifests {
 		tlog.Logf(t, "Applying %s", manifestLocation)
-		suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, manifestLocation, true)
+		suite.Applier.MustApplyWithCleanup(t, suite.Client, suite.TimeoutConfig, manifestLocation, suite.CleanupTestResources)
 	}
 
 	if featuresInfo != "" {

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -69,6 +69,7 @@ type ConformanceTestSuite struct {
 	ControllerName           string
 	Debug                    bool
 	Cleanup                  bool
+	CleanupTestResources     bool
 	BaseManifests            string
 	MeshManifests            string
 	Applier                  kubernetes.Applier
@@ -152,7 +153,10 @@ type ConformanceOptions struct {
 
 	// CleanupBaseResources indicates whether or not the base test
 	// resources such as Gateways should be cleaned up after the run.
-	CleanupBaseResources       bool
+	CleanupBaseResources bool
+	// CleanupTestResources indicates whether or not test-specific manifests
+	// should be cleaned up after each test.
+	CleanupTestResources       bool
 	SupportedFeatures          FeaturesSet
 	ExemptFeatures             FeaturesSet
 	EnableAllSupportedFeatures bool
@@ -287,17 +291,18 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 	}
 
 	suite := &ConformanceTestSuite{
-		Client:           options.Client,
-		ClientOptions:    options.ClientOptions,
-		Clientset:        options.Clientset,
-		RestConfig:       options.RestConfig,
-		RoundTripper:     roundTripper,
-		GRPCClient:       grpcClient,
-		GatewayClassName: options.GatewayClassName,
-		Debug:            options.Debug,
-		Cleanup:          options.CleanupBaseResources,
-		BaseManifests:    options.BaseManifests,
-		MeshManifests:    options.MeshManifests,
+		Client:               options.Client,
+		ClientOptions:        options.ClientOptions,
+		Clientset:            options.Clientset,
+		RestConfig:           options.RestConfig,
+		RoundTripper:         roundTripper,
+		GRPCClient:           grpcClient,
+		GatewayClassName:     options.GatewayClassName,
+		Debug:                options.Debug,
+		Cleanup:              options.CleanupBaseResources,
+		CleanupTestResources: options.CleanupTestResources,
+		BaseManifests:        options.BaseManifests,
+		MeshManifests:        options.MeshManifests,
 		Applier: kubernetes.Applier{
 			NamespaceLabels:      options.NamespaceLabels,
 			NamespaceAnnotations: options.NamespaceAnnotations,


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind test

Optionally add one or more of the following kinds if applicable:
/area conformance-test
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Add a new suite-level option to control cleanup of test-specific manifests after each test run.

This introduces --cleanup-test-resources (default: true) so local debugging can preserve resources from a single test when needed.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
