### PR TITLE
Update Envoy Gateway conformance report for v1.5.1

### DIFF
--- a/conformance/reports/v1.5/envoy-gateway/README.md
+++ b/conformance/reports/v1.5/envoy-gateway/README.md
@@ -4,8 +4,8 @@
 
 | API channel  | Implementation version                                                        | Mode                         | Report                                                                |
 |--------------|-------------------------------------------------------------------------------|------------------------------|-----------------------------------------------------------------------|
-| experimental | [v1.8.0-rc.0](https://github.com/envoyproxy/gateway/releases/tag/v1.8.0-rc.0) | ControllerNamespace(default) | [link](./experimental-v1.8.0-rc.0-default-report.yaml)                |
-| experimental | [v1.8.0-rc.0](https://github.com/envoyproxy/gateway/releases/tag/v1.8.0-rc.0) | GatewayNamespace             | [link](./experimental-v1.8.0-rc.0-gateway-namespace-mode-report.yaml) |
+| experimental | [v1.8.0](https://github.com/envoyproxy/gateway/releases/tag/v1.8.0)           | ControllerNamespace(default) | [link](./experimental-v1.8.0-default-report.yaml)                     |
+| experimental | [v1.8.0](https://github.com/envoyproxy/gateway/releases/tag/v1.8.0)           | GatewayNamespace             | [link](./experimental-v1.8.0-gateway-namespace-mode-report.yaml)      |
 
 
 ## Overview

--- a/conformance/reports/v1.5/envoy-gateway/experimental-v1.8.0-default-report.yaml
+++ b/conformance/reports/v1.5/envoy-gateway/experimental-v1.8.0-default-report.yaml
@@ -1,5 +1,5 @@
 apiVersion: gateway.networking.k8s.io/v1
-date: "2026-03-24T17:48:24Z"
+date: "2026-05-13T05:30:18Z"
 gatewayAPIChannel: experimental
 gatewayAPIVersion: v1.5.1
 implementation:
@@ -8,70 +8,10 @@ implementation:
   organization: envoyproxy
   project: envoy-gateway
   url: https://github.com/envoyproxy/gateway
-  version: v1.8.0-rc.0
+  version: v1.8.0
 kind: ConformanceReport
-mode: gateway-namespace-mode
+mode: default
 profiles:
-- core:
-    result: success
-    statistics:
-      Failed: 0
-      Passed: 13
-      Skipped: 0
-  extended:
-    result: partial
-    skippedTests:
-    - ListenerSetHostnameConflict
-    - ListenerSetProtocolConflict
-    statistics:
-      Failed: 0
-      Passed: 7
-      Skipped: 2
-    supportedFeatures:
-    - GatewayAddressEmpty
-    - GatewayBackendClientCertificate
-    - GatewayFrontendClientCertificateValidation
-    - GatewayFrontendClientCertificateValidationInsecureFallback
-    - GatewayHTTPListenerIsolation
-    - GatewayHTTPSListenerDetectMisdirectedRequests
-    - GatewayInfrastructurePropagation
-    - GatewayPort8080
-    - ListenerSet
-    unsupportedFeatures:
-    - GatewayStaticAddresses
-  name: GATEWAY-GRPC
-  summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
-- core:
-    result: success
-    statistics:
-      Failed: 0
-      Passed: 18
-      Skipped: 0
-  extended:
-    result: partial
-    skippedTests:
-    - ListenerSetHostnameConflict
-    - ListenerSetProtocolConflict
-    statistics:
-      Failed: 0
-      Passed: 12
-      Skipped: 2
-    supportedFeatures:
-    - GatewayAddressEmpty
-    - GatewayBackendClientCertificate
-    - GatewayFrontendClientCertificateValidation
-    - GatewayFrontendClientCertificateValidationInsecureFallback
-    - GatewayHTTPListenerIsolation
-    - GatewayHTTPSListenerDetectMisdirectedRequests
-    - GatewayInfrastructurePropagation
-    - GatewayPort8080
-    - ListenerSet
-    - TLSRouteModeMixed
-    - TLSRouteModeTerminate
-    unsupportedFeatures:
-    - GatewayStaticAddresses
-  name: GATEWAY-TLS
-  summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
 - core:
     result: success
     statistics:
@@ -81,19 +21,12 @@ profiles:
   extended:
     result: partial
     skippedTests:
-    - GatewayBackendClientCertificateFeature
-    - GatewayFrontendClientCertificateValidation
-    - GatewayFrontendClientCertificateValidationInsecureFallback
-    - GatewayFrontendInvalidDefaultClientCertificateValidation
-    - GatewayInvalidFrontendClientCertificateValidation
-    - GatewayInvalidTLSBackendConfiguration
-    - HTTPRouteHTTPSListenerDetectMisdirectedRequests
     - ListenerSetHostnameConflict
     - ListenerSetProtocolConflict
     statistics:
       Failed: 0
-      Passed: 44
-      Skipped: 9
+      Passed: 50
+      Skipped: 2
     supportedFeatures:
     - BackendTLSPolicy
     - BackendTLSPolicySANValidation
@@ -102,9 +35,8 @@ profiles:
     - GatewayFrontendClientCertificateValidation
     - GatewayFrontendClientCertificateValidationInsecureFallback
     - GatewayHTTPListenerIsolation
-    - GatewayHTTPSListenerDetectMisdirectedRequests
-    - GatewayInfrastructurePropagation
     - GatewayPort8080
+    - GatewayStaticAddresses
     - HTTPRoute303RedirectStatusCode
     - HTTPRoute307RedirectStatusCode
     - HTTPRoute308RedirectStatusCode
@@ -130,12 +62,72 @@ profiles:
     - HTTPRouteSchemeRedirect
     - ListenerSet
     unsupportedFeatures:
-    - GatewayStaticAddresses
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
   name: GATEWAY-HTTP
-  summary: Core tests succeeded. Extended tests partially succeeded with 9 test skips.
+  summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 13
+      Skipped: 0
+  extended:
+    result: partial
+    skippedTests:
+    - ListenerSetHostnameConflict
+    - ListenerSetProtocolConflict
+    statistics:
+      Failed: 0
+      Passed: 7
+      Skipped: 2
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPListenerIsolation
+    - GatewayPort8080
+    - GatewayStaticAddresses
+    - ListenerSet
+    unsupportedFeatures:
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
+  name: GATEWAY-GRPC
+  summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 18
+      Skipped: 0
+  extended:
+    result: partial
+    skippedTests:
+    - ListenerSetHostnameConflict
+    - ListenerSetProtocolConflict
+    statistics:
+      Failed: 0
+      Passed: 12
+      Skipped: 2
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPListenerIsolation
+    - GatewayPort8080
+    - GatewayStaticAddresses
+    - ListenerSet
+    - TLSRouteModeMixed
+    - TLSRouteModeTerminate
+    unsupportedFeatures:
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
+  name: GATEWAY-TLS
+  summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
 succeededProvisionalTests:
 - GRPCRouteNamedRule
-- GatewayInfrastructure
 - GatewayOptionalAddressValue
 - HTTPRoute303Redirect
 - HTTPRoute307Redirect

--- a/conformance/reports/v1.5/envoy-gateway/experimental-v1.8.0-gateway-namespace-mode-report.yaml
+++ b/conformance/reports/v1.5/envoy-gateway/experimental-v1.8.0-gateway-namespace-mode-report.yaml
@@ -1,5 +1,5 @@
 apiVersion: gateway.networking.k8s.io/v1
-date: "2026-03-24T17:48:10Z"
+date: "2026-05-13T05:29:38Z"
 gatewayAPIChannel: experimental
 gatewayAPIVersion: v1.5.1
 implementation:
@@ -8,9 +8,9 @@ implementation:
   organization: envoyproxy
   project: envoy-gateway
   url: https://github.com/envoyproxy/gateway
-  version: v1.8.0-rc.0
+  version: v1.8.0
 kind: ConformanceReport
-mode: default
+mode: gateway-namespace-mode
 profiles:
 - core:
     result: success
@@ -21,19 +21,12 @@ profiles:
   extended:
     result: partial
     skippedTests:
-    - GatewayBackendClientCertificateFeature
-    - GatewayFrontendClientCertificateValidation
-    - GatewayFrontendClientCertificateValidationInsecureFallback
-    - GatewayFrontendInvalidDefaultClientCertificateValidation
-    - GatewayInvalidFrontendClientCertificateValidation
-    - GatewayInvalidTLSBackendConfiguration
-    - HTTPRouteHTTPSListenerDetectMisdirectedRequests
     - ListenerSetHostnameConflict
     - ListenerSetProtocolConflict
     statistics:
       Failed: 0
-      Passed: 43
-      Skipped: 9
+      Passed: 51
+      Skipped: 2
     supportedFeatures:
     - BackendTLSPolicy
     - BackendTLSPolicySANValidation
@@ -42,8 +35,9 @@ profiles:
     - GatewayFrontendClientCertificateValidation
     - GatewayFrontendClientCertificateValidationInsecureFallback
     - GatewayHTTPListenerIsolation
-    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
     - GatewayPort8080
+    - GatewayStaticAddresses
     - HTTPRoute303RedirectStatusCode
     - HTTPRoute307RedirectStatusCode
     - HTTPRoute308RedirectStatusCode
@@ -69,10 +63,9 @@ profiles:
     - HTTPRouteSchemeRedirect
     - ListenerSet
     unsupportedFeatures:
-    - GatewayInfrastructurePropagation
-    - GatewayStaticAddresses
+    - GatewayHTTPSListenerDetectMisdirectedRequests
   name: GATEWAY-HTTP
-  summary: Core tests succeeded. Extended tests partially succeeded with 9 test skips.
+  summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
 - core:
     result: success
     statistics:
@@ -86,7 +79,7 @@ profiles:
     - ListenerSetProtocolConflict
     statistics:
       Failed: 0
-      Passed: 6
+      Passed: 8
       Skipped: 2
     supportedFeatures:
     - GatewayAddressEmpty
@@ -94,12 +87,12 @@ profiles:
     - GatewayFrontendClientCertificateValidation
     - GatewayFrontendClientCertificateValidationInsecureFallback
     - GatewayHTTPListenerIsolation
-    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
     - GatewayPort8080
+    - GatewayStaticAddresses
     - ListenerSet
     unsupportedFeatures:
-    - GatewayInfrastructurePropagation
-    - GatewayStaticAddresses
+    - GatewayHTTPSListenerDetectMisdirectedRequests
   name: GATEWAY-GRPC
   summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
 - core:
@@ -115,7 +108,7 @@ profiles:
     - ListenerSetProtocolConflict
     statistics:
       Failed: 0
-      Passed: 11
+      Passed: 13
       Skipped: 2
     supportedFeatures:
     - GatewayAddressEmpty
@@ -123,18 +116,19 @@ profiles:
     - GatewayFrontendClientCertificateValidation
     - GatewayFrontendClientCertificateValidationInsecureFallback
     - GatewayHTTPListenerIsolation
-    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
     - GatewayPort8080
+    - GatewayStaticAddresses
     - ListenerSet
     - TLSRouteModeMixed
     - TLSRouteModeTerminate
     unsupportedFeatures:
-    - GatewayInfrastructurePropagation
-    - GatewayStaticAddresses
+    - GatewayHTTPSListenerDetectMisdirectedRequests
   name: GATEWAY-TLS
   summary: Core tests succeeded. Extended tests partially succeeded with 2 test skips.
 succeededProvisionalTests:
 - GRPCRouteNamedRule
+- GatewayInfrastructure
 - GatewayOptionalAddressValue
 - HTTPRoute303Redirect
 - HTTPRoute307Redirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind documentation

**What this PR does / why we need it**:
Update v1.5.1 conformance report for envoy-gateway

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
