### PR TITLE
fix: add `j2_line_comment_prefix` back to mkdocs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,7 @@ plugins:
   - awesome-pages
   - macros:
       include_dir: examples
-
+      j2_line_comment_prefix: "#$"
       module_name: hack/mkdocs_main
   - redirects:
       redirect_maps:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind bug
/kind regression

**What this PR does / why we need it**:
The PR https://github.com/kubernetes-sigs/gateway-api/pull/3999#pullrequestreview-4216137107 caused a site regression that prevents reference headers in YAML files from being hidden.

<img width="913" height="490" alt="image" src="https://github.com/user-attachments/assets/d9178094-c34a-4e25-b5e6-b871240e1290" />

Src: https://deploy-preview-3999--kubernetes-sigs-gateway-api.netlify.app/api-types/httproute/

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```

**Root Cause Analysis (RCA)**:

Since this issue has already been causing problems on live pages **since April 30**, I’m putting it here instead of continuing the solution discussion in Slack.

This issue was caused by a false positive warning that misled the developer into removing this line:
```bash
WARNING -  Config value 'plugins': Plugin 'macros' option 'j2_line_comment_prefix': Unrecognised configuration name: j2_line_comment_prefix
```

However, `j2_line_comment_prefix` is being used since 2022 and cause no problem: https://github.com/kubernetes-sigs/gateway-api/commit/9d9a10f4378152e00effd0eefb1803166ff5581a

After further digging into the issue, I found that this warning should be categorized as an **upstream issue**. Details here: https://github.com/fralau/mkdocs-macros-plugin/issues/288

**Solution**:
So, two solutions:
1. Use `j2_comment_start_string` and `j2_comment_end_string` instead, as they are being listed as plugin's recognized parameters: https://github.com/fralau/mkdocs-macros-plugin/blob/0536f4da1dc643e1fa1f0cc90e71512ada67dc04/mkdocs_macros/plugin.py#L145-L146
2. Since this should be intended behaviour as upstream project document says, submit issue to upstream to fix (fix is merged in upstream, pending on version release), and we continue using `j2_line_comment_prefix`. (simple revert)

Solution 1 is to simply avoid emitting the warning. Solution 2 is to keep the original approach, which has been in place for four years.

I put solution 2 here. When upstream releases a new version with the fix, @dependabot should be able to update the dependency automatically (so the relative warning will no longer be emitted). If SIG Gateway API decides to use `j2_comment_start_string` and `j2_comment_end_string`, then I can update the config accordingly in this PR.

For now, issue fixed as shown: 
<img width="914" height="525" alt="image" src="https://github.com/user-attachments/assets/cb49f09d-f278-4108-b701-e4408cb8aac7" />
Src: https://deploy-preview-4822--kubernetes-sigs-gateway-api.netlify.app/api-types/httproute/
