### PR TITLE
Modernize API markers: Replace immutable CEL validation rules with +k8s:immutable marker

### DIFF
--- a/apis/v1/gatewayclass_types.go
+++ b/apis/v1/gatewayclass_types.go
@@ -88,7 +88,7 @@ type GatewayClassSpec struct {
 	//
 	// Support: Core
 	//
-	// +kubebuilder:validation:XValidation:message="Value is immutable",rule="self == oldSelf"
+	// +k8s:immutable
 	// +required
 	ControllerName GatewayController `json:"controllerName"`
 

--- a/apisx/v1alpha1/xmesh_types.go
+++ b/apisx/v1alpha1/xmesh_types.go
@@ -65,7 +65,7 @@ type MeshSpec struct {
 	//
 	// Support: Core
 	//
-	// +kubebuilder:validation:XValidation:message="Value is immutable",rule="self == oldSelf"
+	// +k8s:immutable
 	// +required
 	ControllerName gatewayapiv1.GatewayController `json:"controllerName,omitempty"`
 

--- a/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -93,7 +93,7 @@ spec:
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                 type: string
                 x-kubernetes-validations:
-                - message: Value is immutable
+                - message: field is immutable
                   rule: self == oldSelf
               description:
                 description: Description helps describe a GatewayClass with more details.
@@ -337,7 +337,7 @@ spec:
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                 type: string
                 x-kubernetes-validations:
-                - message: Value is immutable
+                - message: field is immutable
                   rule: self == oldSelf
               description:
                 description: Description helps describe a GatewayClass with more details.

--- a/config/crd/experimental/gateway.networking.x-k8s.io_xmeshes.yaml
+++ b/config/crd/experimental/gateway.networking.x-k8s.io_xmeshes.yaml
@@ -68,7 +68,7 @@ spec:
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                 type: string
                 x-kubernetes-validations:
-                - message: Value is immutable
+                - message: field is immutable
                   rule: self == oldSelf
               description:
                 description: Description optionally provides a human-readable description

--- a/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -93,7 +93,7 @@ spec:
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                 type: string
                 x-kubernetes-validations:
-                - message: Value is immutable
+                - message: field is immutable
                   rule: self == oldSelf
               description:
                 description: Description helps describe a GatewayClass with more details.
@@ -337,7 +337,7 @@ spec:
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
                 type: string
                 x-kubernetes-validations:
-                - message: Value is immutable
+                - message: field is immutable
                   rule: self == oldSelf
               description:
                 description: Description helps describe a GatewayClass with more details.

--- a/tests/cel/gatewayclass_test.go
+++ b/tests/cel/gatewayclass_test.go
@@ -52,7 +52,7 @@ func TestValidateGatewayClassUpdate(t *testing.T) {
 			updationMutate: func(gwc *gatewayv1.GatewayClass) {
 				gwc.Spec.ControllerName = "example.net/gateway-controller-2"
 			},
-			wantError: "Value is immutable",
+			wantError: "field is immutable",
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Replaces the `self == oldSelf` CEL XValidation rules with the controller-tools 0.21.0 `+k8s:immutable` marker on:

- `GatewayClass.controllerName`
- `XMesh.controllerName`

These are the only two occurrences of this pattern. Scoped to immutability only for now; can follow up`AtMostOneOf` separately

**Which issue(s) this PR fixes**:

Ref #4834

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

Currently, the immutability validation message for `GatewayClass.spec.controllerName` changed from "Value is immutable" to "field is immutable"