### PR TITLE
fix: HTTPRouteNoBackendRefs allows route with any condition

### DIFF
--- a/conformance/tests/httproute-omitted-backendrefs.go
+++ b/conformance/tests/httproute-omitted-backendrefs.go
@@ -19,8 +19,11 @@ package tests
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
@@ -43,8 +46,25 @@ var HTTPRouteNoBackendRefs = confsuite.ConformanceTest{
 		ns := confsuite.InfrastructureNamespace
 		routeNN := types.NamespacedName{Name: "omitted-backendrefs", Namespace: ns}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
-		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		gwAddr, err := kubernetes.WaitForGatewayAddress(t, suite.Client, suite.TimeoutConfig, kubernetes.NewGatewayRef(gwNN))
+		require.NoErrorf(t, err, "timed out waiting for Gateway address to be assigned")
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		parentRef := parentRefTo(gwNN)
+		// Set the namespace to nil since it is in the same namespace as the parent
+		parentRef.Namespace = nil
+		parents := []v1.RouteParentStatus{{
+			ParentRef:      parentRef,
+			ControllerName: v1.GatewayController(suite.ControllerName),
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(v1.RouteConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: "", // any reason
+				},
+			},
+		}}
+		kubernetes.HTTPRouteMustHaveParents(t, suite.Client, suite.TimeoutConfig, routeNN, parents, true)
 
 		testCases := []http.ExpectedResponse{
 			{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind cleanup
**What this PR does / why we need it**:

In HTTPRouteNoBackendRefs, the test assumes that the HTTP route is accepted with the ACCEPTED reason.
This might not be the case since the route is accepted, but it may have a different reason since one of the backends is invalid.

This PR does not aim to determine the reason but leaves it up to the impementation for now

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
