### PR TITLE
chore: Update TCP && UDP Route version in conformance tests

### DIFF
--- a/conformance/tests/tcproute-invalid-backendref-nonexistent.yaml
+++ b/conformance/tests/tcproute-invalid-backendref-nonexistent.yaml
@@ -13,7 +13,7 @@ spec:
         kinds:
           - kind: TCPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-route-invalid-backend-ref-nonexistent

--- a/conformance/tests/tcproute-invalid-cross-namespace-backend-ref.go
+++ b/conformance/tests/tcproute-invalid-cross-namespace-backend-ref.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	v1 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/pkg/features"

--- a/conformance/tests/tcproute-invalid-cross-namespace-backend-ref.yaml
+++ b/conformance/tests/tcproute-invalid-cross-namespace-backend-ref.yaml
@@ -71,7 +71,7 @@ spec:
           - kind: TCPRoute
 ---
 # No ReferenceGrant: the cross-namespace backendRef must NOT be permitted.
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-invalid-cross-namespace-backend-ref

--- a/conformance/tests/tcproute-invalid-non-tcp-listener.go
+++ b/conformance/tests/tcproute-invalid-non-tcp-listener.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	v1 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/pkg/features"

--- a/conformance/tests/tcproute-invalid-non-tcp-listener.yaml
+++ b/conformance/tests/tcproute-invalid-non-tcp-listener.yaml
@@ -13,7 +13,7 @@ spec:
         kinds:
           - kind: HTTPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-route

--- a/conformance/tests/tcproute-multiple-routes-attachment.go
+++ b/conformance/tests/tcproute-multiple-routes-attachment.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/conformance/utils/tcp"
@@ -64,19 +64,19 @@ var TCPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
 		// is strictly newer than the first.
 		time.Sleep(time.Second)
 
-		newerRoute := &v1alpha2.TCPRoute{
+		newerRoute := &v1.TCPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      newerRouteNN.Name,
 				Namespace: newerRouteNN.Namespace,
 			},
-			Spec: v1alpha2.TCPRouteSpec{
+			Spec: v1.TCPRouteSpec{
 				CommonRouteSpec: gatewayv1.CommonRouteSpec{
 					ParentRefs: []gatewayv1.ParentReference{{
 						Name:        gatewayv1.ObjectName(gwNN.Name),
 						SectionName: ptr.To(gatewayv1.SectionName("tcp")),
 					}},
 				},
-				Rules: []v1alpha2.TCPRouteRule{{
+				Rules: []v1.TCPRouteRule{{
 					BackendRefs: []gatewayv1.BackendRef{{
 						BackendObjectReference: gatewayv1.BackendObjectReference{
 							Name: gatewayv1.ObjectName("tcp-attach-backend-2"),

--- a/conformance/tests/tcproute-multiple-routes-attachment.go
+++ b/conformance/tests/tcproute-multiple-routes-attachment.go
@@ -28,7 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/conformance/utils/tcp"
@@ -64,19 +63,19 @@ var TCPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
 		// is strictly newer than the first.
 		time.Sleep(time.Second)
 
-		newerRoute := &v1.TCPRoute{
+		newerRoute := &gatewayv1.TCPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      newerRouteNN.Name,
 				Namespace: newerRouteNN.Namespace,
 			},
-			Spec: v1.TCPRouteSpec{
+			Spec: gatewayv1.TCPRouteSpec{
 				CommonRouteSpec: gatewayv1.CommonRouteSpec{
 					ParentRefs: []gatewayv1.ParentReference{{
 						Name:        gatewayv1.ObjectName(gwNN.Name),
 						SectionName: ptr.To(gatewayv1.SectionName("tcp")),
 					}},
 				},
-				Rules: []v1.TCPRouteRule{{
+				Rules: []gatewayv1.TCPRouteRule{{
 					BackendRefs: []gatewayv1.BackendRef{{
 						BackendObjectReference: gatewayv1.BackendObjectReference{
 							Name: gatewayv1.ObjectName("tcp-attach-backend-2"),

--- a/conformance/tests/tcproute-multiple-routes-attachment.yaml
+++ b/conformance/tests/tcproute-multiple-routes-attachment.yaml
@@ -130,7 +130,7 @@ spec:
         namespaces:
           from: Same
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcproute-attach-older

--- a/conformance/tests/tcproute-parentref-attach-all.yaml
+++ b/conformance/tests/tcproute-parentref-attach-all.yaml
@@ -91,7 +91,7 @@ spec:
 # parentRef with neither `port` nor `sectionName`. Should attach to every TCP
 # listener on the Gateway, so traffic to any of the four listeners must reach
 # the same backend.
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-route-attach-all

--- a/conformance/tests/tcproute-parentref-port-and-section-name.yaml
+++ b/conformance/tests/tcproute-parentref-port-and-section-name.yaml
@@ -197,7 +197,7 @@ spec:
           - kind: TCPRoute
 ---
 # Scenario 1: parentRef with `port` only (matches listener `one` on port 9300).
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-route-by-port
@@ -212,7 +212,7 @@ spec:
           port: 3000
 ---
 # Scenario 2: parentRef with `sectionName` only (matches listener `two`).
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-route-by-section
@@ -227,7 +227,7 @@ spec:
           port: 3000
 ---
 # Scenario 3: parentRef with both `sectionName` and `port` (listener `three`).
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-route-by-section-and-port

--- a/conformance/tests/tcproute-reference-grant.yaml
+++ b/conformance/tests/tcproute-reference-grant.yaml
@@ -85,7 +85,7 @@ spec:
         kinds:
           - kind: TCPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-reference-grant

--- a/conformance/tests/tcproute-weighted-routing.yaml
+++ b/conformance/tests/tcproute-weighted-routing.yaml
@@ -184,7 +184,7 @@ spec:
         kinds:
           - kind: TCPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-weighted-route

--- a/conformance/tests/udproute-invalid-backendref-nonexistent.yaml
+++ b/conformance/tests/udproute-invalid-backendref-nonexistent.yaml
@@ -13,7 +13,7 @@ spec:
         kinds:
           - kind: UDPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: UDPRoute
 metadata:
   name: udp-route-invalid-backend-ref-nonexistent

--- a/conformance/tests/udproute-invalid-cross-namespace-backend-ref.yaml
+++ b/conformance/tests/udproute-invalid-cross-namespace-backend-ref.yaml
@@ -13,7 +13,7 @@ spec:
         kinds:
           - kind: UDPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: UDPRoute
 metadata:
   name: udp-route-invalid-cross-namespace-backend-ref

--- a/conformance/tests/udproute-multiple-routes-attachment.go
+++ b/conformance/tests/udproute-multiple-routes-attachment.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
@@ -67,19 +66,19 @@ var UDPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
 		// is strictly newer than the first.
 		time.Sleep(time.Second)
 
-		newerRoute := &v1.UDPRoute{
+		newerRoute := &gatewayv1.UDPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      newerRouteNN.Name,
 				Namespace: newerRouteNN.Namespace,
 			},
-			Spec: v1.UDPRouteSpec{
+			Spec: gatewayv1.UDPRouteSpec{
 				CommonRouteSpec: gatewayv1.CommonRouteSpec{
 					ParentRefs: []gatewayv1.ParentReference{{
 						Name:        gatewayv1.ObjectName(gwNN.Name),
 						SectionName: ptr.To(gatewayv1.SectionName("udp")),
 					}},
 				},
-				Rules: []v1.UDPRouteRule{{
+				Rules: []gatewayv1.UDPRouteRule{{
 					BackendRefs: []gatewayv1.BackendRef{{
 						BackendObjectReference: gatewayv1.BackendObjectReference{
 							Name: gatewayv1.ObjectName("udp-attach-backend-2"),

--- a/conformance/tests/udproute-multiple-routes-attachment.go
+++ b/conformance/tests/udproute-multiple-routes-attachment.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
@@ -67,19 +67,19 @@ var UDPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
 		// is strictly newer than the first.
 		time.Sleep(time.Second)
 
-		newerRoute := &v1alpha2.UDPRoute{
+		newerRoute := &v1.UDPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      newerRouteNN.Name,
 				Namespace: newerRouteNN.Namespace,
 			},
-			Spec: v1alpha2.UDPRouteSpec{
+			Spec: v1.UDPRouteSpec{
 				CommonRouteSpec: gatewayv1.CommonRouteSpec{
 					ParentRefs: []gatewayv1.ParentReference{{
 						Name:        gatewayv1.ObjectName(gwNN.Name),
 						SectionName: ptr.To(gatewayv1.SectionName("udp")),
 					}},
 				},
-				Rules: []v1alpha2.UDPRouteRule{{
+				Rules: []v1.UDPRouteRule{{
 					BackendRefs: []gatewayv1.BackendRef{{
 						BackendObjectReference: gatewayv1.BackendObjectReference{
 							Name: gatewayv1.ObjectName("udp-attach-backend-2"),

--- a/conformance/tests/udproute-multiple-routes-attachment.yaml
+++ b/conformance/tests/udproute-multiple-routes-attachment.yaml
@@ -127,7 +127,7 @@ spec:
         kinds:
           - kind: UDPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: UDPRoute
 metadata:
   name: udproute-attach-older

--- a/conformance/tests/udproute-not-allowed-by-listeners.yaml
+++ b/conformance/tests/udproute-not-allowed-by-listeners.yaml
@@ -15,7 +15,7 @@ spec:
         namespaces:
           from: Same
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: UDPRoute
 metadata:
   name: udproute-not-allowed-by-listeners

--- a/conformance/tests/udproute-parentref-attach-all-listeners.yaml
+++ b/conformance/tests/udproute-parentref-attach-all-listeners.yaml
@@ -84,7 +84,7 @@ spec:
 ---
 # A UDPRoute with no `port` and no `sectionName` set on its parentRef should
 # attach to every UDP listener on the Gateway.
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: UDPRoute
 metadata:
   name: udp-route-attach-all

--- a/conformance/tests/udproute-parentref-port-and-section-name.yaml
+++ b/conformance/tests/udproute-parentref-port-and-section-name.yaml
@@ -197,7 +197,7 @@ spec:
           - kind: UDPRoute
 ---
 # Scenario 1: parentRef with `port` only -> attaches to the listener on port 5300.
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: UDPRoute
 metadata:
   name: udp-route-by-port
@@ -212,7 +212,7 @@ spec:
           port: 8080
 ---
 # Scenario 2: parentRef with `sectionName` only -> attaches to the by-section listener.
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: UDPRoute
 metadata:
   name: udp-route-by-section
@@ -227,7 +227,7 @@ spec:
           port: 8080
 ---
 # Scenario 3: parentRef with both `sectionName` and `port` -> attaches to the by-section-and-port listener.
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: UDPRoute
 metadata:
   name: udp-route-by-section-and-port

--- a/conformance/tests/udproute-reference-grant.yaml
+++ b/conformance/tests/udproute-reference-grant.yaml
@@ -85,7 +85,7 @@ spec:
         kinds:
           - kind: UDPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: UDPRoute
 metadata:
   name: udp-route-reference-grant

--- a/conformance/tests/udproute-simple.yaml
+++ b/conformance/tests/udproute-simple.yaml
@@ -13,7 +13,7 @@ spec:
         kinds:
           - kind: UDPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: UDPRoute
 metadata:
   name: udp-coredns

--- a/conformance/tests/udproute-weighted-routing.yaml
+++ b/conformance/tests/udproute-weighted-routing.yaml
@@ -184,7 +184,7 @@ spec:
         kinds:
           - kind: UDPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: UDPRoute
 metadata:
   name: udp-weighted-route

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -41,7 +41,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	"sigs.k8s.io/gateway-api/conformance/utils/config"
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
 )
@@ -774,7 +773,7 @@ func TLSRouteMustHaveNoAcceptedParents(t *testing.T, client client.Client, timeo
 }
 
 // RouteTypeMustHaveParentsField ensures the provided routeType has a
-// routeType.Status.Parents field of type []v1alpha2.RouteParentStatus.
+// routeType.Status.Parents field of type []gatewayv1.RouteParentStatus.
 func RouteTypeMustHaveParentsField(t *testing.T, routeType any) string {
 	t.Helper()
 	routeTypePointerObj := reflect.TypeOf(routeType)
@@ -788,7 +787,7 @@ func RouteTypeMustHaveParentsField(t *testing.T, routeType any) string {
 
 	parentsField, ok := statusField.Type.FieldByName("Parents")
 	require.True(t, ok, "%s.Status does not have a Parents field", routeTypeName)
-	require.Equal(t, parentsField.Type, reflect.TypeFor[[]v1alpha2.RouteParentStatus]())
+	require.Equal(t, parentsField.Type, reflect.TypeFor[[]gatewayv1.RouteParentStatus]())
 
 	return routeTypeName
 }
@@ -818,7 +817,7 @@ func RouteMustHaveParents(t *testing.T, cli client.Client, timeoutConfig config.
 			}
 		}
 
-		actual = reflect.ValueOf(cliObj).Elem().FieldByName("Status").FieldByName("Parents").Interface().([]v1alpha2.RouteParentStatus)
+		actual = reflect.ValueOf(cliObj).Elem().FieldByName("Status").FieldByName("Parents").Interface().([]gatewayv1.RouteParentStatus)
 		return parentsForRouteMatch(t, routeName, parents, actual, namespaceRequired), nil
 	})
 	require.NoErrorf(t, waitErr, "error waiting for %s to have parents matching expectations", routeTypeName)

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -516,7 +516,7 @@ func GatewayAndHTTPRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutCo
 // Gateway. The test will fail if these conditions are not met before the
 // timeouts.
 func GatewayAndUDPRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, controllerName string, gw GatewayRef, routeNNs ...types.NamespacedName) string {
-	return GatewayAndRoutesMustBeAccepted(t, c, timeoutConfig, controllerName, gw, &v1alpha2.UDPRoute{}, true, routeNNs...)
+	return GatewayAndRoutesMustBeAccepted(t, c, timeoutConfig, controllerName, gw, &gatewayv1.UDPRoute{}, true, routeNNs...)
 }
 
 // WaitForGatewayAddress waits until at least one IP Address has been set in the
@@ -835,14 +835,14 @@ func HTTPRouteMustHaveParents(t *testing.T, client client.Client, timeoutConfig 
 // in status that match the expected parents. This will cause the test to halt
 // if the specified timeout is exceeded.
 func UDPRouteMustHaveParents(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, routeName types.NamespacedName, parents []gatewayv1.RouteParentStatus, namespaceRequired bool) {
-	RouteMustHaveParents(t, client, timeoutConfig, routeName, parents, namespaceRequired, &v1alpha2.UDPRoute{})
+	RouteMustHaveParents(t, client, timeoutConfig, routeName, parents, namespaceRequired, &gatewayv1.UDPRoute{})
 }
 
 // TCPRouteMustHaveParents waits for the specified TCPRoute to have parents
 // in status that match the expected parents. This will cause the test to halt
 // if the specified timeout is exceeded.
 func TCPRouteMustHaveParents(t *testing.T, client client.Client, timeoutConfig config.TimeoutConfig, routeName types.NamespacedName, parents []gatewayv1.RouteParentStatus, namespaceRequired bool) {
-	RouteMustHaveParents(t, client, timeoutConfig, routeName, parents, namespaceRequired, &v1alpha2.TCPRoute{})
+	RouteMustHaveParents(t, client, timeoutConfig, routeName, parents, namespaceRequired, &gatewayv1.TCPRoute{})
 }
 
 // TCPRouteMustHaveCondition checks that the supplied TCPRoute has the supplied Condition,
@@ -851,7 +851,7 @@ func TCPRouteMustHaveCondition(t *testing.T, client client.Client, timeoutConfig
 	t.Helper()
 
 	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.TCPRouteMustHaveCondition, true, func(ctx context.Context) (bool, error) {
-		route := &v1alpha2.TCPRoute{}
+		route := &gatewayv1.TCPRoute{}
 		err := client.Get(ctx, routeNN, route)
 		if err != nil {
 			return false, fmt.Errorf("error fetching TCPRoute: %w", err)
@@ -886,7 +886,7 @@ func UDPRouteMustHaveCondition(t *testing.T, client client.Client, timeoutConfig
 	t.Helper()
 
 	waitErr := wait.PollUntilContextTimeout(context.Background(), timeoutConfig.DefaultPollInterval, timeoutConfig.UDPRouteMustHaveCondition, true, func(ctx context.Context) (bool, error) {
-		route := &v1alpha2.UDPRoute{}
+		route := &gatewayv1.UDPRoute{}
 		err := client.Get(ctx, routeNN, route)
 		if err != nil {
 			return false, fmt.Errorf("error fetching UDPRoute: %w", err)
@@ -924,7 +924,7 @@ func TCPRouteMustHaveNoAcceptedParents(t *testing.T, client client.Client, timeo
 	emptyChecked := false
 	// We explicitly do not use timeoutConfig.DefaultPollInterval here since we are doing negative testing
 	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.HTTPRouteMustNotHaveParents, true, func(ctx context.Context) (bool, error) {
-		route := &v1alpha2.TCPRoute{}
+		route := &gatewayv1.TCPRoute{}
 		err := client.Get(ctx, routeName, route)
 		if err != nil {
 			return false, fmt.Errorf("error fetching TCPRoute: %w", err)
@@ -966,7 +966,7 @@ func TCPRouteMustHaveNoAcceptedParents(t *testing.T, client client.Client, timeo
 // Gateway. The test will fail if these conditions are not met before the
 // timeouts.
 func GatewayAndTCPRoutesMustBeAccepted(t *testing.T, c client.Client, timeoutConfig config.TimeoutConfig, controllerName string, gw GatewayRef, routeNNs ...types.NamespacedName) string {
-	return GatewayAndRoutesMustBeAccepted(t, c, timeoutConfig, controllerName, gw, &v1alpha2.TCPRoute{}, true, routeNNs...)
+	return GatewayAndRoutesMustBeAccepted(t, c, timeoutConfig, controllerName, gw, &gatewayv1.TCPRoute{}, true, routeNNs...)
 }
 
 // TLSRouteMustHaveParents waits for the specified TLSRoute to have parents
@@ -1129,7 +1129,7 @@ func UDPRouteMustHaveNoAcceptedParents(t *testing.T, client client.Client, timeo
 	emptyChecked := false
 	// We explicitly do not use timeoutConfig.DefaultPollInterval here since we are doing negative testing
 	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeoutConfig.HTTPRouteMustNotHaveParents, true, func(ctx context.Context) (bool, error) {
-		route := &v1alpha2.UDPRoute{}
+		route := &gatewayv1.UDPRoute{}
 		err := client.Get(ctx, routeName, route)
 		if err != nil {
 			return false, fmt.Errorf("error fetching UDPRoute: %w", err)

--- a/examples/experimental/basic-tcp.yaml
+++ b/examples/experimental/basic-tcp.yaml
@@ -20,7 +20,7 @@ spec:
       kinds:
       - kind: TCPRoute
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-app-1
@@ -33,7 +33,7 @@ spec:
     - name: my-foo-service
       port: 6000
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: tcp-app-2

--- a/examples/experimental/destination-port-matching-tcp.yaml
+++ b/examples/experimental/destination-port-matching-tcp.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute
 metadata:
   name: destination-port-matching-example


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind cleanup

**What this PR does / why we need it**:

Updates the version of TCP && UDP Route in conformance tests to v1

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
