### PR TITLE
Remove dependabot hacks for gowork

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,6 @@ updates:
   - package-ecosystem: "gomod"
     directories:
     - "/"
-    - "/conformance"
-    - "/tests"
-    - "/tools"
     - "/site"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

With https://github.com/dependabot/dependabot-core/pull/14909 dependabot should support properly go.work files. This means we can remove the current workarounds and just let it work correctly

**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
