### PR TITLE
conformance: make grpc DefaultClient safe for concurrent SendRPC and reuse after Close

### DIFF
--- a/conformance/utils/grpc/grpc.go
+++ b/conformance/utils/grpc/grpc.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -57,6 +58,10 @@ type Client interface {
 // DefaultClient is the default implementation of Client. It will
 // be used if a custom implementation is not specified.
 type DefaultClient struct {
+	// mu guards Conn so SendRPC is safe for concurrent use and the client is
+	// reusable after Close (Close drops Conn so the next SendRPC redials,
+	// instead of short-circuiting onto an already-closed connection).
+	mu   sync.Mutex
 	Conn *grpc.ClientConn
 }
 
@@ -155,25 +160,32 @@ func (er *ExpectedResponse) GetTestCaseName(i int) string {
 	return fmt.Sprintf("%s should receive a %s (%d)", reqStr, er.Response.Code.String(), er.Response.Code)
 }
 
-func (c *DefaultClient) ensureConnection(address string, req *RequestMetadata) error {
+func (c *DefaultClient) ensureConnection(address string, req *RequestMetadata) (*grpc.ClientConn, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.Conn != nil {
-		return nil
+		return c.Conn, nil
 	}
-	var err error
 	dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 	if req != nil && req.Authority != "" {
 		dialOpts = append(dialOpts, grpc.WithAuthority(req.Authority))
 	}
 
-	c.Conn, err = grpc.NewClient(address, dialOpts...)
+	conn, err := grpc.NewClient(address, dialOpts...)
 	if err != nil {
-		c.Conn = nil
-		return err
+		return nil, err
 	}
-	return nil
+	c.Conn = conn
+	return c.Conn, nil
 }
 
+// resetConnection closes and clears the shared connection so the next SendRPC
+// redials. SendRPC holds no lock during the RPC, so a reset triggered by one
+// caller (on a codes.Internal response) closes the connection other goroutines
+// may still be using; their in-flight RPCs surface the cancellation as an error.
 func (c *DefaultClient) resetConnection() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.Conn == nil {
 		return
 	}
@@ -186,7 +198,8 @@ func (c *DefaultClient) resetConnection() {
 // is received.
 func (c *DefaultClient) SendRPC(t *testing.T, address string, expected ExpectedResponse, timeout time.Duration) (*Response, error) {
 	t.Helper()
-	if err := c.ensureConnection(address, expected.RequestMetadata); err != nil {
+	conn, err := c.ensureConnection(address, expected.RequestMetadata)
+	if err != nil {
 		return &Response{}, err
 	}
 
@@ -202,8 +215,7 @@ func (c *DefaultClient) SendRPC(t *testing.T, address string, expected ExpectedR
 
 	defer cancel()
 
-	stub := pb.NewGrpcEchoClient(c.Conn)
-	var err error
+	stub := pb.NewGrpcEchoClient(conn)
 	tlog.Logf(t, "Sending RPC")
 
 	switch {
@@ -233,8 +245,11 @@ func (c *DefaultClient) SendRPC(t *testing.T, address string, expected ExpectedR
 }
 
 func (c *DefaultClient) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.Conn != nil {
 		c.Conn.Close()
+		c.Conn = nil
 	}
 }
 

--- a/conformance/utils/grpc/grpc_test.go
+++ b/conformance/utils/grpc/grpc_test.go
@@ -17,9 +17,14 @@ limitations under the License.
 package grpc
 
 import (
+	"context"
+	"net"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
 	pb "sigs.k8s.io/gateway-api/conformance/echo-basic/grpcechoserver"
@@ -72,4 +77,87 @@ func TestMakeRequestDoesNotCloseCallerSuppliedClient(t *testing.T) {
 	if client.closed {
 		t.Fatal("helper must not Close a caller-supplied client it does not own")
 	}
+}
+
+// testEchoServer is a minimal in-process GrpcEcho server whose Echo always
+// succeeds, used to exercise DefaultClient against a real connection.
+type testEchoServer struct {
+	pb.UnimplementedGrpcEchoServer
+}
+
+func (testEchoServer) Echo(_ context.Context, _ *pb.EchoRequest) (*pb.EchoResponse, error) {
+	return &pb.EchoResponse{}, nil
+}
+
+// TestDefaultClientConcurrentSendRPC drives a single shared DefaultClient from many
+// goroutines. The exported client documents no single-goroutine restriction, so
+// ensureConnection must serialize access to the shared connection: without the lock,
+// `go test -race` flags a data race on DefaultClient.Conn. Every concurrent request
+// against the in-process server must also succeed.
+func TestDefaultClientConcurrentSendRPC(t *testing.T) {
+	t.Parallel()
+
+	lis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := grpc.NewServer()
+	pb.RegisterGrpcEchoServer(srv, testEchoServer{})
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Stop()
+	addr := lis.Addr().String()
+
+	c := &DefaultClient{}
+	expected := ExpectedResponse{EchoRequest: &pb.EchoRequest{}}
+
+	const n = 50
+	start := make(chan struct{})
+	results := make(chan codes.Code, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			<-start
+			resp, err := c.SendRPC(t, addr, expected, 5*time.Second)
+			if err != nil {
+				results <- codes.Unknown
+				return
+			}
+			results <- resp.Code
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	for code := range results {
+		require.Equal(t, codes.OK, code, "every concurrent SendRPC on a shared client must succeed")
+	}
+}
+
+// TestDefaultClientReusableAfterClose verifies a DefaultClient can be reused after
+// Close: Close must drop the underlying connection so the next SendRPC redials,
+// instead of short-circuiting ensureConnection on an already-closed connection.
+func TestDefaultClientReusableAfterClose(t *testing.T) {
+	t.Parallel()
+
+	lis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := grpc.NewServer()
+	pb.RegisterGrpcEchoServer(srv, testEchoServer{})
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Stop()
+	addr := lis.Addr().String()
+
+	expected := ExpectedResponse{EchoRequest: &pb.EchoRequest{}}
+
+	c := &DefaultClient{}
+	resp, err := c.SendRPC(t, addr, expected, 5*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, codes.OK, resp.Code, "first request on a fresh client must succeed")
+
+	c.Close()
+
+	resp2, err2 := c.SendRPC(t, addr, expected, 5*time.Second)
+	require.NoError(t, err2)
+	require.Equal(t, codes.OK, resp2.Code, "a DefaultClient must be reusable after Close")
 }


### PR DESCRIPTION
## What this PR does

Makes the conformance gRPC `DefaultClient` safe for concurrent `SendRPC` and reusable after `Close`.

`ensureConnection` read and wrote the shared `Conn` field without synchronization, so concurrent `SendRPC` calls raced on it (`go test -race` flags a data race on `DefaultClient.Conn`). `Close` also left `Conn` non-nil after shutting the connection, so a client reused after `Close` short-circuited `ensureConnection` onto an already-closed connection and every subsequent RPC failed with `Canceled`.

The fix guards `Conn` with a mutex, has `ensureConnection` return the connection so the RPC runs on a local handle without holding the lock, and clears `Conn` in `Close`/`resetConnection` so the next call redials. Both behaviours are covered by new tests that fail without the fix (one under `-race`).

Fixes #4941

```release-note
conformance: the gRPC DefaultClient is now safe for concurrent SendRPC and reusable after Close.
```

---

This PR was written in part with the assistance of generative AI. All changes pass the project's automated gates (CI, linters, conformance tests) and were personally reviewed and verified before submission.
