### PR TITLE
Add an injectable WebSocket dialer to the conformance suite

### DIFF
--- a/conformance/tests/httproute-backend-protocol-websocket.go
+++ b/conformance/tests/httproute-backend-protocol-websocket.go
@@ -62,7 +62,7 @@ var HTTPRouteBackendProtocolWebSocket = confsuite.ConformanceTest{
 				origin := fmt.Sprintf("ws://gateway/%s", t.Name())
 				remote := fmt.Sprintf("ws://%s/ws", gwAddr)
 
-				ws, err := websocket.Dial(remote, "", origin)
+				ws, err := suite.WebSocketDialer.Dial(remote, "", origin)
 				if err != nil {
 					t.Log("failed to dial", err)
 					return false

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -45,6 +45,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
+	"sigs.k8s.io/gateway-api/conformance/utils/websocket"
 	"sigs.k8s.io/gateway-api/pkg/consts"
 	"sigs.k8s.io/gateway-api/pkg/features"
 )
@@ -63,6 +64,7 @@ type ConformanceTestSuite struct {
 	RestConfig               *rest.Config
 	RoundTripper             roundtripper.RoundTripper
 	GRPCClient               grpc.Client
+	WebSocketDialer          websocket.Dialer
 	GatewayClassName         string
 	MeshName                 string
 	ControllerName           string
@@ -177,14 +179,15 @@ type ConfigurableOptions struct {
 type ConformanceOptions struct {
 	ConfigurableOptions
 
-	Client        client.Client
-	ClientOptions client.Options
-	Clientset     clientset.Interface
-	RestConfig    *rest.Config
-	RoundTripper  roundtripper.RoundTripper
-	GRPCClient    grpc.Client
-	BaseManifests string
-	MeshManifests string
+	Client          client.Client
+	ClientOptions   client.Options
+	Clientset       clientset.Interface
+	RestConfig      *rest.Config
+	RoundTripper    roundtripper.RoundTripper
+	GRPCClient      grpc.Client
+	WebSocketDialer websocket.Dialer
+	BaseManifests   string
+	MeshManifests   string
 	// Hook is an optional function that can be used to run custom logic after each test at suite level.
 	Hook       func(t *testing.T, test ConformanceTest, suite *ConformanceTestSuite)
 	ManifestFS []fs.FS
@@ -271,6 +274,11 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 
 	grpcClient := options.GRPCClient
 
+	webSocketDialer := options.WebSocketDialer
+	if webSocketDialer == nil {
+		webSocketDialer = &websocket.DefaultDialer{}
+	}
+
 	installedCRDs := &apiextensionsv1.CustomResourceDefinitionList{}
 	err := options.Client.List(context.TODO(), installedCRDs)
 	if err != nil {
@@ -295,6 +303,7 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 		RestConfig:           options.RestConfig,
 		RoundTripper:         roundTripper,
 		GRPCClient:           grpcClient,
+		WebSocketDialer:      webSocketDialer,
 		GatewayClassName:     options.GatewayClassName,
 		Debug:                options.Debug,
 		Cleanup:              options.CleanupBaseResources,

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	xnetws "golang.org/x/net/websocket"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,6 +31,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	xmeshv1alpha1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
 	confv1 "sigs.k8s.io/gateway-api/conformance/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/websocket"
 	"sigs.k8s.io/gateway-api/pkg/consts"
 	"sigs.k8s.io/gateway-api/pkg/features"
 )
@@ -558,6 +560,64 @@ func TestInferGWCSupportedFeatures(t *testing.T) {
 			assert.Equal(t, tc.expectedExtendedFeatures, cSuite.extendedSupportedFeatures, "expectedExtendedFeatures mismatch")
 		})
 	}
+}
+
+// stubWebSocketDialer is a no-op websocket.Dialer used to verify the suite
+// preserves a caller-supplied dialer instead of overwriting it with the default.
+type stubWebSocketDialer struct{}
+
+func (*stubWebSocketDialer) Dial(_, _, _ string) (*xnetws.Conn, error) {
+	return nil, nil
+}
+
+// TestNewConformanceTestSuiteWebSocketDialer pins the injection-point contract:
+// an unset WebSocketDialer defaults to the package DefaultDialer (preserving the
+// historical websocket.Dial behavior), and a caller-supplied dialer is kept.
+func TestNewConformanceTestSuiteWebSocketDialer(t *testing.T) {
+	scheme := runtime.NewScheme()
+	gatewayv1.Install(scheme)
+	apiextensionsv1.AddToScheme(scheme)
+	gwc := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "gateway-conformance"},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: "example.com/gateway-controller"},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gwc).
+		WithLists(&apiextensionsv1.CustomResourceDefinitionList{}).
+		Build()
+
+	newSuite := func(t *testing.T, dialer websocket.Dialer) *ConformanceTestSuite {
+		t.Helper()
+		cSuite, err := NewConformanceTestSuite(ConformanceOptions{
+			ConfigurableOptions: ConfigurableOptions{
+				AllowCRDsMismatch:          true,
+				GatewayClassName:           "gateway-conformance",
+				EnableAllSupportedFeatures: true,
+			},
+			Client:          fakeClient,
+			WebSocketDialer: dialer,
+		})
+		if err != nil {
+			t.Fatalf("error initializing conformance suite: %v", err)
+		}
+		return cSuite
+	}
+
+	t.Run("defaults to DefaultDialer when unset", func(t *testing.T) {
+		cSuite := newSuite(t, nil)
+		if _, ok := cSuite.WebSocketDialer.(*websocket.DefaultDialer); !ok {
+			t.Fatalf("expected WebSocketDialer to default to *websocket.DefaultDialer, got %T", cSuite.WebSocketDialer)
+		}
+	})
+
+	t.Run("preserves a custom dialer", func(t *testing.T) {
+		custom := &stubWebSocketDialer{}
+		cSuite := newSuite(t, custom)
+		if cSuite.WebSocketDialer != custom {
+			t.Fatalf("expected the supplied WebSocketDialer to be preserved, got %T", cSuite.WebSocketDialer)
+		}
+	})
 }
 
 var meshStatusFeatureNames = []string{

--- a/conformance/utils/websocket/websocket.go
+++ b/conformance/utils/websocket/websocket.go
@@ -1,0 +1,46 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package websocket
+
+import (
+	"golang.org/x/net/websocket"
+)
+
+// Dialer is an interface used to establish WebSocket connections within
+// conformance tests. Like the HTTP RoundTripper and the gRPC Client, it can be
+// overridden with a custom implementation whenever necessary — for example when
+// the Gateway address is not directly dialable by the test runner and the
+// connection must be routed through an implementation-supplied data plane.
+type Dialer interface {
+	// Dial opens a WebSocket connection to url, requesting the given
+	// subprotocol (may be empty) and presenting origin as the Origin header.
+	// The returned *websocket.Conn is used with the websocket.Message codec by
+	// the conformance test.
+	Dial(url, protocol, origin string) (*websocket.Conn, error)
+}
+
+// DefaultDialer is the default implementation of Dialer. It is used when a
+// custom implementation is not specified, preserving the suite's historical
+// behavior of dialing the Gateway address directly via websocket.Dial.
+type DefaultDialer struct{}
+
+var _ Dialer = (*DefaultDialer)(nil)
+
+// Dial dials the WebSocket endpoint directly using golang.org/x/net/websocket.
+func (d *DefaultDialer) Dial(url, protocol, origin string) (*websocket.Conn, error) {
+	return websocket.Dial(url, protocol, origin)
+}

--- a/conformance/utils/websocket/websocket_test.go
+++ b/conformance/utils/websocket/websocket_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package websocket
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/websocket"
+)
+
+// TestDefaultDialerDial verifies that DefaultDialer performs a real WebSocket
+// handshake and round-trips a message — i.e. that the default injection point
+// preserves the historical websocket.Dial behavior the suite relied on before
+// the dialer was made overridable.
+func TestDefaultDialerDial(t *testing.T) {
+	server := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+		var msg string
+		if err := websocket.Message.Receive(ws, &msg); err != nil {
+			return
+		}
+		_ = websocket.Message.Send(ws, msg)
+	}))
+	defer server.Close()
+
+	url := strings.Replace(server.URL, "http://", "ws://", 1) + "/"
+
+	conn, err := (&DefaultDialer{}).Dial(url, "", "http://example.com/")
+	if err != nil {
+		t.Fatalf("DefaultDialer.Dial(%q) returned error: %v", url, err)
+	}
+	defer conn.Close()
+
+	const want = "websocket round-trip"
+	if err := websocket.Message.Send(conn, want); err != nil {
+		t.Fatalf("failed to send message: %v", err)
+	}
+
+	var got string
+	if err := websocket.Message.Receive(conn, &got); err != nil {
+		t.Fatalf("failed to receive message: %v", err)
+	}
+
+	if got != want {
+		t.Fatalf("unexpected echo: want %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/area conformance-machinery

**What this PR does / why we need it**:

The conformance suite lets implementations override how requests reach the Gateway for two of the three protocols it tests — HTTP via `Options.RoundTripper` and gRPC via `Options.GRPCClient`. WebSocket was the exception: `HTTPRouteBackendProtocolWebSocket` always dialed the Gateway address directly via `golang.org/x/net/websocket.Dial`, with no override hook. An implementation whose Gateway address is not directly dialable by the test runner therefore could not run this test even when WebSocket routing works end to end.

This adds an opt-in `ConformanceOptions.WebSocketDialer` (a `Dialer` interface in a new `conformance/utils/websocket` package), modeled on the existing `RoundTripper` / `GRPCClient` injection points. It defaults to a `DefaultDialer` that preserves the historical `websocket.Dial` behavior, so nothing changes for implementations with a directly-routable Gateway. The WebSocket conformance test now dials through `suite.WebSocketDialer`.

Scope is intentionally limited to the injection point. The conformance-report annotation idea raised in the issue discussion is left for a follow-up.

**Which issue(s) this PR fixes**:

Fixes #4925

**Does this PR introduce a user-facing change?**:

```release-note
The conformance suite now supports an injectable WebSocket dialer (ConformanceOptions.WebSocketDialer), mirroring the existing HTTP RoundTripper and gRPC client, so implementations whose Gateway address is not directly dialable by the test runner can run the WebSocket backend-protocol test. It defaults to the previous websocket.Dial behavior when unset.
```

---

This PR was written in part with the assistance of generative AI. All changes pass the project's automated gates (CI, linters, conformance tests) and were personally reviewed and verified before submission.
