### PR TITLE
chore: Update TCP && UDP Route version in conformance tests

### DIFF
--- a/conformance/tests/tcproute-invalid-backendref-nonexistent.yaml
+++ b/conformance/tests/tcproute-invalid-backendref-nonexistent.yaml
@@ -13,7 +13,7 @@ spec:
         kinds:
           - kind: TCPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-route-invalid-backend-ref-nonexistent

--- a/conformance/tests/tcproute-invalid-cross-namespace-backend-ref.yaml
+++ b/conformance/tests/tcproute-invalid-cross-namespace-backend-ref.yaml
@@ -71,7 +71,7 @@ spec:
           - kind: TCPRoute
 ---
 # No ReferenceGrant: the cross-namespace backendRef must NOT be permitted.
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-invalid-cross-namespace-backend-ref

--- a/conformance/tests/tcproute-invalid-non-tcp-listener.yaml
+++ b/conformance/tests/tcproute-invalid-non-tcp-listener.yaml
@@ -13,7 +13,7 @@ spec:
         kinds:
           - kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-route

--- a/conformance/tests/tcproute-multiple-routes-attachment.yaml
+++ b/conformance/tests/tcproute-multiple-routes-attachment.yaml
@@ -130,7 +130,7 @@ spec:
         namespaces:
           from: Same
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcproute-attach-older

--- a/conformance/tests/tcproute-parentref-attach-all.yaml
+++ b/conformance/tests/tcproute-parentref-attach-all.yaml
@@ -91,7 +91,7 @@ spec:
 # parentRef with neither `port` nor `sectionName`. Should attach to every TCP
 # listener on the Gateway, so traffic to any of the four listeners must reach
 # the same backend.
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-route-attach-all

--- a/conformance/tests/tcproute-parentref-port-and-section-name.yaml
+++ b/conformance/tests/tcproute-parentref-port-and-section-name.yaml
@@ -197,7 +197,7 @@ spec:
           - kind: TCPRoute
 ---
 # Scenario 1: parentRef with `port` only (matches listener `one` on port 9300).
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-route-by-port
@@ -212,7 +212,7 @@ spec:
           port: 3000
 ---
 # Scenario 2: parentRef with `sectionName` only (matches listener `two`).
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-route-by-section
@@ -227,7 +227,7 @@ spec:
           port: 3000
 ---
 # Scenario 3: parentRef with both `sectionName` and `port` (listener `three`).
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-route-by-section-and-port

--- a/conformance/tests/tcproute-reference-grant.yaml
+++ b/conformance/tests/tcproute-reference-grant.yaml
@@ -85,7 +85,7 @@ spec:
         kinds:
           - kind: TCPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-reference-grant

--- a/conformance/tests/tcproute-weighted-routing.yaml
+++ b/conformance/tests/tcproute-weighted-routing.yaml
@@ -184,7 +184,7 @@ spec:
         kinds:
           - kind: TCPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-weighted-route

--- a/examples/experimental/basic-tcp.yaml
+++ b/examples/experimental/basic-tcp.yaml
@@ -20,7 +20,7 @@ spec:
       kinds:
       - kind: TCPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-app-1
@@ -33,7 +33,7 @@ spec:
     - name: my-foo-service
       port: 6000
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-app-2

--- a/examples/experimental/destination-port-matching-tcp.yaml
+++ b/examples/experimental/destination-port-matching-tcp.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: destination-port-matching-example


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind cleanup

**What this PR does / why we need it**:

Updates the version of TCP && UDP Route in conformance tests to v1

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
