### PR TITLE
conformance: add GRPCRoute request mirror test (#3514)

### DIFF
--- a/conformance/echo-basic/grpc/grpc.go
+++ b/conformance/echo-basic/grpc/grpc.go
@@ -80,6 +80,7 @@ func (s *echoServer) doEcho(methodName string, ctx context.Context, in *pb.EchoR
 		connectionType = "TLS"
 	}
 	fmt.Printf("Received over %s: %v\n", connectionType, in)
+	fmt.Printf("Echoing back gRPC request made to %s to client\n", s.fullMethod(methodName))
 	mdElems, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		msg := "failed to retrieve metadata from incoming request"

--- a/conformance/tests/grpcroute-request-mirror.go
+++ b/conformance/tests/grpcroute-request-mirror.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	pb "sigs.k8s.io/gateway-api/conformance/echo-basic/grpcechoserver"
+	"sigs.k8s.io/gateway-api/conformance/utils/grpc"
+	httputil "sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GRPCRouteRequestMirror)
+}
+
+var GRPCRouteRequestMirror = confsuite.ConformanceTest{
+	ShortName:   "GRPCRouteRequestMirror",
+	Description: "A GRPCRoute with request mirror filter",
+	Manifests:   []string{"tests/grpcroute-request-mirror.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportGRPCRoute,
+		features.SupportGRPCRouteRequestMirror,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "grpc-request-mirror", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &v1.GRPCRoute{}, true, routeNN)
+
+		testCases := []grpc.ExpectedResponse{
+			{
+				EchoRequest: &pb.EchoRequest{},
+				Response:    grpc.Response{Code: codes.OK},
+				Backend:     "grpc-infra-backend-v1",
+				Namespace:   ns,
+				TestCaseName: "Request mirrored to second backend",
+			},
+		}
+
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				grpc.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.GRPCClient, suite.TimeoutConfig, gwAddr, tc)
+				grpc.ExpectMirroredRequest(t, suite.Client, suite.Clientset, []httputil.MirroredBackend{
+					{
+						BackendRef: httputil.BackendRef{
+							Name:      "grpc-infra-backend-v2",
+							Namespace: ns,
+						},
+					},
+				}, tc, suite.TimeoutConfig)
+			})
+		}
+	},
+}

--- a/conformance/tests/grpcroute-request-mirror.yaml
+++ b/conformance/tests/grpcroute-request-mirror.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: grpc-request-mirror
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: grpc-infra-backend-v1
+      port: 8080
+    filters:
+    - type: RequestMirror
+      requestMirror:
+        backendRef:
+          name: grpc-infra-backend-v2
+          namespace: gateway-conformance-infra
+          port: 8080

--- a/conformance/utils/grpc/mirror.go
+++ b/conformance/utils/grpc/mirror.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"fmt"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	clientset "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/config"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
+)
+
+// ExpectMirroredRequest verifies that gRPC requests for the given ExpectedResponse
+// were mirrored to each backend in mirrorPods, by scanning pod logs for the echo
+// server's log line emitted on every received request.
+func ExpectMirroredRequest(t *testing.T, c client.Client, cs clientset.Interface, mirrorPods []http.MirroredBackend, expected ExpectedResponse, timeoutConfig config.TimeoutConfig) {
+	t.Helper()
+	for i, mirrorPod := range mirrorPods {
+		if mirrorPod.Name == "" {
+			tlog.Fatalf(t, "Mirrored BackendRef[%d].Name wasn't provided in the testcase, this test should only check gRPC request mirror.", i)
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(mirrorPods))
+
+	assertionStart := time.Now()
+	method := getFullyQualifiedMethod(&expected)
+
+	for _, mirrorPod := range mirrorPods {
+		go func(mirrorPod http.MirroredBackend) {
+			defer wg.Done()
+
+			require.Eventually(t, func() bool {
+				mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back gRPC request made to \\%s to client", method))
+
+				tlog.Log(t, "Searching for the mirrored gRPC request log")
+				tlog.Logf(t, `Reading "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name)
+				logs, err := kubernetes.DumpEchoLogs(t.Context(), mirrorPod.Namespace, mirrorPod.Name, c, cs, assertionStart)
+				if err != nil {
+					tlog.Logf(t, `Couldn't read "%s/%s" logs: %v`, mirrorPod.Namespace, mirrorPod.Name, err)
+					return false
+				}
+
+				for _, log := range logs {
+					if mirrorLogRegexp.MatchString(log) {
+						return true
+					}
+				}
+				return false
+			}, timeoutConfig.RequestTimeout, time.Second, `Couldn't find mirrored gRPC request in "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name)
+		}(mirrorPod)
+	}
+
+	wg.Wait()
+
+	tlog.Log(t, "Found mirrored gRPC request log in all desired backends")
+}

--- a/pkg/features/grpcroute.go
+++ b/pkg/features/grpcroute.go
@@ -49,6 +49,9 @@ const (
 
 	// This option indicates support for RequestHeaderModifier filter in GRPCRoute (extended conformance)
 	SupportGRPCRouteRequestHeaderModifier FeatureName = "GRPCRouteRequestHeaderModifier"
+
+	// This option indicates support for GRPCRoute request mirror (extended conformance).
+	SupportGRPCRouteRequestMirror FeatureName = "GRPCRouteRequestMirror"
 )
 
 // GRPCRouteNamedRouteRule contains metadata for the SupportGRPCRouteNamedRouteRule feature.
@@ -63,10 +66,17 @@ var GRPCRouteRequestHeaderModifier = Feature{
 	Channel: FeatureChannelStandard,
 }
 
+// GRPCRouteRequestMirrorFeature contains metadata for the SupportGRPCRouteRequestMirror feature.
+var GRPCRouteRequestMirrorFeature = Feature{
+	Name:    SupportGRPCRouteRequestMirror,
+	Channel: FeatureChannelStandard,
+}
+
 // GRPCRouteExtendedFeatures includes all extended features for GRPCRoute
 // conformance and can be used to opt-in to run all GRPCRoute extended features tests.
 // This does not include any Core Features.
 var GRPCRouteExtendedFeatures = sets.New(
 	GRPCRouteNamedRouteRule,
 	GRPCRouteRequestHeaderModifier,
+	GRPCRouteRequestMirrorFeature,
 )


### PR DESCRIPTION
GRPCRoute already supports the `RequestMirror` filter (Extended conformance,                                                                             `apis/v1/grpcroute_types.go`), but there were no conformance tests to verify implementations support it correctly.                                                                                                                       
                                                                                                                                                              
  This PR adds end-to-end conformance coverage by:                                                                                                            
  - Adding `SupportGRPCRouteRequestMirror` (`GRPCRouteRequestMirror`) as a new                                                                                
    Extended feature in `pkg/features/grpcroute.go`, following the GEP-2162                                                                                   
    naming convention.                                                                                                                                        
  - Adding `conformance/utils/grpc/mirror.go` with `ExpectMirroredRequest`, which                                                                             
    reads mirror backend pod logs and matches the fully qualified gRPC method                                                                                 
    name — the same approach used by `http.ExpectMirroredRequest`.                                                                                            
  - Adding `conformance/tests/grpcroute-request-mirror.{go,yaml}`: a GRPCRoute                                                                                
    that routes `Echo` requests to `grpc-infra-backend-v1` and mirrors them to                                                                                
    `grpc-infra-backend-v2`.                                                                                                                                  
  - Patching the gRPC echo server (`conformance/echo-basic/grpc/grpc.go`) to log                                                                              
    the fully qualified method name on each received request                                                                                                  
    (`"Echoing back gRPC request made to <method> to client"`), enabling
    log-based mirror verification.                                                                                                                            
                                                            
  **Which issue(s) this PR fixes**:                                                                                                                           
                                                            
  Fixes #3514                                                                                                                                                 
                                                            
  **Does this PR introduce a user-facing change?**:

  ```release-note                                                                                                                                             
  Added GRPCRouteRequestMirror conformance test. Implementations that support
  the RequestMirror filter on GRPCRoute can now declare                                                                                                       
  SupportGRPCRouteRequestMirror as a supported feature.
  ``` 
                                                             