### PR TITLE
conformance: add BackendRef URLRewrite and RequestRedirect tests

### DIFF
--- a/conformance/tests/httproute-backend-request-redirect.go
+++ b/conformance/tests/httproute-backend-request-redirect.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/conformance/tests/httproute-backend-request-redirect.go
+++ b/conformance/tests/httproute-backend-request-redirect.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteBackendRequestRedirect)
+}
+
+var HTTPRouteBackendRequestRedirect = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteBackendRequestRedirect",
+	Description: "An HTTPRoute with RequestRedirect filter applied at the BackendRef level",
+	Manifests:   []string{"tests/httproute-backend-request-redirect.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteBackendRequestRedirect,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "backend-request-redirect", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Path:             "/full/original",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Path: "/redirected-full",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path:             "/prefix/original",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Path: "/redirected-prefix/original",
+				},
+				Namespace: ns,
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-backend-request-redirect.yaml
+++ b/conformance/tests/httproute-backend-request-redirect.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-request-redirect
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /full
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          path:
+            type: ReplaceFullPath
+            replaceFullPath: /redirected-full
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /prefix
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /redirected-prefix

--- a/conformance/tests/httproute-backend-url-rewrite.go
+++ b/conformance/tests/httproute-backend-url-rewrite.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/conformance/tests/httproute-backend-url-rewrite.go
+++ b/conformance/tests/httproute-backend-url-rewrite.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteBackendURLRewrite)
+}
+
+var HTTPRouteBackendURLRewrite = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteBackendURLRewrite",
+	Description: "An HTTPRoute with URLRewrite filter applied at the BackendRef level",
+	Manifests:   []string{"tests/httproute-backend-url-rewrite.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteBackendURLRewrite,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "backend-url-rewrite", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Path: "/full/original",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/rewritten-full",
+					},
+				},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path: "/prefix/original",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/rewritten-prefix/original",
+					},
+				},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-backend-url-rewrite.yaml
+++ b/conformance/tests/httproute-backend-url-rewrite.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-url-rewrite
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /full
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplaceFullPath
+            replaceFullPath: /rewritten-full
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /prefix
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /rewritten-prefix

--- a/pkg/features/httproute.go
+++ b/pkg/features/httproute.go
@@ -120,6 +120,12 @@ const (
 
 	// This option indicates support for HTTPRoute retry on connection error (extended conformance)
 	SupportHTTPRouteRetryConnectionError FeatureName = "HTTPRouteRetryConnectionError"
+
+	// This option indicates support for URLRewrite filter on HTTPRoute BackendRef (extended conformance).
+	SupportHTTPRouteBackendURLRewrite FeatureName = "HTTPRouteBackendURLRewrite"
+
+	// This option indicates support for RequestRedirect filter on HTTPRoute BackendRef (extended conformance).
+	SupportHTTPRouteBackendRequestRedirect FeatureName = "HTTPRouteBackendRequestRedirect"
 )
 
 var (
@@ -253,6 +259,16 @@ var (
 		Name:    SupportHTTPRouteRetryConnectionError,
 		Channel: FeatureChannelExperimental,
 	}
+	// HTTPRouteBackendURLRewriteFeature contains metadata for the HTTPRouteBackendURLRewrite feature.
+	HTTPRouteBackendURLRewriteFeature = Feature{
+		Name:    SupportHTTPRouteBackendURLRewrite,
+		Channel: FeatureChannelStandard,
+	}
+	// HTTPRouteBackendRequestRedirectFeature contains metadata for the HTTPRouteBackendRequestRedirect feature.
+	HTTPRouteBackendRequestRedirectFeature = Feature{
+		Name:    SupportHTTPRouteBackendRequestRedirect,
+		Channel: FeatureChannelStandard,
+	}
 )
 
 // HTTPRouteExtendedFeatures includes all extended features for HTTPRoute
@@ -285,4 +301,6 @@ var HTTPRouteExtendedFeatures = sets.New(
 	HTTPRouteRetryFeature,
 	HTTPRouteRetryBackendTimeoutFeature,
 	HTTPRouteRetryConnectionErrorFeature,
+	HTTPRouteBackendURLRewriteFeature,
+	HTTPRouteBackendRequestRedirectFeature,
 )


### PR DESCRIPTION
## Summary

- Add `SupportHTTPRouteBackendURLRewrite` feature constant and conformance test for URLRewrite filter on `HTTPBackendRef` (fixes #2937)
- Add `SupportHTTPRouteBackendRequestRedirect` feature constant and conformance test for RequestRedirect filter on `HTTPBackendRef` (fixes #2936)
- Tests cover `ReplaceFullPath` and `ReplacePrefixMatch` for each filter type applied via `backendRef.filters` (not rule-level)

## Motivation

Issues #2937 and #2936 identified missing conformance tests for `URLRewrite` and `RequestRedirect` filters at the `HTTPBackendRef` level. Rule-level redirect is already tested, but BackendRef-level filters are structurally different and require their own test coverage.

## Changes

- `pkg/features/httproute.go`: two new `Extended` features + entries in `HTTPRouteExtendedFeatures`
- `conformance/tests/httproute-backend-url-rewrite.{go,yaml}`: new test pair
- `conformance/tests/httproute-backend-request-redirect.{go,yaml}`: new test pair

```release-note
Add conformance tests for URLRewrite and RequestRedirect filters at HTTPBackendRef level (HTTPRouteBackendURLRewrite, HTTPRouteBackendRequestRedirect extended features)
```