### PR TITLE
conformance: add v1.4.1 reports for Calico v3.32.0

### DIFF
--- a/conformance/reports/v1.4.1/projectcalico-calico/README.md
+++ b/conformance/reports/v1.4.1/projectcalico-calico/README.md
@@ -1,0 +1,58 @@
+# Calico
+
+[Calico][calico] is an open-source networking and security solution for
+Kubernetes and other cloud-native environments. Calico's Gateway API
+implementation is built on the [tigera-operator][calico-operator] and
+[Envoy Gateway][envoy-gateway]: the operator reconciles a `GatewayAPI`
+custom resource, provisions an Envoy Gateway control plane, and creates
+a default `tigera-gateway-class` GatewayClass on the cluster. The
+underlying Envoy data plane is integrated with Calico's native
+networking and policy.
+
+## Table of Contents
+
+| API channel  | Implementation version                                                  | Mode    | Report                                              |
+|--------------|-------------------------------------------------------------------------|---------|-----------------------------------------------------|
+| experimental | [v3.32.0](https://github.com/projectcalico/calico/releases/tag/v3.32.0) | default | [link](./experimental-v3.32.0-default-report.yaml)  |
+
+The submitted report covers the GATEWAY-HTTP, GATEWAY-GRPC, and
+GATEWAY-TLS profiles. All core and extended tests in those profiles
+passed (Failed: 0, Skipped: 0).
+
+## Reproduce
+
+1. Clone the Calico repository:
+
+   ```bash
+   git clone https://github.com/projectcalico/calico && cd calico
+   ```
+
+2. Run the conformance suite:
+
+   ```bash
+   make e2e-test-gateway-conformance \
+     GATEWAY_CONFORMANCE_VERSION=v3.32.0 \
+     GATEWAY_CONFORMANCE_CONTACT=https://slack.projectcalico.org
+   ```
+
+3. Inspect the produced report:
+
+   ```bash
+   cat report/gateway-conformance-report.yaml
+   ```
+
+> **Note**: The conformance runner landed on `master` after the v3.32.0
+> tag was cut. The Envoy Gateway version (`v1.7.0`) and Gateway API
+> channel (`experimental`, `v1.4.1`) bundled by tigera-operator on
+> `master` match what ships in the v3.32.0 release; the version metadata
+> in the report is pinned via `GATEWAY_CONFORMANCE_VERSION`.
+
+## Contact
+
+Questions and issues are tracked in the [Calico project][calico] and on
+the [Project Calico Slack][calico-slack].
+
+[calico]: https://github.com/projectcalico/calico
+[calico-operator]: https://github.com/tigera/operator
+[envoy-gateway]: https://gateway.envoyproxy.io
+[calico-slack]: https://slack.projectcalico.org

--- a/conformance/reports/v1.4.1/projectcalico-calico/README.md
+++ b/conformance/reports/v1.4.1/projectcalico-calico/README.md
@@ -32,7 +32,7 @@ passed (Failed: 0, Skipped: 0).
    ```bash
    make e2e-test-gateway-conformance \
      GATEWAY_CONFORMANCE_VERSION=v3.32.0 \
-     GATEWAY_CONFORMANCE_CONTACT=https://slack.projectcalico.org
+     GATEWAY_CONFORMANCE_CONTACT=https://www.tigera.io/contact/
    ```
 
 3. Inspect the produced report:
@@ -49,10 +49,10 @@ passed (Failed: 0, Skipped: 0).
 
 ## Contact
 
-Questions and issues are tracked in the [Calico project][calico] and on
-the [Project Calico Slack][calico-slack].
+Questions and issues are tracked in the [Calico project][calico]. For
+commercial and maintainer inquiries, see the [Tigera contact form][tigera-contact].
 
 [calico]: https://github.com/projectcalico/calico
 [calico-operator]: https://github.com/tigera/operator
 [envoy-gateway]: https://gateway.envoyproxy.io
-[calico-slack]: https://slack.projectcalico.org
+[tigera-contact]: https://www.tigera.io/contact/

--- a/conformance/reports/v1.4.1/projectcalico-calico/experimental-v3.32.0-default-report.yaml
+++ b/conformance/reports/v1.4.1/projectcalico-calico/experimental-v3.32.0-default-report.yaml
@@ -1,0 +1,105 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-05-21T05:42:44Z"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.4.1
+implementation:
+  contact:
+  - https://slack.projectcalico.org
+  organization: projectcalico
+  project: calico
+  url: https://github.com/projectcalico/calico
+  version: v3.32.0
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 33
+      Skipped: 0
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 32
+      Skipped: 0
+    supportedFeatures:
+    - BackendTLSPolicy
+    - BackendTLSPolicySANValidation
+    - GatewayAddressEmpty
+    - GatewayHTTPListenerIsolation
+    - GatewayPort8080
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteCORS
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRouteNamedRouteRule
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRedirect
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestPercentageMirror
+    - HTTPRouteRequestTimeout
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    unsupportedFeatures:
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+  name: GATEWAY-HTTP
+  summary: Core tests succeeded. Extended tests succeeded.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 13
+      Skipped: 0
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 1
+      Skipped: 0
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayHTTPListenerIsolation
+    - GatewayPort8080
+    unsupportedFeatures:
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+  name: GATEWAY-GRPC
+  summary: Core tests succeeded. Extended tests succeeded.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 11
+      Skipped: 0
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 1
+      Skipped: 0
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayHTTPListenerIsolation
+    - GatewayPort8080
+    unsupportedFeatures:
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+  name: GATEWAY-TLS
+  summary: Core tests succeeded. Extended tests succeeded.
+succeededProvisionalTests:
+- GRPCRouteNamedRule
+- GatewayOptionalAddressValue
+- HTTPRouteNamedRule
+- HTTPRouteRequestPercentageMirror
+- UDPRoute

--- a/conformance/reports/v1.4.1/projectcalico-calico/experimental-v3.32.0-default-report.yaml
+++ b/conformance/reports/v1.4.1/projectcalico-calico/experimental-v3.32.0-default-report.yaml
@@ -4,7 +4,7 @@ gatewayAPIChannel: experimental
 gatewayAPIVersion: v1.4.1
 implementation:
   contact:
-  - https://slack.projectcalico.org
+  - https://www.tigera.io/contact/
   organization: projectcalico
   project: calico
   url: https://github.com/projectcalico/calico

--- a/site/content/en/docs/implementations/list.md
+++ b/site/content/en/docs/implementations/list.md
@@ -261,13 +261,13 @@ implementation is built on the [tigera-operator][calico-operator] and
 custom resource, provisions an Envoy Gateway control plane, and creates
 a default `tigera-gateway-class` GatewayClass on the cluster.
 
-Questions and contributions are welcome on the
-[Project Calico Slack][calico-slack] or on [GitHub][calico].
+Questions and contributions are welcome on [GitHub][calico]. For
+commercial and maintainer inquiries, see the [Tigera contact form][tigera-contact].
 
 [calico]: https://github.com/projectcalico/calico
 [calico-operator]: https://github.com/tigera/operator
 [envoy-gateway]: https://gateway.envoyproxy.io
-[calico-slack]: https://slack.projectcalico.org
+[tigera-contact]: https://www.tigera.io/contact/
 
 ### Cilium
 

--- a/site/content/en/docs/implementations/list.md
+++ b/site/content/en/docs/implementations/list.md
@@ -94,6 +94,7 @@ class.
 ### Conformant
 - [Agentgateway][40]
 - [Airlock Microgateway][34]
+- [Calico][46]
 - [Cilium][16]
 - [Gloo Gateway][5]
 - [Google Kubernetes Engine][6]
@@ -169,6 +170,7 @@ class.
 [43]:#alibaba-cloud-service-mesh
 [44]:#aws-load-balancer-controller
 [45]:#varnish-gateway
+[46]:#calico
 
 
 [gamma]: /docs/mesh/
@@ -247,6 +249,25 @@ See the [AWS Load Balancer Controller documentation][aws-lbc-docs] for informati
 
 [azure-application-gateway-for-containers]: https://aka.ms/appgwcontainers/docs
 [azure-application-gateway-for-containers-quickstart-controller]: https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller
+
+### Calico
+
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.4.1-Calico-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.4.1/projectcalico-calico/experimental-v3.32.0-default-report.yaml)
+
+[Calico][calico] is an open-source networking and security solution for
+Kubernetes and other cloud-native environments. Calico's Gateway API
+implementation is built on the [tigera-operator][calico-operator] and
+[Envoy Gateway][envoy-gateway]: the operator reconciles a `GatewayAPI`
+custom resource, provisions an Envoy Gateway control plane, and creates
+a default `tigera-gateway-class` GatewayClass on the cluster.
+
+Questions and contributions are welcome on the
+[Project Calico Slack][calico-slack] or on [GitHub][calico].
+
+[calico]: https://github.com/projectcalico/calico
+[calico-operator]: https://github.com/tigera/operator
+[envoy-gateway]: https://gateway.envoyproxy.io
+[calico-slack]: https://slack.projectcalico.org
 
 ### Cilium
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
/area conformance-test

**What this PR does / why we need it**:

Adds the first Gateway API v1.4.1 experimental conformance report for [Calico](https://github.com/projectcalico/calico) v3.32.0, and lists Calico under the conformant Gateway controller implementations.

Calico's Gateway API support is provided via the [tigera-operator](https://github.com/tigera/operator), which reconciles a `GatewayAPI` custom resource, provisions an [Envoy Gateway](https://gateway.envoyproxy.io) control plane (`v1.7.0`), and creates a default `tigera-gateway-class` GatewayClass.

Results in `default` mode:

| Profile         | Core         | Extended     |
|-----------------|--------------|--------------|
| GATEWAY-HTTP    | 33 passed    | 32 passed    |
| GATEWAY-GRPC    | 13 passed    |  1 passed    |
| GATEWAY-TLS     | 11 passed    |  1 passed    |

No failures and no skips across all three profiles. Reproduction steps are in `conformance/reports/v1.4.1/projectcalico-calico/README.md`.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```