### PR TITLE
[refactor] change kind node version to v1.31.0

### DIFF
--- a/hack/implementations/common/create-cluster.sh
+++ b/hack/implementations/common/create-cluster.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 # Setup default values
 CLUSTER_NAME=${CLUSTER_NAME:-"envoy-gateway"}
 METALLB_VERSION=${METALLB_VERSION:-"v0.13.10"}
-KIND_NODE_TAG=${KIND_NODE_TAG:-"v1.28.0"}
+KIND_NODE_TAG=${KIND_NODE_TAG:-"v1.31.0"}
 NUM_WORKERS=${NUM_WORKERS:-""}
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind failing-test
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:
When I try to run the steps described in envoy-gateway read me file, in the step that I apply the helm chart I get the following error:

> Pulled: docker.io/envoyproxy/gateway-helm:v0.0.0-latest
Digest: sha256:44fc92ea22188e5ffb7ee9220e2980d688592f09edb9015bb515390628eff179
Error: INSTALLATION FAILED: failed to install CRD crds/gatewayapi-crds.yaml: [resource mapping not found for name: "safe-upgrades.gateway.networking.k8s.io" namespace: "" from "": no matches for kind "ValidatingAdmissionPolicy" in version "admissionregistration.k8s.io/v1"
ensure CRDs are installed first, resource mapping not found for name: "safe-upgrades.gateway.networking.k8s.io" namespace: "" from "": no matches for kind "ValidatingAdmissionPolicyBinding" in version "admissionregistration.k8s.io/v1"
ensure CRDs are installed first]

If I put version v1.30.0 I get:

> Pulled: docker.io/envoyproxy/gateway-helm:v0.0.0-latest
Digest: sha256:44fc92ea22188e5ffb7ee9220e2980d688592f09edb9015bb515390628eff179
Error: INSTALLATION FAILED: failed to install CRD crds/gatewayapi-crds.yaml: server-side apply failed for object /tlsroutes.gateway.networking.k8s.io apiextensions.k8s.io/v1, Kind=CustomResourceDefinition: CustomResourceDefinition.apiextensions.k8s.io "tlsroutes.gateway.networking.k8s.io" is invalid: [spec.versions[0].schema.openAPIV3Schema.properties[spec].properties[hostnames].x-kubernetes-validations[0].rule: Invalid value: apiextensions.ValidationRule{Rule:"self.all(h, !isIP(h))", Message:"Hostnames cannot contain an IP", MessageExpression:"", Reason:(*apiextensions.FieldValueErrorReason)(nil), FieldPath:"", OptionalOldSelf:(*bool)(nil)}: compilation failed: ERROR: <input>:1:18: undeclared reference to 'isIP' (in container '')
 | self.all(h, !isIP(h))
 | .................^, spec.versions[2].schema.openAPIV3Schema.properties[spec].properties[hostnames].x-kubernetes-validations[0].rule: Invalid value: apiextensions.ValidationRule{Rule:"self.all(h, !isIP(h))", Message:"Hostnames cannot contain an IP", MessageExpression:"", Reason:(*apiextensions.FieldValueErrorReason)(nil), FieldPath:"", OptionalOldSelf:(*bool)(nil)}: compilation failed: ERROR: <input>:1:18: undeclared reference to 'isIP' (in container '')
 | self.all(h, !isIP(h))
 | .................^]

But v1.31.0 looks good

> Pulled: docker.io/envoyproxy/gateway-helm:v0.0.0-latest
Digest: sha256:44fc92ea22188e5ffb7ee9220e2980d688592f09edb9015bb515390628eff179
NAME: eg
LAST DEPLOYED: Fri May 15 19:52:10 2026
NAMESPACE: envoy-gateway-system
STATUS: deployed
REVISION: 1
DESCRIPTION: Install complete
TEST SUITE: None
NOTES:

**Which issue(s) this PR fixes**:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Fixes #
-->


**Does this PR introduce a user-facing change?**:
None
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
