### PR TITLE
conformance: add ListenerSet tests for Route parentRefs

### DIFF
--- a/conformance/tests/listenerset-dual-parentref-independence.go
+++ b/conformance/tests/listenerset-dual-parentref-independence.go
@@ -1,0 +1,146 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, ListenerSetDualParentRefIndependence)
+}
+
+var ListenerSetDualParentRefIndependence = confsuite.ConformanceTest{
+	ShortName:   "ListenerSetDualParentRefIndependence",
+	Description: "A Route with both Gateway and ListenerSet parentRefs has independently evaluated Accepted conditions for each parentRef",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportListenerSet,
+		features.SupportHTTPRoute,
+	},
+	Manifests: []string{
+		"tests/listenerset-dual-parentref-independence.yaml",
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+
+		gwNN := types.NamespacedName{Name: "gateway-dual-parentref", Namespace: ns}
+		gwAddr, err := kubernetes.WaitForGatewayAddress(t, suite.Client, suite.TimeoutConfig, kubernetes.NewGatewayRef(gwNN, "gw-dual-parentref-listener"))
+		require.NoErrorf(t, err, "timed out waiting for Gateway address to be assigned")
+		kubernetes.GatewayMustHaveCondition(t, suite.Client, suite.TimeoutConfig, gwNN, metav1.Condition{
+			Type:   string(gatewayv1.GatewayConditionAccepted),
+			Status: metav1.ConditionTrue,
+		})
+		kubernetes.GatewayMustHaveAttachedListeners(t, suite.Client, suite.TimeoutConfig, gwNN, 1)
+
+		listenerSetGK := schema.GroupKind{
+			Group: gatewayv1.GroupVersion.Group,
+			Kind:  "ListenerSet",
+		}
+		lsNN := types.NamespacedName{Name: "ls-dual-parentref", Namespace: ns}
+		kubernetes.ListenerSetStatusMustHaveListeners(t, suite.Client, suite.TimeoutConfig, lsNN, []gatewayv1.ListenerEntryStatus{
+			{
+				Name:           "ls-dual-parentref-listener",
+				SupportedKinds: generateSupportedRouteKinds(),
+				AttachedRoutes: 2,
+				Conditions:     generateAcceptedListenerConditions(),
+			},
+		})
+
+		t.Run("Both parentRefs are Accepted", func(t *testing.T) {
+			dualRouteNN := types.NamespacedName{Name: "route-dual-parentref-both", Namespace: ns}
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, dualRouteNN, gwNN, metav1.Condition{
+				Type:   string(gatewayv1.RouteConditionAccepted),
+				Status: metav1.ConditionTrue,
+			})
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, dualRouteNN, lsNN, metav1.Condition{
+				Type:   string(gatewayv1.RouteConditionAccepted),
+				Status: metav1.ConditionTrue,
+			})
+
+			testCases := []http.ExpectedResponse{
+				{
+					Request:   http.Request{Host: "gw-dual.com", Path: "/dualboth"},
+					Backend:   confsuite.InfraBackendServiceNameV1,
+					Namespace: ns,
+				},
+				{
+					Request:   http.Request{Host: "ls-dual.com", Path: "/dualboth"},
+					Backend:   confsuite.InfraBackendServiceNameV1,
+					Namespace: ns,
+				},
+			}
+
+			for i := range testCases {
+				tc := testCases[i]
+				t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+					t.Parallel()
+					http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+				})
+			}
+		})
+
+		t.Run("One of two parentRefs is Accepted", func(t *testing.T) {
+			badGWRouteNN := types.NamespacedName{Name: "route-dual-parentref-one", Namespace: ns}
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, badGWRouteNN, gwNN, metav1.Condition{
+				Type:   string(gatewayv1.RouteConditionAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(gatewayv1.RouteReasonNoMatchingParent),
+			})
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, badGWRouteNN, lsNN, metav1.Condition{
+				Type:   string(gatewayv1.RouteConditionAccepted),
+				Status: metav1.ConditionTrue,
+			})
+
+			lsRef := kubernetes.NewResourceRef(listenerSetGK, lsNN)
+			kubernetes.RoutesAndParentMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, lsRef, &gatewayv1.HTTPRoute{},
+				types.NamespacedName{Name: "route-dual-parentref-one", Namespace: ns})
+
+			testCases := []http.ExpectedResponse{
+				{
+					Request:   http.Request{Host: "ls-dual.com", Path: "/dualone"},
+					Backend:   confsuite.InfraBackendServiceNameV2,
+					Namespace: ns,
+				},
+				{
+					Request:  http.Request{Host: "gw-dual.com", Path: "/dualone"},
+					Response: http.Response{StatusCode: 404},
+				},
+			}
+
+			for i := range testCases {
+				tc := testCases[i]
+				t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+					t.Parallel()
+					http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+				})
+			}
+		})
+	},
+}

--- a/conformance/tests/listenerset-dual-parentref-independence.yaml
+++ b/conformance/tests/listenerset-dual-parentref-independence.yaml
@@ -1,0 +1,89 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-dual-parentref
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: gw-dual-parentref-listener
+    port: 80
+    protocol: HTTP
+    hostname: "gw-dual.com"
+    allowedRoutes:
+      namespaces:
+        from: Same
+  allowedListeners:
+    namespaces:
+      from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: ls-dual-parentref
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    kind: Gateway
+    group: gateway.networking.k8s.io
+    name: gateway-dual-parentref
+    namespace: gateway-conformance-infra
+  listeners:
+  - name: ls-dual-parentref-listener
+    port: 80
+    protocol: HTTP
+    hostname: "ls-dual.com"
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-dual-parentref-both
+  namespace: gateway-conformance-infra
+spec:
+  # We expect to see Accepted=True for both of these parentRefs
+  parentRefs:
+  - name: gateway-dual-parentref
+    namespace: gateway-conformance-infra
+  - kind: ListenerSet
+    group: gateway.networking.k8s.io
+    name: ls-dual-parentref
+    namespace: gateway-conformance-infra
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /dualboth
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-dual-parentref-one
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: gateway-dual-parentref
+    namespace: gateway-conformance-infra
+    # We expect to see Accepted=False for this parentRef because this listener
+    # name does not exist on the Gateway resource
+    sectionName: ls-dual-parentref-listener
+  - kind: ListenerSet
+    group: gateway.networking.k8s.io
+    name: ls-dual-parentref
+    namespace: gateway-conformance-infra
+    # We expect to see Accepted=True for this parentRef because this listener
+    # name does exist on the ListenerSet resource
+    sectionName: ls-dual-parentref-listener
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /dualone
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080

--- a/conformance/tests/listenerset-gateway-parent-section-name-not-found.go
+++ b/conformance/tests/listenerset-gateway-parent-section-name-not-found.go
@@ -1,0 +1,94 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, ListenerSetGatewayParentSectionNameNotFound)
+}
+
+var ListenerSetGatewayParentSectionNameNotFound = confsuite.ConformanceTest{
+	ShortName:   "ListenerSetGatewayParentSectionNameNotFound",
+	Description: "A Route must not be able to find a ListenerSet sectionName using a Gateway parentRef",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportListenerSet,
+		features.SupportHTTPRoute,
+	},
+	Manifests: []string{
+		"tests/listenerset-gateway-parent-section-name-not-found.yaml",
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+
+		gwNN := types.NamespacedName{Name: "gateway-section-name", Namespace: ns}
+		gwAddr, err := kubernetes.WaitForGatewayAddress(t, suite.Client, suite.TimeoutConfig, kubernetes.NewGatewayRef(gwNN, "gw-listener"))
+		require.NoErrorf(t, err, "timed out waiting for Gateway address to be assigned")
+		kubernetes.GatewayMustHaveCondition(t, suite.Client, suite.TimeoutConfig, gwNN, metav1.Condition{
+			Type:   string(gatewayv1.GatewayConditionAccepted),
+			Status: metav1.ConditionTrue,
+		})
+		kubernetes.GatewayMustHaveAttachedListeners(t, suite.Client, suite.TimeoutConfig, gwNN, 1)
+
+		listenerSetGK := schema.GroupKind{
+			Group: gatewayv1.GroupVersion.Group,
+			Kind:  "ListenerSet",
+		}
+		lsNN := types.NamespacedName{Name: "listenerset-section-name", Namespace: ns}
+		listenerSetRef := kubernetes.NewResourceRef(listenerSetGK, lsNN)
+
+		kubernetes.RoutesAndParentMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, listenerSetRef, &gatewayv1.HTTPRoute{},
+			types.NamespacedName{Name: "route-via-listenerset", Namespace: ns})
+
+		kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig,
+			types.NamespacedName{Name: "route-via-gateway", Namespace: ns},
+			gwNN,
+			metav1.Condition{
+				Type:   string(gatewayv1.RouteConditionAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(gatewayv1.RouteReasonNoMatchingParent),
+			})
+
+		http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
+			http.ExpectedResponse{
+				Request:   http.Request{Host: "ls-section-name.com", Path: "/goodsection"},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+			})
+
+		http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
+			http.ExpectedResponse{
+				Request:  http.Request{Host: "gw-section.com", Path: "/badsection"},
+				Response: http.Response{StatusCode: 404},
+			})
+	},
+}

--- a/conformance/tests/listenerset-gateway-parent-section-name-not-found.yaml
+++ b/conformance/tests/listenerset-gateway-parent-section-name-not-found.yaml
@@ -1,0 +1,80 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-section-name
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: gw-listener
+    port: 80
+    protocol: HTTP
+    hostname: "gw-section.com"
+    allowedRoutes:
+      namespaces:
+        from: Same
+  allowedListeners:
+    namespaces:
+      from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: listenerset-section-name
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    kind: Gateway
+    group: gateway.networking.k8s.io
+    name: gateway-section-name
+    namespace: gateway-conformance-infra
+  listeners:
+  - name: ls-only-listener
+    port: 80
+    protocol: HTTP
+    hostname: "ls-section-name.com"
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+# This route attaches correctly to the ListenerSet directly
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-via-listenerset
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - kind: ListenerSet
+    group: gateway.networking.k8s.io
+    name: listenerset-section-name
+    namespace: gateway-conformance-infra
+    sectionName: ls-only-listener
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /goodsection
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+# This route attempts to attach to a ListenerSet sectionName via a Gateway
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-via-gateway
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: gateway-section-name
+    namespace: gateway-conformance-infra
+    sectionName: ls-only-listener
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /badsection
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080

--- a/conformance/tests/listenerset-route-status-scoped-to-parentref.go
+++ b/conformance/tests/listenerset-route-status-scoped-to-parentref.go
@@ -1,0 +1,127 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, ListenerSetRouteStatusScopedToParentRef)
+}
+
+var ListenerSetRouteStatusScopedToParentRef = confsuite.ConformanceTest{
+	ShortName:   "ListenerSetRouteStatusScopedToParentRef",
+	Description: "A Route's status.parents must contain entries only for its explicitly declared parentRefs",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportListenerSet,
+		features.SupportHTTPRoute,
+	},
+	Manifests: []string{
+		"tests/listenerset-route-status-scoped-to-parentref.yaml",
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+
+		gwNN := types.NamespacedName{Name: "gateway-parentref", Namespace: ns}
+		kubernetes.GatewayMustHaveCondition(t, suite.Client, suite.TimeoutConfig, gwNN, metav1.Condition{
+			Type:   string(gatewayv1.GatewayConditionAccepted),
+			Status: metav1.ConditionTrue,
+		})
+		kubernetes.GatewayMustHaveAttachedListeners(t, suite.Client, suite.TimeoutConfig, gwNN, 1)
+
+		listenerSetGK := schema.GroupKind{
+			Group: gatewayv1.GroupVersion.Group,
+			Kind:  "ListenerSet",
+		}
+		lsNN := types.NamespacedName{Name: "listenerset-parentref", Namespace: ns}
+		lsRef := kubernetes.NewResourceRef(listenerSetGK, lsNN)
+
+		kubernetes.ListenerSetStatusMustHaveListeners(t, suite.Client, suite.TimeoutConfig, lsNN, []gatewayv1.ListenerEntryStatus{
+			{
+				Name:           "listenerset-parentref-listener",
+				SupportedKinds: generateSupportedRouteKinds(),
+				AttachedRoutes: 1,
+				Conditions:     generateAcceptedListenerConditions(),
+			},
+		})
+
+		t.Run("Gateway-only parentRef", func(t *testing.T) {
+			gwOnlyRouteNN := types.NamespacedName{Name: "route-parentref-gwonly", Namespace: ns}
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, gwOnlyRouteNN, gwNN, metav1.Condition{
+				Type:   string(gatewayv1.RouteConditionAccepted),
+				Status: metav1.ConditionTrue,
+			})
+			kubernetes.HTTPRouteMustHaveParents(t, suite.Client, suite.TimeoutConfig, gwOnlyRouteNN,
+				[]gatewayv1.RouteParentStatus{
+					{
+						ParentRef: gatewayv1.ParentReference{
+							Group:     new(gatewayv1.Group(gatewayv1.GroupVersion.Group)),
+							Kind:      new(gatewayv1.Kind("Gateway")),
+							Name:      "gateway-parentref",
+							Namespace: new(gatewayv1.Namespace(ns)),
+						},
+						ControllerName: gatewayv1.GatewayController(suite.ControllerName),
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gatewayv1.RouteConditionAccepted),
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+				true,
+			)
+		})
+
+		t.Run("ListenerSet-only parentRef", func(t *testing.T) {
+			lsOnlyRouteNN := types.NamespacedName{Name: "route-parentref-lsonly", Namespace: ns}
+			kubernetes.RoutesAndParentMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, lsRef, &gatewayv1.HTTPRoute{}, lsOnlyRouteNN)
+			kubernetes.HTTPRouteMustHaveParents(t, suite.Client, suite.TimeoutConfig, lsOnlyRouteNN,
+				[]gatewayv1.RouteParentStatus{
+					{
+						ParentRef: gatewayv1.ParentReference{
+							Group:     new(gatewayv1.Group(gatewayv1.GroupVersion.Group)),
+							Kind:      new(gatewayv1.Kind("ListenerSet")),
+							Name:      "listenerset-parentref",
+							Namespace: new(gatewayv1.Namespace(ns)),
+						},
+						ControllerName: gatewayv1.GatewayController(suite.ControllerName),
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(gatewayv1.RouteConditionAccepted),
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+				true,
+			)
+		})
+	},
+}

--- a/conformance/tests/listenerset-route-status-scoped-to-parentref.yaml
+++ b/conformance/tests/listenerset-route-status-scoped-to-parentref.yaml
@@ -1,0 +1,76 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-parentref
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  listeners:
+  - name: gw-parentref-listener
+    port: 80
+    protocol: HTTP
+    hostname: "gw-parentref.com"
+    allowedRoutes:
+      namespaces:
+        from: Same
+  allowedListeners:
+    namespaces:
+      from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: listenerset-parentref
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    kind: Gateway
+    group: gateway.networking.k8s.io
+    name: gateway-parentref
+    namespace: gateway-conformance-infra
+  listeners:
+  - name: listenerset-parentref-listener
+    port: 80
+    protocol: HTTP
+    hostname: "listenerset-parentref.com"
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-parentref-gwonly
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: gateway-parentref
+    namespace: gateway-conformance-infra
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /gwonly
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-parentref-lsonly
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - kind: ListenerSet
+    group: gateway.networking.k8s.io
+    name: listenerset-parentref
+    namespace: gateway-conformance-infra
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /lsonly
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
/kind test
/area conformance-test

**What this PR does / why we need it**:

Add three conformance tests related to Route parentRefs when using ListenerSets.

These tests caught bugs in a draft implementation of ListenerSets for Cilium.

Add a conformance test which validates that when a Route has both a parentRef to a Gateway and a parentRef to a ListenerSet, that the Accepted condition is evaluated independently for each of these parentRefs.

Add a conformance tests which validates that when a Route attaches to a ListenerSet sectionName, that the sectionName cannot be found if the Route only has a Gateway parentRef, even if a ListenerSet with that same Gateway parentRef would satisfy the sectionName.

Add a conformance test which confirms that when a Route has a parentRef pointing to a ListenerSet, that the Route's status reflects exactly one parent, the ListenerSet, and not also that ListenerSet's Gateway.

**Does this PR introduce a user-facing change?**:
```release-note
conformance: add ListenerSet tests for Route parentRef cases
```
