### PR TITLE
test: enhance retry simulation with TCP failure mode and retry delay

### DIFF
--- a/conformance/echo-basic/echo-basic.go
+++ b/conformance/echo-basic/echo-basic.go
@@ -21,8 +21,10 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"regexp"
@@ -191,6 +193,10 @@ type retrySimulation struct {
 	attempts map[string]int
 }
 
+// retrySimulationHandler simulates a flaky backend to test Gateway retry logic.
+// It tracks the number of attempts per request (identified by uuid) and induces
+// failures until succeedAfter attempts have been made, at which point it
+// responds successfully by echoing the request back.
 func (r *retrySimulation) retrySimulationHandler(w http.ResponseWriter, request *http.Request) {
 	uuid := request.URL.Query().Get("uuid")
 	if uuid == "" {
@@ -204,26 +210,64 @@ func (r *retrySimulation) retrySimulationHandler(w http.ResponseWriter, request 
 		fmt.Fprintf(w, "succeedAfter is required")
 		return
 	}
-	responseCode, err := strconv.Atoi(request.URL.Query().Get("responseCode"))
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, "responseCode is required")
-		return
+
+	// TCP failure mode (default): the simulator hijacks the connection and
+	// aborts it with a TCP RST. The client observes a connection reset rather
+	// than an HTTP response.
+	handleAttempt := func(w http.ResponseWriter) error {
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			return errors.New("response writer does not support hijacking")
+		}
+		conn, _, err := hijacker.Hijack()
+		if err != nil {
+			return err
+		}
+		if tcp, ok := conn.(*net.TCPConn); ok {
+			if err := tcp.SetLinger(0); err != nil {
+				return err
+			}
+		}
+
+		return conn.Close()
+	}
+
+	// HTTP failure mode: if ?responseCode=<int> is set, the simulator replies
+	// with that status code instead of dropping the connection.
+	// For example, ?responseCode=503 simulates a server returning 503 on each
+	// failing attempt.
+	if responseCode, err := strconv.Atoi(request.URL.Query().Get("responseCode")); err == nil {
+		handleAttempt = func(w http.ResponseWriter) error {
+			w.WriteHeader(responseCode)
+			return nil
+		}
 	}
 
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	if r.attempts[uuid] < succeedAfter {
 		r.attempts[uuid]++
-		w.WriteHeader(responseCode)
+
+		// If the request has form ?delayRetry=[:duration], wait for that
+		// duration before emitting the failing response.
+		if err := delayResponse(request, "delayRetry"); err != nil {
+			processError(w, err, http.StatusInternalServerError)
+			return
+		}
+
+		if err := handleAttempt(w); err != nil {
+			processError(w, err, http.StatusInternalServerError)
+			return
+		}
+
 		return
 	}
 
 	echoHandler(w, request)
 }
 
-func delayResponse(request *http.Request) error {
-	d := request.FormValue("delay")
+func delayResponse(request *http.Request, key string) error {
+	d := request.FormValue(key)
 	if len(d) == 0 {
 		return nil
 	}
@@ -263,7 +307,7 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 
 	// If the request has form ?delay=[:duration] wait for duration
 	// For example, ?delay=10s will cause the response to wait 10s before responding
-	if err := delayResponse(r); err != nil {
+	if err := delayResponse(r, "delay"); err != nil {
 		processError(w, err, http.StatusInternalServerError)
 		return
 	}

--- a/conformance/echo-basic/echo-basic_test.go
+++ b/conformance/echo-basic/echo-basic_test.go
@@ -55,7 +55,7 @@ func TestDelayResponse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = delayResponse(req)
+	err = delayResponse(req, "delay")
 	if err != nil {
 		t.Errorf("Expected no error, but got %v", err)
 	}
@@ -66,7 +66,7 @@ func TestDelayResponse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = delayResponse(req)
+	err = delayResponse(req, "delay")
 	if err != nil {
 		t.Errorf("Expected no error, but got %v", err)
 	}
@@ -77,7 +77,7 @@ func TestDelayResponse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = delayResponse(req)
+	err = delayResponse(req, "delay")
 	if err == nil {
 		t.Errorf("Expected an error, but got nil")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind test
/area conformance-machinery

**What this PR does / why we need it**:
Extends the retry simulation handler in the echo-basic backend to support two additional failure modes, making it possible to test a wider range of client and gateway retry behavior in conformance tests:
- TCP failure mode (default): the simulator hijacks the connection and aborts it with a TCP RST (via SO_LINGER=0) instead of returning an HTTP response.
- Per-attempt delay: new query parameter `delayRetry` causes failing attempts to stall for the given duration before producing their failure response. Useful for testing per-try timeouts.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
