### PR TITLE
test(conformance): add tests for Gateway listener Accepted condition with UnsupportedProtocol reason

### DIFF
--- a/conformance/tests/gateway-invalid-listeners-unsupported-protocol.go
+++ b/conformance/tests/gateway-invalid-listeners-unsupported-protocol.go
@@ -1,0 +1,107 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GatewayListenerUnsupportedProtocol)
+}
+
+var GatewayListenerUnsupportedProtocol = suite.ConformanceTest{
+	ShortName:   "GatewayListenerUnsupportedProtocol",
+	Description: "A Gateway should set the Accepted condition to False with reason UnsupportedProtocol on listeners whose protocol is not supported. The Gateway itself should only be Accepted if at least one of its listeners is accepted.",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+	},
+	Manifests: []string{"tests/gateway-invalid-listeners-unsupported-protocol.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		t.Run("Gateway with no accepted listeners should not be accepted and the listener should have the Accepted condition set to False with reason UnsupportedProtocol", func(t *testing.T) {
+			t.Parallel()
+
+			gwNN := types.NamespacedName{Name: "gateway-only-unsupported-protocols", Namespace: suite.InfrastructureNamespace}
+
+			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
+			kubernetes.GatewayMustHaveCondition(t, s.Client, s.TimeoutConfig, gwNN, metav1.Condition{
+				Type:   string(gatewayv1.GatewayConditionAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(gatewayv1.GatewayReasonListenersNotValid),
+			})
+
+			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, []gatewayv1.ListenerStatus{
+				{
+					Name:           gatewayv1.SectionName("invalid"),
+					SupportedKinds: []gatewayv1.RouteGroupKind{},
+					Conditions: []metav1.Condition{{
+						Type:   string(gatewayv1.ListenerConditionAccepted),
+						Status: metav1.ConditionFalse,
+						Reason: string(gatewayv1.ListenerReasonUnsupportedProtocol),
+					}},
+					AttachedRoutes: 0,
+				},
+			})
+		})
+		t.Run("Gateway with at least one accepted listeners should be accepted and the listeners should have the Accepted condition set accordingly", func(t *testing.T) {
+			t.Parallel()
+
+			gwNN := types.NamespacedName{Name: "gateway-supported-and-unsupported-protocols", Namespace: suite.InfrastructureNamespace}
+
+			kubernetes.GatewayMustHaveLatestConditions(t, s.Client, s.TimeoutConfig, gwNN)
+			kubernetes.GatewayMustHaveCondition(t, s.Client, s.TimeoutConfig, gwNN, metav1.Condition{
+				Type:   string(gatewayv1.GatewayConditionAccepted),
+				Status: metav1.ConditionTrue,
+				Reason: string(gatewayv1.GatewayReasonListenersNotValid),
+			})
+
+			kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, []gatewayv1.ListenerStatus{
+				{
+					Name: gatewayv1.SectionName("http"),
+					SupportedKinds: []gatewayv1.RouteGroupKind{{
+						Group: (*gatewayv1.Group)(&gatewayv1.GroupVersion.Group),
+						Kind:  gatewayv1.Kind("HTTPRoute"),
+					}},
+					Conditions: []metav1.Condition{{
+						Type:   string(gatewayv1.ListenerConditionAccepted),
+						Status: metav1.ConditionTrue,
+						Reason: string(gatewayv1.ListenerReasonAccepted),
+					}},
+					AttachedRoutes: 0,
+				},
+				{
+					Name:           gatewayv1.SectionName("invalid"),
+					SupportedKinds: []gatewayv1.RouteGroupKind{},
+					Conditions: []metav1.Condition{{
+						Type:   string(gatewayv1.ListenerConditionAccepted),
+						Status: metav1.ConditionFalse,
+						Reason: string(gatewayv1.ListenerReasonUnsupportedProtocol),
+					}},
+					AttachedRoutes: 0,
+				},
+			})
+		})
+	},
+}

--- a/conformance/tests/gateway-invalid-listeners-unsupported-protocol.yaml
+++ b/conformance/tests/gateway-invalid-listeners-unsupported-protocol.yaml
@@ -1,0 +1,28 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-only-unsupported-protocols
+  namespace: gateway-conformance-infra
+  annotations:
+    gateway-api/skip-this-for-readiness: "true"
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: invalid
+      port: 1111
+      protocol: INVALID
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-supported-and-unsupported-protocols
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+    - name: invalid
+      port: 1111
+      protocol: INVALID


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind test
/area conformance-test

**What this PR does / why we need it**:
The `ListenersNotValid` reason for the Gateway `Accepted` condition and the `UnsupportedProtocol` reason for the Listener `Accepted` condition were so far not covered by the conformance tests. This PR adds a test to cover both.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Added a conformance test covering the Gateway `Accepted` condition with reason `ListenersNotValid` and the Listener `Accepted` condition with reason `UnsupportedProtocol`
```
