### PR TITLE
cleanup: use CEL format.dns1123Subdomain() for TLSRoute hostname validation

### DIFF
--- a/apis/v1/tlsroute_types.go
+++ b/apis/v1/tlsroute_types.go
@@ -103,8 +103,8 @@ type TLSRouteSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=16
 	// +kubebuilder:validation:XValidation:message="Hostnames cannot contain an IP",rule="self.all(h, !isIP(h))"
-	// +kubebuilder:validation:XValidation:message="Hostnames must be valid based on RFC-1123",rule="self.all(h, !h.contains('*') ? h.matches('^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$') : true)"
-	// +kubebuilder:validation:XValidation:message="Wildcards on hostnames must be the first label, and the rest of hostname must be valid based on RFC-1123",rule="self.all(h, h.contains('*') ? (h.startsWith('*.') && h.substring(2).matches('^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$')) : true)"
+	// +kubebuilder:validation:XValidation:message="Hostnames must be valid based on RFC-1123",rule="self.all(h, !h.contains('*') ? !format.dns1123Subdomain().validate(h).hasValue() : true)"
+	// +kubebuilder:validation:XValidation:message="Wildcards on hostnames must be the first label, and the rest of hostname must be valid based on RFC-1123",rule="self.all(h, h.contains('*') ? (h.startsWith('*.') && !format.dns1123Subdomain().validate(h.substring(2)).hasValue()) : true)"
 	Hostnames []Hostname `json:"hostnames,omitempty"`
 
 	// Rules are a list of actions.

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -89,12 +89,12 @@ spec:
                 - message: Hostnames cannot contain an IP
                   rule: self.all(h, !isIP(h))
                 - message: Hostnames must be valid based on RFC-1123
-                  rule: 'self.all(h, !h.contains(''*'') ? h.matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$'')
+                  rule: 'self.all(h, !h.contains(''*'') ? !format.dns1123Subdomain().validate(h).hasValue()
                     : true)'
                 - message: Wildcards on hostnames must be the first label, and the
                     rest of hostname must be valid based on RFC-1123
                   rule: 'self.all(h, h.contains(''*'') ? (h.startsWith(''*.'') &&
-                    h.substring(2).matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$''))
+                    !format.dns1123Subdomain().validate(h.substring(2)).hasValue())
                     : true)'
               parentRefs:
                 description: |-
@@ -1669,12 +1669,12 @@ spec:
                 - message: Hostnames cannot contain an IP
                   rule: self.all(h, !isIP(h))
                 - message: Hostnames must be valid based on RFC-1123
-                  rule: 'self.all(h, !h.contains(''*'') ? h.matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$'')
+                  rule: 'self.all(h, !h.contains(''*'') ? !format.dns1123Subdomain().validate(h).hasValue()
                     : true)'
                 - message: Wildcards on hostnames must be the first label, and the
                     rest of hostname must be valid based on RFC-1123
                   rule: 'self.all(h, h.contains(''*'') ? (h.startsWith(''*.'') &&
-                    h.substring(2).matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$''))
+                    !format.dns1123Subdomain().validate(h.substring(2)).hasValue())
                     : true)'
               parentRefs:
                 description: |-

--- a/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
@@ -89,12 +89,12 @@ spec:
                 - message: Hostnames cannot contain an IP
                   rule: self.all(h, !isIP(h))
                 - message: Hostnames must be valid based on RFC-1123
-                  rule: 'self.all(h, !h.contains(''*'') ? h.matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$'')
+                  rule: 'self.all(h, !h.contains(''*'') ? !format.dns1123Subdomain().validate(h).hasValue()
                     : true)'
                 - message: Wildcards on hostnames must be the first label, and the
                     rest of hostname must be valid based on RFC-1123
                   rule: 'self.all(h, h.contains(''*'') ? (h.startsWith(''*.'') &&
-                    h.substring(2).matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$''))
+                    !format.dns1123Subdomain().validate(h.substring(2)).hasValue())
                     : true)'
               parentRefs:
                 description: |-
@@ -1497,12 +1497,12 @@ spec:
                 - message: Hostnames cannot contain an IP
                   rule: self.all(h, !isIP(h))
                 - message: Hostnames must be valid based on RFC-1123
-                  rule: 'self.all(h, !h.contains(''*'') ? h.matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$'')
+                  rule: 'self.all(h, !h.contains(''*'') ? !format.dns1123Subdomain().validate(h).hasValue()
                     : true)'
                 - message: Wildcards on hostnames must be the first label, and the
                     rest of hostname must be valid based on RFC-1123
                   rule: 'self.all(h, h.contains(''*'') ? (h.startsWith(''*.'') &&
-                    h.substring(2).matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$''))
+                    !format.dns1123Subdomain().validate(h.substring(2)).hasValue())
                     : true)'
               parentRefs:
                 description: |-

--- a/conformance/tests/httproute-backend-request-redirect.go
+++ b/conformance/tests/httproute-backend-request-redirect.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteBackendRequestRedirect)
+}
+
+var HTTPRouteBackendRequestRedirect = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteBackendRequestRedirect",
+	Description: "An HTTPRoute with RequestRedirect filter applied at the BackendRef level",
+	Manifests:   []string{"tests/httproute-backend-request-redirect.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteBackendRequestRedirect,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "backend-request-redirect", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Path:             "/full/original",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Path: "/redirected-full",
+				},
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path:             "/prefix/original",
+					UnfollowRedirect: true,
+				},
+				Response: http.Response{
+					StatusCode: 302,
+				},
+				RedirectRequest: &roundtripper.RedirectRequest{
+					Path: "/redirected-prefix/original",
+				},
+				Namespace: ns,
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-backend-request-redirect.yaml
+++ b/conformance/tests/httproute-backend-request-redirect.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-request-redirect
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /full
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          path:
+            type: ReplaceFullPath
+            replaceFullPath: /redirected-full
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /prefix
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /redirected-prefix

--- a/conformance/tests/httproute-backend-url-rewrite.go
+++ b/conformance/tests/httproute-backend-url-rewrite.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteBackendURLRewrite)
+}
+
+var HTTPRouteBackendURLRewrite = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteBackendURLRewrite",
+	Description: "An HTTPRoute with URLRewrite filter applied at the BackendRef level",
+	Manifests:   []string{"tests/httproute-backend-url-rewrite.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteBackendURLRewrite,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "backend-url-rewrite", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Path: "/full/original",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/rewritten-full",
+					},
+				},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Path: "/prefix/original",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/rewritten-prefix/original",
+					},
+				},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-backend-url-rewrite.yaml
+++ b/conformance/tests/httproute-backend-url-rewrite.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-url-rewrite
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /full
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplaceFullPath
+            replaceFullPath: /rewritten-full
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /prefix
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /rewritten-prefix

--- a/pkg/features/httproute.go
+++ b/pkg/features/httproute.go
@@ -111,6 +111,12 @@ const (
 
 	// This option indicates support for HTTPRoute additional redirect status code 303 (extended conformance)
 	SupportHTTPRoute308RedirectStatusCode FeatureName = "HTTPRoute308RedirectStatusCode"
+
+	// This option indicates support for URLRewrite filter on HTTPRoute BackendRef (extended conformance).
+	SupportHTTPRouteBackendURLRewrite FeatureName = "HTTPRouteBackendURLRewrite"
+
+	// This option indicates support for RequestRedirect filter on HTTPRoute BackendRef (extended conformance).
+	SupportHTTPRouteBackendRequestRedirect FeatureName = "HTTPRouteBackendRequestRedirect"
 )
 
 var (
@@ -229,6 +235,16 @@ var (
 		Name:    SupportHTTPRoute308RedirectStatusCode,
 		Channel: FeatureChannelStandard,
 	}
+	// HTTPRouteBackendURLRewriteFeature contains metadata for the HTTPRouteBackendURLRewrite feature.
+	HTTPRouteBackendURLRewriteFeature = Feature{
+		Name:    SupportHTTPRouteBackendURLRewrite,
+		Channel: FeatureChannelStandard,
+	}
+	// HTTPRouteBackendRequestRedirectFeature contains metadata for the HTTPRouteBackendRequestRedirect feature.
+	HTTPRouteBackendRequestRedirectFeature = Feature{
+		Name:    SupportHTTPRouteBackendRequestRedirect,
+		Channel: FeatureChannelStandard,
+	}
 )
 
 // HTTPRouteExtendedFeatures includes all extended features for HTTPRoute
@@ -258,4 +274,6 @@ var HTTPRouteExtendedFeatures = sets.New(
 	HTTPRoute303RedirectStatusCodeFeature,
 	HTTPRoute307RedirectStatusCodeFeature,
 	HTTPRoute308RedirectStatusCodeFeature,
+	HTTPRouteBackendURLRewriteFeature,
+	HTTPRouteBackendRequestRedirectFeature,
 )


### PR DESCRIPTION
## Summary

- Replace regex-based CEL hostname validation in `TLSRouteSpec.Hostnames` with native `format.dns1123Subdomain()` library calls
- Applies to both non-wildcard and wildcard hostname rules

## Motivation

Fixes #4450. The `format.dns1123Subdomain()` CEL function requires Kubernetes >= v1.31. This was previously blocked because our min supported version was older, but #4819 bumped k8s dependencies to v1.36, making v1.31 our effective minimum.

As noted by @youngnick: _"once we update our dependencies, we should be able to proceed with this"_.

## Changes

- `apis/v1/tlsroute_types.go`: replace two regex `+kubebuilder:validation:XValidation` rules with `format.dns1123Subdomain()` equivalents
- `config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml`: regenerated
- `config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml`: regenerated

```release-note
NONE
```