### PR TITLE
Introduce RouteReasonConflicted to indicate when a route has conflicts

### DIFF
--- a/apis/v1/shared_types.go
+++ b/apis/v1/shared_types.go
@@ -394,6 +394,10 @@ const (
 	// are incompatible filters present on a route rule (for example if
 	// the URLRewrite and RequestRedirect are both present on an HTTPRoute).
 	RouteReasonIncompatibleFilters RouteConditionReason = "IncompatibleFilters"
+
+	// This reason is used with the "Accepted" condition when the Route conflicts
+	// with an existing route.
+	RouteReasonConflicted RouteConditionReason = "Conflicted"
 )
 
 const (

--- a/conformance/tests/tcproute-multiple-routes-attachment.go
+++ b/conformance/tests/tcproute-multiple-routes-attachment.go
@@ -93,13 +93,14 @@ var TCPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
 			Status: metav1.ConditionTrue,
 			Reason: string(gatewayv1.RouteReasonAccepted),
 		}
+		kubernetes.TCPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, olderRouteNN, gwNN, acceptedCond)
 
-		t.Run("Both TCPRoutes should be Accepted by the Gateway", func(t *testing.T) {
-			// Both routes report Accepted=True; the newer route is rejected at the
-			// listener-attachment level rather than via the route's Accepted condition.
-			kubernetes.TCPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, olderRouteNN, gwNN, acceptedCond)
-			kubernetes.TCPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, newerRouteNN, gwNN, acceptedCond)
-		})
+		conflictedCond := metav1.Condition{
+			Type:   string(gatewayv1.RouteConditionAccepted),
+			Status: metav1.ConditionFalse,
+			Reason: string(gatewayv1.RouteReasonConflicted),
+		}
+		kubernetes.TCPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, newerRouteNN, gwNN, conflictedCond)
 
 		t.Run("Gateway listener should report 2 attached Routes", func(t *testing.T) {
 			listeners := []gatewayv1.ListenerStatus{{

--- a/conformance/tests/tcproute-multiple-routes-attachment.yaml
+++ b/conformance/tests/tcproute-multiple-routes-attachment.yaml
@@ -122,7 +122,7 @@ spec:
   listeners:
     - name: tcp
       protocol: TCP
-      port: 9091
+      port: 9090
       allowedRoutes:
         kinds:
           - kind: TCPRoute

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -1017,7 +1017,7 @@ func parentsForRouteMatch(t *testing.T, routeName types.NamespacedName, expected
 			}
 			if !reflect.DeepEqual(aParent.ParentRef.Namespace, eParent.ParentRef.Namespace) {
 				if namespaceRequired || aParent.ParentRef.Namespace != nil {
-					tlog.Logf(t, "Route %s expected ParentReference.Namespace to be %v, got %v", routeName, eParent.ParentRef.Namespace, aParent.ParentRef.Namespace)
+					tlog.Logf(t, "Route %s expected ParentReference.Namespace to be '%v', got '%v'", routeName, ptr.Deref(eParent.ParentRef.Namespace, ""), ptr.Deref(aParent.ParentRef.Namespace, ""))
 					continue
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

As a user, I would like to know when my routes have an issue rather than just being accepted but seeing different behaviour. Eg: If a listener in a listenerset has a conflict, it is marked as conflicted and that is near instant feedback but that is not the case for routes. This aims to fix that

- Introduce RouteReasonConflicted to signal when a Route conflicts with an existing route,
- Use this in the TCPRouteMultipleRoutesAttachment conformance test to expect Accepted=False/Conflicted on the newer route instead of Accepted=True.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
