### PR TITLE
Clarify HTTPHeader duplicate handling

### DIFF
--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -1020,18 +1020,16 @@ const (
 
 // HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.
 type HTTPHeader struct {
-	// Name is the name of the HTTP Header to be matched. Name matching MUST be
+	// Name is the name of the HTTP Header. Name matching MUST be
 	// case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 	//
-	// If multiple entries specify equivalent header names, the first entry with
-	// an equivalent name MUST be considered for a match. Subsequent entries
-	// with an equivalent header name MUST be ignored. Due to the
-	// case-insensitivity of header names, "foo" and "Foo" are considered
-	// equivalent.
+	// When this type is used in HTTPHeaderFilter lists, entries with equivalent
+	// header names are considered duplicates. Due to the case-insensitivity of
+	// header names, "foo" and "Foo" are considered equivalent.
 	// +required
 	Name HTTPHeaderName `json:"name"`
 
-	// Value is the value of HTTP Header to be matched.
+	// Value is the value of HTTP Header.
 	// <gateway:experimental:description>
 	// Must consist of printable US-ASCII characters, optionally separated
 	// by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2

--- a/applyconfiguration/apis/v1/httpheader.go
+++ b/applyconfiguration/apis/v1/httpheader.go
@@ -27,16 +27,14 @@ import (
 //
 // HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.
 type HTTPHeaderApplyConfiguration struct {
-	// Name is the name of the HTTP Header to be matched. Name matching MUST be
+	// Name is the name of the HTTP Header. Name matching MUST be
 	// case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 	//
-	// If multiple entries specify equivalent header names, the first entry with
-	// an equivalent name MUST be considered for a match. Subsequent entries
-	// with an equivalent header name MUST be ignored. Due to the
-	// case-insensitivity of header names, "foo" and "Foo" are considered
-	// equivalent.
+	// When this type is used in HTTPHeaderFilter lists, entries with equivalent
+	// header names are considered duplicates. Due to the case-insensitivity of
+	// header names, "foo" and "Foo" are considered equivalent.
 	Name *apisv1.HTTPHeaderName `json:"name,omitempty"`
-	// Value is the value of HTTP Header to be matched.
+	// Value is the value of HTTP Header.
 	// <gateway:experimental:description>
 	// Must consist of printable US-ASCII characters, optionally separated
 	// by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -532,21 +532,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -611,21 +609,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -827,21 +823,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -906,21 +900,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -1204,21 +1196,19 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -1282,21 +1272,19 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -1497,21 +1485,19 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -1575,21 +1561,19 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -1079,21 +1079,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -1158,21 +1156,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -1530,21 +1526,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -1609,21 +1603,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -2605,21 +2597,19 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -2683,21 +2673,19 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -3054,21 +3042,19 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -3132,21 +3118,19 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -5333,21 +5317,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -5412,21 +5394,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -5784,21 +5764,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -5863,21 +5841,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -6859,21 +6835,19 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -6937,21 +6911,19 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -7308,21 +7280,19 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -7386,21 +7356,19 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2

--- a/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
@@ -485,21 +485,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -560,21 +558,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -772,21 +768,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -847,21 +841,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -1141,21 +1133,18 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -1215,21 +1204,18 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -1426,21 +1412,18 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -1500,21 +1483,18 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -782,21 +782,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -857,21 +855,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -1225,21 +1221,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -1300,21 +1294,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -2037,21 +2029,18 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -2111,21 +2100,18 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -2478,21 +2464,18 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -2552,21 +2535,18 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -4232,21 +4212,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -4307,21 +4285,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -4675,21 +4651,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -4750,21 +4724,19 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                              header names are considered duplicates. Due to the case-insensitivity of
+                                              header names, "foo" and "Foo" are considered equivalent.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -5487,21 +5459,18 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -5561,21 +5530,18 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -5928,21 +5894,18 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -6002,21 +5965,18 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        When this type is used in HTTPHeaderFilter lists, entries with equivalent
+                                        header names are considered duplicates. Due to the case-insensitivity of
+                                        header names, "foo" and "Foo" are considered equivalent.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -4940,7 +4940,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_HTTPHeader(ref common.ReferenceCallbac
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is the name of the HTTP Header to be matched. Name matching MUST be case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with an equivalent name MUST be considered for a match. Subsequent entries with an equivalent header name MUST be ignored. Due to the case-insensitivity of header names, \"foo\" and \"Foo\" are considered equivalent.",
+							Description: "Name is the name of the HTTP Header. Name matching MUST be case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nWhen this type is used in HTTPHeaderFilter lists, entries with equivalent header names are considered duplicates. Due to the case-insensitivity of header names, \"foo\" and \"Foo\" are considered equivalent.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -4948,7 +4948,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_HTTPHeader(ref common.ReferenceCallbac
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Value is the value of HTTP Header to be matched. <gateway:experimental:description> Must consist of printable US-ASCII characters, optionally separated by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2 </gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+							Description: "Value is the value of HTTP Header. <gateway:experimental:description> Must consist of printable US-ASCII characters, optionally separated by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2 </gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",


### PR DESCRIPTION
Fixes #4480.

This updates the `HTTPHeader` API comment to avoid describing header modifier entries as match rules. It clarifies that equivalent header names in `HTTPHeaderFilter` lists are duplicate entries, then regenerates the apply configuration, OpenAPI schema, and CRDs.

Verification:
- `make generate`
- `hack/verify-codegen.sh`
