### PR TITLE
test(conformance):Add BackendTLSPolicy conformance test for GRPCRoute

### DIFF
--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -645,6 +645,9 @@ spec:
       containers:
         - name: grpc-infra-backend-v1
           image: registry.k8s.io/gateway-api/conformance/echo-basic:v0.1.0
+          volumeMounts:
+            - name: secret-volume
+              mountPath: /etc/secret-volume
           env:
             - name: POD_NAME
               valueFrom:
@@ -656,9 +659,22 @@ spec:
                   fieldPath: metadata.namespace
             - name: GRPC_ECHO_SERVER
               value: "1"
+            - name: TLS_SERVER_CERT
+              value: /etc/secret-volume/crt
+            - name: TLS_SERVER_PRIV_KEY
+              value: /etc/secret-volume/key
           resources:
             requests:
               cpu: 10m
+      volumes:
+        - name: secret-volume
+          secret:
+            secretName: tls-checks-certificate
+            items:
+              - key: tls.crt
+                path: crt
+              - key: tls.key
+                path: key
 ---
 apiVersion: v1
 kind: Service

--- a/conformance/tests/backendtlspolicy-grpcroute.go
+++ b/conformance/tests/backendtlspolicy-grpcroute.go
@@ -1,0 +1,113 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	pb "sigs.k8s.io/gateway-api-conformance-images/echo-basic/grpcechoserver"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/grpc"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, BackendTLSPolicyGRPCRoute)
+}
+
+var BackendTLSPolicyGRPCRoute = confsuite.ConformanceTest{
+	ShortName:   "BackendTLSPolicyGRPCRoute",
+	Description: "A BackendTLSPolicy attached to a Service consumed by a GRPCRoute should configure TLS between gateway and backend",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportGRPCRoute,
+		features.SupportBackendTLSPolicy,
+	},
+	Manifests: []string{"tests/backendtlspolicy-grpcroute.yaml"},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+
+		acceptedCond := metav1.Condition{
+			Type:   string(gatewayv1.PolicyConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.PolicyReasonAccepted),
+		}
+		resolvedRefsCond := metav1.Condition{
+			Type:   string(gatewayv1.BackendTLSPolicyConditionResolvedRefs),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.BackendTLSPolicyReasonResolvedRefs),
+		}
+
+		routeNN := types.NamespacedName{Name: "backendtlspolicy-grpcroute", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gatewayv1.GRPCRoute{}, true, routeNN)
+
+		t.Run("gRPC request sent to Service with valid BackendTLSPolicy should succeed", func(t *testing.T) {
+			validPolicyNN := types.NamespacedName{Name: "grpc-normative-test", Namespace: ns}
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, validPolicyNN, gwNN, acceptedCond)
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, validPolicyNN, gwNN, resolvedRefsCond)
+
+			grpc.MakeRequestAndExpectEventuallyConsistentResponse(t, nil, suite.TimeoutConfig, gwAddr,
+				grpc.ExpectedResponse{
+					EchoRequest: &pb.EchoRequest{},
+					RequestMetadata: &grpc.RequestMetadata{
+						Authority: "abc.example.com",
+					},
+					Backend:   "grpc-infra-backend-v1",
+					Namespace: ns,
+				})
+		})
+
+		t.Run("gRPC request sent to Service targeted by BackendTLSPolicy with mismatched hostname should fail", func(t *testing.T) {
+			invalidPolicyNN := types.NamespacedName{Name: "grpc-host-mismatch", Namespace: ns}
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, invalidPolicyNN, gwNN, acceptedCond)
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, invalidPolicyNN, gwNN, resolvedRefsCond)
+
+			grpc.MakeRequestAndExpectEventuallyConsistentFailure(t, nil, suite.TimeoutConfig, gwAddr,
+				grpc.ExpectedResponse{
+					EchoTwoRequest: &pb.EchoRequest{},
+					RequestMetadata: &grpc.RequestMetadata{
+						Authority: "abc.example.com",
+					},
+				})
+		})
+
+		t.Run("gRPC request sent to Service targeted by BackendTLSPolicy with mismatched cert should fail", func(t *testing.T) {
+			certMismatchRouteNN := types.NamespacedName{Name: "backendtlspolicy-grpcroute-cert-mismatch", Namespace: ns}
+			kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &gatewayv1.GRPCRoute{}, true, certMismatchRouteNN)
+
+			invalidCertPolicyNN := types.NamespacedName{Name: "grpc-cert-mismatch", Namespace: ns}
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, invalidCertPolicyNN, gwNN, acceptedCond)
+			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, invalidCertPolicyNN, gwNN, resolvedRefsCond)
+
+			grpc.MakeRequestAndExpectEventuallyConsistentFailure(t, nil, suite.TimeoutConfig, gwAddr,
+				grpc.ExpectedResponse{
+					EchoRequest: &pb.EchoRequest{},
+					RequestMetadata: &grpc.RequestMetadata{
+						Authority: "cert-mismatch.example.com",
+					},
+				})
+		})
+	},
+}

--- a/conformance/tests/backendtlspolicy-grpcroute.yaml
+++ b/conformance/tests/backendtlspolicy-grpcroute.yaml
@@ -1,0 +1,148 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: backendtlspolicy-grpcroute
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+    namespace: gateway-conformance-infra
+  hostnames:
+  - abc.example.com
+  rules:
+  - matches:
+    - method:
+        service: gateway_api_conformance.echo_basic.grpcecho.GrpcEcho
+        method: Echo
+    backendRefs:
+    - group: ""
+      kind: Service
+      name: backendtlspolicy-grpc-test
+      port: 443
+  - matches:
+    - method:
+        service: gateway_api_conformance.echo_basic.grpcecho.GrpcEcho
+        method: EchoTwo
+    backendRefs:
+    - group: ""
+      kind: Service
+      name: backendtlspolicy-grpc-host-mismatch-test
+      port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: backendtlspolicy-grpcroute-cert-mismatch
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+    namespace: gateway-conformance-infra
+  hostnames:
+  - cert-mismatch.example.com
+  rules:
+  - matches:
+    - method:
+        service: gateway_api_conformance.echo_basic.grpcecho.GrpcEcho
+        method: Echo
+    backendRefs:
+    - group: ""
+      kind: Service
+      name: backendtlspolicy-grpc-cert-mismatch-test
+      port: 443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendtlspolicy-grpc-test
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: grpc-infra-backend-v1
+  ports:
+  - name: "btls"
+    protocol: TCP
+    port: 443
+    targetPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendtlspolicy-grpc-host-mismatch-test
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: grpc-infra-backend-v1
+  ports:
+  - name: "btls"
+    protocol: TCP
+    port: 443
+    targetPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendtlspolicy-grpc-cert-mismatch-test
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: grpc-infra-backend-v1
+  ports:
+  - name: "btls"
+    protocol: TCP
+    port: 443
+    targetPort: 8443
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: grpc-normative-test
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: "backendtlspolicy-grpc-test"
+    sectionName: "btls"
+  validation:
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      name: "tls-checks-ca-certificate"
+    hostname: "abc.example.com"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: grpc-host-mismatch
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: "backendtlspolicy-grpc-host-mismatch-test"
+    sectionName: "btls"
+  validation:
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      name: "tls-checks-ca-certificate"
+    hostname: "mismatch.example.com"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: grpc-cert-mismatch
+  namespace: gateway-conformance-infra
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: "backendtlspolicy-grpc-cert-mismatch-test"
+    sectionName: "btls"
+  validation:
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      name: "mismatch-ca-certificate"
+    hostname: "abc.example.com"

--- a/conformance/utils/grpc/grpc.go
+++ b/conformance/utils/grpc/grpc.go
@@ -314,6 +314,29 @@ func MakeRequestAndExpectEventuallyConsistentResponse(t *testing.T, c Client, ti
 	tlog.Logf(t, "Request passed")
 }
 
+func MakeRequestAndExpectEventuallyConsistentFailure(t *testing.T, c Client, timeoutConfig config.TimeoutConfig, gwAddr string, expected ExpectedResponse) {
+	t.Helper()
+	validateExpectedResponse(t, expected)
+	if c == nil {
+		c = &DefaultClient{Conn: nil}
+	}
+	defer c.Close()
+	sendRPC := func(elapsed time.Duration) bool {
+		resp, err := c.SendRPC(t, gwAddr, expected, timeoutConfig.MaxTimeToConsistency-elapsed)
+		if err != nil {
+			tlog.Logf(t, "Failed to send RPC, not ready yet: %v (after %v)", err, elapsed)
+			return false
+		}
+		if resp.Code == codes.OK {
+			t.Fatalf("Request should have failed, but got status OK")
+			return false
+		}
+		return true
+	}
+	http.AwaitConvergence(t, timeoutConfig, sendRPC)
+	tlog.Logf(t, "Expectation for failing request met")
+}
+
 // AddEntropy adds randomness to ExpectedResponse to avoid caching issues and ensure each request is unique.
 // It randomly chooses to add a delay, random metadata, or both.
 func AddEntropy(exp *ExpectedResponse) error {

--- a/conformance/utils/suite/profiles.go
+++ b/conformance/utils/suite/profiles.go
@@ -151,7 +151,12 @@ var (
 			features.SupportReferenceGrant,
 			features.SupportGRPCRoute,
 		),
-		ExtendedFeatures: features.SetsToNamesSet(features.GatewayExtendedFeatures),
+		ExtendedFeatures: sets.New[features.FeatureName]().
+			Insert(features.SetsToNamesSet(
+				features.GatewayExtendedFeatures,
+				features.BackendTLSPolicyCoreFeatures,
+				features.BackendTLSPolicyExtendedFeatures,
+			).UnsortedList()...),
 	}
 
 	// MeshHTTPConformanceProfile is a ConformanceProfile that covers testing HTTP


### PR DESCRIPTION


/kind test
/area conformance-test

**What this PR does / why we need it**:
Add BackendTLSPolicy conformance test for GRPCRoute

Add conformance tests verifying that BackendTLSPolicy works correctly with GRPCRoute, covering valid TLS configuration, hostname mismatch and CA certificate mismatch scenarios.

Also adds MakeRequestAndExpectEventuallyConsistentFailure to the gRPC test utilities and registers BackendTLSPolicy features in the GATEWAY-GRPC conformance profile.


**Which issue(s) this PR fixes**:
Fixes #4754

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
