### PR TITLE
bugfix: crdify should not break on description change

### DIFF
--- a/crdify.yaml
+++ b/crdify.yaml
@@ -1,0 +1,9 @@
+validations:
+  # Changing a field description is fine
+  - name: description
+    enforcement: None
+  # Adding a new enum is fine. Removing or changing is not
+  - name: enum
+    enforcement: Error
+    configuration:
+      additionPolicy: Allow

--- a/hack/verify-crdify.sh
+++ b/hack/verify-crdify.sh
@@ -23,6 +23,7 @@ readonly SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 CRDIFY_ENFORCE=${CRDIFY_ENFORCE:-true}
 CRDIFY_BASE_REF=${CRDIFY_BASE_REF:-${PULL_BASE_SHA:-main}}
 REMOTE=${REMOTE:-origin}
+CRDIFY_CONFIG_FILE="${CRDIFY_CONFIG_FILE:-${SCRIPT_ROOT}/crdify.yaml}"
 
 cd "${SCRIPT_ROOT}"
 
@@ -48,7 +49,8 @@ for file in config/crd/standard/*.yaml; do
   echo -e "\n${filename}:"
   if ! ${GOTOOL} sigs.k8s.io/crdify \
     "git://${CRDIFY_BASE_REF}?path=${file}" \
-    "file://${SCRIPT_ROOT}/${file}"; then
+    "file://${SCRIPT_ROOT}/${file}" \
+    --config "${CRDIFY_CONFIG_FILE}"; then
     error_count=$((error_count + 1))
     error_files="${error_files}\n- ${filename}"
   fi


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

Stop validating description field on crdify. While changing a description field can be semantically a breaking change, it is not a functionality breaking change and reviewers are very diligent on reviewing/approving changes on descriptions.

Also adding new enum values is fine

**Which issue(s) this PR fixes**:
Related to failures on https://github.com/kubernetes-sigs/gateway-api/pull/4880

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
