### PR TITLE
docs: add ListenerSet to SectionName interpretation table

### DIFF
--- a/apis/v1/policy_types.go
+++ b/apis/v1/policy_types.go
@@ -95,6 +95,7 @@ type LocalPolicyTargetReferenceWithSectionName struct {
 	// resources, SectionName is interpreted as the following:
 	//
 	// * Gateway: Listener name
+	// * ListenerSet: Listener name
 	// * HTTPRoute: HTTPRouteRule name
 	// * Service: Port name
 	//

--- a/applyconfiguration/apis/v1/localpolicytargetreferencewithsectionname.go
+++ b/applyconfiguration/apis/v1/localpolicytargetreferencewithsectionname.go
@@ -41,6 +41,7 @@ type LocalPolicyTargetReferenceWithSectionNameApplyConfiguration struct {
 	// resources, SectionName is interpreted as the following:
 	//
 	// * Gateway: Listener name
+	// * ListenerSet: Listener name
 	// * HTTPRoute: HTTPRouteRule name
 	// * Service: Port name
 	//

--- a/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -169,6 +169,7 @@ spec:
                         resources, SectionName is interpreted as the following:
 
                         * Gateway: Listener name
+                        * ListenerSet: Listener name
                         * HTTPRoute: HTTPRouteRule name
                         * Service: Port name
 
@@ -863,6 +864,7 @@ spec:
                         resources, SectionName is interpreted as the following:
 
                         * Gateway: Listener name
+                        * ListenerSet: Listener name
                         * HTTPRoute: HTTPRouteRule name
                         * Service: Port name
 

--- a/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -169,6 +169,7 @@ spec:
                         resources, SectionName is interpreted as the following:
 
                         * Gateway: Listener name
+                        * ListenerSet: Listener name
                         * HTTPRoute: HTTPRouteRule name
                         * Service: Port name
 
@@ -845,6 +846,7 @@ spec:
                         resources, SectionName is interpreted as the following:
 
                         * Gateway: Listener name
+                        * ListenerSet: Listener name
                         * HTTPRoute: HTTPRouteRule name
                         * Service: Port name
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -6567,7 +6567,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_LocalPolicyTargetReferenceWithSectionN
 					},
 					"sectionName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SectionName is the name of a section within the target resource. When unspecified, this targetRef targets the entire resource. In the following resources, SectionName is interpreted as the following:\n\n* Gateway: Listener name * HTTPRoute: HTTPRouteRule name * Service: Port name\n\nIf a SectionName is specified, but does not exist on the targeted object, the Policy must fail to attach, and the policy implementation should record a `ResolvedRefs` or similar Condition in the Policy's status.",
+							Description: "SectionName is the name of a section within the target resource. When unspecified, this targetRef targets the entire resource. In the following resources, SectionName is interpreted as the following:\n\n* Gateway: Listener name * ListenerSet: Listener name * HTTPRoute: HTTPRouteRule name * Service: Port name\n\nIf a SectionName is specified, but does not exist on the targeted object, the Policy must fail to attach, and the policy implementation should record a `ResolvedRefs` or similar Condition in the Policy's status.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8378,7 +8378,7 @@ func schema_sigsk8sio_gateway_api_apis_v1alpha2_LocalPolicyTargetReferenceWithSe
 					},
 					"sectionName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SectionName is the name of a section within the target resource. When unspecified, this targetRef targets the entire resource. In the following resources, SectionName is interpreted as the following:\n\n* Gateway: Listener name * HTTPRoute: HTTPRouteRule name * Service: Port name\n\nIf a SectionName is specified, but does not exist on the targeted object, the Policy must fail to attach, and the policy implementation should record a `ResolvedRefs` or similar Condition in the Policy's status.",
+							Description: "SectionName is the name of a section within the target resource. When unspecified, this targetRef targets the entire resource. In the following resources, SectionName is interpreted as the following:\n\n* Gateway: Listener name * ListenerSet: Listener name * HTTPRoute: HTTPRouteRule name * Service: Port name\n\nIf a SectionName is specified, but does not exist on the targeted object, the Policy must fail to attach, and the policy implementation should record a `ResolvedRefs` or similar Condition in the Policy's status.",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

`LocalPolicyTargetReferenceWithSectionName` documents how `SectionName` is interpreted for `Gateway`, `HTTPRoute`, and `Service`, but omits `ListenerSet`. Since `ListenerSet` listeners are addressed by name via `SectionName`, the same as `Gateway`, it should appear in the table.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```