### PR TITLE
Update Envoy Gateway conformance report for v1.5.1

### DIFF
--- a/conformance/reports/v1.5.1/envoy-gateway/experimental-v1.8.0-rc.0-default-report.yaml
+++ b/conformance/reports/v1.5.1/envoy-gateway/experimental-v1.8.0-rc.0-default-report.yaml
@@ -1,5 +1,5 @@
 apiVersion: gateway.networking.k8s.io/v1
-date: "2026-03-24T17:48:10Z"
+date: "2026-04-17T22:57:37Z"
 gatewayAPIChannel: experimental
 gatewayAPIVersion: v1.5.1
 implementation:
@@ -21,19 +21,13 @@ profiles:
   extended:
     result: partial
     skippedTests:
-    - GatewayBackendClientCertificateFeature
-    - GatewayFrontendClientCertificateValidation
-    - GatewayFrontendClientCertificateValidationInsecureFallback
-    - GatewayFrontendInvalidDefaultClientCertificateValidation
-    - GatewayInvalidFrontendClientCertificateValidation
-    - GatewayInvalidTLSBackendConfiguration
     - HTTPRouteHTTPSListenerDetectMisdirectedRequests
     - ListenerSetHostnameConflict
     - ListenerSetProtocolConflict
     statistics:
       Failed: 0
-      Passed: 43
-      Skipped: 9
+      Passed: 50
+      Skipped: 3
     supportedFeatures:
     - BackendTLSPolicy
     - BackendTLSPolicySANValidation
@@ -44,6 +38,7 @@ profiles:
     - GatewayHTTPListenerIsolation
     - GatewayHTTPSListenerDetectMisdirectedRequests
     - GatewayPort8080
+    - GatewayStaticAddresses
     - HTTPRoute303RedirectStatusCode
     - HTTPRoute307RedirectStatusCode
     - HTTPRoute308RedirectStatusCode
@@ -70,9 +65,8 @@ profiles:
     - ListenerSet
     unsupportedFeatures:
     - GatewayInfrastructurePropagation
-    - GatewayStaticAddresses
   name: GATEWAY-HTTP
-  summary: Core tests succeeded. Extended tests partially succeeded with 9 test skips.
+  summary: Core tests succeeded. Extended tests partially succeeded with 3 test skips.
 - core:
     result: success
     statistics:
@@ -86,7 +80,7 @@ profiles:
     - ListenerSetProtocolConflict
     statistics:
       Failed: 0
-      Passed: 6
+      Passed: 7
       Skipped: 2
     supportedFeatures:
     - GatewayAddressEmpty
@@ -96,10 +90,10 @@ profiles:
     - GatewayHTTPListenerIsolation
     - GatewayHTTPSListenerDetectMisdirectedRequests
     - GatewayPort8080
+    - GatewayStaticAddresses
     - ListenerSet
     unsupportedFeatures:
     - GatewayInfrastructurePropagation
-    - GatewayStaticAddresses
   name: GATEWAY-GRPC
   summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
 - core:
@@ -115,7 +109,7 @@ profiles:
     - ListenerSetProtocolConflict
     statistics:
       Failed: 0
-      Passed: 11
+      Passed: 12
       Skipped: 2
     supportedFeatures:
     - GatewayAddressEmpty
@@ -125,12 +119,12 @@ profiles:
     - GatewayHTTPListenerIsolation
     - GatewayHTTPSListenerDetectMisdirectedRequests
     - GatewayPort8080
+    - GatewayStaticAddresses
     - ListenerSet
     - TLSRouteModeMixed
     - TLSRouteModeTerminate
     unsupportedFeatures:
     - GatewayInfrastructurePropagation
-    - GatewayStaticAddresses
   name: GATEWAY-TLS
   summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
 succeededProvisionalTests:

--- a/conformance/reports/v1.5.1/envoy-gateway/experimental-v1.8.0-rc.0-gateway-namespace-mode-report.yaml
+++ b/conformance/reports/v1.5.1/envoy-gateway/experimental-v1.8.0-rc.0-gateway-namespace-mode-report.yaml
@@ -1,5 +1,5 @@
 apiVersion: gateway.networking.k8s.io/v1
-date: "2026-03-24T17:48:24Z"
+date: "2026-04-17T22:57:46Z"
 gatewayAPIChannel: experimental
 gatewayAPIVersion: v1.5.1
 implementation:
@@ -16,84 +16,18 @@ profiles:
     result: success
     statistics:
       Failed: 0
-      Passed: 13
-      Skipped: 0
-  extended:
-    result: partial
-    skippedTests:
-    - ListenerSetHostnameConflict
-    - ListenerSetProtocolConflict
-    statistics:
-      Failed: 0
-      Passed: 7
-      Skipped: 2
-    supportedFeatures:
-    - GatewayAddressEmpty
-    - GatewayBackendClientCertificate
-    - GatewayFrontendClientCertificateValidation
-    - GatewayFrontendClientCertificateValidationInsecureFallback
-    - GatewayHTTPListenerIsolation
-    - GatewayHTTPSListenerDetectMisdirectedRequests
-    - GatewayInfrastructurePropagation
-    - GatewayPort8080
-    - ListenerSet
-    unsupportedFeatures:
-    - GatewayStaticAddresses
-  name: GATEWAY-GRPC
-  summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
-- core:
-    result: success
-    statistics:
-      Failed: 0
-      Passed: 18
-      Skipped: 0
-  extended:
-    result: partial
-    skippedTests:
-    - ListenerSetHostnameConflict
-    - ListenerSetProtocolConflict
-    statistics:
-      Failed: 0
-      Passed: 12
-      Skipped: 2
-    supportedFeatures:
-    - GatewayAddressEmpty
-    - GatewayBackendClientCertificate
-    - GatewayFrontendClientCertificateValidation
-    - GatewayFrontendClientCertificateValidationInsecureFallback
-    - GatewayHTTPListenerIsolation
-    - GatewayHTTPSListenerDetectMisdirectedRequests
-    - GatewayInfrastructurePropagation
-    - GatewayPort8080
-    - ListenerSet
-    - TLSRouteModeMixed
-    - TLSRouteModeTerminate
-    unsupportedFeatures:
-    - GatewayStaticAddresses
-  name: GATEWAY-TLS
-  summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
-- core:
-    result: success
-    statistics:
-      Failed: 0
       Passed: 33
       Skipped: 0
   extended:
     result: partial
     skippedTests:
-    - GatewayBackendClientCertificateFeature
-    - GatewayFrontendClientCertificateValidation
-    - GatewayFrontendClientCertificateValidationInsecureFallback
-    - GatewayFrontendInvalidDefaultClientCertificateValidation
-    - GatewayInvalidFrontendClientCertificateValidation
-    - GatewayInvalidTLSBackendConfiguration
     - HTTPRouteHTTPSListenerDetectMisdirectedRequests
     - ListenerSetHostnameConflict
     - ListenerSetProtocolConflict
     statistics:
       Failed: 0
-      Passed: 44
-      Skipped: 9
+      Passed: 51
+      Skipped: 3
     supportedFeatures:
     - BackendTLSPolicy
     - BackendTLSPolicySANValidation
@@ -105,6 +39,7 @@ profiles:
     - GatewayHTTPSListenerDetectMisdirectedRequests
     - GatewayInfrastructurePropagation
     - GatewayPort8080
+    - GatewayStaticAddresses
     - HTTPRoute303RedirectStatusCode
     - HTTPRoute307RedirectStatusCode
     - HTTPRoute308RedirectStatusCode
@@ -129,10 +64,66 @@ profiles:
     - HTTPRouteResponseHeaderModification
     - HTTPRouteSchemeRedirect
     - ListenerSet
-    unsupportedFeatures:
-    - GatewayStaticAddresses
   name: GATEWAY-HTTP
-  summary: Core tests succeeded. Extended tests partially succeeded with 9 test skips.
+  summary: Core tests succeeded. Extended tests partially succeeded with 3 test skips.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 13
+      Skipped: 0
+  extended:
+    result: partial
+    skippedTests:
+    - ListenerSetHostnameConflict
+    - ListenerSetProtocolConflict
+    statistics:
+      Failed: 0
+      Passed: 8
+      Skipped: 2
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPListenerIsolation
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
+    - GatewayPort8080
+    - GatewayStaticAddresses
+    - ListenerSet
+  name: GATEWAY-GRPC
+  summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 18
+      Skipped: 0
+  extended:
+    result: partial
+    skippedTests:
+    - ListenerSetHostnameConflict
+    - ListenerSetProtocolConflict
+    statistics:
+      Failed: 0
+      Passed: 13
+      Skipped: 2
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPListenerIsolation
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
+    - GatewayPort8080
+    - GatewayStaticAddresses
+    - ListenerSet
+    - TLSRouteModeMixed
+    - TLSRouteModeTerminate
+  name: GATEWAY-TLS
+  summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
 succeededProvisionalTests:
 - GRPCRouteNamedRule
 - GatewayInfrastructure


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind documentation

**What this PR does / why we need it**:
Update v1.5.1 conformance report for envoy-gateway

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
