### PR TITLE
fix: enforce TLS configuration for HTTPS listeners via CEL

### DIFF
--- a/apis/v1/gateway_types.go
+++ b/apis/v1/gateway_types.go
@@ -242,7 +242,7 @@ type GatewaySpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64
 	// +kubebuilder:validation:XValidation:message="tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']",rule="self.all(l, l.protocol in ['HTTP', 'TCP', 'UDP'] ? !has(l.tls) : true)"
-	// +kubebuilder:validation:XValidation:message="tls mode must be Terminate for protocol HTTPS",rule="self.all(l, (l.protocol == 'HTTPS' && has(l.tls)) ? (l.tls.mode == '' || l.tls.mode == 'Terminate') : true)"
+	// +kubebuilder:validation:XValidation:message="tls mode must be Terminate for protocol HTTPS",rule="self.all(l, (l.protocol == 'HTTPS' ? has(l.tls) && (l.tls.mode == '' || l.tls.mode == 'Terminate') : true))"
 	// +kubebuilder:validation:XValidation:message="tls mode must be set for protocol TLS",rule="self.all(l, (l.protocol == 'TLS' ? has(l.tls) && has(l.tls.mode) && l.tls.mode != '' : true))"
 	// +kubebuilder:validation:XValidation:message="hostname must not be specified for protocols ['TCP', 'UDP']",rule="self.all(l, l.protocol in ['TCP', 'UDP']  ? (!has(l.hostname) || l.hostname == '') : true)"
 	// +kubebuilder:validation:XValidation:message="Listener name must be unique within the Gateway",rule="self.all(l1, self.exists_one(l2, l1.name == l2.name))"

--- a/apis/v1/listenerset_types.go
+++ b/apis/v1/listenerset_types.go
@@ -111,7 +111,7 @@ type ListenerSetSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64
 	// +kubebuilder:validation:XValidation:message="tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']",rule="self.all(l, l.protocol in ['HTTP', 'TCP', 'UDP'] ? !has(l.tls) : true)"
-	// +kubebuilder:validation:XValidation:message="tls mode must be Terminate for protocol HTTPS",rule="self.all(l, (l.protocol == 'HTTPS' && has(l.tls)) ? (l.tls.mode == '' || l.tls.mode == 'Terminate') : true)"
+	// +kubebuilder:validation:XValidation:message="tls mode must be Terminate for protocol HTTPS",rule="self.all(l, (l.protocol == 'HTTPS' ? has(l.tls) && (l.tls.mode == '' || l.tls.mode == 'Terminate') : true))"
 	// +kubebuilder:validation:XValidation:message="tls mode must be set for protocol TLS",rule="self.all(l, (l.protocol == 'TLS' ? has(l.tls) && has(l.tls.mode) && l.tls.mode != '' : true))"
 	// +kubebuilder:validation:XValidation:message="hostname must not be specified for protocols ['TCP', 'UDP']",rule="self.all(l, l.protocol in ['TCP', 'UDP']  ? (!has(l.hostname) || l.hostname == '') : true)"
 	// +kubebuilder:validation:XValidation:message="Listener name must be unique within the Gateway",rule="self.all(l1, self.exists_one(l2, l1.name == l2.name))"

--- a/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -922,8 +922,8 @@ spec:
                   rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
                     !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
-                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' ? has(l.tls) && (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true))'
                 - message: tls mode must be set for protocol TLS
                   rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
                     && l.tls.mode != '''' : true))'
@@ -2579,8 +2579,8 @@ spec:
                   rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
                     !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
-                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' ? has(l.tls) && (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true))'
                 - message: tls mode must be set for protocol TLS
                   rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
                     && l.tls.mode != '''' : true))'

--- a/config/crd/experimental/gateway.networking.k8s.io_listenersets.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_listenersets.yaml
@@ -469,8 +469,8 @@ spec:
                   rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
                     !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
-                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' ? has(l.tls) && (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true))'
                 - message: tls mode must be set for protocol TLS
                   rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
                     && l.tls.mode != '''' : true))'

--- a/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
@@ -899,8 +899,8 @@ spec:
                   rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
                     !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
-                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' ? has(l.tls) && (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true))'
                 - message: tls mode must be set for protocol TLS
                   rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
                     && l.tls.mode != '''' : true))'
@@ -2533,8 +2533,8 @@ spec:
                   rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
                     !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
-                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' ? has(l.tls) && (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true))'
                 - message: tls mode must be set for protocol TLS
                   rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
                     && l.tls.mode != '''' : true))'

--- a/config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
@@ -469,8 +469,8 @@ spec:
                   rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
                     !has(l.tls) : true)'
                 - message: tls mode must be Terminate for protocol HTTPS
-                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
-                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' ? has(l.tls) && (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true))'
                 - message: tls mode must be set for protocol TLS
                   rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
                     && l.tls.mode != '''' : true))'

--- a/tests/cel/gateway_test.go
+++ b/tests/cel/gateway_test.go
@@ -124,6 +124,7 @@ func TestValidateGateway(t *testing.T) {
 					},
 				}
 			},
+			wantErrors: []string{"tls mode must be Terminate for protocol HTTPS"},
 		},
 		{
 			desc: "tls config not set with tls protocol",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind bug

**What this PR does / why we need it**:
TLS configuration in the Listener is required when the Protocol is `HTTPS` or `TLS`, and must not be set when the Protocol is `HTTP`, `TCP`, or `UDP`. However, this constraint was not being enforced for `HTTPS`, allowing invalid Listener configurations to be created.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Breaking: listeners: tls must be configured for protocol: HTTPS
```
