### PR TITLE
test(conformance): add test covering shared and dedicated routes across multiple Gateways

### DIFF
--- a/conformance/tests/httproute-multiple-gateways.go
+++ b/conformance/tests/httproute-multiple-gateways.go
@@ -1,0 +1,99 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteMultipleGateways)
+}
+
+var HTTPRouteMultipleGateways = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteMultipleGateways",
+	Description: "An HTTPRoute that is attached to multiple Gateways receives traffic from each Gateway independently, and shared routes are accessible via all parent Gateways while dedicated routes are only accessible via their respective parent.",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+	},
+	Manifests: []string{"tests/httproute-multiple-gateways.yaml"},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		t.Run("Gateway same-namespace", func(t *testing.T) {
+			t.Parallel()
+
+			routeNNs := []types.NamespacedName{
+				{Name: "multiple-gateways-shared-route", Namespace: confsuite.InfrastructureNamespace},
+				{Name: "same-namespace-dedicated-route", Namespace: confsuite.InfrastructureNamespace},
+			}
+			gwNN := types.NamespacedName{Name: "same-namespace", Namespace: confsuite.InfrastructureNamespace}
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNNs...)
+
+			t.Run("shared route is accessible and routed to infra-backend-v1", func(t *testing.T) {
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
+					Request:   http.Request{Path: "/shared"},
+					Response:  http.Response{StatusCode: 200},
+					Backend:   confsuite.InfraBackendServiceNameV1,
+					Namespace: confsuite.InfrastructureNamespace,
+				})
+			})
+			t.Run("dedicated route is accessible and routed to infra-backend-v2", func(t *testing.T) {
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
+					Request:   http.Request{Path: "/"},
+					Response:  http.Response{StatusCode: 200},
+					Backend:   confsuite.InfraBackendServiceNameV2,
+					Namespace: confsuite.InfrastructureNamespace,
+				})
+			})
+		})
+
+		t.Run("Gateway all-namespaces", func(t *testing.T) {
+			t.Parallel()
+
+			routeNNs := []types.NamespacedName{
+				{Name: "multiple-gateways-shared-route", Namespace: confsuite.InfrastructureNamespace},
+				{Name: "all-namespaces-dedicated-route", Namespace: confsuite.InfrastructureNamespace},
+			}
+			gwNN := types.NamespacedName{Name: "all-namespaces", Namespace: confsuite.InfrastructureNamespace}
+			gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNNs...)
+
+			t.Run("shared route is accessible and routed to infra-backend-v1", func(t *testing.T) {
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
+					Request:   http.Request{Path: "/shared"},
+					Response:  http.Response{StatusCode: 200},
+					Backend:   confsuite.InfraBackendServiceNameV1,
+					Namespace: confsuite.InfrastructureNamespace,
+				})
+			})
+			t.Run("dedicated route is accessible and routed to infra-backend-v3", func(t *testing.T) {
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
+					Request:   http.Request{Path: "/"},
+					Response:  http.Response{StatusCode: 200},
+					Backend:   confsuite.InfraBackendServiceNameV3,
+					Namespace: confsuite.InfrastructureNamespace,
+				})
+			})
+		})
+	},
+}

--- a/conformance/tests/httproute-multiple-gateways.yaml
+++ b/conformance/tests/httproute-multiple-gateways.yaml
@@ -9,12 +9,12 @@ spec:
   - name: all-namespaces
   rules:
   - matches:
-      - path:
-          type: PathPrefix
-          value: /shared
+    - path:
+        type: PathPrefix
+        value: /shared
     backendRefs:
-      - name: infra-backend-v1
-        port: 8080
+    - name: infra-backend-v1
+      port: 8080
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -23,15 +23,15 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: same-namespace
+  - name: same-namespace
   rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /
-      backendRefs:
-        - name: infra-backend-v2
-          port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -40,12 +40,12 @@ metadata:
   namespace: gateway-conformance-infra
 spec:
   parentRefs:
-    - name: all-namespaces
+  - name: all-namespaces
   rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /
-      backendRefs:
-        - name: infra-backend-v3
-          port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: infra-backend-v3
+      port: 8080

--- a/conformance/tests/httproute-multiple-gateways.yaml
+++ b/conformance/tests/httproute-multiple-gateways.yaml
@@ -1,0 +1,51 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: multiple-gateways-shared-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  - name: all-namespaces
+  rules:
+  - matches:
+      - path:
+          type: PathPrefix
+          value: /shared
+    backendRefs:
+      - name: infra-backend-v1
+        port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: same-namespace-dedicated-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: infra-backend-v2
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: all-namespaces-dedicated-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: all-namespaces
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: infra-backend-v3
+          port: 8080


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/kind test
/area conformance-test

**What this PR does / why we need it**:
So far, conformance tests only covered the case of a single HTTPRoute attached to a single Gateway. This PR adds a test verifying that an HTTPRoute attached to multiple parent Gateways correctly routes traffic from each Gateway independently. Covers both a shared route (attached to all parents) and dedicated routes (attached to a single parent), ensuring backends receive traffic only from their expected Gateway.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
