### PR TITLE
Fix: Clarify HTTPHeader duplicate and case-variant name handling

### DIFF
--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -1017,11 +1017,8 @@ type HTTPHeader struct {
 	// Name is the name of the HTTP Header to be matched. Name matching MUST be
 	// case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 	//
-	// If multiple entries specify equivalent header names, the first entry with
-	// an equivalent name MUST be considered for a match. Subsequent entries
-	// with an equivalent header name MUST be ignored. Due to the
-	// case-insensitivity of header names, "foo" and "Foo" are considered
-	// equivalent.
+	// Due to the case-insensitivity of header names, "foo" and "Foo" are
+	// considered equivalent.
 	// +required
 	Name HTTPHeaderName `json:"name"`
 
@@ -1048,6 +1045,10 @@ type HTTPHeaderFilter struct {
 	// Set overwrites the request with the given header (name, value)
 	// before the action.
 	//
+	// Only one action for a given header name is permitted. Filters
+	// specifying multiple actions of the same or different type for any
+	// one header name are invalid.
+	//
 	// Input:
 	//   GET /foo HTTP/1.1
 	//   my-header: foo
@@ -1070,6 +1071,10 @@ type HTTPHeaderFilter struct {
 	// Add adds the given header(s) (name, value) to the request
 	// before the action. It appends to any existing values associated
 	// with the header name.
+	//
+	// Only one action for a given header name is permitted. Filters
+	// specifying multiple actions of the same or different type for any
+	// one header name are invalid.
 	//
 	// Input:
 	//   GET /foo HTTP/1.1

--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -1014,15 +1014,19 @@ const (
 
 // HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.
 type HTTPHeader struct {
-	// Name is the name of the HTTP Header to be matched. Name matching MUST be
+	// Name is the name of the HTTP Header. Name matching MUST be
 	// case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 	//
 	// Due to the case-insensitivity of header names, "foo" and "Foo" are
-	// considered equivalent.
+	// considered equivalent. Each header name within an HTTPHeaderFilter list
+	// must be unique; entries with identical names are invalid. When two
+	// entries are equivalent only because of case (for example "foo" and
+	// "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+	// ignored.
 	// +required
 	Name HTTPHeaderName `json:"name"`
 
-	// Value is the value of HTTP Header to be matched.
+	// Value is the value of HTTP Header.
 	// <gateway:experimental:description>
 	// Must consist of printable US-ASCII characters, optionally separated
 	// by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -1044,10 +1048,6 @@ type HTTPHeader struct {
 type HTTPHeaderFilter struct {
 	// Set overwrites the request with the given header (name, value)
 	// before the action.
-	//
-	// Only one action for a given header name is permitted. Filters
-	// specifying multiple actions of the same or different type for any
-	// one header name are invalid.
 	//
 	// Input:
 	//   GET /foo HTTP/1.1
@@ -1071,10 +1071,6 @@ type HTTPHeaderFilter struct {
 	// Add adds the given header(s) (name, value) to the request
 	// before the action. It appends to any existing values associated
 	// with the header name.
-	//
-	// Only one action for a given header name is permitted. Filters
-	// specifying multiple actions of the same or different type for any
-	// one header name are invalid.
 	//
 	// Input:
 	//   GET /foo HTTP/1.1

--- a/applyconfiguration/apis/v1/httpheader.go
+++ b/applyconfiguration/apis/v1/httpheader.go
@@ -27,16 +27,17 @@ import (
 //
 // HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.
 type HTTPHeaderApplyConfiguration struct {
-	// Name is the name of the HTTP Header to be matched. Name matching MUST be
+	// Name is the name of the HTTP Header. Name matching MUST be
 	// case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 	//
-	// If multiple entries specify equivalent header names, the first entry with
-	// an equivalent name MUST be considered for a match. Subsequent entries
-	// with an equivalent header name MUST be ignored. Due to the
-	// case-insensitivity of header names, "foo" and "Foo" are considered
-	// equivalent.
+	// Due to the case-insensitivity of header names, "foo" and "Foo" are
+	// considered equivalent. Each header name within an HTTPHeaderFilter list
+	// must be unique; entries with identical names are invalid. When two
+	// entries are equivalent only because of case (for example "foo" and
+	// "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+	// ignored.
 	Name *apisv1.HTTPHeaderName `json:"name,omitempty"`
-	// Value is the value of HTTP Header to be matched.
+	// Value is the value of HTTP Header.
 	// <gateway:experimental:description>
 	// Must consist of printable US-ASCII characters, optionally separated
 	// by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -532,21 +532,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -611,21 +612,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -823,21 +825,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -902,21 +905,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -1200,21 +1204,22 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -1278,21 +1283,22 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -1489,21 +1495,22 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -1567,21 +1574,22 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -1084,21 +1084,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -1163,21 +1164,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -1531,21 +1533,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -1610,21 +1613,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -2609,21 +2613,22 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -2687,21 +2692,22 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -3054,21 +3060,22 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -3132,21 +3139,22 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -5345,21 +5353,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -5424,21 +5433,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -5792,21 +5802,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -5871,21 +5882,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: |-
-                                              Value is the value of HTTP Header to be matched.
+                                              Value is the value of HTTP Header.
 
                                               Must consist of printable US-ASCII characters, optionally separated
                                               by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -6870,21 +6882,22 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -6948,21 +6961,22 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -7315,21 +7329,22 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
@@ -7393,21 +7408,22 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
                                       description: |-
-                                        Value is the value of HTTP Header to be matched.
+                                        Value is the value of HTTP Header.
 
                                         Must consist of printable US-ASCII characters, optionally separated
                                         by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2

--- a/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
@@ -485,21 +485,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -560,21 +561,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -768,21 +770,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -843,21 +846,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -1137,21 +1141,21 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -1211,21 +1215,21 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -1418,21 +1422,21 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -1492,21 +1496,21 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -787,21 +787,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -862,21 +863,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -1226,21 +1228,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -1301,21 +1304,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -2041,21 +2045,21 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -2115,21 +2119,21 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -2478,21 +2482,21 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -2552,21 +2556,21 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -4235,21 +4239,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -4310,21 +4315,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -4674,21 +4680,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -4749,21 +4756,22 @@ spec:
                                         properties:
                                           name:
                                             description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              Name is the name of the HTTP Header. Name matching MUST be
                                               case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                              If multiple entries specify equivalent header names, the first entry with
-                                              an equivalent name MUST be considered for a match. Subsequent entries
-                                              with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
+                                              Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                              considered equivalent. Each header name within an HTTPHeaderFilter list
+                                              must be unique; entries with identical names are invalid. When two
+                                              entries are equivalent only because of case (for example "foo" and
+                                              "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                              ignored.
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           value:
                                             description: Value is the value of HTTP
-                                              Header to be matched.
+                                              Header.
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -5489,21 +5497,21 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -5563,21 +5571,21 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -5926,21 +5934,21 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string
@@ -6000,21 +6008,21 @@ spec:
                                   properties:
                                     name:
                                       description: |-
-                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        Name is the name of the HTTP Header. Name matching MUST be
                                         case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
-                                        If multiple entries specify equivalent header names, the first entry with
-                                        an equivalent name MUST be considered for a match. Subsequent entries
-                                        with an equivalent header name MUST be ignored. Due to the
-                                        case-insensitivity of header names, "foo" and "Foo" are considered
-                                        equivalent.
+                                        Due to the case-insensitivity of header names, "foo" and "Foo" are
+                                        considered equivalent. Each header name within an HTTPHeaderFilter list
+                                        must be unique; entries with identical names are invalid. When two
+                                        entries are equivalent only because of case (for example "foo" and
+                                        "Foo"), the first entry MUST be applied and the subsequent entry MUST be
+                                        ignored.
                                       maxLength: 256
                                       minLength: 1
                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                       type: string
                                     value:
-                                      description: Value is the value of HTTP Header
-                                        to be matched.
+                                      description: Value is the value of HTTP Header.
                                       maxLength: 4096
                                       minLength: 1
                                       type: string

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -4940,7 +4940,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_HTTPHeader(ref common.ReferenceCallbac
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is the name of the HTTP Header to be matched. Name matching MUST be case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with an equivalent name MUST be considered for a match. Subsequent entries with an equivalent header name MUST be ignored. Due to the case-insensitivity of header names, \"foo\" and \"Foo\" are considered equivalent.",
+							Description: "Name is the name of the HTTP Header. Name matching MUST be case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nDue to the case-insensitivity of header names, \"foo\" and \"Foo\" are considered equivalent. Each header name within an HTTPHeaderFilter list must be unique; entries with identical names are invalid. When two entries are equivalent only because of case (for example \"foo\" and \"Foo\"), the first entry MUST be applied and the subsequent entry MUST be ignored.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -4948,7 +4948,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_HTTPHeader(ref common.ReferenceCallbac
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Value is the value of HTTP Header to be matched. <gateway:experimental:description> Must consist of printable US-ASCII characters, optionally separated by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2 </gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+							Description: "Value is the value of HTTP Header. <gateway:experimental:description> Must consist of printable US-ASCII characters, optionally separated by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2 </gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/geps/overview/#process
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR updates the documentation for HTTPHeader and HTTPHeaderFilter which is outdated as of now.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/gateway-api/issues/4480

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Clarify HTTPHeader duplicate and case-variant handling in API docs

HTTPHeader is used only by HTTPHeaderFilter (set/add), not for matching, but its field docs were copied from the match type. They claimed a "first entry considered for a match, subsequent ignored" semantic, which contradicts actual behavior: set/add are listType=map keyed on name, so identical names are rejected as invalid (the issue's report).

  - Drop the "to be matched" wording from Name and Value (filter-only type).
  - State that identical names within a filter list are invalid, while names equivalent only by case (e.g. "foo"/"Foo") are accepted and resolved first-wins, since listMapKey uniqueness is case-sensitive.
  - Remove the per-field set/add notes that duplicated the existing HTTPHeaderFilter struct comment.
  - Regenerate applyconfiguration, OpenAPI, and CRDs.
```

Previous PR: https://github.com/kubernetes-sigs/gateway-api/pull/4633