### PR TITLE
fix: point mkdocs linking helper at the current docs path

### DIFF
--- a/hack/README-mkdocs-linking.md
+++ b/hack/README-mkdocs-linking.md
@@ -37,7 +37,7 @@ id: concept-api-overview
 ### 2. State Mapping
 The algorithm maintains two "states":
 -   Before State: A snapshot stored in hack/page_id_map.json which maps every page_id to its known file path (e.g., concepts/api.md).
--   After State: A real-time scan of the site-src/ directory, identifying the current file path for every page_id.
+-   After State: A real-time scan of the `site/content/en/` directory, identifying the current file path for every page_id.
 
 ### 3. Change Detection & Rule Generation
 By comparing these two states, the script identifies three scenarios:
@@ -61,7 +61,7 @@ PYTHONPATH=hack python3 hack/mkdocs_linking.py --prepare --dry-run
 ```
 
 ### 2. Prepare Documentation
-Scans `site-src/`, injects missing IDs, and updates `hack/page_id_map.json`.
+Scans `site/content/en/`, injects missing IDs, and updates `hack/page_id_map.json`.
 ```bash
 PYTHONPATH=hack python3 hack/mkdocs_linking.py --prepare
 ```
@@ -95,9 +95,9 @@ PYTHONPATH=hack python3 -m unittest discover -s hack/mkdocs/__tests__/ -p 'test_
 This toolkit requires Python 3.9+ and several dependencies.
 
 ### 1. Dependencies
-Install the required libraries using the repository's requirements file:
+Install the required libraries:
 ```bash
-pip install -r hack/mkdocs/image/requirements.txt
+pip install python-frontmatter PyYAML
 ```
 
 ### 2. Page ID Map

--- a/hack/mkdocs_linking.py
+++ b/hack/mkdocs_linking.py
@@ -65,7 +65,9 @@ def main() -> None:
         help="Convert all relative Markdown links to the internal_link macro.",
     )
     parser.add_argument(
-        "--docs-dir", default="site-src", help="Documentation directory (default: site-src)."
+        "--docs-dir",
+        default="site/content/en",
+        help="Documentation directory (default: site/content/en).",
     )
     parser.add_argument(
         "--dry-run",

--- a/hack/mkdocs_utils.py
+++ b/hack/mkdocs_utils.py
@@ -485,7 +485,7 @@ def build_id_map(docs_dir: Path) -> Dict[str, Path]:
 
 # --- Configuration ---
 # Global constants defining key file paths and metadata keys.
-DOCS_DIR: Path = Path("site-src")
+DOCS_DIR: Path = Path("site/content/en")
 PAGE_ID_MAP_FILE: Path = Path("hack/page_id_map.json")
 MKDOCS_YML_PATH: Path = Path("mkdocs.yml")
 FRONTMATTER_ID_KEY: str = "id"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind documentation

**What this PR does / why we need it**:

`hack/mkdocs_linking.py --prepare` still defaults to `site-src`, but the repo docs live in `site/content/en` now. So the documented command bails right away on a fresh checkout.

Repro on `origin/main`:

```bash
python3 -m venv /tmp/gateway-api-pr-venv
/tmp/gateway-api-pr-venv/bin/pip install python-frontmatter PyYAML
/tmp/gateway-api-pr-venv/bin/python hack/mkdocs_linking.py --prepare
```

Before:

```text
ERROR: Documentation directory 'site-src' does not exist.
```

This patch points the helper at `site/content/en` and trims the README setup text so the quickstart works again. tiny fix, but it unbricks the default flow.

**Which issue(s) this PR fixes**:

None. Related to #3999 and #4867.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
