### PR TITLE
test(conformance) Touch up L4 conformance 

### DIFF
--- a/conformance/tests/tcproute-invalid-backendref-nonexistent.go
+++ b/conformance/tests/tcproute-invalid-backendref-nonexistent.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	v1 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/pkg/features"

--- a/conformance/tests/tcproute-multiple-routes-attachment.go
+++ b/conformance/tests/tcproute-multiple-routes-attachment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ var TCPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
 
 		// CreationTimestamp has second-level precision; sleep ensures the second route
 		// is strictly newer than the first.
-		time.Sleep(5 * time.Second)
+		time.Sleep(time.Second)
 
 		newerRoute := &v1alpha2.TCPRoute{
 			ObjectMeta: metav1.ObjectMeta{
@@ -119,7 +119,7 @@ var TCPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
 		})
 
 		t.Run("Only the oldest TCPRoute should receive traffic", func(t *testing.T) {
-			// Per GEP-713 conflict-resolution, only the oldest route is bound to the
+			// https://gateway-api.sigs.k8s.io/guides/api-design/#conflicts, only the oldest route is bound to the
 			// listener; traffic must reach pods backing tcp-attach-backend-1 and never
 			// pods backing tcp-attach-backend-2.
 			//

--- a/conformance/tests/tcproute-multiple-routes-attachment.go
+++ b/conformance/tests/tcproute-multiple-routes-attachment.go
@@ -17,9 +17,11 @@ limitations under the License.
 package tests
 
 import (
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -120,11 +122,34 @@ var TCPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
 			// Per GEP-713 conflict-resolution, only the oldest route is bound to the
 			// listener; traffic must reach pods backing tcp-attach-backend-1 and never
 			// pods backing tcp-attach-backend-2.
+			//
+			// First wait for the data plane to converge so the older route is
+			// consistently serving traffic.
 			tcp.MakeTCPRequestAndExpectEventuallyValidResponse(t, suite.TimeoutConfig, gwAddr, nil, "", false,
 				tcp.ExpectedResponse{
 					Backend:   "tcp-attach-backend-1",
 					Namespace: ns,
 				})
+
+			// Sample many connections and assert the newer route's backend is
+			// never selected. A single request can hit the older backend by
+			// chance even if both routes were attached, so repeated sampling
+			// strengthens the guarantee that only the oldest route is bound.
+			const (
+				sampleCount   = 100
+				perReqTimeout = 5 * time.Second
+			)
+			const olderBackendPrefix = "tcp-attach-backend-1-"
+			const newerBackendPrefix = "tcp-attach-backend-2-"
+
+			for i := range sampleCount {
+				pod, err := tcp.EchoSendOnce(t.Context(), gwAddr, perReqTimeout)
+				require.NoErrorf(t, err, "TCP echo request %d/%d failed", i+1, sampleCount)
+				require.Falsef(t, strings.HasPrefix(pod, newerBackendPrefix),
+					"request %d/%d reached newer route backend %q; only the oldest route should be attached", i+1, sampleCount, pod)
+				require.Truef(t, strings.HasPrefix(pod, olderBackendPrefix),
+					"request %d/%d reached unexpected backend %q; expected pod from %q", i+1, sampleCount, pod, olderBackendPrefix)
+			}
 		})
 	},
 }

--- a/conformance/tests/tcproute-multiple-routes-attachment.go
+++ b/conformance/tests/tcproute-multiple-routes-attachment.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tcp"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, TCPRouteMultipleRoutesAttachment)
+}
+
+var TCPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
+	ShortName: "TCPRouteMultipleRoutesAttachment",
+	Description: "When two TCPRoutes target the same Gateway listener, both must report Accepted=True. " +
+		"Only the oldest route is attached to the listener, and the listener's AttachedRoutes count must reflect this.",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportTCPRoute,
+	},
+	Manifests: []string{"tests/tcproute-multiple-routes-attachment.yaml"},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		gwNN := types.NamespacedName{Name: "tcp-multi-route-attach-gateway", Namespace: ns}
+		olderRouteNN := types.NamespacedName{Name: "tcproute-attach-older", Namespace: ns}
+		newerRouteNN := types.NamespacedName{Name: "tcproute-attach-newer", Namespace: ns}
+
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+
+		// Wait for the Gateway and the older TCPRoute to be ready before introducing the
+		// second route, so creation-time ordering is unambiguous.
+		gwAddr := kubernetes.GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN, "tcp"), olderRouteNN)
+
+		// CreationTimestamp has second-level precision; sleep ensures the second route
+		// is strictly newer than the first.
+		time.Sleep(5 * time.Second)
+
+		newerRoute := &v1alpha2.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      newerRouteNN.Name,
+				Namespace: newerRouteNN.Namespace,
+			},
+			Spec: v1alpha2.TCPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{{
+						Name:        gatewayv1.ObjectName(gwNN.Name),
+						SectionName: ptr.To(gatewayv1.SectionName("tcp")),
+					}},
+				},
+				Rules: []v1alpha2.TCPRouteRule{{
+					BackendRefs: []gatewayv1.BackendRef{{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: gatewayv1.ObjectName("tcp-attach-backend-2"),
+							Port: ptr.To(gatewayv1.PortNumber(3000)),
+						},
+					}},
+				}},
+			},
+		}
+		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{newerRoute}, suite.Cleanup)
+
+		acceptedCond := metav1.Condition{
+			Type:   string(gatewayv1.RouteConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.RouteReasonAccepted),
+		}
+
+		t.Run("Both TCPRoutes should be Accepted by the Gateway", func(t *testing.T) {
+			// Both routes report Accepted=True; the newer route is rejected at the
+			// listener-attachment level rather than via the route's Accepted condition.
+			kubernetes.TCPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, olderRouteNN, gwNN, acceptedCond)
+			kubernetes.TCPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, newerRouteNN, gwNN, acceptedCond)
+		})
+
+		t.Run("Gateway listener should report 2 attached Routes", func(t *testing.T) {
+			listeners := []gatewayv1.ListenerStatus{{
+				Name: gatewayv1.SectionName("tcp"),
+				SupportedKinds: []gatewayv1.RouteGroupKind{{
+					Group: ptr.To(gatewayv1.Group(gatewayv1.GroupName)),
+					Kind:  gatewayv1.Kind("TCPRoute"),
+				}},
+				Conditions: []metav1.Condition{{
+					Type:   string(gatewayv1.ListenerConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: string(gatewayv1.ListenerReasonAccepted),
+				}},
+				AttachedRoutes: 2,
+			}}
+			kubernetes.GatewayStatusMustHaveListeners(t, suite.Client, suite.TimeoutConfig, gwNN, listeners)
+		})
+
+		t.Run("Only the oldest TCPRoute should receive traffic", func(t *testing.T) {
+			// Per GEP-713 conflict-resolution, only the oldest route is bound to the
+			// listener; traffic must reach pods backing tcp-attach-backend-1 and never
+			// pods backing tcp-attach-backend-2.
+			tcp.MakeTCPRequestAndExpectEventuallyValidResponse(t, suite.TimeoutConfig, gwAddr, nil, "", false,
+				tcp.ExpectedResponse{
+					Backend:   "tcp-attach-backend-1",
+					Namespace: ns,
+				})
+		})
+	},
+}

--- a/conformance/tests/tcproute-multiple-routes-attachment.yaml
+++ b/conformance/tests/tcproute-multiple-routes-attachment.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: tcp-backend
-          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
+          image: registry.k8s.io/gateway-api/echo-basic:v1.6.0-dev.2
           imagePullPolicy: IfNotPresent
           env:
             - name: TCP_ECHO_SERVER
@@ -90,7 +90,7 @@ spec:
     spec:
       containers:
         - name: tcp-backend
-          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
+          image: registry.k8s.io/gateway-api/echo-basic:v1.6.0-dev.2
           imagePullPolicy: IfNotPresent
           env:
             - name: TCP_ECHO_SERVER

--- a/conformance/tests/tcproute-multiple-routes-attachment.yaml
+++ b/conformance/tests/tcproute-multiple-routes-attachment.yaml
@@ -1,0 +1,145 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-attach-backend-1
+  namespace: gateway-conformance-infra
+  labels:
+    app: tcp-attach-backend-1
+spec:
+  selector:
+    app: tcp-attach-backend-1
+  ports:
+    - name: tcp
+      protocol: TCP
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcp-attach-backend-1
+  namespace: gateway-conformance-infra
+  labels:
+    app: tcp-attach-backend-1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tcp-attach-backend-1
+  template:
+    metadata:
+      labels:
+        app: tcp-attach-backend-1
+    spec:
+      containers:
+        - name: tcp-backend
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: TCP_ECHO_SERVER
+              value: "1"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SERVICE_NAME
+              value: tcp-attach-backend-1
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 10m
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-attach-backend-2
+  namespace: gateway-conformance-infra
+  labels:
+    app: tcp-attach-backend-2
+spec:
+  selector:
+    app: tcp-attach-backend-2
+  ports:
+    - name: tcp
+      protocol: TCP
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcp-attach-backend-2
+  namespace: gateway-conformance-infra
+  labels:
+    app: tcp-attach-backend-2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tcp-attach-backend-2
+  template:
+    metadata:
+      labels:
+        app: tcp-attach-backend-2
+    spec:
+      containers:
+        - name: tcp-backend
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: TCP_ECHO_SERVER
+              value: "1"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SERVICE_NAME
+              value: tcp-attach-backend-2
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 10m
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: tcp-multi-route-attach-gateway
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: tcp
+      protocol: TCP
+      port: 9091
+      allowedRoutes:
+        kinds:
+          - kind: TCPRoute
+            group: gateway.networking.k8s.io
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: tcproute-attach-older
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: tcp-multi-route-attach-gateway
+      sectionName: tcp
+  rules:
+    - backendRefs:
+        - name: tcp-attach-backend-1
+          port: 3000

--- a/conformance/tests/tcproute-parentref-attach-all.go
+++ b/conformance/tests/tcproute-parentref-attach-all.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	v1 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/conformance/utils/tcp"

--- a/conformance/tests/tcproute-parentref-port-and-section-name.go
+++ b/conformance/tests/tcproute-parentref-port-and-section-name.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	v1 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/conformance/utils/tcp"

--- a/conformance/tests/tcproute-weighted-routing.go
+++ b/conformance/tests/tcproute-weighted-routing.go
@@ -17,16 +17,8 @@ limitations under the License.
 package tests
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"math"
-	"strings"
-	"sync"
 	"testing"
-	"time"
 
-	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
@@ -43,7 +35,7 @@ func init() {
 
 var TCPRouteWeightedRouting = confsuite.ConformanceTest{
 	ShortName:   "TCPRouteWeightedRouting",
-	Description: "A TCPRoute with multiple weighted backends should distribute TCP traffic across the backends in proportion to the configured weights.",
+	Description: "A TCPRoute with multiple weighted backends should distribute TCP traffic across the backends in proportion to the configured weights, and a backend with weight 0 should receive no traffic.",
 	Manifests:   []string{"tests/tcproute-weighted-routing.yaml"},
 	Features: []features.FeatureName{
 		features.SupportGateway,
@@ -62,83 +54,25 @@ var TCPRouteWeightedRouting = confsuite.ConformanceTest{
 		gwAddr := kubernetes.GatewayAndTCPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName,
 			kubernetes.NewGatewayRef(gwNN, "tcp"), routeNN)
 
-		t.Run("TCP traffic should be distributed across the weighted backends", func(t *testing.T) {
+		t.Run("TCP traffic should be distributed across the weighted backends and skip the zero-weighted backend", func(t *testing.T) {
 			expectedWeights := map[string]float64{
 				"tcp-backend-v1": 0.7,
 				"tcp-backend-v2": 0.3,
+				"tcp-backend-v3": 0.0,
 			}
 
+			sender := weight.NewFunctionBasedSender(func() (string, error) {
+				return tcp.EchoSendOnce(t.Context(), gwAddr, suite.TimeoutConfig.RequestTimeout)
+			})
+
 			for i := range weight.MaxTestRetries {
-				err := assertTCPWeightedDistribution(t.Context(), gwAddr, expectedWeights, 0.03)
-				if err == nil {
+				if err := weight.TestWeightedDistribution(sender, expectedWeights); err != nil {
+					tlog.Logf(t, "TCP weighted distribution attempt %d/%d failed: %s", i+1, weight.MaxTestRetries, err)
+				} else {
 					return
 				}
-				tlog.Logf(t, "TCP weighted distribution attempt %d/%d failed: %s", i+1, weight.MaxTestRetries, err)
 			}
 			t.Fatal("TCP weighted distribution did not converge within tolerance")
 		})
 	},
-}
-
-// assertTCPWeightedDistribution opens a fixed number of TCP connections to
-// gwAddr in parallel, classifies each response by the backend Deployment that
-// produced it (extracted from the tcpserver TCPAssertions JSON pod name), and
-// returns nil if the observed distribution is within tolerance of
-// expectedWeights for every backend.
-func assertTCPWeightedDistribution(ctx context.Context, gwAddr string, expectedWeights map[string]float64, tolerance float64) error {
-	const (
-		concurrentRequests = 10
-		totalRequests      = 500
-		probeTimeout       = 5 * time.Second
-	)
-
-	var (
-		mu   sync.Mutex
-		seen = make(map[string]float64, len(expectedWeights))
-		g    errgroup.Group
-	)
-	g.SetLimit(concurrentRequests)
-
-	for range totalRequests {
-		g.Go(func() error {
-			pod, err := tcp.EchoSendOnce(ctx, gwAddr, probeTimeout)
-			if err != nil {
-				return err
-			}
-			backend := extractTCPBackendName(pod)
-
-			mu.Lock()
-			defer mu.Unlock()
-			if _, ok := expectedWeights[backend]; !ok {
-				return fmt.Errorf("response from unexpected backend %q (pod %q)", backend, pod)
-			}
-			seen[backend]++
-			return nil
-		})
-	}
-	if err := g.Wait(); err != nil {
-		return fmt.Errorf("error while sending TCP probes: %w", err)
-	}
-
-	var errs []error
-	for backend, want := range expectedWeights {
-		got := seen[backend] / float64(totalRequests)
-		if math.Abs(got-want) > tolerance {
-			errs = append(errs, fmt.Errorf("backend %q got %.2f%% of traffic; expected %.2f%% (+/- %.2f%%)",
-				backend, got*100, want*100, tolerance*100))
-		}
-	}
-	return errors.Join(errs...)
-}
-
-// extractTCPBackendName trims the {deployment-hash}-{pod-hash} suffix from a
-// pod name to recover the Deployment name. Pod names follow the pattern
-// {deployment}-{rs-hash}-{pod-hash}; if the input doesn't match the pattern
-// the original name is returned.
-func extractTCPBackendName(podName string) string {
-	parts := strings.Split(podName, "-")
-	if len(parts) < 3 {
-		return podName
-	}
-	return strings.Join(parts[:len(parts)-2], "-")
 }

--- a/conformance/tests/tcproute-weighted-routing.yaml
+++ b/conformance/tests/tcproute-weighted-routing.yaml
@@ -112,6 +112,63 @@ spec:
             requests:
               cpu: 10m
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-backend-v3
+  namespace: gateway-conformance-infra
+  labels:
+    app: tcp-backend-v3
+spec:
+  selector:
+    app: tcp-backend-v3
+  ports:
+    - name: tcp
+      protocol: TCP
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcp-backend-v3
+  namespace: gateway-conformance-infra
+  labels:
+    app: tcp-backend-v3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tcp-backend-v3
+  template:
+    metadata:
+      labels:
+        app: tcp-backend-v3
+    spec:
+      containers:
+        - name: tcp-backend
+          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: TCP_ECHO_SERVER
+              value: "1"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SERVICE_NAME
+              value: tcp-backend-v3
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 10m
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -144,3 +201,6 @@ spec:
         - name: tcp-backend-v2
           port: 3000
           weight: 30
+        - name: tcp-backend-v3
+          port: 3000
+          weight: 0

--- a/conformance/tests/tcproute-weighted-routing.yaml
+++ b/conformance/tests/tcproute-weighted-routing.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: tcp-backend
-          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
+          image: registry.k8s.io/gateway-api/echo-basic:v1.6.0-dev.2
           imagePullPolicy: IfNotPresent
           env:
             - name: TCP_ECHO_SERVER
@@ -90,7 +90,7 @@ spec:
     spec:
       containers:
         - name: tcp-backend
-          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
+          image: registry.k8s.io/gateway-api/echo-basic:v1.6.0-dev.2
           imagePullPolicy: IfNotPresent
           env:
             - name: TCP_ECHO_SERVER
@@ -147,7 +147,7 @@ spec:
     spec:
       containers:
         - name: tcp-backend
-          image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
+          image: registry.k8s.io/gateway-api/echo-basic:v1.6.0-dev.2
           imagePullPolicy: IfNotPresent
           env:
             - name: TCP_ECHO_SERVER

--- a/conformance/tests/udproute-invalid-backendref-nonexistent.go
+++ b/conformance/tests/udproute-invalid-backendref-nonexistent.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	v1 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/pkg/features"

--- a/conformance/tests/udproute-invalid-cross-namespace-backend-ref.go
+++ b/conformance/tests/udproute-invalid-cross-namespace-backend-ref.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	v1 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/pkg/features"

--- a/conformance/tests/udproute-multiple-routes-attachment.go
+++ b/conformance/tests/udproute-multiple-routes-attachment.go
@@ -131,7 +131,7 @@ var UDPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
 			)
 			pollErr := wait.PollUntilContextTimeout(t.Context(), time.Second, suite.TimeoutConfig.DefaultTestTimeout, true,
 				func(ctx context.Context) (bool, error) {
-					for i := 0; i < probes; i++ {
+					for i := range probes {
 						pod, err := udpEchoSendOnce(ctx, gwAddr, probeTimeout)
 						if err != nil {
 							tlog.Logf(t, "UDP probe %d failed, will retry: %v", i+1, err)

--- a/conformance/tests/udproute-multiple-routes-attachment.go
+++ b/conformance/tests/udproute-multiple-routes-attachment.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, UDPRouteMultipleRoutesAttachment)
+}
+
+var UDPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
+	ShortName: "UDPRouteMultipleRoutesAttachment",
+	Description: "When two UDPRoutes target the same Gateway listener, both must report Accepted=True. " +
+		"Only the oldest route is attached and receives traffic; the listener's AttachedRoutes count must reflect both.",
+	Manifests: []string{"tests/udproute-multiple-routes-attachment.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportUDPRoute,
+	},
+	Provisional: true,
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		gwNN := types.NamespacedName{Name: "udp-multi-route-attach-gateway", Namespace: ns}
+		olderRouteNN := types.NamespacedName{Name: "udproute-attach-older", Namespace: ns}
+		newerRouteNN := types.NamespacedName{Name: "udproute-attach-newer", Namespace: ns}
+
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+
+		// Wait for the Gateway and the older UDPRoute to be ready before introducing the
+		// second route, so creation-time ordering is unambiguous.
+		gwAddr := kubernetes.GatewayAndUDPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName,
+			kubernetes.NewGatewayRef(gwNN, "udp"), olderRouteNN)
+
+		// CreationTimestamp has second-level precision; sleep ensures the second route
+		// is strictly newer than the first.
+		time.Sleep(5 * time.Second)
+
+		newerRoute := &v1alpha2.UDPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      newerRouteNN.Name,
+				Namespace: newerRouteNN.Namespace,
+			},
+			Spec: v1alpha2.UDPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{{
+						Name:        gatewayv1.ObjectName(gwNN.Name),
+						SectionName: ptr.To(gatewayv1.SectionName("udp")),
+					}},
+				},
+				Rules: []v1alpha2.UDPRouteRule{{
+					BackendRefs: []gatewayv1.BackendRef{{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: gatewayv1.ObjectName("udp-attach-backend-2"),
+							Port: ptr.To(gatewayv1.PortNumber(8080)),
+						},
+					}},
+				}},
+			},
+		}
+		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{newerRoute}, suite.Cleanup)
+
+		acceptedCond := metav1.Condition{
+			Type:   string(gatewayv1.RouteConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gatewayv1.RouteReasonAccepted),
+		}
+
+		t.Run("Both UDPRoutes should be Accepted by the Gateway", func(t *testing.T) {
+			// Both routes report Accepted=True; the newer route is rejected at the
+			// listener-attachment level rather than via the route's Accepted condition.
+			kubernetes.UDPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, olderRouteNN, gwNN, acceptedCond)
+			kubernetes.UDPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, newerRouteNN, gwNN, acceptedCond)
+		})
+
+		t.Run("Gateway listener should report 2 attached Routes", func(t *testing.T) {
+			listeners := []gatewayv1.ListenerStatus{{
+				Name: gatewayv1.SectionName("udp"),
+				SupportedKinds: []gatewayv1.RouteGroupKind{{
+					Group: ptr.To(gatewayv1.Group(gatewayv1.GroupName)),
+					Kind:  gatewayv1.Kind("UDPRoute"),
+				}},
+				Conditions: []metav1.Condition{{
+					Type:   string(gatewayv1.ListenerConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: string(gatewayv1.ListenerReasonAccepted),
+				}},
+				AttachedRoutes: 2,
+			}}
+			kubernetes.GatewayStatusMustHaveListeners(t, suite.Client, suite.TimeoutConfig, gwNN, listeners)
+		})
+
+		t.Run("Only the oldest UDPRoute should receive traffic", func(t *testing.T) {
+			// Per GEP-713 conflict-resolution, only the oldest route is bound to the
+			// listener; UDP datagrams must be answered by udp-attach-backend-1 pods
+			// and never by udp-attach-backend-2 pods.
+			const (
+				probeTimeout = 2 * time.Second
+				probes       = 20
+			)
+			pollErr := wait.PollUntilContextTimeout(t.Context(), time.Second, suite.TimeoutConfig.DefaultTestTimeout, true,
+				func(ctx context.Context) (bool, error) {
+					for i := 0; i < probes; i++ {
+						pod, err := udpEchoSendOnce(ctx, gwAddr, probeTimeout)
+						if err != nil {
+							tlog.Logf(t, "UDP probe %d failed, will retry: %v", i+1, err)
+							return false, nil
+						}
+						backend := extractBackendName(pod)
+						if backend != "udp-attach-backend-1" {
+							return false, fmt.Errorf("UDP traffic reached unexpected backend %q (pod %q); only udp-attach-backend-1 should receive traffic", backend, pod)
+						}
+					}
+					return true, nil
+				})
+			if pollErr != nil {
+				t.Fatalf("UDP traffic verification failed: %v", pollErr)
+			}
+		})
+	},
+}

--- a/conformance/tests/udproute-multiple-routes-attachment.go
+++ b/conformance/tests/udproute-multiple-routes-attachment.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ var UDPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
 
 		// CreationTimestamp has second-level precision; sleep ensures the second route
 		// is strictly newer than the first.
-		time.Sleep(5 * time.Second)
+		time.Sleep(time.Second)
 
 		newerRoute := &v1alpha2.UDPRoute{
 			ObjectMeta: metav1.ObjectMeta{
@@ -122,7 +122,7 @@ var UDPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
 		})
 
 		t.Run("Only the oldest UDPRoute should receive traffic", func(t *testing.T) {
-			// Per GEP-713 conflict-resolution, only the oldest route is bound to the
+			// https://gateway-api.sigs.k8s.io/guides/api-design/#conflicts, only the oldest route is bound to the
 			// listener; UDP datagrams must be answered by udp-attach-backend-1 pods
 			// and never by udp-attach-backend-2 pods.
 			const (

--- a/conformance/tests/udproute-multiple-routes-attachment.yaml
+++ b/conformance/tests/udproute-multiple-routes-attachment.yaml
@@ -1,0 +1,142 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: udp-attach-backend-1
+  namespace: gateway-conformance-infra
+  labels:
+    app: udp-attach-backend-1
+spec:
+  selector:
+    app: udp-attach-backend-1
+  ports:
+    - name: udp
+      protocol: UDP
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: udp-attach-backend-1
+  namespace: gateway-conformance-infra
+  labels:
+    app: udp-attach-backend-1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: udp-attach-backend-1
+  template:
+    metadata:
+      labels:
+        app: udp-attach-backend-1
+    spec:
+      containers:
+        - name: udp-backend
+          image: registry.k8s.io/gateway-api/echo-basic:v1.6.0-dev.2
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: UDP_ECHO_SERVER
+              value: "1"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SERVICE_NAME
+              value: udp-attach-backend-1
+          ports:
+            - containerPort: 8080
+              protocol: UDP
+          resources:
+            requests:
+              cpu: 10m
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: udp-attach-backend-2
+  namespace: gateway-conformance-infra
+  labels:
+    app: udp-attach-backend-2
+spec:
+  selector:
+    app: udp-attach-backend-2
+  ports:
+    - name: udp
+      protocol: UDP
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: udp-attach-backend-2
+  namespace: gateway-conformance-infra
+  labels:
+    app: udp-attach-backend-2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: udp-attach-backend-2
+  template:
+    metadata:
+      labels:
+        app: udp-attach-backend-2
+    spec:
+      containers:
+        - name: udp-backend
+          image: registry.k8s.io/gateway-api/echo-basic:v1.6.0-dev.2
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: UDP_ECHO_SERVER
+              value: "1"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SERVICE_NAME
+              value: udp-attach-backend-2
+          ports:
+            - containerPort: 8080
+              protocol: UDP
+          resources:
+            requests:
+              cpu: 10m
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: udp-multi-route-attach-gateway
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: udp
+      protocol: UDP
+      port: 5301
+      allowedRoutes:
+        kinds:
+          - kind: UDPRoute
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: udproute-attach-older
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: udp-multi-route-attach-gateway
+      sectionName: udp
+  rules:
+    - backendRefs:
+        - name: udp-attach-backend-1
+          port: 8080

--- a/conformance/tests/udproute-not-allowed-by-listeners.go
+++ b/conformance/tests/udproute-not-allowed-by-listeners.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -33,19 +33,21 @@ func init() {
 }
 
 var UDPRouteNotAllowedByListeners = confsuite.ConformanceTest{
-	ShortName: "UDPRouteNotAllowedByListener",
+	ShortName: "UDPRouteNotAllowedByListeners",
 	Description: "A UDPRoute targeting a Gateway listener whose protocol is not UDP must report " +
 		"Accepted=False with reason NotAllowedByListeners and must not be attached to the listener.",
 	Manifests: []string{"tests/udproute-not-allowed-by-listeners.yaml"},
 	Features: []features.FeatureName{
 		features.SupportGateway,
 		features.SupportUDPRoute,
-		features.SupportTCPRoute,
 	},
 	Provisional: true,
 	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		if !suite.SupportedFeatures.Has(features.SupportTLSRoute) {
+			return
+		}
 		ns := confsuite.InfrastructureNamespace
-		gwNN := types.NamespacedName{Name: "udproute-tcp-only-gateway", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "udproute-tls-only-gateway", Namespace: ns}
 		routeNN := types.NamespacedName{Name: "udproute-not-allowed-by-listeners", Namespace: ns}
 
 		// This test creates an additional Gateway in the gateway-conformance-infra
@@ -60,7 +62,7 @@ var UDPRouteNotAllowedByListeners = confsuite.ConformanceTest{
 			})
 		})
 
-		t.Run("Gateway should have 0 Routes attached on the TCP listener", func(t *testing.T) {
+		t.Run("Gateway should have 0 Routes attached on the TLS listener", func(t *testing.T) {
 			kubernetes.GatewayMustHaveZeroRoutes(t, suite.Client, suite.TimeoutConfig, gwNN)
 		})
 	},

--- a/conformance/tests/udproute-not-allowed-by-listeners.go
+++ b/conformance/tests/udproute-not-allowed-by-listeners.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, UDPRouteNotAllowedByListeners)
+}
+
+var UDPRouteNotAllowedByListeners = confsuite.ConformanceTest{
+	ShortName: "UDPRouteNotAllowedByListener",
+	Description: "A UDPRoute targeting a Gateway listener whose protocol is not UDP must report " +
+		"Accepted=False with reason NotAllowedByListeners and must not be attached to the listener.",
+	Manifests: []string{"tests/udproute-not-allowed-by-listeners.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportUDPRoute,
+		features.SupportTCPRoute,
+	},
+	Provisional: true,
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		gwNN := types.NamespacedName{Name: "udproute-tcp-only-gateway", Namespace: ns}
+		routeNN := types.NamespacedName{Name: "udproute-not-allowed-by-listeners", Namespace: ns}
+
+		// This test creates an additional Gateway in the gateway-conformance-infra
+		// namespace so we have to wait for it to be ready.
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+
+		t.Run("UDPRoute should have Accepted=False with reason NotAllowedByListeners", func(t *testing.T) {
+			kubernetes.UDPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, metav1.Condition{
+				Type:   string(gatewayv1.RouteConditionAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(gatewayv1.RouteReasonNotAllowedByListeners),
+			})
+		})
+
+		t.Run("Gateway should have 0 Routes attached on the TCP listener", func(t *testing.T) {
+			kubernetes.GatewayMustHaveZeroRoutes(t, suite.Client, suite.TimeoutConfig, gwNN)
+		})
+	},
+}

--- a/conformance/tests/udproute-not-allowed-by-listeners.yaml
+++ b/conformance/tests/udproute-not-allowed-by-listeners.yaml
@@ -1,14 +1,16 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: udproute-tcp-only-gateway
+  name: udproute-tls-only-gateway
   namespace: gateway-conformance-infra
 spec:
   gatewayClassName: "{GATEWAY_CLASS_NAME}"
   listeners:
-    - name: tcp
-      port: 80
-      protocol: TCP
+    - name: tls
+      port: 443
+      protocol: TLS
+      tls:
+        mode: Passthrough
       allowedRoutes:
         namespaces:
           from: Same
@@ -20,8 +22,8 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: udproute-tcp-only-gateway
-      sectionName: tcp
+    - name: udproute-tls-only-gateway
+      sectionName: tls
   rules:
     - backendRefs:
         - name: coredns

--- a/conformance/tests/udproute-not-allowed-by-listeners.yaml
+++ b/conformance/tests/udproute-not-allowed-by-listeners.yaml
@@ -1,0 +1,28 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: udproute-tcp-only-gateway
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+    - name: tcp
+      port: 80
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: udproute-not-allowed-by-listeners
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: udproute-tcp-only-gateway
+      sectionName: tcp
+  rules:
+    - backendRefs:
+        - name: coredns
+          port: 53

--- a/conformance/tests/udproute-parentref-attach-all-listeners.go
+++ b/conformance/tests/udproute-parentref-attach-all-listeners.go
@@ -22,8 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	v1 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/conformance/utils/udp"
@@ -82,35 +81,35 @@ var UDPRouteParentRefAttachAllListeners = confsuite.ConformanceTest{
 		t.Run("Every UDP listener on the Gateway has the UDPRoute attached", func(t *testing.T) {
 			ready := []metav1.Condition{
 				{
-					Type:   string(gatewayv1.ListenerConditionAccepted),
+					Type:   string(v1.ListenerConditionAccepted),
 					Status: metav1.ConditionTrue,
 					Reason: "", // any reason
 				},
 				{
-					Type:   string(gatewayv1.ListenerConditionResolvedRefs),
+					Type:   string(v1.ListenerConditionResolvedRefs),
 					Status: metav1.ConditionTrue,
 					Reason: "", // any reason
 				},
 			}
-			udpRouteKind := []gatewayv1.RouteGroupKind{{
-				Group: (*gatewayv1.Group)(&gatewayv1.GroupVersion.Group),
-				Kind:  gatewayv1.Kind("UDPRoute"),
+			udpRouteKind := []v1.RouteGroupKind{{
+				Group: (*v1.Group)(&v1.GroupVersion.Group),
+				Kind:  v1.Kind("UDPRoute"),
 			}}
-			expectedListeners := []gatewayv1.ListenerStatus{
+			expectedListeners := []v1.ListenerStatus{
 				{
-					Name:           gatewayv1.SectionName("udp-1"),
+					Name:           v1.SectionName("udp-1"),
 					SupportedKinds: udpRouteKind,
 					AttachedRoutes: 1,
 					Conditions:     ready,
 				},
 				{
-					Name:           gatewayv1.SectionName("udp-2"),
+					Name:           v1.SectionName("udp-2"),
 					SupportedKinds: udpRouteKind,
 					AttachedRoutes: 1,
 					Conditions:     ready,
 				},
 				{
-					Name:           gatewayv1.SectionName("udp-3"),
+					Name:           v1.SectionName("udp-3"),
 					SupportedKinds: udpRouteKind,
 					AttachedRoutes: 1,
 					Conditions:     ready,

--- a/conformance/tests/udproute-parentref-port-and-section-name.go
+++ b/conformance/tests/udproute-parentref-port-and-section-name.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	v1 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/conformance/utils/udp"

--- a/conformance/tests/udproute-reference-grant.go
+++ b/conformance/tests/udproute-reference-grant.go
@@ -24,8 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	v1 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/conformance/utils/udp"
@@ -72,7 +71,7 @@ var UDPRouteReferenceGrant = confsuite.ConformanceTest{
 
 		ctx, cancel := context.WithTimeout(context.Background(), suite.TimeoutConfig.DeleteTimeout)
 		defer cancel()
-		rg := gatewayv1.ReferenceGrant{
+		rg := v1.ReferenceGrant{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "udp-reference-grant",
 				Namespace: confsuite.AppBackendNamespace,

--- a/conformance/tests/udproute-weighted-routing.go
+++ b/conformance/tests/udproute-weighted-routing.go
@@ -19,16 +19,12 @@ package tests
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"math"
 	"net"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
-	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/echo-basic/udpechoserver"
@@ -45,7 +41,7 @@ func init() {
 
 var UDPRouteWeightedRouting = confsuite.ConformanceTest{
 	ShortName:   "UDPRouteWeightedRouting",
-	Description: "A UDPRoute with multiple weighted backends should distribute UDP traffic across the backends in proportion to the configured weights.",
+	Description: "A UDPRoute with multiple weighted backends should distribute UDP traffic across the backends in proportion to the configured weights, and a backend with weight 0 should not receive any traffic.",
 	Manifests:   []string{"tests/udproute-weighted-routing.yaml"},
 	Features: []features.FeatureName{
 		features.SupportGateway,
@@ -65,72 +61,29 @@ var UDPRouteWeightedRouting = confsuite.ConformanceTest{
 			kubernetes.NewGatewayRef(gwNN, "udp"), routeNN)
 
 		t.Run("UDP traffic should be distributed across the weighted backends", func(t *testing.T) {
+			// udp-backend-v3 has weight 0 and must not receive any traffic.
+			// Including it in expectedWeights at 0.0 ensures any traffic
+			// landing on it would be caught by weight.TestWeightedDistribution.
 			expectedWeights := map[string]float64{
 				"udp-backend-v1": 0.7,
 				"udp-backend-v2": 0.3,
+				"udp-backend-v3": 0.0,
 			}
 
+			sender := weight.NewFunctionBasedSender(func() (string, error) {
+				return udpEchoSendOnce(t.Context(), gwAddr, 2*time.Second)
+			})
+
 			for i := range weight.MaxTestRetries {
-				err := assertUDPWeightedDistribution(t.Context(), gwAddr, expectedWeights, 0.03)
-				if err == nil {
+				if err := weight.TestWeightedDistribution(sender, expectedWeights); err != nil {
+					tlog.Logf(t, "UDP weighted distribution attempt %d/%d failed: %s", i+1, weight.MaxTestRetries, err)
+				} else {
 					return
 				}
-				tlog.Logf(t, "UDP weighted distribution attempt %d/%d failed: %s", i+1, weight.MaxTestRetries, err)
 			}
 			t.Fatal("UDP weighted distribution did not converge within tolerance")
 		})
 	},
-}
-
-// assertUDPWeightedDistribution sends a fixed number of UDP datagrams to
-// gwAddr in parallel, classifies each response by the backend Deployment that
-// produced it (extracted from the udpechoserver JSON envelope's pod name),
-// and returns nil if the observed distribution is within tolerance of
-// expectedWeights for every backend.
-func assertUDPWeightedDistribution(ctx context.Context, gwAddr string, expectedWeights map[string]float64, tolerance float64) error {
-	const (
-		concurrentRequests = 10
-		totalRequests      = 500
-		probeTimeout       = 2 * time.Second
-	)
-
-	var (
-		mu   sync.Mutex
-		seen = make(map[string]float64, len(expectedWeights))
-		g    errgroup.Group
-	)
-	g.SetLimit(concurrentRequests)
-
-	for range totalRequests {
-		g.Go(func() error {
-			pod, err := udpEchoSendOnce(ctx, gwAddr, probeTimeout)
-			if err != nil {
-				return err
-			}
-			backend := extractBackendName(pod)
-
-			mu.Lock()
-			defer mu.Unlock()
-			if _, ok := expectedWeights[backend]; !ok {
-				return fmt.Errorf("response from unexpected backend %q (pod %q)", backend, pod)
-			}
-			seen[backend]++
-			return nil
-		})
-	}
-	if err := g.Wait(); err != nil {
-		return fmt.Errorf("error while sending UDP probes: %w", err)
-	}
-
-	var errs []error
-	for backend, want := range expectedWeights {
-		got := seen[backend] / float64(totalRequests)
-		if math.Abs(got-want) > tolerance {
-			errs = append(errs, fmt.Errorf("backend %q got %.2f%% of traffic; expected %.2f%% (+/- %.2f%%)",
-				backend, got*100, want*100, tolerance*100))
-		}
-	}
-	return errors.Join(errs...)
 }
 
 // udpEchoSendOnce sends a single UDP datagram to gwAddr and returns the pod

--- a/conformance/tests/udproute-weighted-routing.yaml
+++ b/conformance/tests/udproute-weighted-routing.yaml
@@ -112,6 +112,63 @@ spec:
             requests:
               cpu: 10m
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: udp-backend-v3
+  namespace: gateway-conformance-infra
+  labels:
+    app: udp-backend-v3
+spec:
+  selector:
+    app: udp-backend-v3
+  ports:
+    - name: udp
+      protocol: UDP
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: udp-backend-v3
+  namespace: gateway-conformance-infra
+  labels:
+    app: udp-backend-v3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: udp-backend-v3
+  template:
+    metadata:
+      labels:
+        app: udp-backend-v3
+    spec:
+      containers:
+        - name: udp-backend
+          image: registry.k8s.io/gateway-api/echo-basic:v1.6.0-dev.2
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: UDP_ECHO_SERVER
+              value: "1"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SERVICE_NAME
+              value: udp-backend-v3
+          ports:
+            - containerPort: 8080
+              protocol: UDP
+          resources:
+            requests:
+              cpu: 10m
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -144,3 +201,6 @@ spec:
         - name: udp-backend-v2
           port: 8080
           weight: 30
+        - name: udp-backend-v3
+          port: 8080
+          weight: 0

--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -84,6 +84,7 @@ type TimeoutConfig struct {
 	// TCPRouteMustHaveCondition represents the maximum time for a TCPRoute to have the supplied Condition.
 	// Max value for conformant implementation: None
 	TCPRouteMustHaveCondition time.Duration
+
 	// UDPRouteMustHaveCondition represents the maximum time for a UDPRoute to have the supplied Condition.
 	// Max value for conformant implementation: None
 	UDPRouteMustHaveCondition time.Duration

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -872,6 +872,41 @@ func TCPRouteMustHaveCondition(t *testing.T, client client.Client, timeoutConfig
 	require.NoErrorf(t, waitErr, "error waiting for TCPRoute status to have a Condition matching expectations")
 }
 
+// UDPRouteMustHaveCondition checks that the supplied UDPRoute has the supplied Condition,
+// halting after the specified timeout is exceeded.
+func UDPRouteMustHaveCondition(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, routeNN types.NamespacedName, gwNN types.NamespacedName, condition metav1.Condition) {
+	t.Helper()
+
+	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.UDPRouteMustHaveCondition, true, func(ctx context.Context) (bool, error) {
+		route := &v1alpha2.UDPRoute{}
+		err := client.Get(ctx, routeNN, route)
+		if err != nil {
+			return false, fmt.Errorf("error fetching UDPRoute: %w", err)
+		}
+
+		parents := route.Status.Parents
+		var conditionFound bool
+		for _, parent := range parents {
+			if err := ConditionsHaveLatestObservedGeneration(route, parent.Conditions); err != nil {
+				tlog.Logf(t, "UDPRoute %s (parentRef=%v) %v",
+					routeNN, parentRefToString(parent.ParentRef), err,
+				)
+				return false, nil
+			}
+
+			if parent.ParentRef.Name == gatewayv1.ObjectName(gwNN.Name) && (parent.ParentRef.Namespace == nil || string(*parent.ParentRef.Namespace) == gwNN.Namespace) {
+				if findConditionInList(t, parent.Conditions, condition.Type, string(condition.Status), condition.Reason) {
+					conditionFound = true
+				}
+			}
+		}
+
+		return conditionFound, nil
+	})
+
+	require.NoErrorf(t, waitErr, "error waiting for UDPRoute status to have a Condition matching expectations")
+}
+
 // TCPRouteMustHaveNoAcceptedParents waits for the specified TCPRoute to have either no parents
 // or a single parent that is not accepted. This is used to validate TCPRoute errors.
 func TCPRouteMustHaveNoAcceptedParents(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, routeName types.NamespacedName) {
@@ -1075,41 +1110,6 @@ func HTTPRouteMustHaveCondition(t *testing.T, client client.Client, timeoutConfi
 	})
 
 	require.NoErrorf(t, waitErr, "error waiting for HTTPRoute status to have a Condition matching expectations")
-}
-
-// UDPRouteMustHaveCondition checks that the supplied UDPRoute has the supplied Condition,
-// halting after the specified timeout is exceeded.
-func UDPRouteMustHaveCondition(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, routeNN types.NamespacedName, gwNN types.NamespacedName, condition metav1.Condition) {
-	t.Helper()
-
-	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.UDPRouteMustHaveCondition, true, func(ctx context.Context) (bool, error) {
-		route := &v1alpha2.UDPRoute{}
-		err := client.Get(ctx, routeNN, route)
-		if err != nil {
-			return false, fmt.Errorf("error fetching UDPRoute: %w", err)
-		}
-
-		parents := route.Status.Parents
-		var conditionFound bool
-		for _, parent := range parents {
-			if err := ConditionsHaveLatestObservedGeneration(route, parent.Conditions); err != nil {
-				tlog.Logf(t, "UDPRoute %s (parentRef=%v) %v",
-					routeNN, parentRefToString(parent.ParentRef), err,
-				)
-				return false, nil
-			}
-
-			if parent.ParentRef.Name == gatewayv1.ObjectName(gwNN.Name) && (parent.ParentRef.Namespace == nil || string(*parent.ParentRef.Namespace) == gwNN.Namespace) {
-				if findConditionInList(t, parent.Conditions, condition.Type, string(condition.Status), condition.Reason) {
-					conditionFound = true
-				}
-			}
-		}
-
-		return conditionFound, nil
-	})
-
-	require.NoErrorf(t, waitErr, "error waiting for UDPRoute status to have a Condition matching expectations")
 }
 
 // UDPRouteMustHaveNoAcceptedParents waits for the specified UDPRoute to have either no parents


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind test
/area conformance-test

**What this PR does / why we need it**:
Touch ups from these PRs:
https://github.com/kubernetes-sigs/gateway-api/pull/4874
https://github.com/kubernetes-sigs/gateway-api/pull/4861

Specifically - 

Added tests for TCP / UDP route that validate when multiple routes are attached to a listener, the oldest route receives all the traffic. 

Added zero weight tests to both TCP / UDP routes, also refactored to remove the custom weight logic, favoring the utility that already exists.

I added a test case for UDPRoute fails attachment to a non-UDP listener when port or sectionName is specified - Should have Accepted=False with Reason NotAllowedByListeners (hard to test on an UDP only Gateway) however, I needed to use a TCP listener for this. If this is acceptable, I will do the inverse (UDP Listener, TCPRoute trying to connect). 

This test case was requested:
```
Two listeners of type UDP on the same port must have Accepted = True, but also Conflicted=True with reason ProtocolConflict and no traffic must be routed (more on a Gateway test than on a route test)
```

But, I am unable to apply a Gateway with this configuration [unless we use a listenerset, in which case then one listener would win].

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Part of https://github.com/kubernetes-sigs/gateway-api/issues/4790

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```

