### PR TITLE
fix: drop GRPCRoute from supported kinds assertion as the test does not require to support them

### DIFF
--- a/conformance/tests/listenerset-http-routing.go
+++ b/conformance/tests/listenerset-http-routing.go
@@ -293,8 +293,5 @@ func generateSupportedRouteKinds() []gatewayv1.RouteGroupKind {
 	return []gatewayv1.RouteGroupKind{{
 		Group: (*gatewayv1.Group)(&gatewayv1.GroupVersion.Group),
 		Kind:  gatewayv1.Kind("HTTPRoute"),
-	}, {
-		Group: (*gatewayv1.Group)(&gatewayv1.GroupVersion.Group),
-		Kind:  gatewayv1.Kind("GRPCRoute"),
 	}}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind bug
/area conformance-test

**What this PR does / why we need it**:
Implementations that do not support `GRPCRoute` currently cannot pass the `ListenerSetAllowedRoutesNamespaces` and `ListenerSetHTTPRouting` tests, because both assert that `GRPCRoute` is present in SupportedKinds.

There are two ways to address this, either add `GRPCRoute` as a prerequisite feature for these tests, or relax the assertion so it does not require `GRPCRoute` to be present in SupportedKinds.
Since neither test actually uses  `GRPCRoute` functionality, this PR takes the second approach and removes `GRPCRoute` from the SupportedKinds assertion.

This is a blocker and should be backported to 1.5.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
