### PR TITLE
Route the GRPCRouteWeight sampler through the injectable GRPCClient

### DIFF
--- a/conformance/tests/grpcroute-weight.go
+++ b/conformance/tests/grpcroute-weight.go
@@ -73,8 +73,19 @@ var GRPCRouteWeight = confsuite.ConformanceTest{
 				if err := grpc.AddEntropy(&uniqueExpected); err != nil {
 					return "", fmt.Errorf("error adding entropy: %w", err)
 				}
-				client := &grpc.DefaultClient{}
-				defer client.Close()
+				// Route the sampler through the injectable Options.GRPCClient, as
+				// the rest of the GRPCRoute tests do, so an implementation whose
+				// Gateway address is not directly dialable still exercises this
+				// test. GRPCClient is nil-guarded at the call site rather than
+				// defaulted in the suite, so on the default path fall back to a
+				// fresh per-request DefaultClient that is closed after the call —
+				// behavior-preserving, and isolated per concurrent sample.
+				client := suite.GRPCClient
+				if client == nil {
+					defaultClient := &grpc.DefaultClient{}
+					defer defaultClient.Close()
+					client = defaultClient
+				}
 				resp, err := client.SendRPC(t, gwAddr, uniqueExpected, suite.TimeoutConfig.MaxTimeToConsistency)
 				if err != nil {
 					return "", fmt.Errorf("failed to send gRPC request: %w", err)

--- a/conformance/utils/grpc/grpc.go
+++ b/conformance/utils/grpc/grpc.go
@@ -45,6 +45,10 @@ const (
 
 // Client is an interface used to make requests within conformance tests for grpc scenarios.
 // This can be overridden with custom implementations whenever necessary.
+//
+// A custom implementation must be safe for concurrent SendRPC calls: the
+// GRPCRouteWeight distribution sampler invokes the suite's client from multiple
+// goroutines.
 type Client interface {
 	SendRPC(t *testing.T, address string, expected ExpectedResponse, timeout time.Duration) (*Response, error)
 	Close()


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/area conformance-test

**What this PR does / why we need it**:

`GRPCRouteWeight` honored the injectable `Options.GRPCClient` for its readiness probe, but its distribution sampler newed a hardcoded `grpc.DefaultClient` and dialed the Gateway address directly. An implementation whose Gateway address is not directly dialable by the test runner could run every other GRPCRoute test through its custom client but had to skip this one — the gRPC analogue of #4925 for WebSocket.

The sampler now routes through `suite.GRPCClient`. One nuance worth calling out: `GRPCClient` is **not** defaulted in the suite constructor (unlike `RoundTripper`) — it is nil-guarded at the call site in `grpc.MakeRequestAndExpectEventuallyConsistentResponse`. So `suite.GRPCClient` is nil on a default conformance run, and the sampler falls back to a fresh per-request `DefaultClient` (closed after the call) when it is nil. This is behavior-preserving on the default path and keeps concurrent samples isolated; the shared injected client is not closed per sample.

Because the sampler is driven by `weight.TestWeightedDistribution`'s `errgroup` (multiple goroutines), a custom `grpc.Client` must be safe for concurrent `SendRPC` — now documented on the `Client` interface.

Pre-existing note (not addressed here): the readiness probe passes `suite.GRPCClient` to `MakeRequestAndExpectEventuallyConsistentResponse`, which `defer`s `Close()` on it; with this change the sampler then re-uses that injected client, so a custom client must tolerate being closed by the probe and re-used. This lifecycle wrinkle predates this PR (the probe already closed the caller's client). Filed separately as #4938 so this change isn't blocked on it.

**Which issue(s) this PR fixes**:

Fixes #4926

**Does this PR introduce a user-facing change?**:

```release-note
The GRPCRouteWeight conformance test now sends its distribution-sampling requests through the injectable Options.GRPCClient instead of a hardcoded DefaultClient, so implementations that supply a custom gRPC client can run it. Behavior is unchanged on the default path. Custom grpc.Client implementations must be safe for concurrent SendRPC.
```

---

This PR was written in part with the assistance of generative AI. All changes pass the project's automated gates (CI, linters, conformance tests) and were personally reviewed and verified before submission.
