### PR TITLE
Add v1.6 conformance report and implementations list entry for cloudflare-tunnel-gateway-controller

### DIFF
--- a/conformance/list/implementations/lexfrei-cloudflare-tunnel-gateway-controller/details.yaml
+++ b/conformance/list/implementations/lexfrei-cloudflare-tunnel-gateway-controller/details.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.kubernetes.io/v1
+kind: ImplementationListDetails
+organization: lexfrei
+project: cloudflare-tunnel-gateway-controller
+fullName: Lexfrei's Cloudflare Tunnel Gateway Controller
+description: |
+  [Lexfrei's Cloudflare Tunnel Gateway Controller][cloudflare-tunnel-gateway-controller]
+  is a Kubernetes controller that implements the Gateway API on top of Cloudflare
+  Tunnel: it watches Gateway, HTTPRoute, and GRPCRoute resources and programs
+  Cloudflare Tunnel ingress through the Cloudflare API, serving traffic through an
+  in-process L7 proxy data plane that embeds the cloudflared tunnel transport.
+
+  It is open source under the BSD-3-Clause license, maintained by an individual
+  (lexfrei), and not affiliated with or endorsed by Cloudflare; see the
+  [documentation][cloudflare-tunnel-gateway-controller-docs] for setup and
+  configuration.
+
+  [cloudflare-tunnel-gateway-controller]: https://github.com/lexfrei/cloudflare-tunnel-gateway-controller
+  [cloudflare-tunnel-gateway-controller-docs]: https://cf.k8s.lex.la

--- a/conformance/reports/v1.6/lexfrei-cloudflare-tunnel-gateway-controller/README.md
+++ b/conformance/reports/v1.6/lexfrei-cloudflare-tunnel-gateway-controller/README.md
@@ -1,0 +1,44 @@
+# Lexfrei's Cloudflare Tunnel Gateway Controller
+
+A Kubernetes controller that implements the Gateway API on top of Cloudflare Tunnel. It watches Gateway, HTTPRoute, and GRPCRoute resources and serves traffic through an in-process L7 reverse proxy that embeds the cloudflared tunnel transport, so all routing, matching, and filtering happen in-cluster.
+
+## Table of Contents
+
+| API channel | Implementation version | Mode | Report |
+| --- | --- | --- | --- |
+| standard | [v3.3.1](https://github.com/lexfrei/cloudflare-tunnel-gateway-controller/releases/tag/v3.3.1) | default | [standard-v3.3.1-default-report.yaml](./standard-v3.3.1-default-report.yaml) |
+
+## Reproduce
+
+The project ships a conformance harness (`hack/conformance-setup.sh`) that stands up a kind cluster, installs the Gateway API CRDs, builds and deploys the controller, and runs the suite end to end against a live Cloudflare Tunnel.
+
+1. Clone the controller repository and check out the release under test:
+
+   ```bash
+   git clone https://github.com/lexfrei/cloudflare-tunnel-gateway-controller.git
+   cd cloudflare-tunnel-gateway-controller
+   git checkout v3.3.1
+   ```
+
+2. Provide a `.env` file in the repository root with the Cloudflare Tunnel credentials the harness reads: the account ID, an API token scoped to the tunnel, the tunnel ID, the tunnel token, and the edge hostname routing to that tunnel.
+
+3. Run the harness against the standard channel. It creates a fresh kind cluster, installs the standard-channel Gateway API v1.6.1 CRDs, deploys the controller, runs the GATEWAY-HTTP and GATEWAY-GRPC profiles, and writes the report:
+
+   ```bash
+   CONTROLLER_VERSION=v3.3.1 \
+   CONFORMANCE_REPORT_OUTPUT="$PWD/standard-v3.3.1-default-report.yaml" \
+     ./hack/conformance-setup.sh --channel standard --test
+   ```
+
+4. Inspect the generated report:
+
+   ```bash
+   cat ./standard-v3.3.1-default-report.yaml
+   ```
+
+## Notes
+
+- The tunnel transport runs over HTTP/2 (`proxy.tunnel.protocol=http2`, which the harness sets), because QUIC drops gRPC trailers; this is required for the GATEWAY-GRPC profile.
+- The suite reaches the implementation through the Cloudflare edge over HTTPS. Test Host headers are carried in an `X-Original-Host` header so the edge forwards hostnames that are not registered on the account; this is a conformance-only shim, not a production pattern.
+- The three skipped tests reflect Cloudflare Tunnel semantics, not controller gaps. TLS terminates at the Cloudflare edge, so the `HTTPRouteHTTPSListener` test cannot run: there is no in-cluster HTTPS listener. The tunnel exposes a single port (`HTTPRouteListenerPortMatching`), and its shared routing table flattens all listeners, so the multi-Gateway isolation case (`HTTPRouteMultipleGateways`) does not apply. Hard per-Gateway isolation requires the opt-in dedicated data plane, which this default-mode report does not exercise.
+- `BackendTLSPolicy`, its SAN-validation companion, and `GatewayBackendClientCertificate` are implemented but listed unsupported here. Their tests are all gated on `SupportBackendTLSPolicy`, whose parent test needs an in-cluster HTTPS listener for the re-encrypt case that edge-terminated TLS cannot serve, so the feature is not claimed (see #5103).

--- a/conformance/reports/v1.6/lexfrei-cloudflare-tunnel-gateway-controller/standard-v3.3.1-default-report.yaml
+++ b/conformance/reports/v1.6/lexfrei-cloudflare-tunnel-gateway-controller/standard-v3.3.1-default-report.yaml
@@ -1,0 +1,108 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-07-23T15:47:30+03:00"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.6.1
+implementation:
+  contact:
+  - '@lexfrei'
+  organization: lexfrei
+  project: cloudflare-tunnel-gateway-controller
+  url: https://github.com/lexfrei/cloudflare-tunnel-gateway-controller
+  version: v3.3.1
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: partial
+    skippedTests:
+    - HTTPRouteHTTPSListener
+    - HTTPRouteMultipleGateways
+    statistics:
+      Failed: 0
+      Passed: 35
+      Skipped: 2
+  extended:
+    result: partial
+    skippedTests:
+    - HTTPRouteListenerPortMatching
+    statistics:
+      Failed: 0
+      Passed: 37
+      Skipped: 1
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - HTTPRoute303RedirectStatusCode
+    - HTTPRoute307RedirectStatusCode
+    - HTTPRoute308RedirectStatusCode
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteCORS
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRouteNamedRouteRule
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRedirect
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestPercentageMirror
+    - HTTPRouteRequestTimeout
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    - ListenerSet
+    unsupportedFeatures:
+    - BackendTLSPolicy
+    - BackendTLSPolicySANValidation
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPListenerIsolation
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
+    - GatewayPort8080
+    - GatewayStaticAddresses
+    - HTTPRouteRetry
+    - HTTPRouteRetryBackendTimeout
+    - HTTPRouteRetryConnectionError
+  name: GATEWAY-HTTP
+  summary: Core tests partially succeeded with 2 test skips. Extended tests partially
+    succeeded with 1 test skips.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 15
+      Skipped: 0
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 8
+      Skipped: 0
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - ListenerSet
+    unsupportedFeatures:
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPListenerIsolation
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
+    - GatewayPort8080
+    - GatewayStaticAddresses
+  name: GATEWAY-GRPC
+  summary: Core tests succeeded. Extended tests succeeded.
+succeededProvisionalTests:
+- GRPCRouteNamedRule
+- GatewayOptionalAddressValue
+- HTTPRoute303Redirect
+- HTTPRoute307Redirect
+- HTTPRoute308Redirect
+- HTTPRouteNamedRule
+- HTTPRouteRequestPercentageMirror

--- a/site/content/en/docs/implementations/list.md
+++ b/site/content/en/docs/implementations/list.md
@@ -115,6 +115,7 @@ class.
 - [Envoy Gateway][18]
 - [Gravitee Kubernetes Operator][42]
 - [Kong Operator][35]
+- [Lexfrei's Cloudflare Tunnel Gateway Controller][49]
 
 ### Stale
 
@@ -175,6 +176,7 @@ class.
 [46]:#calico
 [47]:#sunbeam-proxy
 [48]:#wso2-gateway
+[49]:#lexfreis-cloudflare-tunnel-gateway-controller
 
 
 [gamma]: /docs/mesh/
@@ -449,6 +451,17 @@ For help and support with Kong Operator please feel free to [create an issue][ko
 [Kubvernor][kubvernor] is an open-source, highly experimental implementation of API controller in Rust programming language. Currently, Kubvernor supports Envoy Proxy. The project aims to be as generic as possible so Kubvernor can be used to manage/deploy different gateways (Envoy, Nginx, HAProxy, etc.).
 
 [kubvernor]:https://github.com/kubvernor/kubvernor
+
+### Lexfrei's Cloudflare Tunnel Gateway Controller
+
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Partial%20Conformance%20v1.6.1-Lexfrei%27s%20Cloudflare%20Tunnel%20Gateway%20Controller-orange)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.6/lexfrei-cloudflare-tunnel-gateway-controller)
+
+[Lexfrei's Cloudflare Tunnel Gateway Controller][cloudflare-tunnel-gateway-controller] is a Kubernetes controller that implements the Gateway API on top of Cloudflare Tunnel: it watches Gateway, HTTPRoute, and GRPCRoute resources and programs Cloudflare Tunnel ingress through the Cloudflare API, serving traffic through an in-process L7 proxy data plane that embeds the cloudflared tunnel transport.
+
+It is open source under the BSD-3-Clause license, maintained by an individual (lexfrei), and not affiliated with or endorsed by Cloudflare; see the [documentation][cloudflare-tunnel-gateway-controller-docs] for setup and configuration.
+
+[cloudflare-tunnel-gateway-controller]: https://github.com/lexfrei/cloudflare-tunnel-gateway-controller
+[cloudflare-tunnel-gateway-controller-docs]: https://cf.k8s.lex.la
 
 ### Linkerd
 


### PR DESCRIPTION
This PR adds a Gateway API conformance report for my cloudflare-tunnel-gateway-controller and lists it under `site/content/en/docs/implementations/list.md`.

The report is a standard-channel run against gateway-api v1.6.1 for controller v3.3.1, covering the GATEWAY-HTTP and GATEWAY-GRPC profiles in default mode. It's a partial-conformance report: three tests are skipped for Cloudflare Tunnel reasons rather than controller gaps, and the report README explains each. The controller is listed under Partially Conformant.

BackendTLSPolicy, BackendTLSPolicySANValidation, and GatewayBackendClientCertificate are implemented but listed unsupported: their tests are all gated on SupportBackendTLSPolicy, whose parent test needs an in-cluster HTTPS listener for the re-encrypt case that this controller can't serve (it terminates TLS at the Cloudflare edge). Follow-up filed as #5103.

The report README is titled "Lexfrei's Cloudflare Tunnel Gateway Controller" to make clear this is an individual's project, not an official Cloudflare product.



## AI disclosure

This PR was prepared with AIL:3. I personally reviewed each line of the submission prior to opening this PR.
