### PR TITLE
Add session persistence cookies conformance test for HTTPRoute and GRPCRoute

### DIFF
--- a/conformance/tests/grpcroute-session-persistence-cookie-permanent-lifetime.go
+++ b/conformance/tests/grpcroute-session-persistence-cookie-permanent-lifetime.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	pb "sigs.k8s.io/gateway-api/conformance/echo-basic/grpcechoserver"
+	"sigs.k8s.io/gateway-api/conformance/utils/grpc"
+	httputils "sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GRPCRouteSessionPersistenceCookiePermanentLifetime)
+}
+
+var GRPCRouteSessionPersistenceCookiePermanentLifetime = confsuite.ConformanceTest{
+	ShortName:   "GRPCRouteSessionPersistenceCookiePermanentLifetime",
+	Description: "A GRPCRoute with permanent cookie lifetime sets a cookie with an Expires or Max-Age attribute",
+	Manifests:   []string{"tests/grpcroute-session-persistence-cookie-permanent-lifetime.yaml"},
+	Provisional: true,
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportGRPCRoute,
+		features.SupportCookieSessionPersistence,
+		features.SupportCookieSessionPersistencePermanentLifetime,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "grpcroute-session-persistence-cookie-permanent-lifetime", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &v1.GRPCRoute{}, true, routeNN)
+
+		req := grpc.ExpectedResponse{
+			EchoRequest: &pb.EchoRequest{},
+		}
+
+		// Wait for the route to stabilize and capture the permanent cookie.
+		var cookie *httputils.CookieInfo
+		httputils.AwaitConvergence(t, 1, suite.TimeoutConfig.MaxTimeToConsistency, func(elapsed time.Duration) bool {
+			client := &grpc.DefaultClient{}
+			defer client.Close()
+			resp, err := client.SendRPC(t, gwAddr, req, suite.TimeoutConfig.RequestTimeout)
+			if err != nil {
+				tlog.Logf(t, "request failed: %v (after %v)", err, elapsed)
+				return false
+			}
+			if resp.Headers == nil {
+				tlog.Logf(t, "nil response headers (after %v)", elapsed)
+				return false
+			}
+			h := make(http.Header)
+			for k, v := range *resp.Headers {
+				h[http.CanonicalHeaderKey(k)] = v
+			}
+			c, err := httputils.ExtractResponseCookie(h)
+			if err != nil {
+				tlog.Logf(t, "no session cookie in response (after %v): %v", elapsed, err)
+				return false
+			}
+			cookie = c
+			tlog.Logf(t, "received set-cookie: %v attributes=%v", resp.Headers.Get("set-cookie"), cookie.Attributes)
+			return true
+		})
+
+		// Permanent cookies must carry either Expires or Max-Age to communicate the expiry time to clients.
+		if !cookie.HasAttribute("Expires") && !cookie.HasAttribute("Max-Age") {
+			t.Errorf("permanent cookie must have an Expires or Max-Age attribute, got attributes: %v", cookie.Attributes)
+		}
+	},
+}

--- a/conformance/tests/grpcroute-session-persistence-cookie-permanent-lifetime.yaml
+++ b/conformance/tests/grpcroute-session-persistence-cookie-permanent-lifetime.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: grpcroute-session-persistence-cookie-permanent-lifetime
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - sessionPersistence:
+      type: Cookie
+      absoluteTimeout: 1h
+      cookieConfig:
+        lifetimeType: Permanent
+    backendRefs:
+    - name: grpc-infra-backend-v1
+      port: 8080

--- a/conformance/tests/grpcroute-session-persistence-cookie.go
+++ b/conformance/tests/grpcroute-session-persistence-cookie.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	pb "sigs.k8s.io/gateway-api/conformance/echo-basic/grpcechoserver"
+	"sigs.k8s.io/gateway-api/conformance/utils/grpc"
+	httputils "sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, GRPCRouteSessionPersistenceCookie)
+}
+
+var GRPCRouteSessionPersistenceCookie = confsuite.ConformanceTest{
+	ShortName:   "GRPCRouteSessionPersistenceCookie",
+	Description: "A GRPCRoute with cookie-based session persistence sets a session cookie (no Expires or Max-Age) and routes all subsequent requests carrying that cookie to the same backend pod",
+	Manifests:   []string{"tests/grpcroute-session-persistence-cookie.yaml"},
+	Provisional: true,
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportGRPCRoute,
+		features.SupportCookieSessionPersistence,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "grpcroute-session-persistence-cookie", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), &v1.GRPCRoute{}, true, routeNN)
+
+		baseReq := grpc.ExpectedResponse{
+			EchoRequest: &pb.EchoRequest{},
+		}
+
+		// Wait for the route to be data-plane ready and capture the first session cookie.
+		var cookie *httputils.CookieInfo
+		var firstPod string
+		httputils.AwaitConvergence(t, 1, suite.TimeoutConfig.MaxTimeToConsistency, func(elapsed time.Duration) bool {
+			client := &grpc.DefaultClient{}
+			defer client.Close()
+			resp, err := client.SendRPC(t, gwAddr, baseReq, suite.TimeoutConfig.RequestTimeout)
+			if err != nil {
+				tlog.Logf(t, "request failed: %v (after %v)", err, elapsed)
+				return false
+			}
+			if resp.Response == nil || resp.Response.Assertions == nil || resp.Response.Assertions.Context == nil {
+				tlog.Logf(t, "empty response assertions (after %v)", elapsed)
+				return false
+			}
+			if resp.Headers == nil {
+				tlog.Logf(t, "nil response headers (after %v)", elapsed)
+				return false
+			}
+			h := make(http.Header)
+			for k, v := range *resp.Headers {
+				h[http.CanonicalHeaderKey(k)] = v
+			}
+			c, err := httputils.ExtractResponseCookie(h)
+			if err != nil {
+				tlog.Logf(t, "no session cookie in response (after %v): %v", elapsed, err)
+				return false
+			}
+			cookie = c
+			firstPod = resp.Response.Assertions.Context.Pod
+			tlog.Logf(t, "session established: set-cookie=%v pod=%s attributes=%v", resp.Headers.Get("set-cookie"), firstPod, cookie.Attributes)
+			return true
+		})
+
+		if cookie.HasAttribute("Expires") {
+			t.Errorf("session cookie must not have an Expires attribute, got attributes: %v", cookie.Attributes)
+		}
+		if cookie.HasAttribute("Max-Age") {
+			t.Errorf("session cookie must not have a Max-Age attribute, got attributes: %v", cookie.Attributes)
+		}
+
+		// Verify stickiness: each sticky request uses a fresh connection so routing is driven
+		// by the cookie, not connection-level affinity.
+		stickyReq := grpc.ExpectedResponse{
+			EchoRequest: &pb.EchoRequest{},
+			RequestMetadata: &grpc.RequestMetadata{
+				Metadata: map[string]string{
+					"cookie": cookie.Name + "=" + cookie.Value,
+				},
+			},
+		}
+		for i := 0; i < 10; i++ {
+			client := &grpc.DefaultClient{}
+			resp, err := client.SendRPC(t, gwAddr, stickyReq, suite.TimeoutConfig.RequestTimeout)
+			client.Close()
+			if err != nil {
+				t.Errorf("sticky request %d failed: %v", i+1, err)
+				continue
+			}
+			if resp.Response == nil || resp.Response.Assertions == nil || resp.Response.Assertions.Context == nil {
+				t.Errorf("sticky request %d: empty response assertions", i+1)
+				continue
+			}
+			pod := resp.Response.Assertions.Context.Pod
+			tlog.Logf(t, "sticky request %d: pod=%s", i+1, pod)
+			if pod != firstPod {
+				t.Errorf("sticky request %d: expected pod %q, got %q (session cookie not honored)", i+1, firstPod, pod)
+			}
+		}
+	},
+}

--- a/conformance/tests/grpcroute-session-persistence-cookie.yaml
+++ b/conformance/tests/grpcroute-session-persistence-cookie.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: grpcroute-session-persistence-cookie
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - sessionPersistence:
+      type: Cookie
+    backendRefs:
+    - name: grpc-infra-backend-v1
+      port: 8080

--- a/conformance/tests/httproute-session-persistence-cookie-permanent-lifetime.go
+++ b/conformance/tests/httproute-session-persistence-cookie-permanent-lifetime.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	httputils "sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteSessionPersistenceCookiePermanentLifetime)
+}
+
+var HTTPRouteSessionPersistenceCookiePermanentLifetime = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteSessionPersistenceCookiePermanentLifetime",
+	Description: "An HTTPRoute with permanent cookie lifetime sets a cookie with an Expires or Max-Age attribute",
+	Manifests:   []string{"tests/httproute-session-persistence-cookie-permanent-lifetime.yaml"},
+	Provisional: true,
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportCookieSessionPersistence,
+		features.SupportCookieSessionPersistencePermanentLifetime,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		routeNN := types.NamespacedName{Name: "session-persistence-cookie-permanent-lifetime", Namespace: confsuite.InfrastructureNamespace}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: confsuite.InfrastructureNamespace}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		req := roundtripper.Request{
+			T:      t,
+			Method: "GET",
+			URL: url.URL{
+				Scheme: "http",
+				Host:   httputils.CalculateHost(t, gwAddr, "http"),
+				Path:   "/session-persistence-permanent-lifetime",
+			},
+			Headers: map[string][]string{},
+		}
+
+		// Wait for the route to stabilize and capture the permanent cookie.
+		var cookie *httputils.CookieInfo
+		httputils.AwaitConvergence(t, 1, suite.TimeoutConfig.MaxTimeToConsistency, func(elapsed time.Duration) bool {
+			_, cRes, err := suite.RoundTripper.CaptureRoundTrip(req)
+			if err != nil {
+				tlog.Logf(t, "request failed: %v (after %v)", err, elapsed)
+				return false
+			}
+			if cRes.StatusCode != 200 {
+				tlog.Logf(t, "expected status 200, got %d (after %v)", cRes.StatusCode, elapsed)
+				return false
+			}
+			c, err := httputils.ExtractResponseCookie(http.Header(cRes.Headers))
+			if err != nil {
+				tlog.Logf(t, "no session cookie in response (after %v): %v", elapsed, err)
+				return false
+			}
+			cookie = c
+			tlog.Logf(t, "received Set-Cookie: %q attributes=%v", cRes.Headers["Set-Cookie"], cookie.Attributes)
+			return true
+		})
+
+		// Permanent cookies must carry either Expires or Max-Age to communicate the expiry time to clients.
+		if !cookie.HasAttribute("Expires") && !cookie.HasAttribute("Max-Age") {
+			t.Errorf("permanent cookie must have an Expires or Max-Age attribute, got attributes: %v", cookie.Attributes)
+		}
+	},
+}

--- a/conformance/tests/httproute-session-persistence-cookie-permanent-lifetime.yaml
+++ b/conformance/tests/httproute-session-persistence-cookie-permanent-lifetime.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: session-persistence-cookie-permanent-lifetime
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /session-persistence-permanent-lifetime
+    sessionPersistence:
+      type: Cookie
+      absoluteTimeout: 1h
+      cookieConfig:
+        lifetimeType: Permanent
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/httproute-session-persistence-cookie.go
+++ b/conformance/tests/httproute-session-persistence-cookie.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	httputils "sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
+	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteSessionPersistenceCookie)
+}
+
+var HTTPRouteSessionPersistenceCookie = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteSessionPersistenceCookie",
+	Description: "An HTTPRoute with cookie-based session persistence sets a session cookie (no Expires or Max-Age) and routes all subsequent requests carrying that cookie to the same backend pod",
+	Manifests:   []string{"tests/httproute-session-persistence-cookie.yaml"},
+	Provisional: true,
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportCookieSessionPersistence,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		routeNN := types.NamespacedName{Name: "session-persistence-cookie", Namespace: confsuite.InfrastructureNamespace}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: confsuite.InfrastructureNamespace}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		baseReq := roundtripper.Request{
+			T:      t,
+			Method: "GET",
+			URL: url.URL{
+				Scheme: "http",
+				Host:   httputils.CalculateHost(t, gwAddr, "http"),
+				Path:   "/session-persistence",
+			},
+			Headers: map[string][]string{},
+		}
+
+		// Wait for the route to be data-plane ready and capture the first session cookie.
+		var cookie *httputils.CookieInfo
+		var firstPod string
+		httputils.AwaitConvergence(t, 1, suite.TimeoutConfig.MaxTimeToConsistency, func(elapsed time.Duration) bool {
+			cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(baseReq)
+			if err != nil {
+				tlog.Logf(t, "request failed: %v (after %v)", err, elapsed)
+				return false
+			}
+			if cRes.StatusCode != 200 {
+				tlog.Logf(t, "expected status 200, got %d (after %v)", cRes.StatusCode, elapsed)
+				return false
+			}
+			c, err := httputils.ExtractResponseCookie(http.Header(cRes.Headers))
+			if err != nil {
+				tlog.Logf(t, "no session cookie in response (after %v): %v", elapsed, err)
+				return false
+			}
+			cookie = c
+			firstPod = cReq.Pod
+			tlog.Logf(t, "session established: Set-Cookie=%q pod=%s attributes=%v", cRes.Headers["Set-Cookie"], firstPod, cookie.Attributes)
+			return true
+		})
+
+		if cookie.HasAttribute("Expires") {
+			t.Errorf("session cookie must not have an Expires attribute, got attributes: %v", cookie.Attributes)
+		}
+		if cookie.HasAttribute("Max-Age") {
+			t.Errorf("session cookie must not have a Max-Age attribute, got attributes: %v", cookie.Attributes)
+		}
+
+		// Verify stickiness: all subsequent requests carrying the session cookie must reach the same pod.
+		stickyReq := baseReq
+		stickyReq.Headers = map[string][]string{
+			"Cookie": {cookie.Name + "=" + cookie.Value},
+		}
+		for i := 0; i < 10; i++ {
+			cReq, cRes, err := suite.RoundTripper.CaptureRoundTrip(stickyReq)
+			if err != nil {
+				t.Errorf("sticky request %d failed: %v", i+1, err)
+				continue
+			}
+			tlog.Logf(t, "sticky request %d: status=%d pod=%s", i+1, cRes.StatusCode, cReq.Pod)
+			if cRes.StatusCode != 200 {
+				t.Errorf("sticky request %d: expected status 200, got %d", i+1, cRes.StatusCode)
+				continue
+			}
+			if cReq.Pod != firstPod {
+				t.Errorf("sticky request %d: expected pod %q, got %q (session cookie not honored)", i+1, firstPod, cReq.Pod)
+			}
+		}
+	},
+}

--- a/conformance/tests/httproute-session-persistence-cookie.yaml
+++ b/conformance/tests/httproute-session-persistence-cookie.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: session-persistence-cookie
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /session-persistence
+    sessionPersistence:
+      type: Cookie
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/utils/http/cookies.go
+++ b/conformance/utils/http/cookies.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http //nolint:revive
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// CookieInfo holds the parsed name, value, and attributes of a Set-Cookie header.
+type CookieInfo struct {
+	Name       string
+	Value      string
+	Attributes map[string]string
+}
+
+// ExtractResponseCookie parses the first Set-Cookie header from the response and
+// returns the cookie name, value, and a map of its attributes (e.g. "Max-Age", "Expires").
+func ExtractResponseCookie(h http.Header) (*CookieInfo, error) {
+	values := h.Values("Set-Cookie")
+	if len(values) == 0 {
+		return nil, fmt.Errorf("no Set-Cookie header found in response")
+	}
+
+	raw := strings.TrimSpace(values[0])
+	if raw == "" {
+		return nil, fmt.Errorf("empty Set-Cookie header")
+	}
+
+	parts := strings.Split(raw, ";")
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("malformed Set-Cookie header: %q", raw)
+	}
+
+	// First part is cookie-name=value.
+	pair := strings.TrimSpace(parts[0])
+	nv := strings.SplitN(pair, "=", 2)
+	if len(nv) != 2 {
+		return nil, fmt.Errorf("malformed Set-Cookie header (no name=value): %q", raw)
+	}
+
+	name := strings.TrimSpace(nv[0])
+	value := strings.TrimSpace(nv[1])
+	if name == "" || value == "" {
+		return nil, fmt.Errorf("malformed Set-Cookie header (empty name or value): %q", raw)
+	}
+
+	attrs := make(map[string]string)
+	for _, p := range parts[1:] {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		kv := strings.SplitN(p, "=", 2)
+		key := strings.ToLower(strings.TrimSpace(kv[0]))
+		val := ""
+		if len(kv) == 2 {
+			val = strings.TrimSpace(kv[1])
+		}
+		attrs[key] = val
+	}
+
+	return &CookieInfo{Name: name, Value: value, Attributes: attrs}, nil
+}
+
+// HasAttribute reports whether the cookie has the given attribute (case-insensitive).
+func (c *CookieInfo) HasAttribute(attr string) bool {
+	_, ok := c.Attributes[strings.ToLower(attr)]
+	return ok
+}

--- a/pkg/features/grpcroute.go
+++ b/pkg/features/grpcroute.go
@@ -59,4 +59,6 @@ var GRPCRouteNamedRouteRule = Feature{
 // This does not include any Core Features.
 var GRPCRouteExtendedFeatures = sets.New(
 	GRPCRouteNamedRouteRule,
+	CookieSessionPersistenceFeature,
+	CookieSessionPersistencePermanentLifetimeFeature,
 )

--- a/pkg/features/httproute.go
+++ b/pkg/features/httproute.go
@@ -120,6 +120,12 @@ const (
 
 	// This option indicates support for HTTPRoute retry on connection error (extended conformance)
 	SupportHTTPRouteRetryConnectionError FeatureName = "HTTPRouteRetryConnectionError"
+
+	// This option indicates support for cookie-based session persistence (experimental conformance).
+	SupportCookieSessionPersistence FeatureName = "CookieSessionPersistence"
+
+	// This option indicates support for permanent cookie lifetime in cookie-based session persistence (experimental conformance).
+	SupportCookieSessionPersistencePermanentLifetime FeatureName = "CookieSessionPersistencePermanentLifetime"
 )
 
 var (
@@ -253,6 +259,16 @@ var (
 		Name:    SupportHTTPRouteRetryConnectionError,
 		Channel: FeatureChannelExperimental,
 	}
+	// CookieSessionPersistenceFeature contains metadata for the CookieSessionPersistence feature.
+	CookieSessionPersistenceFeature = Feature{
+		Name:    SupportCookieSessionPersistence,
+		Channel: FeatureChannelExperimental,
+	}
+	// CookieSessionPersistencePermanentLifetimeFeature contains metadata for the CookieSessionPersistencePermanentLifetime feature.
+	CookieSessionPersistencePermanentLifetimeFeature = Feature{
+		Name:    SupportCookieSessionPersistencePermanentLifetime,
+		Channel: FeatureChannelExperimental,
+	}
 )
 
 // HTTPRouteExtendedFeatures includes all extended features for HTTPRoute
@@ -285,4 +301,6 @@ var HTTPRouteExtendedFeatures = sets.New(
 	HTTPRouteRetryFeature,
 	HTTPRouteRetryBackendTimeoutFeature,
 	HTTPRouteRetryConnectionErrorFeature,
+	CookieSessionPersistenceFeature,
+	CookieSessionPersistencePermanentLifetimeFeature,
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind test
/area conformance-test

**What this PR does / why we need it**:

It adds cookie-based session persistence tests for GRPCRoute and HTTPRoute. 

Session persistence is currently defined on HTTPRouteRule and GRPCRouteRule, but the spec is experimental and under active discussion for potential relocation to a backend resource. Naming the features after the capability rather than the resource means:

- Implementations can declare support once and the feature name stays stable if the API moves
- Conformance tests don't need to be renamed or re-registered when the resource changes
- Both HTTPRoute and GRPCRoute tests share the same feature flags, reflecting that session persistence is a backend-level capability regardless of which route type configures it.


**Which issue(s) this PR fixes**:

Related to GEP-1619

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
