### PR TITLE
docs: mark Upstream TLS (BackendTLSPolicy) as Standard Channel since v1.4.0

### DIFF
--- a/site/content/en/guides/user-guides/tls.md
+++ b/site/content/en/guides/user-guides/tls.md
@@ -162,6 +162,14 @@ This example shows how to configure client certificate validation with default c
 
 ## Upstream TLS
 
+{{< details title="Standard Channel since v1.4.0" color="success" >}}
+
+The `BackendTLSPolicy` resource is GA and has been part of the Standard Channel
+since `v1.4.0`. For more information on release channels, refer to our
+[versioning guide](docs/concepts/versioning/).
+
+{{< /details >}}
+
 Upstream TLS settings are configured using the `BackendTLSPolicy` attached to a
 `Service` via a target reference.
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The TLS user guide marks `TLSRoute` and the frontend certificate validation features as "Standard Channel since v1.5.0", but the Upstream TLS section carries no channel badge, hiding that `BackendTLSPolicy` graduated to the Standard Channel in v1.4.0 (#4074, issue #3940). This adds the same `details` badge used by the other sections to the Upstream TLS section.

**Which issue(s) this PR fixes**:

Fixes #4928

```release-note
NONE
```
