### PR TITLE
Fix MeshHTTPRoute307Redirect conformance test

### DIFF
--- a/conformance/tests/mesh/httproute-307-redirect.go
+++ b/conformance/tests/mesh/httproute-307-redirect.go
@@ -39,7 +39,7 @@ var MeshHTTPRoute307Redirect = suite.ConformanceTest{
 		features.SupportHTTPRoute,
 		features.SupportHTTPRoute307RedirectStatusCode,
 	},
-	Manifests: []string{"tests/mesh/httproute-303-redirect.yaml"},
+	Manifests: []string{"tests/mesh/httproute-307-redirect.yaml"},
 	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
 		ns := suite.MeshNamespace
 		client := echo.ConnectToApp(t, s, echo.MeshAppEchoV1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
/kind bug
/area conformance-test
-->

**What this PR does / why we need it**:

Changes manifest reference in this test from 303 to 307

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Fixed MeshHTTPRoute307Redirect conformance test bug where the wrong manifest was used.
```
