### PR TITLE
fix: make mkdocs CLI exception test reach prepare_docs

### DIFF
--- a/hack/mkdocs/__tests__/test_cli.py
+++ b/hack/mkdocs/__tests__/test_cli.py
@@ -58,13 +58,8 @@ class TestCommandLineInterface(unittest.TestCase):
 
         linking.prepare_docs = failing_prepare_docs
 
-        import sys
-        import mkdocs_utils
-        # Ensure prepare_docs in linking module is the one called by main
-        # (main calls linking.prepare_docs)
-
         original_argv = sys.argv
-        sys.argv = ["linking.py", "--prepare"]
+        sys.argv = ["linking.py", "--prepare", "--docs-dir", str(self.docs_path)]
 
         try:
             # Act & Assert: Exception should propagate (this is expected behavior)


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

Tiny MkDocs CLI test fix. The exception-path test mocked `prepare_docs`, but then ran `main()` without a temp `--docs-dir`, so it bailed on missing `site-src` before the mock was reached. Oops, test never hit the thing it said it was testing.

Repro on `origin/main`:

```bash
PYTHONPATH=hack python -m unittest discover -s hack/mkdocs/__tests__ -p 'test_cli.py' -k test_main_handles_prepare_docs_exceptions
```

Before: `AssertionError: Exception not raised`.
After: the test reaches the mocked `prepare_docs` and passes. No cloud/API limits or quotas involved here; this is just local CLI arg handling.

**Which issue(s) this PR fixes**:

None. Related to #3999 and #3860.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
