### PR TITLE
conformance: wait for resource deletion in MustApply cleanup

### DIFF
--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -184,7 +184,7 @@ func parseDuration(val any) (time.Duration, error) {
 func DefaultTimeoutConfig() TimeoutConfig {
 	return TimeoutConfig{
 		CreateTimeout:                          60 * time.Second,
-		DeleteTimeout:                          10 * time.Second,
+		DeleteTimeout:                          30 * time.Second,
 		GetTimeout:                             10 * time.Second,
 		GatewayMustHaveAddress:                 180 * time.Second,
 		GatewayMustHaveCondition:               180 * time.Second,

--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -214,6 +215,27 @@ func (a Applier) prepareResources(t *testing.T, decoder *yaml.YAMLOrJSONDecoder)
 	return resources, nil
 }
 
+// deleteAndWait deletes obj and blocks until it is fully gone, bounded by
+// timeoutConfig.DeleteTimeout. Needed because a Namespace Delete only starts an
+// async finalizer drain, which would otherwise break a go test -count>1 re-run.
+func deleteAndWait(t *testing.T, c client.Client, obj client.Object, timeoutConfig config.TimeoutConfig) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutConfig.DeleteTimeout)
+	defer cancel()
+	tlog.Logf(t, "Deleting %s %s", obj.GetName(), obj.GetObjectKind().GroupVersionKind().Kind)
+	if err := c.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+		require.NoErrorf(t, err, "error deleting resource")
+	}
+
+	key := client.ObjectKeyFromObject(obj)
+	err := wait.PollUntilContextCancel(ctx, timeoutConfig.DefaultPollInterval, true, func(ctx context.Context) (bool, error) {
+		probe := obj.DeepCopyObject().(client.Object)
+		return apierrors.IsNotFound(c.Get(ctx, key, probe)), nil
+	})
+	require.NoErrorf(t, err, "resource %s/%s still present after delete", key.Namespace, key.Name)
+}
+
 func (a Applier) MustApplyObjectsWithCleanup(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, resources []client.Object, cleanup bool) {
 	for _, resource := range resources {
 		ctx, cancel := context.WithTimeout(context.Background(), timeoutConfig.CreateTimeout)
@@ -230,11 +252,7 @@ func (a Applier) MustApplyObjectsWithCleanup(t *testing.T, c client.Client, time
 
 		if cleanup {
 			t.Cleanup(func() {
-				ctx, cancel = context.WithTimeout(context.Background(), timeoutConfig.DeleteTimeout)
-				defer cancel()
-				tlog.Logf(t, "Deleting %s %s", resource.GetName(), resource.GetObjectKind().GroupVersionKind().Kind)
-				err = c.Delete(ctx, resource)
-				require.NoErrorf(t, err, "error deleting resource")
+				deleteAndWait(t, c, resource, timeoutConfig)
 			})
 		}
 	}
@@ -274,13 +292,7 @@ func (a Applier) MustApplyWithCleanup(t *testing.T, c client.Client, timeoutConf
 
 			if cleanup {
 				t.Cleanup(func() {
-					ctx, cancel = context.WithTimeout(context.Background(), timeoutConfig.DeleteTimeout)
-					defer cancel()
-					tlog.Logf(t, "Deleting %s %s", uObj.GetName(), uObj.GetKind())
-					err = c.Delete(ctx, uObj)
-					if !apierrors.IsNotFound(err) {
-						require.NoErrorf(t, err, "error deleting resource")
-					}
+					deleteAndWait(t, c, uObj, timeoutConfig)
 				})
 			}
 			continue
@@ -292,13 +304,7 @@ func (a Applier) MustApplyWithCleanup(t *testing.T, c client.Client, timeoutConf
 
 		if cleanup {
 			t.Cleanup(func() {
-				ctx, cancel = context.WithTimeout(context.Background(), timeoutConfig.DeleteTimeout)
-				defer cancel()
-				tlog.Logf(t, "Deleting %s %s", uObj.GetName(), uObj.GetKind())
-				err = c.Delete(ctx, uObj)
-				if !apierrors.IsNotFound(err) {
-					require.NoErrorf(t, err, "error deleting resource")
-				}
+				deleteAndWait(t, c, uObj, timeoutConfig)
 			})
 		}
 		require.NoErrorf(t, err, "error updating resource")

--- a/conformance/utils/kubernetes/apply_test.go
+++ b/conformance/utils/kubernetes/apply_test.go
@@ -17,12 +17,23 @@ limitations under the License.
 package kubernetes
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/config"
 )
 
 func TestPrepareResources(t *testing.T) {
@@ -178,6 +189,59 @@ spec:
 
 			require.NoError(t, err, "unexpected error preparing resources")
 			require.Equal(t, tc.expected, resources)
+		})
+	}
+}
+
+func TestDeleteAndWaitBlocksUntilGone(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	tests := []struct {
+		name string
+		obj  client.Object
+	}{
+		{
+			name: "namespace held by a finalizer",
+			obj: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+				Name: "conformance-ns", Finalizers: []string{"conformance.gateway-api/test"},
+			}},
+		},
+		{
+			name: "namespaced resource held by a finalizer",
+			obj: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+				Name: "held", Namespace: "default", Finalizers: []string{"conformance.gateway-api/test"},
+			}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			key := client.ObjectKeyFromObject(tc.obj)
+
+			// Object present on the first poll, gone on the next: drives the wait loop with no timing dependence.
+			var polls int
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.obj).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						polls++
+						if polls >= 2 {
+							fresh := tc.obj.DeepCopyObject().(client.Object)
+							if err := cl.Get(ctx, key, fresh); err == nil {
+								fresh.SetFinalizers(nil)
+								_ = cl.Update(ctx, fresh)
+							}
+						}
+						return cl.Get(ctx, key, obj, opts...)
+					},
+				}).Build()
+
+			deleteAndWait(t, c, tc.obj, config.TimeoutConfig{DeleteTimeout: 5 * time.Second, DefaultPollInterval: time.Millisecond})
+
+			probe := tc.obj.DeepCopyObject().(client.Object)
+			err := c.Get(context.Background(), key, probe)
+			require.True(t, apierrors.IsNotFound(err),
+				"%s must be fully deleted after deleteAndWait returns, got err=%v", tc.name, err)
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does

The base-resource cleanup deleted each created object with a plain `Delete` and returned immediately. `Delete` on a Namespace only moves it to `Terminating` and drains its finalizers asynchronously, so running the suite more than once in a single process (`go test -count>1`) re-applied the base manifests into the still-terminating namespace and the API server rejected it with "namespace ... is being terminated".

Add a `deleteAndWait` helper that deletes an object and blocks until it is actually gone (one `DeleteTimeout` budget governs the whole delete-and-disappear cycle), and route all three `MustApply` cleanups through it.

Note: cleanup now blocks until each resource is fully deleted rather than returning after the `Delete` call, which adds bounded (`DeleteTimeout`-capped) wall-clock to teardown. The default `DeleteTimeout` is raised from 10s to 30s to cover this; clusters with very slow namespace garbage collection (e.g. cloud LoadBalancer teardown) can raise it further without code changes via `--timeout-config-overrides="DeleteTimeout:N"` or the `deleteTimeout` config field.

Fixes #4942

```release-note
conformance: base-resource cleanup now waits for deletion to complete, so the suite can be re-run in a single process (go test -count>1).
```

/kind bug

/area conformance-machinery

---

This PR was written in part with the assistance of generative AI. All changes pass the project's automated gates (CI, linters, conformance tests) and were personally reviewed and verified before submission.
