### PR TITLE
Add Ciilum conformance report for v1.5.1

### DIFF
--- a/conformance/reports/v1.5/cilium/README.md
+++ b/conformance/reports/v1.5/cilium/README.md
@@ -1,0 +1,30 @@
+# Cilium
+
+## Table of Contents
+
+| API channel  | Implementation version                    | Mode    | Report                                                 |
+|--------------|-------------------------------------------|---------|--------------------------------------------------------|
+| experimental | [main](https://github.com/cilium/cilium/) | default | [v1.20.0-pre.2 report](./experimental-v1.20.0-pre.2-default-report.yaml) |
+
+## Reproduce
+
+Cilium conformance tests can be reproduced by the following steps from within the [Cilium repo](https://github.com/cilium/cilium).
+
+1. Build a Kind cluster, and ensure Cilium is working. Cilium will install the checked-out version from the Cilium repo for you if you use the make target:
+
+```sh
+WAIT_DURATION=120s make kind-servicemesh-install-cilium-fast
+```
+(The WAIT_DURATION is there because pulling the images and building all the BPF code can take a while the first time.)
+
+2. Run the conformance tests using the make target:
+
+```sh
+make gateway-api-conformance
+```
+
+This will run the conformance test using the currently-configured kubeconfig - so it will also work against a non-Kind cluster,
+as long as the cluster has:
+
+* Cilium installed with Gateway API enabled
+* Loadbalancer Service support

--- a/conformance/reports/v1.5/cilium/experimental-v1.20.0-pre.2-default-report.yaml
+++ b/conformance/reports/v1.5/cilium/experimental-v1.20.0-pre.2-default-report.yaml
@@ -1,0 +1,165 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-05-05T13:15:46+10:00"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.5.1
+implementation:
+  contact:
+    - https://github.com/cilium/community/blob/main/roles/Maintainers.md
+  organization: cilium
+  project: cilium
+  url: github.com/cilium/cilium
+  version: v1.20.0-pre.2
+kind: ConformanceReport
+mode: default
+profiles:
+  - core:
+      result: partial
+      skippedTests:
+        - MeshGRPCRouteWeight
+      statistics:
+        Failed: 0
+        Passed: 1
+        Skipped: 1
+    name: MESH-GRPC
+    summary: Core tests partially succeeded with 1 test skips.
+  - core:
+      result: partial
+      skippedTests:
+        - MeshHTTPRouteMatching
+      statistics:
+        Failed: 0
+        Passed: 6
+        Skipped: 1
+    extended:
+      result: partial
+      skippedTests:
+        - MeshHTTPRouteNamedRule
+      statistics:
+        Failed: 0
+        Passed: 6
+        Skipped: 1
+      supportedFeatures:
+        - MeshClusterIPMatching
+        - MeshHTTPRouteBackendRequestHeaderModification
+        - MeshHTTPRouteNamedRouteRule
+        - MeshHTTPRouteQueryParamMatching
+        - MeshHTTPRouteRedirectPath
+        - MeshHTTPRouteRedirectPort
+        - MeshHTTPRouteRewritePath
+        - MeshHTTPRouteSchemeRedirect
+      unsupportedFeatures:
+        - MeshConsumerRoute
+    name: MESH-HTTP
+    summary: Core tests partially succeeded with 1 test skips. Extended tests
+      partially succeeded with 1 test skips.
+  - core:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 33
+        Skipped: 0
+    extended:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 30
+        Skipped: 0
+      supportedFeatures:
+        - BackendTLSPolicy
+        - GatewayAddressEmpty
+        - GatewayFrontendClientCertificateValidationInsecureFallback
+        - GatewayHTTPListenerIsolation
+        - GatewayInfrastructurePropagation
+        - GatewayPort8080
+        - GatewayStaticAddresses
+        - HTTPRouteBackendProtocolH2C
+        - HTTPRouteBackendProtocolWebSocket
+        - HTTPRouteBackendRequestHeaderModification
+        - HTTPRouteBackendTimeout
+        - HTTPRouteDestinationPortMatching
+        - HTTPRouteHostRewrite
+        - HTTPRouteMethodMatching
+        - HTTPRouteNamedRouteRule
+        - HTTPRoutePathRedirect
+        - HTTPRoutePathRewrite
+        - HTTPRoutePortRedirect
+        - HTTPRouteQueryParamMatching
+        - HTTPRouteRequestMirror
+        - HTTPRouteRequestMultipleMirrors
+        - HTTPRouteRequestPercentageMirror
+        - HTTPRouteRequestTimeout
+        - HTTPRouteResponseHeaderModification
+        - HTTPRouteSchemeRedirect
+      unsupportedFeatures:
+        - BackendTLSPolicySANValidation
+        - GatewayBackendClientCertificate
+        - GatewayFrontendClientCertificateValidation
+        - GatewayHTTPSListenerDetectMisdirectedRequests
+        - HTTPRoute303RedirectStatusCode
+        - HTTPRoute307RedirectStatusCode
+        - HTTPRoute308RedirectStatusCode
+        - HTTPRouteCORS
+        - HTTPRouteParentRefPort
+        - ListenerSet
+    name: GATEWAY-HTTP
+    summary: Core tests succeeded. Extended tests succeeded.
+  - core:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 13
+        Skipped: 0
+    extended:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 3
+        Skipped: 0
+      supportedFeatures:
+        - GatewayAddressEmpty
+        - GatewayFrontendClientCertificateValidationInsecureFallback
+        - GatewayHTTPListenerIsolation
+        - GatewayInfrastructurePropagation
+        - GatewayPort8080
+        - GatewayStaticAddresses
+      unsupportedFeatures:
+        - GatewayBackendClientCertificate
+        - GatewayFrontendClientCertificateValidation
+        - GatewayHTTPSListenerDetectMisdirectedRequests
+        - ListenerSet
+    name: GATEWAY-GRPC
+    summary: Core tests succeeded. Extended tests succeeded.
+  - core:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 18
+        Skipped: 0
+    extended:
+      result: success
+      statistics:
+        Failed: 0
+        Passed: 3
+        Skipped: 0
+      supportedFeatures:
+        - GatewayAddressEmpty
+        - GatewayFrontendClientCertificateValidationInsecureFallback
+        - GatewayHTTPListenerIsolation
+        - GatewayInfrastructurePropagation
+        - GatewayPort8080
+        - GatewayStaticAddresses
+        - TLSRouteModeMixed
+      unsupportedFeatures:
+        - GatewayBackendClientCertificate
+        - GatewayFrontendClientCertificateValidation
+        - GatewayHTTPSListenerDetectMisdirectedRequests
+        - ListenerSet
+        - TLSRouteModeTerminate
+    name: GATEWAY-TLS
+    summary: Core tests succeeded. Extended tests succeeded.
+succeededProvisionalTests:
+  - GRPCRouteNamedRule
+  - GatewayInfrastructure
+  - GatewayOptionalAddressValue
+  - HTTPRouteNamedRule
+  - HTTPRouteRequestPercentageMirror

--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -240,7 +240,7 @@ See the [AWS Load Balancer Controller documentation][aws-lbc-docs] for informati
 
 ### Cilium
 
-[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.4.0-Cilium-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.4.0/cilium)
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.5.1-Cilium-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.5.1/cilium)
 
 [Cilium][cilium] is an eBPF-based networking, observability and security
 solution for Kubernetes and other networking environments. It includes [Cilium


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Add a conformance report for Cilium v1.20.0-pre.2, which is the first released version with Gateway API v1.5.1 support.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
