### PR TITLE
api: use listType=set for HTTPRoute retry status codes and validate retry attempts >= 1

### DIFF
--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -394,7 +394,7 @@ type HTTPRouteRetry struct {
 	// Support: Extended
 	//
 	// +optional
-	// +listType=atomic
+	// +listType=set
 	Codes []HTTPRouteRetryStatusCode `json:"codes,omitempty"`
 
 	// Attempts specifies the maximum number of times an individual request
@@ -409,6 +409,7 @@ type HTTPRouteRetry struct {
 	// Support: Extended
 	//
 	// +optional
+	// +kubebuilder:validation:Minimum:=1
 	Attempts *int `json:"attempts,omitempty"`
 
 	// Backoff specifies the minimum duration a Gateway should wait between

--- a/applyconfiguration/internal/internal.go
+++ b/applyconfiguration/internal/internal.go
@@ -1060,7 +1060,7 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             scalar: numeric
-          elementRelationship: atomic
+          elementRelationship: associative
 - name: io.k8s.sigs.gateway-api.apis.v1.HTTPRouteRule
   map:
     fields:

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -3695,6 +3695,7 @@ spec:
                             a backend request is implementation-specific.
 
                             Support: Extended
+                          minimum: 1
                           type: integer
                         backoff:
                           description: |-
@@ -3763,7 +3764,7 @@ spec:
                             minimum: 400
                             type: integer
                           type: array
-                          x-kubernetes-list-type: atomic
+                          x-kubernetes-list-type: set
                       type: object
                     sessionPersistence:
                       description: |-
@@ -7949,6 +7950,7 @@ spec:
                             a backend request is implementation-specific.
 
                             Support: Extended
+                          minimum: 1
                           type: integer
                         backoff:
                           description: |-
@@ -8017,7 +8019,7 @@ spec:
                             minimum: 400
                             type: integer
                           type: array
-                          x-kubernetes-list-type: atomic
+                          x-kubernetes-list-type: set
                       type: object
                     sessionPersistence:
                       description: |-

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -5553,7 +5553,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_HTTPRouteRetry(ref common.ReferenceCal
 					"codes": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-type": "set",
 							},
 						},
 						SchemaProps: spec.SchemaProps{


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind feature

**What this PR does / why we need it**:
This PR tightens validation on HTTPRoute retry configuration:
- use `listType=set` for `codes` so duplicate codes are rejected by the API server
- `attempts` MUST be `>= 1`, since `0` or negative values are not meaningful for a retry policy

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
API validation updated for HTTPRoute retries, `retry.codes` must now be unique and `retry.attempts` must be >= 1
```
