### PR TITLE
Add conformance report for Varnish Gateway v0.20.0

### DIFF
--- a/conformance/reports/v1.5/varnish-software-varnish-gateway/README.md
+++ b/conformance/reports/v1.5/varnish-software-varnish-gateway/README.md
@@ -1,0 +1,46 @@
+# Varnish Gateway
+
+[Varnish Gateway](https://gateway.varnish.org) is a Kubernetes [Gateway API](https://gateway-api.sigs.k8s.io/)
+implementation that uses [Varnish](https://varnish-cache.org/) as its data plane. It is developed and maintained
+by [Varnish Software AS](https://www.varnish-software.com/).
+
+## Table of contents
+
+| API channel | Implementation version | Mode    | Report                                                                |
+|-------------|------------------------|---------|-----------------------------------------------------------------------|
+| standard    | [v0.20.0](https://github.com/varnish/gateway/releases/tag/v0.20.0) | default | [v0.20.0 report](./standard-v0.20.0-default-report.yaml) |
+
+## Reproduce
+
+The following steps reproduce the Varnish Gateway conformance test report.
+
+1. Create a kind cluster and install the Gateway API standard CRDs:
+
+    ```bash
+    git clone https://github.com/varnish/gateway
+    cd gateway
+    git checkout v0.20.0
+    make kind-create
+    ```
+
+1. Build the operator and chaperone images, load them into the kind cluster, and deploy:
+
+    ```bash
+    make docker
+    make kind-load
+    make kind-deploy
+    ```
+
+1. Run the conformance tests and generate the report:
+
+    ```bash
+    make test-conformance-report
+    ```
+
+    The report will be written to `dist/conformance-report.yaml`.
+
+Alternatively, the full cycle (kind cluster create, build, deploy, test, teardown) can be run with:
+
+```bash
+make test-conformance-kind
+```

--- a/conformance/reports/v1.5/varnish-software-varnish-gateway/standard-v0.20.0-default-report.yaml
+++ b/conformance/reports/v1.5/varnish-software-varnish-gateway/standard-v0.20.0-default-report.yaml
@@ -1,0 +1,65 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-05-05T13:50:23+02:00"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.5.0
+implementation:
+  contact:
+  - '@perbu'
+  organization: Varnish Software AS
+  project: Varnish Gateway
+  url: https://gateway.varnish.org
+  version: v0.20.0
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 33
+      Skipped: 0
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 9
+      Skipped: 0
+    supportedFeatures:
+    - GatewayHTTPListenerIsolation
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRoutePathRedirect
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    unsupportedFeatures:
+    - BackendTLSPolicy
+    - BackendTLSPolicySANValidation
+    - GatewayAddressEmpty
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
+    - GatewayPort8080
+    - GatewayStaticAddresses
+    - HTTPRoute303RedirectStatusCode
+    - HTTPRoute307RedirectStatusCode
+    - HTTPRoute308RedirectStatusCode
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteCORS
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteNamedRouteRule
+    - HTTPRouteParentRefPort
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestPercentageMirror
+    - HTTPRouteRequestTimeout
+    - ListenerSet
+  name: GATEWAY-HTTP
+  summary: Core tests succeeded. Extended tests succeeded.

--- a/site-src/implementations.md
+++ b/site-src/implementations.md
@@ -94,6 +94,7 @@ other functions (like managing DNS or creating certificates).
 - [kgateway][37]
 - [NGINX Gateway Fabric][12]
 - [Traefik Proxy][13]
+- [Varnish Gateway][45]
 
 ### Partially Conformant
 
@@ -159,6 +160,7 @@ other functions (like managing DNS or creating certificates).
 [42]:#gravitee-kubernetes-operator
 [43]:#alibaba-cloud-service-mesh
 [44]:#aws-load-balancer-controller
+[45]:#varnish-gateway
 
 
 [gamma]:mesh/index.md
@@ -477,6 +479,25 @@ For help and support with Traefik Proxy, [create an issue][traefik-proxy-issue-n
 [traefik-proxy-gateway-api-doc]:https://doc.traefik.io/traefik/v3.7/reference/install-configuration/providers/kubernetes/kubernetes-gateway
 [traefik-proxy-issue-new]:https://github.com/traefik/traefik/issues/new/choose
 [traefiklabs-community-forum]:https://community.traefik.io/c/traefik/traefik-v3/21
+
+### Varnish Gateway
+
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.5.0-Varnish%20Gateway-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.5/varnish-software-varnish-gateway)
+
+[Varnish Gateway][varnish-gateway] is an open source Kubernetes Gateway API implementation
+developed by [Varnish Software AS][varnish-software], using [Varnish][varnish] as its data plane.
+It implements the Gateway API standard channel and passes the v1.5.0 conformance suite for the
+GATEWAY-HTTP profile (core, plus extended features for path/host/scheme/port redirects, path/host
+rewrites, method and query parameter matching, response header modification, and HTTP listener
+isolation).
+
+In addition to Gateway API resources, Varnish Gateway exposes a `VarnishCachePolicy` policy
+attachment for fine-grained caching control (TTL, grace, request coalescing, cache key
+customization, bypass conditions) at the Gateway, HTTPRoute, or rule level.
+
+[varnish-gateway]:https://gateway.varnish.org
+[varnish-software]:https://www.varnish-software.com/
+[varnish]:https://varnish-cache.org/
 
 ## Integrations
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
/area conformance-test

**What this PR does / why we need it**:

Adds a v1.5 standard-channel conformance report for Varnish Gateway v0.20.0,
an open source Kubernetes Gateway API implementation by Varnish Software AS
using Varnish as its data plane. The report passes all 33 core GATEWAY-HTTP
tests and 9 extended features (path/host/scheme/port redirects, path/host
rewrites, method and query parameter matching, response header modification,
and HTTP listener isolation).

**Which issue(s) this PR fixes**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
