### PR TITLE
docs: add front matter to GEP pages to fix search links

### DIFF
--- a/geps/gep-1016/index.md
+++ b/geps/gep-1016/index.md
@@ -1,4 +1,6 @@
-# GEP-1016: GRPCRoute
+---
+title: "GEP-1016: GRPCRoute"
+---
 
 * Issue: [#1016](https://github.com/kubernetes-sigs/gateway-api/issues/1016)
 * Status: Standard

--- a/geps/gep-1282/index.md
+++ b/geps/gep-1282/index.md
@@ -1,4 +1,6 @@
-# GEP-1282: Describing Backend Properties
+---
+title: "GEP-1282: Describing Backend Properties"
+---
 
 * Issue: [#1282](https://github.com/kubernetes-sigs/gateway-api/issues/1282)
 * Status: Declined

--- a/geps/gep-1294/index.md
+++ b/geps/gep-1294/index.md
@@ -1,4 +1,6 @@
-# GEP-1294: xRoutes Mesh Binding
+---
+title: "GEP-1294: xRoutes Mesh Binding"
+---
 
 * Issue: [#1294](https://github.com/kubernetes-sigs/gateway-api/issues/1294)
 * Status: Standard

--- a/geps/gep-1323/index.md
+++ b/geps/gep-1323/index.md
@@ -1,4 +1,6 @@
-# GEP 1323: Response Header Filter
+---
+title: "GEP 1323: Response Header Filter"
+---
 
 * Issue: [#1323](https://github.com/kubernetes-sigs/gateway-api/issues/1323)
 * Status: Standard

--- a/geps/gep-1324/index.md
+++ b/geps/gep-1324/index.md
@@ -1,4 +1,6 @@
-# GEP-1324: Service Mesh in Gateway API
+---
+title: "GEP-1324: Service Mesh in Gateway API"
+---
 
 * Issue: [#1324](https://github.com/kubernetes-sigs/gateway-api/issues/1324)
 * Status: Memorandum

--- a/geps/gep-1364/index.md
+++ b/geps/gep-1364/index.md
@@ -1,4 +1,6 @@
-# GEP-1364: Status and Conditions Update
+---
+title: "GEP-1364: Status and Conditions Update"
+---
 
 * Issue: [#1364](https://github.com/kubernetes-sigs/gateway-api/issues/1364)
 * Status: Standard

--- a/geps/gep-1494/index.md
+++ b/geps/gep-1494/index.md
@@ -1,4 +1,6 @@
-# GEP-1494: HTTP Auth in Gateway API
+---
+title: "GEP-1494: HTTP Auth in Gateway API"
+---
 
 * Issue: [#1494](https://github.com/kubernetes-sigs/gateway-api/issues/1494)
 * Status: Experimental

--- a/geps/gep-1619/index.md
+++ b/geps/gep-1619/index.md
@@ -1,4 +1,6 @@
-# GEP-1619: Session Persistence via BackendLBPolicy
+---
+title: "GEP-1619: Session Persistence via BackendLBPolicy"
+---
 
 * Issue: [#1619](https://github.com/kubernetes-sigs/gateway-api/issues/1619)
 * Status: Experimental

--- a/geps/gep-1651/index.md
+++ b/geps/gep-1651/index.md
@@ -1,4 +1,6 @@
-# GEP-1651: Gateway Routability
+---
+title: "GEP-1651: Gateway Routability"
+---
 
 * Issue: [#1651](https://github.com/kubernetes-sigs/gateway-api/issues/1651)
 * Status: Provisional

--- a/geps/gep-1686/index.md
+++ b/geps/gep-1686/index.md
@@ -1,4 +1,6 @@
-# GEP-1686: Mesh conformance testing plan
+---
+title: "GEP-1686: Mesh conformance testing plan"
+---
 
 * Issue: [#1686](https://github.com/kubernetes-sigs/gateway-api/issues/1686)
 * Status: Standard

--- a/geps/gep-1709/index.md
+++ b/geps/gep-1709/index.md
@@ -1,4 +1,6 @@
-# GEP-1709: Conformance Profiles
+---
+title: "GEP-1709: Conformance Profiles"
+---
 
 * Issue: [#1709](https://github.com/kubernetes-sigs/gateway-api/issues/1709)
 * Status: Standard

--- a/geps/gep-1713/index.md
+++ b/geps/gep-1713/index.md
@@ -1,4 +1,6 @@
-# GEP-1713: ListenerSets - Standard Mechanism to Merge Multiple Gateways
+---
+title: "GEP-1713: ListenerSets - Standard Mechanism to Merge Multiple Gateways"
+---
 
 * Issue: [#1713](https://github.com/kubernetes-sigs/gateway-api/issues/1713)
 * Status: Standard

--- a/geps/gep-1731/index.md
+++ b/geps/gep-1731/index.md
@@ -1,4 +1,6 @@
-# GEP-1731: HTTPRoute Retries
+---
+title: "GEP-1731: HTTPRoute Retries"
+---
 
 * Issue: [#1731](https://github.com/kubernetes-sigs/gateway-api/issues/1731)
 * Status: Experimental

--- a/geps/gep-1742/index.md
+++ b/geps/gep-1742/index.md
@@ -1,4 +1,6 @@
-# GEP-1742: HTTPRoute Timeouts
+---
+title: "GEP-1742: HTTPRoute Timeouts"
+---
 
 * Issue: [#1742](https://github.com/kubernetes-sigs/gateway-api/issues/1742)
 * Status: Standard

--- a/geps/gep-1748/index.md
+++ b/geps/gep-1748/index.md
@@ -1,4 +1,6 @@
-# GEP-1748: Gateway API Interaction with Multi-Cluster Services
+---
+title: "GEP-1748: Gateway API Interaction with Multi-Cluster Services"
+---
 
 * Issue: [#1748](https://github.com/kubernetes-sigs/gateway-api/issues/1748)
 * Status: Experimental

--- a/geps/gep-1762/index.md
+++ b/geps/gep-1762/index.md
@@ -1,4 +1,6 @@
-# GEP-1762: In Cluster Gateway Deployments
+---
+title: "GEP-1762: In Cluster Gateway Deployments"
+---
 
 * Status: Standard
 

--- a/geps/gep-1767/index.md
+++ b/geps/gep-1767/index.md
@@ -1,4 +1,6 @@
-# GEP 1767: CORS Filter
+---
+title: "GEP 1767: CORS Filter"
+---
 
 * Issue: [#1767](https://github.com/kubernetes-sigs/gateway-api/issues/1767)
 * Status: Standard

--- a/geps/gep-1867/index.md
+++ b/geps/gep-1867/index.md
@@ -1,4 +1,6 @@
-# GEP-1867: Per-Gateway Infrastructure
+---
+title: "GEP-1867: Per-Gateway Infrastructure"
+---
 
 * Status: Standard
 * Issue: [#1867](https://github.com/kubernetes-sigs/gateway-api/issues/1867)

--- a/geps/gep-1897/index.md
+++ b/geps/gep-1897/index.md
@@ -1,4 +1,6 @@
-# GEP-1897: BackendTLSPolicy - Explicit Backend TLS Connection Configuration
+---
+title: "GEP-1897: BackendTLSPolicy - Explicit Backend TLS Connection Configuration"
+---
 
 * Issue: [#1897](https://github.com/kubernetes-sigs/gateway-api/issues/1897)
 * Status: Standard

--- a/geps/gep-1911/index.md
+++ b/geps/gep-1911/index.md
@@ -1,4 +1,6 @@
-# GEP-1911: Backend Protocol Selection
+---
+title: "GEP-1911: Backend Protocol Selection"
+---
 
 * Issue: [#1911](https://github.com/kubernetes-sigs/gateway-api/issues/1911)
 * Status: Standard

--- a/geps/gep-2162/index.md
+++ b/geps/gep-2162/index.md
@@ -1,4 +1,6 @@
-# GEP-2162: Supported features in GatewayClass Status
+---
+title: "GEP-2162: Supported features in GatewayClass Status"
+---
 
 * Issue: [#2162](https://github.com/kubernetes-sigs/gateway-api/issues/2162)
 * Status: Standard

--- a/geps/gep-2257/index.md
+++ b/geps/gep-2257/index.md
@@ -1,4 +1,6 @@
-# GEP-2257: Gateway API Duration Format
+---
+title: "GEP-2257: Gateway API Duration Format"
+---
 
 * Issue: [#2257](https://github.com/kubernetes-sigs/gateway-api/issues/2257)
 * Status: Standard

--- a/geps/gep-2627/index.md
+++ b/geps/gep-2627/index.md
@@ -1,4 +1,6 @@
-# GEP-2627: DNS configuration within Gateway API
+---
+title: "GEP-2627: DNS configuration within Gateway API"
+---
 
 * Issue: [#2627](https://github.com/kubernetes-sigs/gateway-api/issues/2627)
 * Status: Provisional

--- a/geps/gep-2643/index.md
+++ b/geps/gep-2643/index.md
@@ -1,5 +1,6 @@
-
-# GEP-2643: TLS/SNI based routing / TLSRoute
+---
+title: "GEP-2643: TLS/SNI based routing / TLSRoute"
+---
 
 * Issue: [#2643](https://github.com/kubernetes-sigs/gateway-api/issues/2643)
 * Status: Standard

--- a/geps/gep-2644/index.md
+++ b/geps/gep-2644/index.md
@@ -1,4 +1,6 @@
-# GEP-2644: TCPRoute
+---
+title: "GEP-2644: TCPRoute"
+---
 
 - Issue: [#2644](https://github.com/kubernetes-sigs/gateway-api/issues/2644)
 - Status: Provisional

--- a/geps/gep-2645/index.md
+++ b/geps/gep-2645/index.md
@@ -1,4 +1,6 @@
-# GEP-2645: UDPRoute
+---
+title: "GEP-2645: UDPRoute"
+---
 
 - Issue: [#2645](https://github.com/kubernetes-sigs/gateway-api/issues/2645)
 - Status: Provisional

--- a/geps/gep-2648/index.md
+++ b/geps/gep-2648/index.md
@@ -1,4 +1,6 @@
-# GEP-2648: Direct Policy Attachment
+---
+title: "GEP-2648: Direct Policy Attachment"
+---
 
 * Issue: [#2648](https://github.com/kubernetes-sigs/gateway-api/issues/2648)
 * Status: Declined

--- a/geps/gep-2649/index.md
+++ b/geps/gep-2649/index.md
@@ -1,4 +1,6 @@
-# GEP-2649: Inherited Policy Attachment
+---
+title: "GEP-2649: Inherited Policy Attachment"
+---
 
 * Issue: [#2649](https://github.com/kubernetes-sigs/gateway-api/issues/2649)
 * Status: Declined

--- a/geps/gep-2659/index.md
+++ b/geps/gep-2659/index.md
@@ -1,4 +1,6 @@
-# GEP-2659: Document and improve the GEP process
+---
+title: "GEP-2659: Document and improve the GEP process"
+---
 
 * Issue: [#2659](https://github.com/kubernetes-sigs/gateway-api/issues/2659)
 * Type: Memorandum

--- a/geps/gep-2722/index.md
+++ b/geps/gep-2722/index.md
@@ -1,4 +1,6 @@
-# GEP-2722: Goals and UX for gwctl
+---
+title: "GEP-2722: Goals and UX for gwctl"
+---
 
 * Issue: [#2722](https://github.com/kubernetes-sigs/gateway-api/issues/2722)
 * Status: Memorandum

--- a/geps/gep-2907/index.md
+++ b/geps/gep-2907/index.md
@@ -1,4 +1,6 @@
-# GEP-2907: TLS Configuration Placement and Terminology
+---
+title: "GEP-2907: TLS Configuration Placement and Terminology"
+---
 
 * Issue: [#2907](https://github.com/kubernetes-sigs/gateway-api/issues/2907)
 * Status: Memorandum

--- a/geps/gep-3155/index.md
+++ b/geps/gep-3155/index.md
@@ -1,4 +1,6 @@
-# GEP-3155: Complete Backend mutual TLS Configuration
+---
+title: "GEP-3155: Complete Backend mutual TLS Configuration"
+---
 
 * Issue: [#3155](https://github.com/kubernetes-sigs/gateway-api/issues/3155)
 * Status: Standard

--- a/geps/gep-3171/index.md
+++ b/geps/gep-3171/index.md
@@ -1,4 +1,6 @@
-# GEP-3171: Percentage-based Request Mirroring
+---
+title: "GEP-3171: Percentage-based Request Mirroring"
+---
 
 * Issue: [#3171](https://github.com/kubernetes-sigs/gateway-api/issues/3171)
 * Status: Standard

--- a/geps/gep-3388/index.md
+++ b/geps/gep-3388/index.md
@@ -1,4 +1,6 @@
-# GEP-3388: Retry Budgets
+---
+title: "GEP-3388: Retry Budgets"
+---
 
 * Issue: [#3388](https://github.com/kubernetes-sigs/gateway-api/issues/3388)
 * Status: Experimental

--- a/geps/gep-3567/index.md
+++ b/geps/gep-3567/index.md
@@ -1,4 +1,6 @@
-# GEP-3567: Gateway TLS Updates for HTTP/2 Connection Coalescing
+---
+title: "GEP-3567: Gateway TLS Updates for HTTP/2 Connection Coalescing"
+---
 
 * Issue: [#3567](https://github.com/kubernetes-sigs/gateway-api/issues/3567)
 * Status: Experimental

--- a/geps/gep-3779/index.md
+++ b/geps/gep-3779/index.md
@@ -1,4 +1,6 @@
-# GEP-3779: Identity Based Authz for East-West Traffic
+---
+title: "GEP-3779: Identity Based Authz for East-West Traffic"
+---
 
 * Issue: [#3779](https://github.com/kubernetes-sigs/gateway-api/issues/3779)
 * Status: Implementable

--- a/geps/gep-3792/index.md
+++ b/geps/gep-3792/index.md
@@ -1,4 +1,6 @@
-# GEP-3792: Out-of-Cluster Gateways
+---
+title: "GEP-3792: Out-of-Cluster Gateways"
+---
 
 * Issue: [#3792](https://github.com/kubernetes-sigs/gateway-api/issues/3792)
 * Status: Provisional

--- a/geps/gep-3793/index.md
+++ b/geps/gep-3793/index.md
@@ -1,4 +1,6 @@
-# GEP-3793: Default Gateways
+---
+title: "GEP-3793: Default Gateways"
+---
 
 * Issue: [#3793](https://github.com/kubernetes-sigs/gateway-api/issues/3793)
 * Status: Implementable

--- a/geps/gep-3798/index.md
+++ b/geps/gep-3798/index.md
@@ -1,4 +1,6 @@
-# GEP-3798: Client IP-Based Session Persistence
+---
+title: "GEP-3798: Client IP-Based Session Persistence"
+---
 
 * Issue: [#3798](https://github.com/kubernetes-sigs/gateway-api/issues/3798)
 * Status: Deferred

--- a/geps/gep-3949/index.md
+++ b/geps/gep-3949/index.md
@@ -1,4 +1,6 @@
-# GEP-3949: Mesh Resource
+---
+title: "GEP-3949: Mesh Resource"
+---
 
 * Issue: [#3949](https://github.com/kubernetes-sigs/gateway-api/issues/3949)
 * Status: Implementable

--- a/geps/gep-3965/index.md
+++ b/geps/gep-3965/index.md
@@ -1,4 +1,6 @@
-# GEP-3965: HTTPRoute Implementation-Specific Matches
+---
+title: "GEP-3965: HTTPRoute Implementation-Specific Matches"
+---
 
 * Issue: [#3965](https://github.com/kubernetes-sigs/gateway-api/issues/3965)
 * Status: Provisional

--- a/geps/gep-4152/index.md
+++ b/geps/gep-4152/index.md
@@ -1,4 +1,6 @@
-# GEP-4152: Extending TLS Validation in BackendTLSPolicy
+---
+title: "GEP-4152: Extending TLS Validation in BackendTLSPolicy"
+---
 
 * Issue: [#4152](https://github.com/kubernetes-sigs/gateway-api/issues/4152)
 * Status: Provisional

--- a/geps/gep-4488/index.md
+++ b/geps/gep-4488/index.md
@@ -1,4 +1,6 @@
-# GEP-4488: Backend Resource
+---
+title: "GEP-4488: Backend Resource"
+---
 
 * Issue: [#4488](https://github.com/kubernetes-sigs/gateway-api/pull/4488)
   * Incubated by the [AI Gateway Working Group](https://github.com/kubernetes-sigs/wg-ai-gateway/pull/20)

--- a/geps/gep-4768/index.md
+++ b/geps/gep-4768/index.md
@@ -1,4 +1,6 @@
-# GEP: Standardized Telemetry API
+---
+title: "GEP: Standardized Telemetry API"
+---
 
 * Issue: #4768
 * Status: Provisional

--- a/geps/gep-696/index.md
+++ b/geps/gep-696/index.md
@@ -1,4 +1,6 @@
-# GEP-696: GEP template
+---
+title: "GEP-696: GEP template"
+---
 
 * Issue: [#696](https://github.com/kubernetes-sigs/gateway-api/issues/696)
 * Status: Provisional|Prototyping|Implementable|Experimental|Standard|Completed|Memorandum|Deferred|Declined|Withdrawn

--- a/geps/gep-709/index.md
+++ b/geps/gep-709/index.md
@@ -1,4 +1,6 @@
-# GEP-709: Cross Namespace References from Routes
+---
+title: "GEP-709: Cross Namespace References from Routes"
+---
 
 * Issue: [#709](https://github.com/kubernetes-sigs/gateway-api/issues/709)
 * Status: Standard

--- a/geps/gep-713/index.md
+++ b/geps/gep-713/index.md
@@ -1,4 +1,6 @@
-# GEP-713: Metaresources and Policy Attachment
+---
+title: "GEP-713: Metaresources and Policy Attachment"
+---
 
 * Issue: [#713](https://github.com/kubernetes-sigs/gateway-api/issues/713)
 * Status: Memorandum

--- a/geps/gep-718/index.md
+++ b/geps/gep-718/index.md
@@ -1,4 +1,6 @@
-# GEP-718: Rework forwardTo segment in routes
+---
+title: "GEP-718: Rework forwardTo segment in routes"
+---
 
 * Issue: [#718](https://github.com/kubernetes-sigs/gateway-api/issues/718)
 * Status: Standard

--- a/geps/gep-724/index.md
+++ b/geps/gep-724/index.md
@@ -1,4 +1,6 @@
-# GEP-724: Refresh Route-Gateway Binding
+---
+title: "GEP-724: Refresh Route-Gateway Binding"
+---
 
 * Issue: [#724](https://github.com/kubernetes-sigs/gateway-api/issues/724)
 * Status: Standard

--- a/geps/gep-726/index.md
+++ b/geps/gep-726/index.md
@@ -1,4 +1,6 @@
-# GEP-726: Add Path Redirects and Rewrites
+---
+title: "GEP-726: Add Path Redirects and Rewrites"
+---
 
 * Issue: [#726](https://github.com/kubernetes-sigs/gateway-api/issues/726)
 * Status: Standard

--- a/geps/gep-735/index.md
+++ b/geps/gep-735/index.md
@@ -1,4 +1,6 @@
-# GEP-735: TCP and UDP addresses matching
+---
+title: "GEP-735: TCP and UDP addresses matching"
+---
 
 * Issue: [#735](https://github.com/kubernetes-sigs/gateway-api/issues/735)
 * Status: Declined

--- a/geps/gep-746/index.md
+++ b/geps/gep-746/index.md
@@ -1,4 +1,6 @@
-# GEP-746: Replace Cert Refs on HTTPRoute with Cross Namespace Refs from Gateway
+---
+title: "GEP-746: Replace Cert Refs on HTTPRoute with Cross Namespace Refs from Gateway"
+---
 
 * Issue: [#746](https://github.com/kubernetes-sigs/gateway-api/issues/746)
 * Status: Standard

--- a/geps/gep-820/index.md
+++ b/geps/gep-820/index.md
@@ -1,4 +1,6 @@
-# GEP-820: Drop extension points from Route matches
+---
+title: "GEP-820: Drop extension points from Route matches"
+---
 
 * Issue: [#820](https://github.com/kubernetes-sigs/gateway-api/issues/820)
 * Status: Standard

--- a/geps/gep-851/index.md
+++ b/geps/gep-851/index.md
@@ -1,4 +1,6 @@
-# GEP-851: Allow Multiple Certificate Refs per Gateway Listener
+---
+title: "GEP-851: Allow Multiple Certificate Refs per Gateway Listener"
+---
 
 * Issue: [#851](https://github.com/kubernetes-sigs/gateway-api/issues/851)
 * Status: Standard

--- a/geps/gep-91/index.md
+++ b/geps/gep-91/index.md
@@ -1,4 +1,6 @@
-# GEP-91: Client Certificate Validation for TLS terminating at the Gateway
+---
+title: "GEP-91: Client Certificate Validation for TLS terminating at the Gateway"
+---
 
 * Issue: [#91](https://github.com/kubernetes-sigs/gateway-api/issues/91)
 * Status: Standard

--- a/geps/gep-917/index.md
+++ b/geps/gep-917/index.md
@@ -1,4 +1,6 @@
-# GEP-917: Gateway API Conformance Testing
+---
+title: "GEP-917: Gateway API Conformance Testing"
+---
 
 * Issue: [#917](https://github.com/kubernetes-sigs/gateway-api/issues/917)
 * Status: Memorandum

--- a/geps/gep-922/index.md
+++ b/geps/gep-922/index.md
@@ -1,4 +1,6 @@
-# GEP-922: Gateway API Versioning
+---
+title: "GEP-922: Gateway API Versioning"
+---
 
 * Issue: [#922](https://github.com/kubernetes-sigs/gateway-api/issues/922)
 * Status: Memorandum

--- a/geps/gep-957/index.md
+++ b/geps/gep-957/index.md
@@ -1,4 +1,6 @@
-# GEP-957: Destination Port Matching
+---
+title: "GEP-957: Destination Port Matching"
+---
 
 * Issue: [#957](https://github.com/kubernetes-sigs/gateway-api/issues/957)
 * Status: Standard

--- a/geps/gep-995/index.md
+++ b/geps/gep-995/index.md
@@ -1,4 +1,6 @@
-# GEP-995: Named route rules
+---
+title: "GEP-995: Named route rules"
+---
 
 * Issue: [#995](https://github.com/kubernetes-sigs/gateway-api/issues/995)
 * Status: Standard

--- a/site/content/en/geps/_index.md
+++ b/site/content/en/geps/_index.md
@@ -2,5 +2,8 @@
 title: "Enhancements"
 weight: 40
 cascade:
-  type: "docs"
+  - type: "docs"
+  - _target:
+      path: /geps/gep-*
+    toc_hide: true
 ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
GEP index.md files lacked Hugo front matter, causing empty titles in the Docsy search index. Search results showed the path (e.g. /geps/gep-1619) as plain text with no clickable link. Replace the markdown H1 heading with a front matter title field, matching the pattern used by all other site content pages.

Additionally, hide individual GEP pages from the sidebar since they're already accessible via the GEPs List and search.

**Which issue(s) this PR fixes**:
Fixes # N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

Related: https://github.com/kubernetes-sigs/gateway-api/pull/4734
