### PR TITLE
stop building arm64 images on preverify jobs

### DIFF
--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -23,8 +23,10 @@ set -o pipefail
 if [[ -z "${VERIFY-}" ]];
 then
   export DOCKER_PUSH_FLAG="--push"
+  export BUILDX_PLATFORMS="linux/amd64,linux/arm64"
 else
   export DOCKER_PUSH_FLAG=""
+  export BUILDX_PLATFORMS="linux/amd64"
 fi
 
 if [[ -z "${GIT_TAG-}" ]];
@@ -71,8 +73,6 @@ then
     BINARY_TAG="${BASE_REF}"
 fi
 
-# Support multi-arch image build and push.
-BUILDX_PLATFORMS="linux/amd64,linux/arm64"
 
 echo "Building and pushing echo-advanced image (from Istio) ...${BUILDX_PLATFORMS}"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR removes arm64 building from pre verify. Building the arm image is one of the steps that takes more time and is more flaky and in fact we don't really need it if we are not publishing the image.

**Which issue(s) this PR fixes**:
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
