### PR TITLE
Derive percentage-mirror tolerance from the binomial standard deviation

### DIFF
--- a/conformance/tests/httproute-request-percentage-mirror.go
+++ b/conformance/tests/httproute-request-percentage-mirror.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -37,8 +38,13 @@ import (
 )
 
 const (
-	concurrentRequests    = 10
-	tolerancePercentage   = 15.0
+	concurrentRequests = 10
+	// toleranceStdDevs is the acceptance-band half-width expressed in binomial
+	// standard deviations; see testMirroredRequestsDistribution for the
+	// derivation. At 3 sigma the two-sided per-check false-failure probability
+	// is ~2.7e-3 for any mirror percentage, while still rejecting a genuinely
+	// wrong distribution.
+	toleranceStdDevs      = 3.0
 	totalRequests         = 500.0
 	numDistributionChecks = 5
 )
@@ -219,9 +225,21 @@ func testMirroredRequestsDistribution(t *testing.T, suite *confsuite.Conformance
 	var errs []error
 
 	for _, mirrorPod := range mirrorPods {
-		expected := float64(totalRequests) * float64(*mirrorPod.Percent) / 100.0
-		minExpected := expected * (1 - tolerancePercentage/100)
-		maxExpected := expected * (1 + tolerancePercentage/100)
+		// Each request is mirrored independently with probability p, so the
+		// observed mirrored count follows Binomial(totalRequests, p) with
+		// standard deviation sqrt(n*p*(1-p)). Deriving the acceptance band from
+		// that standard deviation keeps the per-check false-failure probability
+		// uniformly low across mirror percentages. A flat relative band does
+		// not: it scales linearly with p while the standard deviation scales
+		// with sqrt(p*(1-p)), so at low percentages the band collapses toward
+		// the sampling noise floor (e.g. p=0.2, n=500 gives stddev ~8.9, so a
+		// +/-15% band spanned only ~1.7 stddev and rejected ~9% of conforming
+		// runs by sampling variance alone).
+		p := float64(*mirrorPod.Percent) / 100.0
+		expected := totalRequests * p
+		margin := toleranceStdDevs * math.Sqrt(totalRequests*p*(1-p))
+		minExpected := expected - margin
+		maxExpected := expected + margin
 
 		actual := float64(mirroredCounts[mirrorPod.Name])
 		tlog.Logf(t, "Pod: %s, Expected: %f (min: %f, max: %f), Actual: %f", mirrorPod.Name, expected, minExpected, maxExpected, actual)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind flake
/area conformance-test

**What this PR does / why we need it**:

`HTTPRouteRequestPercentageMirror` compares the observed mirrored-request count against a flat relative `±15%` band. Mirroring is a Bernoulli process, so the count follows `Binomial(n, p)` with standard deviation `sqrt(n*p*(1-p))`. The relative band scales linearly with `p`, but the standard deviation scales with `sqrt(p*(1-p))`, so the band — measured in standard deviations — collapses toward the sampling noise floor at low mirror percentages.

For the three subcases at `n=500`:

| subcase | p | expected μ | σ | old ±15% band | width | per-check false-fail |
| --- | --- | --- | --- | --- | --- | --- |
| `/percent-mirror` | 20% | 100 | 8.94 | [85, 115] | ±1.68σ | ~9.4% |
| `/percent-mirror-and-modify-headers` | 35% | 175 | 10.67 | [148.8, 201.2] | ±2.46σ | ~1.4% |
| `/percent-mirror-fraction` | 50% | 250 | 11.18 | [212.5, 287.5] | ±3.35σ | ~0.08% |

The 20% subcase rejects ~9% of perfectly-conforming runs by sampling variance alone. The `numDistributionChecks = 5` retry budget hides it at the suite level, but it produces noisy per-attempt failures in the logs.

This PR derives the band from the binomial standard deviation instead: `μ ± 3*sqrt(n*p*(1-p))`. The per-check false-failure probability becomes `~2.7e-3` uniformly across all three subcases (`~1e-13` at the suite level with the existing retries), while still rejecting a grossly wrong distribution (no mirroring, or mirroring at a multiple of the configured fraction). `totalRequests` and `numDistributionChecks` are unchanged.

`toleranceStdDevs` is a single tunable; I used 3.0 (the linked issue floated 3.5). It keeps the per-check false-failure at `~2.7e-3` (`~1e-13` at the suite level with the existing retries) uniformly across subcases. Bumping to 3.5 lowers the per-check false-failure to `~5e-4` (`~2e-17` suite-level) but loosens detection of a moderately-wrong distribution. Detection of small errors is also bounded by the pre-existing `numDistributionChecks = 5` any-of-five retry loop, which I left untouched (it lets, say, a 30%-when-20%-configured implementation clear the 3σ band on at least one of five samples ~6% of the time). Happy to adjust `k`, or to revisit the retry budget separately, if reviewers prefer.

**Which issue(s) this PR fixes**:

Fixes #4933

**Does this PR introduce a user-facing change?**:

```release-note
The HTTPRouteRequestPercentageMirror conformance test now derives its acceptance band from the binomial standard deviation instead of a flat ±15% relative tolerance, removing sampling-variance flakes at low mirror percentages.
```

---

This PR was written in part with the assistance of generative AI. All changes pass the project's automated gates (CI, linters, conformance tests) and were personally reviewed and verified before submission.

