### PR TITLE
conformance: start the mirror log window before the requests are sent

### DIFF
--- a/conformance/utils/http/mirror.go
+++ b/conformance/utils/http/mirror.go
@@ -43,7 +43,16 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 	var wg sync.WaitGroup
 	wg.Add(len(mirrorPods))
 
-	assertionStart := time.Now()
+	// Start the log window before the requests were sent, not at "now". The
+	// caller already dispatched the mirrored requests, and on a high-latency
+	// (e.g. edge-routed) data plane the mirror is logged in-cluster slightly
+	// before the primary response returns to the client, so it can land in an
+	// earlier second than time.Now() and be excluded by the SinceTime filter,
+	// which has 1-second granularity. MaxTimeToConsistency bounds how long the
+	// caller's send loop could have run, and the match regexp is keyed on the
+	// unique request path, so widening the window cannot match an unrelated
+	// test's mirror.
+	assertionStart := time.Now().Add(-timeoutConfig.MaxTimeToConsistency)
 
 	for _, mirrorPod := range mirrorPods {
 		go func(mirrorPod MirroredBackend) {


### PR DESCRIPTION
## What this PR does

`ExpectMirroredRequest` captured its log-window start after the caller had already dispatched the mirrored requests, then filtered echo logs by `SinceTime`, which has 1-second granularity. On a high-latency, edge-routed data plane the mirror is logged in-cluster slightly before the primary response returns, so it can fall in an earlier second than the window start and be excluded — `HTTPRouteRequestMirror` and `HTTPRouteRequestMultipleMirrors` then time out with "Couldn't find mirrored request in logs" even though the mirror was delivered.

Move the window start back by `MaxTimeToConsistency` (which bounds how long the caller's send loop could have run). The match regexp is keyed on the unique request path, so the wider window cannot match an unrelated test's mirror. This mirrors how `HTTPRouteRequestPercentageMirror` already captures its window before sending.

Fixes #4940

```release-note
conformance: ExpectMirroredRequest now starts its log window before the requests are sent, so mirrors are not missed on high-latency data planes.
```

/kind bug
/area conformance-machinery
