### PR TITLE
conformance: avoid mirror log races

### DIFF
--- a/conformance/tests/httproute-request-mirror.go
+++ b/conformance/tests/httproute-request-mirror.go
@@ -105,10 +105,13 @@ var HTTPRouteRequestMirror = confsuite.ConformanceTest{
 			tc := testCases[i]
 			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
 				t.Parallel()
-				tc.AddRequestIDQueryParam(uuid.NewString())
+				err := tc.AddRequestIDQueryParam(uuid.NewString())
+				if err != nil {
+					t.Fatalf("Invalid query in path: %v", err)
+				}
 				// Start inspecting logs before sending the request
 				waitForMirroredRequests := http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
-				defer waitForMirroredRequests() // defer in case we exit below
+				defer waitForMirroredRequests() // clean-up in case we exit below
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})
 		}

--- a/conformance/tests/httproute-request-mirror.go
+++ b/conformance/tests/httproute-request-mirror.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
@@ -104,8 +105,11 @@ var HTTPRouteRequestMirror = confsuite.ConformanceTest{
 			tc := testCases[i]
 			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
 				t.Parallel()
+				tc.AddRequestIDQueryParam(uuid.NewString())
+				// Start inspecting logs before sending the request
+				waitForMirroredRequests := http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
+				defer waitForMirroredRequests() // defer in case we exit below
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
-				http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
 			})
 		}
 	},

--- a/conformance/tests/httproute-request-multiple-mirrors.go
+++ b/conformance/tests/httproute-request-multiple-mirrors.go
@@ -117,10 +117,13 @@ var HTTPRouteRequestMultipleMirrors = confsuite.ConformanceTest{
 			tc := testCases[i]
 			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
 				t.Parallel()
-				tc.AddRequestIDQueryParam(uuid.NewString())
+				err := tc.AddRequestIDQueryParam(uuid.NewString())
+				if err != nil {
+					t.Fatalf("Invalid query in path: %v", err)
+				}
 				// Start inspecting logs before sending the request
 				waitForMirroredRequests := http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
-				defer waitForMirroredRequests() // defer in case we exit below
+				defer waitForMirroredRequests() // clean-up in case we exit below
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
 			})
 		}

--- a/conformance/tests/httproute-request-multiple-mirrors.go
+++ b/conformance/tests/httproute-request-multiple-mirrors.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
@@ -116,8 +117,11 @@ var HTTPRouteRequestMultipleMirrors = confsuite.ConformanceTest{
 			tc := testCases[i]
 			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
 				t.Parallel()
+				tc.AddRequestIDQueryParam(uuid.NewString())
+				// Start inspecting logs before sending the request
+				waitForMirroredRequests := http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
+				defer waitForMirroredRequests() // defer in case we exit below
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
-				http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
 			})
 		}
 	},

--- a/conformance/tests/httproute-request-percentage-mirror.go
+++ b/conformance/tests/httproute-request-percentage-mirror.go
@@ -141,11 +141,8 @@ var HTTPRouteRequestPercentageMirror = confsuite.ConformanceTest{
 		for i := range testCases {
 			expected := testCases[i]
 			t.Run(expected.GetTestCaseName(i), func(t *testing.T) {
-				initialExpected := expected
-				initialExpected.AddRequestIDQueryParam(uuid.NewString())
-
 				// Assert request succeeds before doing our distribution check
-				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, initialExpected)
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expected)
 
 				// Override to not have more requests than expected
 				dedicatedTimeoutConfig := suite.TimeoutConfig
@@ -155,8 +152,10 @@ var HTTPRouteRequestPercentageMirror = confsuite.ConformanceTest{
 				var wg sync.WaitGroup
 
 				for k := range numDistributionChecks {
-					distributionExpected := expected
-					distributionExpected.AddRequestIDQueryParam(uuid.NewString())
+					err := expected.AddRequestIDQueryParam(uuid.NewString())
+					if err != nil {
+						t.Fatalf("Invalid query in path: %v", err)
+					}
 					timeNow := time.Now()
 					for range int(totalRequests) {
 						wg.Add(1)
@@ -165,10 +164,10 @@ var HTTPRouteRequestPercentageMirror = confsuite.ConformanceTest{
 							defer wg.Done()
 							defer func() { <-semaphore }()
 							http.MakeRequestAndExpectEventuallyConsistentResponse(t, r, timeoutConfig, gwAddr, expected)
-						}(t, suite.RoundTripper, dedicatedTimeoutConfig, gwAddr, distributionExpected)
+						}(t, suite.RoundTripper, dedicatedTimeoutConfig, gwAddr, expected)
 					}
 					wg.Wait()
-					if err := testMirroredRequestsDistribution(t, suite, distributionExpected, timeNow); err != nil {
+					if err := testMirroredRequestsDistribution(t, suite, expected, timeNow); err != nil {
 						t.Logf("Traffic distribution test failed (%d/%d): %s", k+1, numDistributionChecks, err)
 						time.Sleep(2 * time.Second)
 					} else {

--- a/conformance/tests/httproute-request-percentage-mirror.go
+++ b/conformance/tests/httproute-request-percentage-mirror.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -140,8 +141,11 @@ var HTTPRouteRequestPercentageMirror = confsuite.ConformanceTest{
 		for i := range testCases {
 			expected := testCases[i]
 			t.Run(expected.GetTestCaseName(i), func(t *testing.T) {
+				initialExpected := expected
+				initialExpected.AddRequestIDQueryParam(uuid.NewString())
+
 				// Assert request succeeds before doing our distribution check
-				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expected)
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, initialExpected)
 
 				// Override to not have more requests than expected
 				dedicatedTimeoutConfig := suite.TimeoutConfig
@@ -151,6 +155,8 @@ var HTTPRouteRequestPercentageMirror = confsuite.ConformanceTest{
 				var wg sync.WaitGroup
 
 				for k := range numDistributionChecks {
+					distributionExpected := expected
+					distributionExpected.AddRequestIDQueryParam(uuid.NewString())
 					timeNow := time.Now()
 					for range int(totalRequests) {
 						wg.Add(1)
@@ -159,10 +165,10 @@ var HTTPRouteRequestPercentageMirror = confsuite.ConformanceTest{
 							defer wg.Done()
 							defer func() { <-semaphore }()
 							http.MakeRequestAndExpectEventuallyConsistentResponse(t, r, timeoutConfig, gwAddr, expected)
-						}(t, suite.RoundTripper, dedicatedTimeoutConfig, gwAddr, expected)
+						}(t, suite.RoundTripper, dedicatedTimeoutConfig, gwAddr, distributionExpected)
 					}
 					wg.Wait()
-					if err := testMirroredRequestsDistribution(t, suite, expected, timeNow); err != nil {
+					if err := testMirroredRequestsDistribution(t, suite, distributionExpected, timeNow); err != nil {
 						t.Logf("Traffic distribution test failed (%d/%d): %s", k+1, numDistributionChecks, err)
 						time.Sleep(2 * time.Second)
 					} else {
@@ -188,7 +194,7 @@ func testMirroredRequestsDistribution(t *testing.T, suite *confsuite.Conformance
 
 	for _, mirrorPod := range mirrorPods {
 		require.Eventually(t, func() bool {
-			mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to \\%s to client", expected.Request.Path))
+			mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to %s to client", regexp.QuoteMeta(expected.Request.Path)))
 
 			tlog.Log(t, "Searching for the mirrored request log")
 			tlog.Logf(t, `Reading "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name)

--- a/conformance/tests/httproute-request-percentage-mirror.go
+++ b/conformance/tests/httproute-request-percentage-mirror.go
@@ -19,7 +19,6 @@ package tests
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"sync"
 	"testing"
 	"time"
@@ -193,7 +192,7 @@ func testMirroredRequestsDistribution(t *testing.T, suite *confsuite.Conformance
 
 	for _, mirrorPod := range mirrorPods {
 		require.Eventually(t, func() bool {
-			mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to %s to client", regexp.QuoteMeta(expected.Request.Path)))
+			mirrorLogRegexp := http.GetMirrorLogRegexp(expected.Request.Path)
 
 			tlog.Log(t, "Searching for the mirrored request log")
 			tlog.Logf(t, `Reading "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name)

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -81,6 +81,31 @@ type Request struct {
 	ClientCert       string
 }
 
+const requestIDQueryParam = "gateway-api-conformance-request-id"
+
+// AddRequestIDQueryParam adds a request ID to the request URI so that echo
+// server logs for this request can be matched unambiguously.
+func (e *ExpectedResponse) AddRequestIDQueryParam(requestID string) {
+	e.Request.Path = addQueryParam(e.Request.Path, requestIDQueryParam, requestID)
+	if e.ExpectedRequest != nil {
+		if e.ExpectedRequest.Path == "" {
+			e.ExpectedRequest.Path = e.Request.Path
+		} else {
+			e.ExpectedRequest.Path = addQueryParam(e.ExpectedRequest.Path, requestIDQueryParam, requestID)
+		}
+	}
+}
+
+func addQueryParam(path, name, value string) string {
+	pathOnly, rawQuery, _ := strings.Cut(path, "?")
+	query, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		query = url.Values{}
+	}
+	query.Set(name, value)
+	return pathOnly + "?" + query.Encode()
+}
+
 // ExpectedRequest defines expected properties of a request that reaches a backend.
 type ExpectedRequest struct {
 	Request
@@ -504,26 +529,26 @@ func CompareRoundTrip(t *testing.T, req *roundtripper.Request, cReq *roundtrippe
 }
 
 // GetTestCaseName gets the user-defined test case name or generates one from expected response to a given request.
-func (er *ExpectedResponse) GetTestCaseName(i int) string {
+func (e *ExpectedResponse) GetTestCaseName(i int) string {
 	// If TestCase name is provided then use that or else generate one.
-	if er.TestCaseName != "" {
-		return er.TestCaseName
+	if e.TestCaseName != "" {
+		return e.TestCaseName
 	}
 
 	headerStr := ""
 	reqStr := ""
 
-	if er.Request.Headers != nil {
+	if e.Request.Headers != nil {
 		headerStr = " with headers"
 	}
 
-	reqStr = fmt.Sprintf("%d request to '%s%s'%s", i, er.Request.Host, er.Request.Path, headerStr)
+	reqStr = fmt.Sprintf("%d request to '%s%s'%s", i, e.Request.Host, e.Request.Path, headerStr)
 
-	if er.Backend != "" {
-		return fmt.Sprintf("%s should go to %s", reqStr, er.Backend)
+	if e.Backend != "" {
+		return fmt.Sprintf("%s should go to %s", reqStr, e.Backend)
 	}
 
-	return fmt.Sprintf("%s should receive one of %v", reqStr, er.Response.StatusCodes)
+	return fmt.Sprintf("%s should receive one of %v", reqStr, e.Response.StatusCodes)
 }
 
 func setRedirectRequestDefaults(req *roundtripper.Request, cRes *roundtripper.CapturedResponse, expected *ExpectedResponse) {

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -105,22 +105,20 @@ func (er *ExpectedResponse) AddRequestIDQueryParam(requestID string) error {
 	return nil
 }
 
-// addQueryParam adds 'name'='value' query parameter to the given 'path'.
-// returns an error if existing query cannot be parsed.
-func addQueryParam(path, name, value string) (string, error) {
-	var query url.Values
-	pathOnly, rawQuery, found := strings.Cut(path, "?")
-	if found {
-		var err error
-		query, err = url.ParseQuery(rawQuery)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		query = url.Values{}
+// addQueryParam adds 'name'='value' query parameter to the given 'rawURL' and returns it.
+// Returns an error if rawURL or its query cannot be parsed.
+func addQueryParam(rawURL, name, value string) (string, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	query, err := url.ParseQuery(parsedURL.RawQuery)
+	if err != nil {
+		return "", err
 	}
 	query.Set(name, value)
-	return pathOnly + "?" + query.Encode(), nil
+	parsedURL.RawQuery = query.Encode()
+	return parsedURL.String(), nil
 }
 
 // ExpectedRequest defines expected properties of a request that reaches a backend.

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -85,25 +85,42 @@ const requestIDQueryParam = "gateway-api-conformance-request-id"
 
 // AddRequestIDQueryParam adds a request ID to the request URI so that echo
 // server logs for this request can be matched unambiguously.
-func (e *ExpectedResponse) AddRequestIDQueryParam(requestID string) {
-	e.Request.Path = addQueryParam(e.Request.Path, requestIDQueryParam, requestID)
-	if e.ExpectedRequest != nil {
-		if e.ExpectedRequest.Path == "" {
-			e.ExpectedRequest.Path = e.Request.Path
+// Returns a non-nil error if either Request.Path or ExpectedRequest.Path has an unparseable query.
+func (er *ExpectedResponse) AddRequestIDQueryParam(requestID string) error {
+	path, err := addQueryParam(er.Request.Path, requestIDQueryParam, requestID)
+	if err != nil {
+		return err
+	}
+	if er.ExpectedRequest != nil {
+		if er.ExpectedRequest.Path == "" {
+			er.ExpectedRequest.Path = path
 		} else {
-			e.ExpectedRequest.Path = addQueryParam(e.ExpectedRequest.Path, requestIDQueryParam, requestID)
+			er.ExpectedRequest.Path, err = addQueryParam(er.ExpectedRequest.Path, requestIDQueryParam, requestID)
+			if err != nil {
+				return err
+			}
 		}
 	}
+	er.Request.Path = path
+	return nil
 }
 
-func addQueryParam(path, name, value string) string {
-	pathOnly, rawQuery, _ := strings.Cut(path, "?")
-	query, err := url.ParseQuery(rawQuery)
-	if err != nil {
+// addQueryParam adds 'name'='value' query parameter to the given 'path'.
+// returns an error if existing query cannot be parsed.
+func addQueryParam(path, name, value string) (string, error) {
+	var query url.Values
+	pathOnly, rawQuery, found := strings.Cut(path, "?")
+	if found {
+		var err error
+		query, err = url.ParseQuery(rawQuery)
+		if err != nil {
+			return "", err
+		}
+	} else {
 		query = url.Values{}
 	}
 	query.Set(name, value)
-	return pathOnly + "?" + query.Encode()
+	return pathOnly + "?" + query.Encode(), nil
 }
 
 // ExpectedRequest defines expected properties of a request that reaches a backend.
@@ -529,26 +546,26 @@ func CompareRoundTrip(t *testing.T, req *roundtripper.Request, cReq *roundtrippe
 }
 
 // GetTestCaseName gets the user-defined test case name or generates one from expected response to a given request.
-func (e *ExpectedResponse) GetTestCaseName(i int) string {
+func (er *ExpectedResponse) GetTestCaseName(i int) string {
 	// If TestCase name is provided then use that or else generate one.
-	if e.TestCaseName != "" {
-		return e.TestCaseName
+	if er.TestCaseName != "" {
+		return er.TestCaseName
 	}
 
 	headerStr := ""
 	reqStr := ""
 
-	if e.Request.Headers != nil {
+	if er.Request.Headers != nil {
 		headerStr = " with headers"
 	}
 
-	reqStr = fmt.Sprintf("%d request to '%s%s'%s", i, e.Request.Host, e.Request.Path, headerStr)
+	reqStr = fmt.Sprintf("%d request to '%s%s'%s", i, er.Request.Host, er.Request.Path, headerStr)
 
-	if e.Backend != "" {
-		return fmt.Sprintf("%s should go to %s", reqStr, e.Backend)
+	if er.Backend != "" {
+		return fmt.Sprintf("%s should go to %s", reqStr, er.Backend)
 	}
 
-	return fmt.Sprintf("%s should receive one of %v", reqStr, e.Response.StatusCodes)
+	return fmt.Sprintf("%s should receive one of %v", reqStr, er.Response.StatusCodes)
 }
 
 func setRedirectRequestDefaults(req *roundtripper.Request, cRes *roundtripper.CapturedResponse, expected *ExpectedResponse) {

--- a/conformance/utils/http/mirror.go
+++ b/conformance/utils/http/mirror.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	clientset "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,15 +33,20 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
 )
 
-func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clientset.Interface, mirrorPods []MirroredBackend, path string, timeoutConfig config.TimeoutConfig) {
+func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clientset.Interface, mirrorPods []MirroredBackend, path string, timeoutConfig config.TimeoutConfig) func() {
 	for i, mirrorPod := range mirrorPods {
 		if mirrorPod.Name == "" {
 			tlog.Fatalf(t, "Mirrored BackendRef[%d].Name wasn't provided in the testcase, this test should only check http request mirror.", i)
 		}
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(len(mirrorPods))
+	mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to %s to client", regexp.QuoteMeta(path)))
+
+	var done sync.WaitGroup
+	done.Add(len(mirrorPods))
+	var started sync.WaitGroup
+	started.Add(len(mirrorPods))
+	results := make(chan bool, len(mirrorPods))
 
 	// Start the log window before the requests were sent, not at "now". The
 	// caller already dispatched the mirrored requests, and on a high-latency
@@ -56,11 +61,11 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 
 	for _, mirrorPod := range mirrorPods {
 		go func(mirrorPod MirroredBackend) {
-			defer wg.Done()
+			var startedOnce sync.Once
 
-			require.Eventually(t, func() bool {
-				mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to \\%s to client", path))
+			defer done.Done()
 
+			success := assert.Eventually(t, func() bool {
 				tlog.Log(t, "Searching for the mirrored request log")
 				tlog.Logf(t, `Reading "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name)
 				logs, err := kubernetes.DumpEchoLogs(t.Context(), mirrorPod.Namespace, mirrorPod.Name, client, clientset, assertionStart)
@@ -69,12 +74,36 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 					return false
 				}
 
+				// Report as started after we have successfully dumped the logs for
+				// the first time.
+				startedOnce.Do(started.Done)
+
 				return slices.ContainsFunc(logs, mirrorLogRegexp.MatchString)
 			}, timeoutConfig.RequestTimeout, time.Second, `Couldn't find mirrored request in "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name)
+
+			// signal done even if all log dumps failed above.
+			startedOnce.Do(started.Done)
+			results <- success
 		}(mirrorPod)
 	}
 
-	wg.Wait()
+	// Wait until each watcher has either dumped logs at least once or timed out.
+	started.Wait()
 
-	tlog.Log(t, "Found mirrored request log in all desired backends")
+	// caller should eventually call the returned function to wait for the goroutines to be done
+	// and to log if successful
+	return func() {
+		done.Wait()
+		close(results)
+
+		successes := 0
+		for result := range results {
+			if result {
+				successes++
+			}
+		}
+		if successes == len(mirrorPods) {
+			tlog.Log(t, "Found mirrored request log in all desired backends")
+		}
+	}
 }

--- a/conformance/utils/http/mirror.go
+++ b/conformance/utils/http/mirror.go
@@ -33,6 +33,10 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
 )
 
+func GetMirrorLogRegexp(path string) *regexp.Regexp {
+	return regexp.MustCompile(fmt.Sprintf("Echoing back request made to %s to client", regexp.QuoteMeta(path)))
+}
+
 func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clientset.Interface, mirrorPods []MirroredBackend, path string, timeoutConfig config.TimeoutConfig) func() {
 	for i, mirrorPod := range mirrorPods {
 		if mirrorPod.Name == "" {
@@ -40,10 +44,9 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 		}
 	}
 
-	mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to %s to client", regexp.QuoteMeta(path)))
+	mirrorLogRegexp := GetMirrorLogRegexp(path)
 
 	var done sync.WaitGroup
-	done.Add(len(mirrorPods))
 	var started sync.WaitGroup
 	started.Add(len(mirrorPods))
 	results := make(chan bool, len(mirrorPods))
@@ -60,10 +63,8 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 	assertionStart := time.Now().Add(-timeoutConfig.MaxTimeToConsistency)
 
 	for _, mirrorPod := range mirrorPods {
-		go func(mirrorPod MirroredBackend) {
+		done.Go(func() {
 			var startedOnce sync.Once
-
-			defer done.Done()
 
 			success := assert.Eventually(t, func() bool {
 				tlog.Log(t, "Searching for the mirrored request log")
@@ -84,7 +85,7 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 			// signal done even if all log dumps failed above.
 			startedOnce.Do(started.Done)
 			results <- success
-		}(mirrorPod)
+		})
 	}
 
 	// Wait until each watcher has either dumped logs at least once or timed out.


### PR DESCRIPTION
Ref. #3708
Start watching mirrored backend logs before sending mirror test requests, and add a unique request ID query parameter to the echoed URI matched in logs. This avoids flakes where the mirrored request is logged before the test starts reading logs, as seen in Cilium CI, and prevents logs from nearby test runs or retry attempts from satisfying the matcher. Also add a small log timestamp lookback for node clock skew and quote the matched URI before building the regex.

/sig network
/cc @mhofstetter 
/kind test
/kind flake

Fixes: cilium/cilium#46078

```release-note
NONE
```
