### PR TITLE
fix wizard theme compatibility for dark mode

### DIFF
--- a/hack/generate-controller-wizard-data.py
+++ b/hack/generate-controller-wizard-data.py
@@ -313,7 +313,7 @@ def main():
 def on_config(config, **kwargs):
     """MkDocs hook: generate wizard data with --all before build."""
     repo_root = os.path.dirname(config.config_file_path)
-    output_path = os.path.join(repo_root, "site-src", "wizard", "data", "controller-wizard-data.json")
+    output_path = os.path.join(repo_root, "site", "static", "wizard", "data", "controller-wizard-data.json")
     if not generate_all(repo_root, output_path):
         log.warning("Controller wizard data not generated: no version dirs under conformance/reports/")
     else:

--- a/site/static/wizard/controller-wizard.css
+++ b/site/static/wizard/controller-wizard.css
@@ -1,12 +1,34 @@
 :root {
   --primary: #326ce5;
   --primary-dark: #2952c3;
+  --bg: #fff;
   --card: #fff;
   --border: #e1e4e8;
   --text: #24292f;
   --text-muted: #57606a;
   --success: #1a7f37;
   --warning: #9a6700;
+}
+
+/* Dark mode theme variables for Docsy (Bootstrap 5) and MkDocs-Material */
+[data-bs-theme="dark"],
+[data-md-color-scheme="slate"] {
+  --bg: #1e1e1e;
+  --card: #252525;
+  --border: #444;
+  --text: #e0e0e0;
+  --text-muted: #a0a0a0;
+}
+
+/* Support for prefers-color-scheme as a fallback */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-bs-theme="light"]):not([data-md-color-scheme="default"]) {
+    --bg: #1e1e1e;
+    --card: #252525;
+    --border: #444;
+    --text: #e0e0e0;
+    --text-muted: #a0a0a0;
+  }
 }
 
 * {

--- a/site/static/wizard/controller-wizard.html
+++ b/site/static/wizard/controller-wizard.html
@@ -5,6 +5,35 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="controller-wizard.css">
+  <script>
+    (function() {
+      // Sync theme with parent Docsy (Bootstrap 5) or MkDocs-Material site
+      function syncTheme() {
+        try {
+          const parentDoc = window.parent.document.documentElement;
+          const theme = parentDoc.getAttribute('data-bs-theme') || 
+                        (parentDoc.getAttribute('data-md-color-scheme') === 'slate' ? 'dark' : 'light');
+          if (theme) {
+            document.documentElement.setAttribute('data-bs-theme', theme);
+          }
+        } catch (e) {
+          // Fallback to system preference if cross-origin or parent not accessible
+          if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            document.documentElement.setAttribute('data-bs-theme', 'dark');
+          }
+        }
+      }
+      syncTheme();
+      // Observe parent theme changes if same-origin
+      try {
+        const observer = new MutationObserver(syncTheme);
+        observer.observe(window.parent.document.documentElement, {
+          attributes: true,
+          attributeFilter: ['data-bs-theme', 'data-md-color-scheme']
+        });
+      } catch (e) {}
+    })();
+  </script>
 </head>
 
 <body>
@@ -336,7 +365,7 @@
       if (statusEl) statusEl.textContent = '';
 
       if (IMPLEMENTATIONS.length === 0) {
-        resultsContent.innerHTML = '<p class="no-results">No implementation data loaded. Run <code>python hack/generate-controller-wizard-data.py --all</code> to generate <code>site-src/wizard/data/controller-wizard-data.json</code>, then serve from <code>site-src/</code> (e.g. <code>python -m http.server 8000</code>), or open the wizard from the built site.</p>';
+        resultsContent.innerHTML = '<p class="no-results">No implementation data loaded. Run <code>python hack/generate-controller-wizard-data.py --all</code> to generate <code>site/static/wizard/data/controller-wizard-data.json</code>, then serve from <code>site/static/</code> (e.g. <code>python -m http.server 8000</code>), or open the wizard from the built site.</p>';
         resultsDiv.classList.add('visible');
         resultsDiv.scrollIntoView({ behavior: 'smooth', block: 'start' });
         return;
@@ -553,7 +582,7 @@
         .catch(() => {
           IMPLEMENTATIONS = [];
           ALL_VERSIONS_DATA = null;
-          statusEl.textContent = 'Could not load wizard/data/controller-wizard-data.json. Run python hack/generate-controller-wizard-data.py --all and serve from site-src/ (e.g. python -m http.server 8000).';
+          statusEl.textContent = 'Could not load wizard/data/controller-wizard-data.json. Run python hack/generate-controller-wizard-data.py --all and serve from site/static/ (e.g. python -m http.server 8000).';
           versionRow.style.display = 'none';
           btn.disabled = false;
         });

--- a/site/static/wizard/index.html
+++ b/site/static/wizard/index.html
@@ -6,6 +6,35 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Gateway API Controller Matching Wizard</title>
   <link rel="stylesheet" href="controller-wizard.css">
+  <script>
+    (function() {
+      // Sync theme with parent Docsy (Bootstrap 5) or MkDocs-Material site
+      function syncTheme() {
+        try {
+          const parentDoc = window.parent.document.documentElement;
+          const theme = parentDoc.getAttribute('data-bs-theme') || 
+                        (parentDoc.getAttribute('data-md-color-scheme') === 'slate' ? 'dark' : 'light');
+          if (theme) {
+            document.documentElement.setAttribute('data-bs-theme', theme);
+          }
+        } catch (e) {
+          // Fallback to system preference if cross-origin or parent not accessible
+          if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            document.documentElement.setAttribute('data-bs-theme', 'dark');
+          }
+        }
+      }
+      syncTheme();
+      // Observe parent theme changes if same-origin
+      try {
+        const observer = new MutationObserver(syncTheme);
+        observer.observe(window.parent.document.documentElement, {
+          attributes: true,
+          attributeFilter: ['data-bs-theme', 'data-md-color-scheme']
+        });
+      } catch (e) {}
+    })();
+  </script>
 </head>
 
 <body>
@@ -149,7 +178,7 @@
         go.run(result.instance);
       })
       .catch(function (err) {
-        statusEl.textContent = err.message || 'Could not load wizard. Run: make wizard-wasm. Then serve from site-src/wizard/ (e.g. cd site-src/wizard && python3 -m http.server 8000) and open http://localhost:8000/';
+        statusEl.textContent = err.message || 'Could not load wizard. Run: make wizard-wasm. Then serve from site/static/wizard/ (e.g. cd site/static/wizard && python3 -m http.server 8000) and open http://localhost:8000/';
         document.getElementById('recommend-btn').disabled = false;
         window.wizardResize();
       });

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 // Controller Matching Wizard - WebAssembly build.
-// Build with: GOOS=js GOARCH=wasm go build -o site-src/wizard/main.wasm ./wasm/
+// Build with: GOOS=js GOARCH=wasm go build -o site/static/wizard/main.wasm ./wasm/
 // Load from HTML: wasm_exec.js + instantiateStreaming(fetch("main.wasm"), go.importObject).then(r => go.run(r.instance))
 package main
 
@@ -164,7 +164,7 @@ func main() {
 		}
 		return nil
 	})).Call("catch", js.FuncOf(func(_ js.Value, _ []js.Value) any {
-		doc.Call("getElementById", "wizard-data-status").Set("textContent", "Could not load data. Run 'make wizard-data' (requires conformance/reports/), then serve from site-src/wizard/.")
+		doc.Call("getElementById", "wizard-data-status").Set("textContent", "Could not load data. Run 'make wizard-data' (requires conformance/reports/), then serve from site/static/wizard/.")
 		doc.Call("getElementById", "recommend-btn").Set("disabled", false)
 		return nil
 	}))


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
The Gateway controller wizard now supports dark mode and syncs its theme with the Docsy theme.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
