### PR TITLE
Add conformance test for BackendTLSPolicy with TLSRoute Terminate

### DIFF
--- a/conformance/tests/backendtlspolicy-tlsroute-terminate.go
+++ b/conformance/tests/backendtlspolicy-tlsroute-terminate.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tcp"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, BackendTLSPolicyTLSRouteTerminate)
+}
+
+var BackendTLSPolicyTLSRouteTerminate = suite.ConformanceTest{
+	ShortName:   "BackendTLSPolicyTLSRouteTerminate",
+	Description: "A BackendTLSPolicy attached to a Service consumed by a TLSRoute using Terminate mode should re-encrypt traffic to the backend",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportTLSRoute,
+		features.SupportTLSRouteModeTerminate,
+		features.SupportBackendTLSPolicy,
+	},
+	Provisional: true,
+	Manifests:   []string{"tests/backendtlspolicy-tlsroute-terminate.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Name: "backendtlspolicy-tlsroute-terminate", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "gateway-btls-tlsroute-terminate", Namespace: ns}
+		policyNN := types.NamespacedName{Name: "btls-tlsroute-terminate-test", Namespace: ns}
+		caCertNN := types.NamespacedName{Name: "tls-checks-ca-certificate", Namespace: ns}
+
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+
+		gwAddr, hostnames := kubernetes.GatewayAndTLSRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		if len(hostnames) != 1 {
+			t.Fatalf("unexpected error in test configuration, found %d hostnames", len(hostnames))
+		}
+		serverStr := string(hostnames[0])
+
+		acceptedCond := metav1.Condition{
+			Type:   string(gatewayv1.PolicyConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.PolicyReasonAccepted),
+		}
+		resolvedRefsCond := metav1.Condition{
+			Type:   string(gatewayv1.BackendTLSPolicyConditionResolvedRefs),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.BackendTLSPolicyReasonResolvedRefs),
+		}
+		kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, policyNN, gwNN, acceptedCond)
+		kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, policyNN, gwNN, resolvedRefsCond)
+
+		caConfigMap, err := kubernetes.GetConfigMapData(suite.Client, suite.TimeoutConfig, caCertNN)
+		if err != nil {
+			t.Fatalf("unexpected error finding CA certificate ConfigMap: %v", err)
+		}
+		caString, ok := caConfigMap["ca.crt"]
+		if !ok {
+			t.Fatalf("ca.crt not found in configmap: %s/%s", caCertNN.Namespace, caCertNN.Name)
+		}
+
+		t.Run("TLS request matching terminated TLSRoute with BackendTLSPolicy should reach backend with re-encrypted TLS", func(t *testing.T) {
+			tcp.MakeTCPRequestAndExpectEventuallyValidResponse(t, suite.TimeoutConfig, gwAddr, []byte(caString), serverStr, true,
+				tcp.ExpectedResponse{
+					BackendIsTLS: true,
+					Backend:      "btls-terminate-tcp-backend",
+					Namespace:    "gateway-conformance-infra",
+					Hostname:     "abc.example.com",
+				})
+		})
+	},
+}

--- a/conformance/tests/backendtlspolicy-tlsroute-terminate.yaml
+++ b/conformance/tests/backendtlspolicy-tlsroute-terminate.yaml
@@ -1,0 +1,120 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-btls-tlsroute-terminate
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: tls-terminate
+    port: 8443
+    protocol: TLS
+    hostname: tls.example.com
+    allowedRoutes:
+      namespaces:
+        from: Same
+      kinds:
+      - kind: TLSRoute
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: tls-terminate-checks-certificate
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: TLSRoute
+metadata:
+  name: backendtlspolicy-tlsroute-terminate
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: gateway-btls-tlsroute-terminate
+    namespace: gateway-conformance-infra
+  hostnames:
+  - tls.example.com
+  rules:
+  - backendRefs:
+    - name: btls-terminate-tcp-backend
+      port: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: btls-terminate-tcp-backend
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: btls-terminate-tcp-backend
+  ports:
+  - name: "btls"
+    protocol: TCP
+    port: 8443
+    targetPort: 8443
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: btls-terminate-tcp-backend
+  namespace: gateway-conformance-infra
+  labels:
+    app: btls-terminate-tcp-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: btls-terminate-tcp-backend
+  template:
+    metadata:
+      labels:
+        app: btls-terminate-tcp-backend
+    spec:
+      containers:
+      - name: btls-terminate-tcp-backend
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20260204-monthly-2026.01-60-g28382302
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - name: secret-volume
+          mountPath: /etc/secret-volume
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: TLS_SERVER_CERT
+          value: /etc/secret-volume/crt
+        - name: TLS_SERVER_PRIV_KEY
+          value: /etc/secret-volume/key
+        - name: TCP_ECHO_SERVER
+          value: "1"
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: tls-checks-certificate
+          items:
+          - key: tls.crt
+            path: crt
+          - key: tls.key
+            path: key
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: btls-tlsroute-terminate-test
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: "btls-terminate-tcp-backend"
+    sectionName: "btls"
+  validation:
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      name: "tls-checks-ca-certificate"
+    hostname: "abc.example.com"


### PR DESCRIPTION
**What type of PR is this?**
/kind test
/area conformance-test

**What this PR does / why we need it**:

Adds a new conformance test that validates the interaction between BackendTLSPolicy and TLSRoute in Terminate mode. When a TLSRoute uses Terminate mode and a BackendTLSPolicy is attached to the backend Service, the gateway should:

1. Terminate the client TLS connection
2. Re-encrypt traffic to the backend using the BackendTLSPolicy configuration
3. The backend should receive the traffic over TLS (re-encryption)

The test creates a dedicated TCP echo backend Deployment with a CA-signed certificate (`tls-checks-certificate`) so that the BackendTLSPolicy can properly validate the backend's identity using the existing `tls-checks-ca-certificate` CA.

**Test assertions:**
- BackendTLSPolicy has `Accepted=True` and `ResolvedRefs=True` conditions
- TCP request through the gateway reaches the backend with TLS re-encryption (`BackendIsTLS=true`)
- Backend SNI matches BackendTLSPolicy hostname (`abc.example.com`)

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```