### PR TITLE
Fix Stored DOM XSS in Controller Wizard

### DIFF
--- a/hack/mkdocs-generate-controller-wizard-data.py
+++ b/hack/mkdocs-generate-controller-wizard-data.py
@@ -96,7 +96,7 @@ def load_yaml(path):
 
 def parse_version(version_dir_name):
     """Return (major, minor, patch) or (0,0,0) for sorting."""
-    m = re.match(r"v?(\d+)\.(\d+)(?:\.(\d+))?", version_dir_name)
+    m = re.match(r"^v?(\d+)\.(\d+)(?:\.(\d+))?$", version_dir_name)
     if m:
         return (int(m.group(1)), int(m.group(2)), int(m.group(3) or 0))
     return (0, 0, 0)

--- a/site-src/wizard/controller-wizard.html
+++ b/site-src/wizard/controller-wizard.html
@@ -522,7 +522,7 @@
                 statusEl.textContent = 'No versions in data file.';
               } else {
                 ALL_VERSIONS_DATA = data;
-                versionSelect.innerHTML = versions.map(v => `<option value="${v}">${v}</option>`).join('');
+                versionSelect.innerHTML = versions.map(v => `<option value="${escapeHtml(v)}">${escapeHtml(v)}</option>`).join('');
                 versionRow.style.display = 'block';
                 applyVersion(versions[0]);
                 versionSelect.onchange = () => applyVersion(versionSelect.value);


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Use strict regex anchor to prevent malicious directory names from being included in the wizard data. Properly escape version strings when populating the version selection dropdown.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
