### PR TITLE
Prevent arbitrary code execution hack scripts

### DIFF
--- a/hack/update-clientset.sh
+++ b/hack/update-clientset.sh
@@ -60,7 +60,8 @@ GATEWAY_INPUT_DIRS_COMMA="${GATEWAY_INPUT_DIRS_COMMA%,}" # drop trailing comma
 GATEWAY_API_DIRS_COMMA="${GATEWAY_API_DIRS_COMMA%,}" # drop trailing comma
 
 # throw away
-new_report="$(mktemp -t "$(basename "$0").api_violations.XXXXXX")"
+new_report="$(mktemp "${SCRIPT_ROOT}/.api_violations.XXXXXX")"
+trap 'rm -f "${new_report}"' EXIT
 
 echo "Generating openapi schema"
 $GOTOOL k8s.io/kube-openapi/cmd/openapi-gen \

--- a/hack/update-protos.sh
+++ b/hack/update-protos.sh
@@ -22,7 +22,7 @@ readonly SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE}")"/.. && pwd)"
 
 echo "Generating gRPC/Protobuf code"
 
-readonly PROTOC_CACHE_DIR="/tmp/protoc.cache"
+readonly PROTOC_CACHE_DIR="${SCRIPT_ROOT}/.protoc_cache"
 readonly PROTOC_BINARY="${PROTOC_CACHE_DIR}/bin/protoc"
 readonly PROTOC_VERSION="22.2"
 readonly PROTOC_REPO="https://github.com/protocolbuffers/protobuf"

--- a/hack/verify-docker-build.sh
+++ b/hack/verify-docker-build.sh
@@ -25,5 +25,5 @@ echo "Verifying docker images"
 docker buildx rm ${BUILDX_CONTEXT} || true
 docker buildx create --use --name ${BUILDX_CONTEXT} --platform "${BUILDX_PLATFORMS}"
 
-VERIFY=true ./hack/build-and-push.sh
+VERIFY=true "${SCRIPT_ROOT}/hack/build-and-push.sh"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
A bad local ombre can execute arbitrary code in the context of the developer or CI running the script.

Instead
- hack/update-protos.sh: Use secure, repository-local PROTOC_CACHE_DIR to prevent TOCTOU vulnerabilities.
- hack/update-clientset.sh: Use secure temporary report file location and add cleanup trap.
- hack/verify-docker-build.sh: Use absolute path for build-and-push.sh to prevent untrusted search path execution.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
