### PR TITLE
conformance: add cross-namespace ListenerSet AllowedRoutes test

### DIFF
--- a/conformance/tests/listenerset-allowed-routes-namespaces.go
+++ b/conformance/tests/listenerset-allowed-routes-namespaces.go
@@ -59,100 +59,149 @@ var ListenerSetAllowedRoutesNamespaces = confsuite.ConformanceTest{
 			Type:   string(gatewayv1.GatewayConditionAccepted),
 			Status: metav1.ConditionTrue,
 		})
-		kubernetes.GatewayMustHaveAttachedListeners(t, suite.Client, suite.TimeoutConfig, gwNN, 1)
+		kubernetes.GatewayMustHaveAttachedListeners(t, suite.Client, suite.TimeoutConfig, gwNN, 2)
 
-		// Verify the accepted listenerSet has the appropriate conditions
-		routes := []types.NamespacedName{
-			{Name: "route-in-same-namespace", Namespace: ns},
-			{Name: "route-in-selected-namespace", Namespace: "gateway-api-routes-allowed-ns"},
-			{Name: "route-not-in-selected-namespace", Namespace: "gateway-api-routes-not-allowed-ns"},
-		}
 		listenerSetGK := schema.GroupKind{
 			Group: gatewayv1.GroupVersion.Group,
 			Kind:  "ListenerSet",
 		}
-		lsNN := types.NamespacedName{Name: "listenerset-test-allowed-routes-namespaces", Namespace: ns}
-		listenerSetRef := kubernetes.NewResourceRef(listenerSetGK, lsNN)
-		kubernetes.RoutesAndParentMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, listenerSetRef, &gatewayv1.HTTPRoute{}, routes...)
-		kubernetes.ListenerSetStatusMustHaveListeners(t, suite.Client, suite.TimeoutConfig, lsNN, []gatewayv1.ListenerEntryStatus{
-			{
-				Name:           "listener-set-listener-allowed-routes-all",
-				SupportedKinds: generateSupportedRouteKinds(),
-				// This attaches to route-in-same-namespace, route-in-selected-namespace, route-not-in-selected-namespace
-				AttachedRoutes: 3,
-				Conditions:     generateAcceptedListenerConditions(),
-			},
-			{
-				Name:           "listener-set-listener-allowed-routes-same",
-				SupportedKinds: generateSupportedRouteKinds(),
-				// This attaches to route-in-same-namespace
-				AttachedRoutes: 1,
-				Conditions:     generateAcceptedListenerConditions(),
-			},
-			{
-				Name:           "listener-set-listener-allowed-routes-selector",
-				SupportedKinds: generateSupportedRouteKinds(),
-				// This attaches to route-in-selected-namespace
-				AttachedRoutes: 1,
-				Conditions:     generateAcceptedListenerConditions(),
-			},
+
+		t.Run("Same-namespace ListenerSet", func(t *testing.T) {
+			lsNN := types.NamespacedName{Name: "listenerset-test-allowed-routes-namespaces", Namespace: ns}
+			listenerSetRef := kubernetes.NewResourceRef(listenerSetGK, lsNN)
+
+			routes := []types.NamespacedName{
+				{Name: "route-in-same-namespace", Namespace: ns},
+				{Name: "route-in-selected-namespace", Namespace: "gateway-api-routes-allowed-ns"},
+				{Name: "route-not-in-selected-namespace", Namespace: "gateway-api-routes-not-allowed-ns"},
+			}
+			kubernetes.RoutesAndParentMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, listenerSetRef, &gatewayv1.HTTPRoute{}, routes...)
+			kubernetes.ListenerSetStatusMustHaveListeners(t, suite.Client, suite.TimeoutConfig, lsNN, []gatewayv1.ListenerEntryStatus{
+				{
+					Name:           "listener-set-listener-allowed-routes-all",
+					SupportedKinds: generateSupportedRouteKinds(),
+					// This attaches to route-in-same-namespace, route-in-selected-namespace, route-not-in-selected-namespace
+					AttachedRoutes: 3,
+					Conditions:     generateAcceptedListenerConditions(),
+				},
+				{
+					Name:           "listener-set-listener-allowed-routes-same",
+					SupportedKinds: generateSupportedRouteKinds(),
+					// This attaches to route-in-same-namespace
+					AttachedRoutes: 1,
+					Conditions:     generateAcceptedListenerConditions(),
+				},
+				{
+					Name:           "listener-set-listener-allowed-routes-selector",
+					SupportedKinds: generateSupportedRouteKinds(),
+					// This attaches to route-in-selected-namespace
+					AttachedRoutes: 1,
+					Conditions:     generateAcceptedListenerConditions(),
+				},
+			})
+
+			testCases := []http.ExpectedResponse{
+				// Requests to all the routes on `listener-set-listener-allowed-routes-all` should succeed
+				{
+					Request:   http.Request{Host: "listener-set-listener-allowed-routes-all.com", Path: "/route-in-same-namespace"},
+					Backend:   confsuite.InfraBackendServiceNameV1,
+					Namespace: ns,
+				},
+				{
+					Request:   http.Request{Host: "listener-set-listener-allowed-routes-all.com", Path: "/route-in-selected-namespace"},
+					Backend:   confsuite.InfraBackendServiceNameV2,
+					Namespace: ns,
+				},
+				{
+					Request:   http.Request{Host: "listener-set-listener-allowed-routes-all.com", Path: "/route-not-in-selected-namespace"},
+					Backend:   confsuite.InfraBackendServiceNameV3,
+					Namespace: ns,
+				},
+				// Requests only to the route in the same namespace on `listener-set-listener-allowed-routes-same` should succeed
+				{
+					Request:   http.Request{Host: "listener-set-listener-allowed-routes-same.com", Path: "/route-in-same-namespace"},
+					Backend:   confsuite.InfraBackendServiceNameV1,
+					Namespace: ns,
+				},
+				{
+					Request:  http.Request{Host: "listener-set-listener-allowed-routes-same.com", Path: "/route-in-selected-namespace"},
+					Response: http.Response{StatusCode: 404},
+				},
+				{
+					Request:  http.Request{Host: "listener-set-listener-allowed-routes-same.com", Path: "/route-not-in-selected-namespace"},
+					Response: http.Response{StatusCode: 404},
+				},
+				// Requests only to the route in the selected namespace on `listener-set-listener-allowed-routes-selector` should succeed
+				{
+					Request:  http.Request{Host: "listener-set-listener-allowed-routes-selector.com", Path: "/route-in-same-namespace"},
+					Response: http.Response{StatusCode: 404},
+				},
+				{
+					Request:   http.Request{Host: "listener-set-listener-allowed-routes-selector.com", Path: "/route-in-selected-namespace"},
+					Backend:   confsuite.InfraBackendServiceNameV2,
+					Namespace: ns,
+				},
+				{
+					Request:  http.Request{Host: "listener-set-listener-allowed-routes-selector.com", Path: "/route-not-in-selected-namespace"},
+					Response: http.Response{StatusCode: 404},
+				},
+			}
+
+			for i := range testCases {
+				// Declare tc here to avoid loop variable
+				// reuse issues across parallel tests.
+				tc := testCases[i]
+				t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+					t.Parallel()
+					http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+				})
+			}
 		})
 
-		testCases := []http.ExpectedResponse{
-			// Requests to all the routes on `listener-set-listener-allowed-routes-all` should succeed
-			{
-				Request:   http.Request{Host: "listener-set-listener-allowed-routes-all.com", Path: "/route-in-same-namespace"},
-				Backend:   confsuite.InfraBackendServiceNameV1,
-				Namespace: ns,
-			},
-			{
-				Request:   http.Request{Host: "listener-set-listener-allowed-routes-all.com", Path: "/route-in-selected-namespace"},
-				Backend:   confsuite.InfraBackendServiceNameV2,
-				Namespace: ns,
-			},
-			{
-				Request:   http.Request{Host: "listener-set-listener-allowed-routes-all.com", Path: "/route-not-in-selected-namespace"},
-				Backend:   confsuite.InfraBackendServiceNameV3,
-				Namespace: ns,
-			},
-			// Requests only to the route in the same namespace on `listener-set-listener-allowed-routes-same` should succeed
-			{
-				Request:   http.Request{Host: "listener-set-listener-allowed-routes-same.com", Path: "/route-in-same-namespace"},
-				Backend:   confsuite.InfraBackendServiceNameV1,
-				Namespace: ns,
-			},
-			{
-				Request:  http.Request{Host: "listener-set-listener-allowed-routes-same.com", Path: "/route-in-selected-namespace"},
-				Response: http.Response{StatusCode: 404},
-			},
-			{
-				Request:  http.Request{Host: "listener-set-listener-allowed-routes-same.com", Path: "/route-not-in-selected-namespace"},
-				Response: http.Response{StatusCode: 404},
-			},
-			// Requests only to the route in the selected namespace on `listener-set-listener-allowed-routes-selector` should succeed
-			{
-				Request:  http.Request{Host: "listener-set-listener-allowed-routes-selector.com", Path: "/route-in-same-namespace"},
-				Response: http.Response{StatusCode: 404},
-			},
-			{
-				Request:   http.Request{Host: "listener-set-listener-allowed-routes-selector.com", Path: "/route-in-selected-namespace"},
-				Backend:   confsuite.InfraBackendServiceNameV2,
-				Namespace: ns,
-			},
-			{
-				Request:  http.Request{Host: "listener-set-listener-allowed-routes-selector.com", Path: "/route-not-in-selected-namespace"},
-				Response: http.Response{StatusCode: 404},
-			},
-		}
+		t.Run("Cross-namespace ListenerSet", func(t *testing.T) {
+			lsNS := "gateway-api-ls-cross-ns"
+			lsNN := types.NamespacedName{Name: "listenerset-test-allowed-routes-cross-ns", Namespace: lsNS}
+			listenerSetRef := kubernetes.NewResourceRef(listenerSetGK, lsNN)
 
-		for i := range testCases {
-			// Declare tc here to avoid loop variable
-			// reuse issues across parallel tests.
-			tc := testCases[i]
-			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
-				t.Parallel()
-				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			routeInLSNS := types.NamespacedName{Name: "route-in-listenerset-namespace", Namespace: lsNS}
+			kubernetes.RoutesAndParentMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, listenerSetRef, &gatewayv1.HTTPRoute{}, routeInLSNS)
+
+			routeInGWNS := types.NamespacedName{Name: "route-in-gateway-namespace", Namespace: ns}
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeInGWNS, lsNN, metav1.Condition{
+				Type:   string(gatewayv1.RouteConditionAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(gatewayv1.RouteReasonNotAllowedByListeners),
 			})
-		}
+
+			kubernetes.ListenerSetStatusMustHaveListeners(t, suite.Client, suite.TimeoutConfig, lsNN, []gatewayv1.ListenerEntryStatus{
+				{
+					Name:           "listener-set-listener-allowed-routes-cross-ns-same",
+					SupportedKinds: generateSupportedRouteKinds(),
+					// Only route-in-listenerset-namespace should attach (same NS as ListenerSet)
+					AttachedRoutes: 1,
+					Conditions:     generateAcceptedListenerConditions(),
+				},
+			})
+
+			testCases := []http.ExpectedResponse{
+				{
+					Request:   http.Request{Host: "listener-set-listener-allowed-routes-cross-ns-same.com", Path: "/route-in-listenerset-namespace"},
+					Backend:   confsuite.InfraBackendServiceNameV1,
+					Namespace: ns,
+				},
+				{
+					Request:  http.Request{Host: "listener-set-listener-allowed-routes-cross-ns-same.com", Path: "/route-in-gateway-namespace"},
+					Response: http.Response{StatusCode: 404},
+				},
+			}
+
+			for i := range testCases {
+				tc := testCases[i]
+				t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+					t.Parallel()
+					http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+				})
+			}
+		})
 	},
 }

--- a/conformance/tests/listenerset-allowed-routes-namespaces.yaml
+++ b/conformance/tests/listenerset-allowed-routes-namespaces.yaml
@@ -130,6 +130,75 @@ spec:
       namespace: gateway-conformance-infra
       port: 8080
 ---
+# This namespace is created for the cross-namespace ListenerSet test
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gateway-api-ls-cross-ns
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: listenerset-test-allowed-routes-cross-ns
+  namespace: gateway-api-ls-cross-ns
+spec:
+  parentRef:
+    kind: Gateway
+    group: gateway.networking.k8s.io
+    name: gateway-with-listener-sets-test-allowed-routes
+    namespace: gateway-conformance-infra
+  listeners:
+  - name: listener-set-listener-allowed-routes-cross-ns-same
+    port: 80
+    protocol: HTTP
+    hostname: "listener-set-listener-allowed-routes-cross-ns-same.com"
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+# Route in the same namespace as the cross-namespace ListenerSet (should be accepted)
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-in-listenerset-namespace
+  namespace: gateway-api-ls-cross-ns
+spec:
+  parentRefs:
+  - kind: ListenerSet
+    group: gateway.networking.k8s.io
+    name: listenerset-test-allowed-routes-cross-ns
+    namespace: gateway-api-ls-cross-ns
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /route-in-listenerset-namespace
+    backendRefs:
+    - name: infra-backend-v1
+      namespace: gateway-conformance-infra
+      port: 8080
+---
+# Route in the Gateway's namespace (should be rejected by the cross-namespace ListenerSet)
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-in-gateway-namespace
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - kind: ListenerSet
+    group: gateway.networking.k8s.io
+    name: listenerset-test-allowed-routes-cross-ns
+    namespace: gateway-api-ls-cross-ns
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /route-in-gateway-namespace
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080
+---
 kind: ReferenceGrant
 apiVersion: gateway.networking.k8s.io/v1
 metadata:
@@ -143,6 +212,9 @@ spec:
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     namespace: gateway-api-routes-not-allowed-ns
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: gateway-api-ls-cross-ns
   to:
   - group: ""
     kind: "Service"


### PR DESCRIPTION
**What type of PR is this?**

/kind test
/area conformance-test

**What this PR does / why we need it:**

In [GEP 1713 under the Conformance Details section](https://gateway-api.sigs.k8s.io/geps/gep-1713/#conformance-details), case number 13 makes it clear that `AllowedRoutes.Namespaces.From` being set to `Same` on a `ListenerSet` means that only Routes from the ListenerSet's namespace should be accepted, and not routes from the Gateway's namespace.

This PR adds a test which verifies that `AllowedRoutes.Namespaces.From: Same` on a ListenerSet listener is evaluated relative to the ListenerSet's namespace, not the parent Gateway's namespace. 

The existing ListenerSetAllowedRoutesNamespaces test places both resources in the same namespace, making it possible for an implementation to incorrectly attribute the value of 'Same' in a ListenerSet spec to mean the GatewayAPI's namespace, and not the ListenerSet namespace. 

This test has been confirmed to catch this bug in a pre-release implementation of ListenerSet.

**Does this PR introduce a user-facing change?:**

```release-note
Add conformance test `ListenerSetAllowedRoutesCrossNamespace` which verifies that a ListenerSet only allows routes in its own namespace by default
```
