### PR TITLE
test(conformance): add test for Gateway OverlappingTLSConfig with reason OverlappingHostnames

### DIFF
--- a/conformance/tests/gateway-overlapping-tls-config-hostnames.go
+++ b/conformance/tests/gateway-overlapping-tls-config-hostnames.go
@@ -62,11 +62,12 @@ var GatewayOverlappingTLSConfigHostnames = suite.ConformanceTest{
 						Reason: string(gatewayv1.ListenerReasonOverlappingHostnames),
 					},
 				},
-				"foo-https", "bar-https", "wildcard-https",
+				"foo-example-https", "bar-example-https", "wildcard-example-https", "wildcard-other-https", "wildcard-bar-other-https",
 			)
 		})
 		t.Run("Gateway listeners without overlapping hostnames must not have OverlappingTLSConfig condition set", func(t *testing.T) {
 			kubernetes.GatewayListenerMustNotHaveCondition(t, s.Client, s.TimeoutConfig, gwNN, "not-overlapping-https", gatewayv1.ListenerConditionOverlappingTLSConfig)
+			kubernetes.GatewayListenerMustNotHaveCondition(t, s.Client, s.TimeoutConfig, gwNN, "not-overlapping-wildcard-https", gatewayv1.ListenerConditionOverlappingTLSConfig)
 		})
 		t.Run("Gateway listeners with overlapping hostnames on different ports must not have OverlappingTLSConfig condition set", func(t *testing.T) {
 			kubernetes.GatewayListenerMustNotHaveCondition(t, s.Client, s.TimeoutConfig, gwNN, "not-overlapping-other-port", gatewayv1.ListenerConditionOverlappingTLSConfig)

--- a/conformance/tests/gateway-overlapping-tls-config-hostnames.go
+++ b/conformance/tests/gateway-overlapping-tls-config-hostnames.go
@@ -1,0 +1,75 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayOverlappingTLSConfigHostnames)
+}
+
+var GatewayOverlappingTLSConfigHostnames = suite.ConformanceTest{
+	ShortName:   "GatewayOverlappingTLSConfigHostnames",
+	Description: "A Gateway with HTTPS listeners that have overlapping hostnames must have the OverlappingTLSConfig condition set True with reason OverlappingHostnames on the affected listeners.",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+	},
+	Manifests: []string{"tests/gateway-overlapping-tls-config-hostnames.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		gwNN := types.NamespacedName{Name: "gateway-overlapping-hostnames", Namespace: ns}
+
+		kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, []string{ns})
+		kubernetes.GatewayListenersMustHaveConditions(t, s.Client, s.TimeoutConfig, gwNN,
+			[]metav1.Condition{
+				{
+					Type:   string(gatewayv1.ListenerSetConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: string(gatewayv1.ListenerConditionAccepted),
+				},
+			})
+
+		t.Run("Gateway listeners with overlapping hostnames on the same port must have OverlappingTLSConfig condition set", func(t *testing.T) {
+			kubernetes.GatewayListenersMustHaveConditions(t, s.Client, s.TimeoutConfig, gwNN,
+				[]metav1.Condition{
+					{
+						Type:   string(gatewayv1.ListenerConditionOverlappingTLSConfig),
+						Status: metav1.ConditionTrue,
+						Reason: string(gatewayv1.ListenerReasonOverlappingHostnames),
+					},
+				},
+				"foo-https", "bar-https", "wildcard-https",
+			)
+		})
+		t.Run("Gateway listeners without overlapping hostnames must not have OverlappingTLSConfig condition set", func(t *testing.T) {
+			kubernetes.GatewayListenerMustNotHaveCondition(t, s.Client, s.TimeoutConfig, gwNN, "not-overlapping-https", gatewayv1.ListenerConditionOverlappingTLSConfig)
+		})
+		t.Run("Gateway listeners with overlapping hostnames on different ports must not have OverlappingTLSConfig condition set", func(t *testing.T) {
+			kubernetes.GatewayListenerMustNotHaveCondition(t, s.Client, s.TimeoutConfig, gwNN, "not-overlapping-other-port", gatewayv1.ListenerConditionOverlappingTLSConfig)
+		})
+	},
+}

--- a/conformance/tests/gateway-overlapping-tls-config-hostnames.yaml
+++ b/conformance/tests/gateway-overlapping-tls-config-hostnames.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
   listeners:
-    - name: foo-https
+    - name: foo-example-https
       port: 443
       protocol: HTTPS
       hostname: foo.example.com
@@ -19,7 +19,7 @@ spec:
       allowedRoutes:
         namespaces:
           from: Same
-    - name: bar-https
+    - name: bar-example-https
       port: 443
       protocol: HTTPS
       hostname: bar.bar.example.com
@@ -32,10 +32,36 @@ spec:
       allowedRoutes:
         namespaces:
           from: Same
-    - name: wildcard-https
+    - name: wildcard-example-https
       port: 443
       protocol: HTTPS
       hostname: "*.example.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: tls-validity-checks-certificate
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: wildcard-other-https
+      port: 443
+      protocol: HTTPS
+      hostname: "*.other.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: tls-validity-checks-certificate
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: wildcard-bar-other-https
+      port: 443
+      protocol: HTTPS
+      hostname: "*.bar.other.com"
       tls:
         mode: Terminate
         certificateRefs:
@@ -49,6 +75,19 @@ spec:
       port: 443
       protocol: HTTPS
       hostname: "example.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: tls-validity-checks-certificate
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: not-overlapping-wildcard-https
+      port: 443
+      protocol: HTTPS
+      hostname: "*.example.io"
       tls:
         mode: Terminate
         certificateRefs:

--- a/conformance/tests/gateway-overlapping-tls-config-hostnames.yaml
+++ b/conformance/tests/gateway-overlapping-tls-config-hostnames.yaml
@@ -1,0 +1,73 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-overlapping-hostnames
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: foo-https
+      port: 443
+      protocol: HTTPS
+      hostname: foo.example.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: tls-validity-checks-certificate
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: bar-https
+      port: 443
+      protocol: HTTPS
+      hostname: bar.bar.example.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: tls-validity-checks-certificate
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: wildcard-https
+      port: 443
+      protocol: HTTPS
+      hostname: "*.example.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: tls-validity-checks-certificate
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: not-overlapping-https
+      port: 443
+      protocol: HTTPS
+      hostname: "example.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: tls-validity-checks-certificate
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: not-overlapping-other-port
+      port: 9443
+      protocol: HTTPS
+      hostname: foo.example.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: tls-validity-checks-certificate
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -638,6 +638,36 @@ func GatewayListenerMustHaveConditions(t *testing.T, client client.Client, timeo
 	require.NoErrorf(t, waitErr, "error waiting for Gateway status to have conditions matching expectations on listener %s", lName)
 }
 
+// GatewayListenerMustNotHaveCondition checks that the listener of the given name
+// in the given gateway does not have a condition of the specified type.
+func GatewayListenerMustNotHaveCondition(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, gwName types.NamespacedName, lName string, conditionType gatewayv1.ListenerConditionType) {
+	t.Helper()
+
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.GatewayListenersMustHaveConditions, true, func(ctx context.Context) (bool, error) {
+		var gw gatewayv1.Gateway
+		if err := client.Get(ctx, gwName, &gw); err != nil {
+			return false, fmt.Errorf("error fetching Gateway: %w", err)
+		}
+
+		for _, listener := range gw.Status.Listeners {
+			if string(listener.Name) != lName {
+				continue
+			}
+
+			if findConditionInList(t, listener.Conditions, string(conditionType), "", "") {
+				tlog.Logf(t, "Gateway %s does have %s condition on %s listener", gwName, conditionType, listener.Name)
+				return false, nil
+			}
+
+			return true, nil
+		}
+		tlog.Logf(t, "Listener %s not found in Gateway %s Status", lName, gwName)
+		return false, nil
+	})
+
+	require.NoErrorf(t, waitErr, "error waiting for Gateway status to not have conditions matching expectations on listener %s", lName)
+}
+
 // GatewayMustHaveZeroRoutes validates that the gateway has zero routes attached.  The status
 // may indicate a single listener with zero attached routes or no listeners.
 func GatewayMustHaveZeroRoutes(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, gwName types.NamespacedName) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind test
/area conformance-test

**What this PR does / why we need it**:
This PR adds a conformance test verifying that a Gateway with HTTPS listeners whose hostnames overlap have the `OverlappingTLSConfig` condition set to `True` with reason `OverlappingHostnames` on the affected listeners, and does not set it on non-overlapping listeners, as specified in [GEP-3567](https://gateway-api.sigs.k8s.io/geps/gep-3567/).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
