### PR TITLE
fix: initialize retry count map to prevent nil map panic

### DIFF
--- a/conformance/echo-basic/echo-basic.go
+++ b/conformance/echo-basic/echo-basic.go
@@ -116,7 +116,9 @@ func main() {
 		Pod:       os.Getenv("POD_NAME"),
 	}
 
-	retrySimulation := &retrySimulation{}
+	retrySimulation := &retrySimulation{
+		attempts: make(map[string]int),
+	}
 
 	httpMux := http.NewServeMux()
 	httpMux.HandleFunc("/health", healthHandler)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind bug
/area conformance-machinery

**What this PR does / why we need it**:
```
2026/05/15 13:18:37 http: panic serving 192.168.206.82:48384: assignment to entry in nil map
goroutine 532 [running]:
net/http.(*conn).serve.func1()
    net/http/server.go:1943 +0xd3
panic({0x9f7be0?, 0xfdcf50?})
    runtime/panic.go:783 +0x132
main.(*retrySimulation).retrySimulationHandler(0xc000023590, {0xba17d8, 0xc00033c000}, 0xc000120140)
    sigs.k8s.io/gateway-api/conformance/echo-basic/echo-basic.go:209 +0x247
net/http.HandlerFunc.ServeHTTP(0xc0000cf980?, {0xba17d8?, 0xc00033c000?}, 0x479105?)
    net/http/server.go:2322 +0x29
net/http.(*ServeMux).ServeHTTP(0xc000324004?, {0xba17d8, 0xc00033c000}, 0xc000120140)
    net/http/server.go:2861 +0x1c7
main.(*preserveSlashes).ServeHTTP(0xc000023610, {0xba17d8, 0xc00033c000}, 0xc000120140)
    sigs.k8s.io/gateway-api/conformance/echo-basic/echo-basic.go:71 +0x9d
net/http.serverHandler.ServeHTTP({0xc0003481c0?}, {0xba17d8?, 0xc00033c000?}, 0x6?)
    net/http/server.go:3340 +0x8e
net/http.(*conn).serve(0xc00021c5a0, {0xba2550, 0xc00020a120})
    net/http/server.go:2109 +0x665
created by net/http.(*Server).Serve in goroutine 7
    net/http/server.go:3493 +0x485
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
