### PR TITLE
conformance: cleanup stale objects in tests

### DIFF
--- a/conformance/tests/backendtlspolicy.go
+++ b/conformance/tests/backendtlspolicy.go
@@ -188,6 +188,14 @@ var BackendTLSPolicy = confsuite.ConformanceTest{
 			}
 
 			testCMNN := types.NamespacedName{Name: testCMName, Namespace: ns}
+			staleCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testCMName,
+					Namespace: ns,
+				},
+			}
+			err = client.IgnoreNotFound(suite.Client.Delete(ctx, staleCM))
+			require.NoError(t, err, "failed to delete stale test-specific ConfigMap")
 
 			policy := &gatewayv1.BackendTLSPolicy{}
 			err = suite.Client.Get(ctx, testPolicyNN, policy)

--- a/conformance/tests/tcproute-multiple-routes-attachment.go
+++ b/conformance/tests/tcproute-multiple-routes-attachment.go
@@ -55,6 +55,14 @@ var TCPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
 		newerRouteNN := types.NamespacedName{Name: "tcproute-attach-newer", Namespace: ns}
 
 		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+		staleNewerRoute := &v1alpha2.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      newerRouteNN.Name,
+				Namespace: newerRouteNN.Namespace,
+			},
+		}
+		err := client.IgnoreNotFound(suite.Client.Delete(t.Context(), staleNewerRoute))
+		require.NoError(t, err, "failed to delete stale newer TCPRoute")
 
 		// Wait for the Gateway and the older TCPRoute to be ready before introducing the
 		// second route, so creation-time ordering is unambiguous.


### PR DESCRIPTION


**What type of PR is this?**

/area conformance-machinery

**What this PR does / why we need it**:
Most tests apply config via the standard helpers and that gets cleaned up automatically. These tests don't AND then fail to run again if the old objects are around.

This should not impact any pure `kind create cluster; go test ./...` but it does impact re-running the tests which is important for development.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
