### PR TITLE
Set release title to tag name in monthly release workflow

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -132,6 +132,7 @@ jobs:
           fi
 
           gh release create ${STEPS_TAG_OUTPUTS_TAG} \
+            --title "${STEPS_TAG_OUTPUTS_TAG}" \
             -F release-notes.md \
             --prerelease \
             --draft release/${STEPS_TAG_OUTPUTS_TAG}-install.yaml


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Uses tag name as a title for the monthly release draft.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
