### PR TITLE
Remove stray https-default-tls-mode listener from Ingress migration example

### DIFF
--- a/examples/standard/simple-http-https/gateway.yaml
+++ b/examples/standard/simple-http-https/gateway.yaml
@@ -20,11 +20,3 @@ spec:
       certificateRefs:
       - kind: Secret
         name: example-com
-  - name: https-default-tls-mode
-    port: 8443
-    protocol: HTTPS
-    hostname: "*.foo.com"
-    tls:
-      certificateRefs:
-      - kind: Secret
-        name: foo-com

--- a/examples/standard/tls-basic.yaml
+++ b/examples/standard/tls-basic.yaml
@@ -12,6 +12,7 @@ spec:
     port: 443
     hostname: foo.example.com
     tls:
+      # mode defaults to `Terminate` when omitted.
       certificateRefs:
       - kind: Secret
         group: ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
/kind documentation
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

The listener `https-default-tls-mode` in [examples/standard/simple-http-https/gateway.yaml](https://github.com/kubernetes-sigs/gateway-api/blob/634aa7cb4fc7ec460609080c4c2b4676d9cf4e9f/examples/standard/simple-http-https/gateway.yaml) has no counterpart in the Ingress being converted and no route attaches to it. It was added in #2652 to demonstrate default TLS mode, which is already shown by [examples/standard/tls-basic.yaml](https://github.com/kubernetes-sigs/gateway-api/blob/634aa7cb4fc7ec460609080c4c2b4676d9cf4e9f/examples/standard/tls-basic.yaml). That listener was causing confusion in [migrating from ingress guide](https://github.com/kubernetes-sigs/gateway-api/blob/634aa7cb4fc7ec460609080c4c2b4676d9cf4e9f/site/content/en/guides/getting-started/migrating-from-ingress.md).  So I removed that listener and also added a note about default mode in tls-basic.yaml

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4794

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
