### PR TITLE
[breaking change] Remove optional marker from ReferenceGrant.Spec

### DIFF
--- a/apis/v1/referencegrant_types.go
+++ b/apis/v1/referencegrant_types.go
@@ -45,8 +45,8 @@ type ReferenceGrant struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the desired state of ReferenceGrant.
-	// +optional
-	Spec ReferenceGrantSpec `json:"spec,omitempty"`
+	// +required
+	Spec ReferenceGrantSpec `json:"spec"`
 
 	// Note that `Status` sub-resource has been excluded at the
 	// moment as it was difficult to work out the design.

--- a/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
@@ -178,6 +178,8 @@ spec:
             - from
             - to
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: false
@@ -341,6 +343,8 @@ spec:
             - from
             - to
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
@@ -178,6 +178,8 @@ spec:
             - from
             - to
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: false
@@ -341,6 +343,8 @@ spec:
             - from
             - to
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -6919,6 +6919,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_ReferenceGrant(ref common.ReferenceCal
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -8062,6 +8063,7 @@ func schema_sigsk8sio_gateway_api_apis_v1alpha2_ReferenceGrant(ref common.Refere
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -9458,6 +9460,7 @@ func schema_sigsk8sio_gateway_api_apis_v1beta1_ReferenceGrant(ref common.Referen
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR marks referencegrant.spec as required. A ReferenceGrant without a .spec doesn't have a meaning, and can break a controller expecting it to be available


**Does this PR introduce a user-facing change?**:
```release-note
Make referencegrant.spec field as required
```
