### PR TITLE
Close only the gRPC client the request helper owns

### DIFF
--- a/conformance/utils/grpc/grpc.go
+++ b/conformance/utils/grpc/grpc.go
@@ -273,9 +273,12 @@ func MakeRequestAndExpectEventuallyConsistentResponse(t *testing.T, c Client, ti
 	t.Helper()
 	validateExpectedResponse(t, expected)
 	if c == nil {
+		// Only the DefaultClient we construct here is ours to close. A
+		// caller-supplied (non-nil) client is owned by the caller and must be
+		// left open so it can be reused after this helper returns.
 		c = &DefaultClient{Conn: nil}
+		defer c.Close()
 	}
-	defer c.Close()
 	sendRPC := func(elapsed time.Duration) bool {
 		resp, err := c.SendRPC(t, gwAddr, expected, timeoutConfig.MaxTimeToConsistency-elapsed)
 		if err != nil {

--- a/conformance/utils/grpc/grpc_test.go
+++ b/conformance/utils/grpc/grpc_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	pb "sigs.k8s.io/gateway-api/conformance/echo-basic/grpcechoserver"
+	"sigs.k8s.io/gateway-api/conformance/utils/config"
+)
+
+// recordingClient is a Client that records whether Close was called and returns
+// a canned response, so MakeRequestAndExpectEventuallyConsistentResponse can be
+// exercised without a real gRPC server.
+type recordingClient struct {
+	closed    bool
+	sendCalls int
+	response  *Response
+}
+
+var _ Client = (*recordingClient)(nil)
+
+func (c *recordingClient) SendRPC(_ *testing.T, _ string, _ ExpectedResponse, _ time.Duration) (*Response, error) {
+	c.sendCalls++
+
+	return c.response, nil
+}
+
+func (c *recordingClient) Close() { c.closed = true }
+
+// TestMakeRequestDoesNotCloseCallerSuppliedClient pins the ownership contract:
+// the helper closes only the DefaultClient it constructs when passed nil, never
+// a caller-supplied (injected) client, which the caller may reuse afterwards.
+func TestMakeRequestDoesNotCloseCallerSuppliedClient(t *testing.T) {
+	t.Parallel()
+
+	client := &recordingClient{response: &Response{Code: codes.Unavailable}}
+
+	timeoutConfig := config.TimeoutConfig{
+		RequiredConsecutiveSuccesses: 1,
+		MaxTimeToConsistency:         5 * time.Second,
+	}
+	// A non-OK code keeps compareResponse from inspecting the (absent) echo
+	// payload; the helper only needs the request to "succeed" once to return.
+	expected := ExpectedResponse{
+		EchoRequest: &pb.EchoRequest{},
+		Response:    Response{Code: codes.Unavailable},
+	}
+
+	MakeRequestAndExpectEventuallyConsistentResponse(t, client, timeoutConfig, "192.0.2.1:50051", expected)
+
+	if client.sendCalls == 0 {
+		t.Fatal("expected the helper to call SendRPC on the supplied client")
+	}
+	if client.closed {
+		t.Fatal("helper must not Close a caller-supplied client it does not own")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/area conformance-machinery

**What this PR does / why we need it**:

`grpc.MakeRequestAndExpectEventuallyConsistentResponse` deferred `Close()` on the `Client` it was passed — including a caller-supplied, injected `suite.GRPCClient` that it does not own. Closing a shared client as a side effect of a single request forces a custom `grpc.Client` to tolerate being closed and re-used, an unusual and undocumented contract. It becomes a real hazard once a test re-uses the injected client after the helper runs (e.g. #4937 routes the `GRPCRouteWeight` sampler through `suite.GRPCClient` after the readiness probe).

The helper now closes only the `DefaultClient` it constructs when passed `nil`; a caller-supplied client is left open, with its lifecycle owned by whoever constructed it. Behavior is unchanged on the default path (the helper still cleans up the client it makes).

A unit test (`conformance/utils/grpc/grpc_test.go`) pins the contract with a recording fake client; it runs in CI via `go test ./conformance/utils/...`.

**Which issue(s) this PR fixes**:

Fixes #4938

**Does this PR introduce a user-facing change?**:

```release-note
The gRPC conformance request helper no longer closes a caller-supplied (injected) Options.GRPCClient; it closes only the DefaultClient it creates internally. This lets implementations reuse a custom gRPC client across requests.
```
