### PR TITLE
test(conformance): add conformance test for BackendTLSPolicy with TLSRoute Terminate

### DIFF
--- a/conformance/tests/backendtlspolicy-tlsroute-terminate.go
+++ b/conformance/tests/backendtlspolicy-tlsroute-terminate.go
@@ -1,0 +1,99 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tcp"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, BackendTLSPolicyTLSRouteTerminate)
+}
+
+var BackendTLSPolicyTLSRouteTerminate = suite.ConformanceTest{
+	ShortName:   "BackendTLSPolicyTLSRouteTerminate",
+	Description: "A BackendTLSPolicy attached to a Service consumed by a TLSRoute using Terminate mode should re-encrypt traffic to the backend",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportTLSRoute,
+		features.SupportTLSRouteModeTerminate,
+		features.SupportBackendTLSPolicy,
+	},
+	Provisional: true,
+	Manifests:   []string{"tests/backendtlspolicy-tlsroute-terminate.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		ns := "gateway-conformance-infra"
+		routeNN := types.NamespacedName{Name: "backendtlspolicy-tlsroute-terminate", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "gateway-btls-tlsroute-terminate", Namespace: ns}
+		policyNN := types.NamespacedName{Name: "btls-tlsroute-terminate-test", Namespace: ns}
+		caCertNN := types.NamespacedName{Name: "tls-checks-ca-certificate", Namespace: ns}
+		expectedBackendName := "btls-terminate-tls-backend"
+		expectedBackendHostname := "abc.example.com"
+
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+
+		gwAddr, hostnames := kubernetes.GatewayAndTLSRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		if len(hostnames) != 1 {
+			t.Fatalf("unexpected error in test configuration, found %d hostnames", len(hostnames))
+		}
+		serverStr := string(hostnames[0])
+
+		acceptedCond := metav1.Condition{
+			Type:   string(gatewayv1.PolicyConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.PolicyReasonAccepted),
+		}
+		resolvedRefsCond := metav1.Condition{
+			Type:   string(gatewayv1.BackendTLSPolicyConditionResolvedRefs),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.BackendTLSPolicyReasonResolvedRefs),
+		}
+		kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, policyNN, gwNN, acceptedCond)
+		kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, policyNN, gwNN, resolvedRefsCond)
+
+		caConfigMap, err := kubernetes.GetConfigMapData(suite.Client, suite.TimeoutConfig, caCertNN)
+		if err != nil {
+			t.Fatalf("unexpected error finding CA certificate ConfigMap: %v", err)
+		}
+		caString, ok := caConfigMap["ca.crt"]
+		if !ok {
+			t.Fatalf("ca.crt not found in configmap: %s/%s", caCertNN.Namespace, caCertNN.Name)
+		}
+
+		t.Run("TLS request matching terminated TLSRoute with BackendTLSPolicy should reach backend with re-encrypted TLS", func(t *testing.T) {
+			// serverStr is the client-facing hostname from the TLSRoute/Gateway listener.
+			// expectedBackendHostname is the backend TLS identity validated via
+			// BackendTLSPolicy.validation.hostname during re-encryption to the Service backend.
+			tcp.MakeTCPRequestAndExpectEventuallyValidResponse(t, suite.TimeoutConfig, gwAddr, []byte(caString), serverStr, true,
+				tcp.ExpectedResponse{
+					BackendIsTLS: true,
+					Backend:      expectedBackendName,
+					Namespace:    ns,
+					Hostname:     expectedBackendHostname,
+				})
+		})
+	},
+}

--- a/conformance/tests/backendtlspolicy-tlsroute-terminate.go
+++ b/conformance/tests/backendtlspolicy-tlsroute-terminate.go
@@ -50,7 +50,7 @@ var BackendTLSPolicyTLSRouteTerminate = suite.ConformanceTest{
 		gwNN := types.NamespacedName{Name: "gateway-btls-tlsroute-terminate", Namespace: ns}
 		policyNN := types.NamespacedName{Name: "btls-tlsroute-terminate-test", Namespace: ns}
 		caCertNN := types.NamespacedName{Name: "tls-checks-ca-certificate", Namespace: ns}
-		expectedBackendName := "btls-terminate-tls-backend"
+		expectedBackendName := "tcp-backend"
 		expectedBackendHostname := "abc.example.com"
 
 		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})

--- a/conformance/tests/backendtlspolicy-tlsroute-terminate.yaml
+++ b/conformance/tests/backendtlspolicy-tlsroute-terminate.yaml
@@ -20,7 +20,7 @@ spec:
       certificateRefs:
       - name: tls-terminate-checks-certificate
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: backendtlspolicy-tlsroute-terminate
@@ -43,7 +43,7 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   selector:
-    app: tls-backend
+    app: tcp-backend
   ports:
   - name: "btls"
     protocol: TCP

--- a/conformance/tests/backendtlspolicy-tlsroute-terminate.yaml
+++ b/conformance/tests/backendtlspolicy-tlsroute-terminate.yaml
@@ -1,0 +1,69 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-btls-tlsroute-terminate
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: tls-terminate
+    port: 8443
+    protocol: TLS
+    hostname: tls.example.com
+    allowedRoutes:
+      namespaces:
+        from: Same
+      kinds:
+      - kind: TLSRoute
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: tls-terminate-checks-certificate
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: TLSRoute
+metadata:
+  name: backendtlspolicy-tlsroute-terminate
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: gateway-btls-tlsroute-terminate
+    namespace: gateway-conformance-infra
+  hostnames:
+  - tls.example.com
+  rules:
+  - backendRefs:
+    - name: btls-terminate-tls-backend
+      port: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: btls-terminate-tls-backend
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: tls-backend
+  ports:
+  - name: "btls"
+    protocol: TCP
+    port: 8443
+    targetPort: 8443
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: btls-tlsroute-terminate-test
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: "btls-terminate-tls-backend"
+    sectionName: "btls"
+  validation:
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      name: "tls-checks-ca-certificate"
+    hostname: "abc.example.com"

--- a/conformance/utils/suite/profiles.go
+++ b/conformance/utils/suite/profiles.go
@@ -103,10 +103,13 @@ var (
 			features.SupportReferenceGrant,
 			features.SupportTLSRoute,
 		),
-		ExtendedFeatures: features.SetsToNamesSet(
-			features.GatewayExtendedFeatures,
-			features.TLSRouteExtendedFeatures,
-		),
+		ExtendedFeatures: sets.New[features.FeatureName]().
+			Insert(features.SetsToNamesSet(
+				features.GatewayExtendedFeatures,
+				features.TLSRouteExtendedFeatures,
+				features.BackendTLSPolicyCoreFeatures,
+				features.BackendTLSPolicyExtendedFeatures,
+			).UnsortedList()...),
 	}
 
 	// GatewayTCPConformanceProfile is a ConformanceProfile that covers testing TCP


### PR DESCRIPTION
**What type of PR is this?**
/kind test
/area conformance-test

**What this PR does / why we need it**:
Conformance tests to BackendTLSPolicy with TLSRoute Terminate


**Which issue(s) this PR fixes**:
Fixes #4754 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

This test validates that when a `TLSRoute` uses `Terminate` mode and a `BackendTLSPolicy` is attached to the backend Service, the gateway correctly re-encrypts traffic to the backend. The test creates a dedicated TCP echo backend with a CA-signed certificate so that the `BackendTLSPolicy` can properly validate the backend's identity.

Traffic flow under test:
```
  Client --[TLS]--> Gateway --[terminates]--> --[re-encrypts]--> Backend
```  
