### PR TITLE
gep/api/test: refine ListenerSet status semantics and add Conflicted reason

### DIFF
--- a/apis/v1/listenerset_types.go
+++ b/apis/v1/listenerset_types.go
@@ -321,9 +321,9 @@ const (
 	//
 	// Possible reasons for this condition to be False are:
 	//
+	// * "Pending"
 	// * "Invalid"
 	// * "ParentNotProgrammed"
-	// * "ListenersNotValid"
 	//
 	// Additional reasons for this condition to be False are influenced by
 	// child ListenerEntry conditions:
@@ -353,6 +353,7 @@ const (
 	// Possible reasons for this condition to be True are:
 	//
 	// * "Accepted"
+	// * "ListenersNotValid"
 	//
 	// Possible reasons for this condition to be False are:
 	//
@@ -478,6 +479,7 @@ const (
 	// * "PortUnavailable"
 	// * "UnsupportedProtocol"
 	// * "TooManyListeners"
+	// * "Conflicted"
 	//
 	// Possible reasons for this condition to be Unknown are:
 	//
@@ -491,6 +493,11 @@ const (
 	// This reason is used with the "Accepted" condition when the condition is
 	// True.
 	ListenerEntryReasonAccepted ListenerEntryConditionReason = "Accepted"
+
+	// This reason is used with the "Accepted" condition when the
+	// Listener could not be attached to the Gateway because it conflicts
+	// with another listener.
+	ListenerEntryReasonConflicted ListenerEntryConditionReason = "Conflicted"
 
 	// This reason is used with the "Accepted" condition when the
 	// Listener could not be attached to the Gateway because its

--- a/conformance/tests/listenerset-allowed-namespace-none.go
+++ b/conformance/tests/listenerset-allowed-namespace-none.go
@@ -66,7 +66,7 @@ var ListenerSetAllowedNamespaceNone = confsuite.ConformanceTest{
 		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, disallowedLsNN, metav1.Condition{
 			Type:   string(gatewayv1.ListenerSetConditionProgrammed),
 			Status: metav1.ConditionFalse,
-			Reason: string(gatewayv1.ListenerSetReasonNotAllowed),
+			Reason: "", // any reason
 		})
 	},
 }

--- a/conformance/tests/listenerset-allowed-namespace-same.go
+++ b/conformance/tests/listenerset-allowed-namespace-same.go
@@ -82,7 +82,7 @@ var ListenerSetAllowedNamespaceSame = confsuite.ConformanceTest{
 		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, disallowedLsNN, metav1.Condition{
 			Type:   string(gatewayv1.ListenerSetConditionProgrammed),
 			Status: metav1.ConditionFalse,
-			Reason: string(gatewayv1.ListenerSetReasonNotAllowed),
+			Reason: "", // any reason
 		})
 	},
 }
@@ -90,19 +90,19 @@ var ListenerSetAllowedNamespaceSame = confsuite.ConformanceTest{
 func generateAcceptedListenerConditions() []metav1.Condition {
 	return []metav1.Condition{
 		{
-			Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+			Type:   string(gatewayv1.ListenerEntryConditionResolvedRefs),
 			Status: metav1.ConditionTrue,
-			Reason: "", // any reason
+			Reason: string(gatewayv1.ListenerEntryReasonResolvedRefs),
 		},
 		{
-			Type:   string(gatewayv1.ListenerConditionAccepted),
+			Type:   string(gatewayv1.ListenerEntryConditionAccepted),
 			Status: metav1.ConditionTrue,
-			Reason: "", // any reason
+			Reason: string(gatewayv1.ListenerEntryReasonAccepted),
 		},
 		{
-			Type:   string(gatewayv1.ListenerConditionProgrammed),
+			Type:   string(gatewayv1.ListenerEntryConditionProgrammed),
 			Status: metav1.ConditionTrue,
-			Reason: "", // any reason
+			Reason: string(gatewayv1.ListenerEntryReasonProgrammed),
 		},
 	}
 }

--- a/conformance/tests/listenerset-allowed-namespace-selector.go
+++ b/conformance/tests/listenerset-allowed-namespace-selector.go
@@ -82,7 +82,7 @@ var ListenerSetAllowedNamespaceSelector = confsuite.ConformanceTest{
 		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, disallowedLsNN, metav1.Condition{
 			Type:   string(gatewayv1.ListenerSetConditionProgrammed),
 			Status: metav1.ConditionFalse,
-			Reason: string(gatewayv1.ListenerSetReasonNotAllowed),
+			Reason: "", // any reason
 		})
 	},
 }

--- a/conformance/tests/listenerset-hostname-conflict.go
+++ b/conformance/tests/listenerset-hostname-conflict.go
@@ -48,19 +48,19 @@ var ListenerSetHostnameConflict = confsuite.ConformanceTest{
 
 		hostnameConflictedListenerConditions := []metav1.Condition{
 			{
-				Type:   string(gatewayv1.ListenerConditionAccepted),
+				Type:   string(gatewayv1.ListenerEntryConditionAccepted),
 				Status: metav1.ConditionFalse,
-				Reason: string(gatewayv1.ListenerReasonHostnameConflict),
+				Reason: string(gatewayv1.ListenerEntryReasonConflicted),
 			},
 			{
-				Type:   string(gatewayv1.ListenerConditionProgrammed),
+				Type:   string(gatewayv1.ListenerEntryConditionProgrammed),
 				Status: metav1.ConditionFalse,
-				Reason: string(gatewayv1.ListenerReasonHostnameConflict),
+				Reason: "", // any reason
 			},
 			{
-				Type:   string(gatewayv1.ListenerConditionConflicted),
+				Type:   string(gatewayv1.ListenerEntryConditionConflicted),
 				Status: metav1.ConditionTrue,
-				Reason: string(gatewayv1.ListenerReasonHostnameConflict),
+				Reason: string(gatewayv1.ListenerEntryReasonHostnameConflict),
 			},
 		}
 
@@ -109,7 +109,7 @@ var ListenerSetHostnameConflict = confsuite.ConformanceTest{
 		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, lsNN, metav1.Condition{
 			Type:   string(gatewayv1.ListenerSetConditionProgrammed),
 			Status: metav1.ConditionFalse,
-			Reason: string(gatewayv1.ListenerSetReasonListenersNotValid),
+			Reason: "", // any reason
 		})
 		// The conflicted listener should not be accepted
 		kubernetes.ListenerSetListenersMustHaveConditions(t, suite.Client, suite.TimeoutConfig, lsNN, hostnameConflictedListenerConditions, "hostname-conflict-with-gateway-listener")
@@ -119,7 +119,7 @@ var ListenerSetHostnameConflict = confsuite.ConformanceTest{
 		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, lsNN, metav1.Condition{
 			Type:   string(gatewayv1.ListenerSetConditionAccepted),
 			Status: metav1.ConditionTrue,
-			Reason: "", // any reason
+			Reason: string(gatewayv1.ListenerSetReasonListenersNotValid),
 		})
 		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, lsNN, metav1.Condition{
 			Type:   string(gatewayv1.ListenerSetConditionProgrammed),
@@ -140,7 +140,7 @@ var ListenerSetHostnameConflict = confsuite.ConformanceTest{
 		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, lsNN, metav1.Condition{
 			Type:   string(gatewayv1.ListenerSetConditionProgrammed),
 			Status: metav1.ConditionFalse,
-			Reason: string(gatewayv1.ListenerSetReasonListenersNotValid),
+			Reason: "", // any reason
 		})
 		// The conflicted listener should not be accepted
 		kubernetes.ListenerSetListenersMustHaveConditions(t, suite.Client, suite.TimeoutConfig, lsNN, hostnameConflictedListenerConditions, "hostname-conflict-with-listener-set-listener")

--- a/conformance/tests/listenerset-parent-not-accepted.go
+++ b/conformance/tests/listenerset-parent-not-accepted.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,41 +29,37 @@ import (
 )
 
 func init() {
-	ConformanceTests = append(ConformanceTests, ListenerSetDefaultNotAllowed)
+	ConformanceTests = append(ConformanceTests, ListenerSetParentNotAccepted)
 }
 
-var ListenerSetDefaultNotAllowed = confsuite.ConformanceTest{
-	ShortName:   "ListenerSetDefaultNotAllowed",
-	Description: "Listener Sets are not allowed on the Gateway by default (i.e. when `allowedListeners` is not set)",
+var ListenerSetParentNotAccepted = confsuite.ConformanceTest{
+	ShortName:   "ListenerSetParentNotAccepted",
+	Description: "A ListenerSet attached to a Gateway that is not Accepted should have the Accepted condition set to False with reason ParentNotAccepted.",
 	Features: []features.FeatureName{
 		features.SupportGateway,
 		features.SupportListenerSet,
 	},
 	Manifests: []string{
-		"tests/listenerset-default-not-allowed.yaml",
+		"tests/listenerset-parent-not-accepted.yaml",
 	},
 	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
 		ns := confsuite.InfrastructureNamespace
 		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
 
-		// Verify the gateway is accepted
-		gwNN := types.NamespacedName{Name: "gateway-default-does-not-allow-listenerset", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "gateway-with-listenerset-not-accepted", Namespace: ns}
 		kubernetes.GatewayMustHaveCondition(t, suite.Client, suite.TimeoutConfig, gwNN, metav1.Condition{
 			Type:   string(gatewayv1.GatewayConditionAccepted),
-			Status: metav1.ConditionTrue,
+			Status: metav1.ConditionFalse,
 		})
-		// Rejected ListenerSets :
-		// - gateway-conformance-infra/listenerset-not-allowed - the gateway is not configured to allow listenerSets
 		kubernetes.GatewayMustHaveAttachedListeners(t, suite.Client, suite.TimeoutConfig, gwNN, 0)
 
-		// Verify the rejected listenerSet has the appropriate conditions
-		disallowedLsNN := types.NamespacedName{Name: "listenerset-default-not-allowed", Namespace: ns}
-		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, disallowedLsNN, metav1.Condition{
+		lsNN := types.NamespacedName{Name: "listenerset-parent-not-accepted", Namespace: ns}
+		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, lsNN, metav1.Condition{
 			Type:   string(gatewayv1.ListenerSetConditionAccepted),
 			Status: metav1.ConditionFalse,
-			Reason: string(gatewayv1.ListenerSetReasonNotAllowed),
+			Reason: string(gatewayv1.ListenerSetReasonParentNotAccepted),
 		})
-		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, disallowedLsNN, metav1.Condition{
+		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, lsNN, metav1.Condition{
 			Type:   string(gatewayv1.ListenerSetConditionProgrammed),
 			Status: metav1.ConditionFalse,
 			Reason: "", // any reason

--- a/conformance/tests/listenerset-parent-not-accepted.yaml
+++ b/conformance/tests/listenerset-parent-not-accepted.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-with-listenerset-not-accepted
+  namespace: gateway-conformance-infra
+  annotations:
+    gateway-api/skip-this-for-readiness: "true"
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+  allowedListeners:
+    namespaces:
+      from: Same
+  infrastructure:
+    parametersRef:
+      group: invalid.io
+      kind: InvalidParameters
+      name: invalid
+---
+# This listenerSet should not be accepted since the Gateway is not accepted
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: listenerset-parent-not-accepted
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    kind: Gateway
+    group: gateway.networking.k8s.io
+    name: gateway-with-listenerset-not-accepted
+  listeners:
+    - name: http
+      port: 8080
+      protocol: HTTP

--- a/conformance/tests/listenerset-protocol-conflict.go
+++ b/conformance/tests/listenerset-protocol-conflict.go
@@ -38,6 +38,7 @@ var ListenerSetProtocolConflict = confsuite.ConformanceTest{
 	Features: []features.FeatureName{
 		features.SupportGateway,
 		features.SupportListenerSet,
+		features.SupportTCPRoute,
 	},
 	Manifests: []string{
 		"tests/listenerset-protocol-conflict.yaml",
@@ -48,19 +49,19 @@ var ListenerSetProtocolConflict = confsuite.ConformanceTest{
 
 		protocolConflictedListenerConditions := []metav1.Condition{
 			{
-				Type:   string(gatewayv1.ListenerConditionAccepted),
+				Type:   string(gatewayv1.ListenerEntryConditionAccepted),
 				Status: metav1.ConditionFalse,
-				Reason: string(gatewayv1.ListenerReasonProtocolConflict),
+				Reason: string(gatewayv1.ListenerEntryReasonConflicted),
 			},
 			{
-				Type:   string(gatewayv1.ListenerConditionProgrammed),
+				Type:   string(gatewayv1.ListenerEntryConditionProgrammed),
 				Status: metav1.ConditionFalse,
-				Reason: string(gatewayv1.ListenerReasonProtocolConflict),
+				Reason: "", // any reason
 			},
 			{
-				Type:   string(gatewayv1.ListenerConditionConflicted),
+				Type:   string(gatewayv1.ListenerEntryConditionConflicted),
 				Status: metav1.ConditionTrue,
-				Reason: string(gatewayv1.ListenerReasonProtocolConflict),
+				Reason: string(gatewayv1.ListenerEntryReasonProtocolConflict),
 			},
 		}
 
@@ -110,7 +111,7 @@ var ListenerSetProtocolConflict = confsuite.ConformanceTest{
 		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, lsNN, metav1.Condition{
 			Type:   string(gatewayv1.ListenerSetConditionProgrammed),
 			Status: metav1.ConditionFalse,
-			Reason: string(gatewayv1.ListenerSetReasonListenersNotValid),
+			Reason: "", // any reason
 		})
 		// The conflicted listener should not be accepted
 		kubernetes.ListenerSetListenersMustHaveConditions(t, suite.Client, suite.TimeoutConfig, lsNN, protocolConflictedListenerConditions, "protocol-conflict-with-gateway-listener")
@@ -141,7 +142,7 @@ var ListenerSetProtocolConflict = confsuite.ConformanceTest{
 		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, lsNN, metav1.Condition{
 			Type:   string(gatewayv1.ListenerSetConditionProgrammed),
 			Status: metav1.ConditionFalse,
-			Reason: string(gatewayv1.ListenerSetReasonListenersNotValid),
+			Reason: "", // any reason
 		})
 		// The conflicted listener should not be accepted
 		kubernetes.ListenerSetListenersMustHaveConditions(t, suite.Client, suite.TimeoutConfig, lsNN, protocolConflictedListenerConditions, "protocol-conflict-with-listener-set-listener")

--- a/conformance/tests/listenerset-reference-grant.go
+++ b/conformance/tests/listenerset-reference-grant.go
@@ -58,14 +58,14 @@ var ListenerSetReferenceGrant = confsuite.ConformanceTest{
 		// kubernetes.GatewayMustHaveAttachedListeners(t, suite.Client, suite.TimeoutConfig, gwNN, 1)
 
 		refPermittedCondition := []metav1.Condition{{
-			Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+			Type:   string(gatewayv1.ListenerEntryConditionResolvedRefs),
 			Status: metav1.ConditionTrue,
-			Reason: "", // any reason
+			Reason: string(gatewayv1.ListenerEntryReasonResolvedRefs),
 		}}
 		refNotPermittedCondition := []metav1.Condition{{
-			Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+			Type:   string(gatewayv1.ListenerEntryConditionResolvedRefs),
 			Status: metav1.ConditionFalse,
-			Reason: string(gatewayv1.ListenerReasonRefNotPermitted),
+			Reason: string(gatewayv1.ListenerEntryReasonRefNotPermitted),
 		}}
 
 		// listenerset-with-reference-grant is accepted with the appropriate conditions
@@ -73,12 +73,12 @@ var ListenerSetReferenceGrant = confsuite.ConformanceTest{
 		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, lsNN, metav1.Condition{
 			Type:   string(gatewayv1.ListenerSetConditionAccepted),
 			Status: metav1.ConditionTrue,
-			Reason: "", // any reason
+			Reason: string(gatewayv1.ListenerSetReasonAccepted),
 		})
 		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, lsNN, metav1.Condition{
 			Type:   string(gatewayv1.ListenerSetConditionProgrammed),
 			Status: metav1.ConditionTrue,
-			Reason: "", // any reason
+			Reason: string(gatewayv1.ListenerSetReasonProgrammed),
 		})
 		kubernetes.ListenerSetListenersMustHaveConditions(t, suite.Client, suite.TimeoutConfig, lsNN, refPermittedCondition, "listenerset-with-reference-grant-listener")
 
@@ -92,7 +92,7 @@ var ListenerSetReferenceGrant = confsuite.ConformanceTest{
 		kubernetes.ListenerSetMustHaveCondition(t, suite.Client, suite.TimeoutConfig, lsNN, metav1.Condition{
 			Type:   string(gatewayv1.ListenerSetConditionProgrammed),
 			Status: metav1.ConditionFalse,
-			Reason: string(gatewayv1.ListenerSetReasonListenersNotValid),
+			Reason: "", // any reason
 		})
 		kubernetes.ListenerSetListenersMustHaveConditions(t, suite.Client, suite.TimeoutConfig, lsNN, refNotPermittedCondition, "listenerset-without-reference-grant-listener")
 	},

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -909,6 +909,12 @@ status:
 
 `Gateway`'s `Accepted` and `Programmed` top-level conditions remain unchanged and reflect the status of the local configuration.
 
+When a `Gateway` has no valid listeners of its own, it would normally have the `Accepted` condition set to `False` with reason `ListenersNotValid`.
+In this case, if an attached `ListenerSet` contributes a valid listener, the Gateway becomes accepted, but the reason `ListenersNotValid` remains to indicate that the `Gateway` listeners are still not valid.
+
+This behavior also anticipates a potential future enhancement where listeners on the `Gateway` itself become optional.
+In that case, a similar pattern would apply, a `Gateway` with no listeners of its own would be treated equivalently to a `Gateway` whose own listeners are all invalid, relying on attached `ListenerSets` to become Accepted.
+
 ### ListenerSet Conditions
 
 `ListenerSets` have top-level `Accepted` and `Programmed` conditions.
@@ -918,10 +924,11 @@ The `Accepted` condition MUST be set on every `ListenerSet`, and indicates that 
 Valid reasons for `Accepted` being `False` are:
 
 - `NotAllowed` — the `parentRef` does not allow attachment
-- `ParentNotAccepted` — the `parentRef` is not accepted (e.g. invalid address)
+- `ParentNotAccepted` — the `parentRef` is not accepted for reasons other than `ListenersNotValid` (e.g., invalid address, invalid parameters ref)
 - `ListenersNotValid` — one or more listeners in the set are invalid (or using an unsupported feature)
 
 The `Programmed` condition MUST be set on every `ListenerSet` and has a similar meaning to the Gateway `Programmed` condition, but only reflects the listeners in that `ListenerSet`.
+In case the `ListenerSet` is not accepted, the `Programmed` condition MUST be set to `False` with an appropriate reason.
 
 `Accepted` and `Programmed` conditions, when surfacing details about listeners, MUST only summarize the `status.listeners` conditions that are exclusive to the `ListenerSet`.
 An exception to this is when the parent `Gateway`'s `Accepted` or `Programmed` conditions transition to `False`.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind cleanup

**What this PR does / why we need it**:
This PR implements the suggestions I made in https://github.com/kubernetes-sigs/gateway-api/pull/4692#issuecomment-4350564459. I decided to bundle the GEP updates, the API changes, and the conformance test changes into a single PR. The main reason is to make the effects of the GEP changes more visible and tangible.

Summary of the GEP changes:
- The `Programmed` condition MUST be set to `False` with an appropriate reason when the `Accepted` condition is set to `False`.
- The `Accepted` condition has a new reason `Conflicted`, which MUST be set when the `Conflicted` condition is set to `True`.
- Clarified the semantics of the `ParentNotAccepted` reason, as well as the effect of a ListenerSet on Gateway acceptance.

Disclaimer: This PR reflects how I would personally resolve the current situation. I'm looking for feedback and happy to adapt it accordingly, my main goal is to create a concrete basis for a more detailed, less high-level discussion.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4760

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
TODO
```
