### PR TITLE
Fix: Mark BackendTLSPolicy SANs and TLS Options as Standard Channel

### DIFF
--- a/site/content/en/reference/api-types/policy/backendtlspolicy.md
+++ b/site/content/en/reference/api-types/policy/backendtlspolicy.md
@@ -134,8 +134,8 @@ Also note:
 
 #### Subject Alternative Names
 
-{{< details title="Experimental Channel since v1.2.0" color="purple" >}}
-This field was added to BackendTLSPolicy in `v1.2.0`
+{{< details title="Standard Channel since v1.4.0" color="success" >}}
+This field was added to BackendTLSPolicy in `v1.2.0` and graduated to the Standard Channel in `v1.4.0`.
 {{< /details >}}
 
 The subjectAltNames field enables basic mutual TLS configuration between Gateways and backends, as well as the optional use of SPIFFE. When subjectAltNames is specified, the certificate served by the backend must have at least one Subject Alternative Name matching one of the specified values. This is particularly useful for SPIFFE implementations where URI-based SANs may not be valid SNIs.  
@@ -151,8 +151,8 @@ Subject Alternative Names may contain one of either a Hostname or URI field, and
 
 #### TLS Options
 
-{{< details title="Experimental Channel since v1.2.0" color="purple" >}}
-This field was added to BackendTLSPolicy in `v1.2.0`
+{{< details title="Standard Channel since v1.4.0" color="success" >}}
+This field was added to BackendTLSPolicy in `v1.2.0` and graduated to the Standard Channel in `v1.4.0`.
 {{< /details >}}
 
 The options field allows specification of implementation-specific TLS configurations. This can include:  

--- a/site/content/en/reference/api-types/policy/backendtlspolicy.md
+++ b/site/content/en/reference/api-types/policy/backendtlspolicy.md
@@ -134,8 +134,9 @@ Also note:
 
 #### Subject Alternative Names
 
-{{< details title="Standard Channel since v1.4.0" color="success" >}}
-This field was added to BackendTLSPolicy in `v1.2.0` and graduated to the Standard Channel in `v1.4.0`.
+{{< details title="Extended Support Feature: BackendTLSPolicySANValidation" open="true" >}}
+This feature is part of extended support, and requires your implementation to support the feature `BackendTLSPolicySANValidation`. For more information on support levels, refer to our [conformance guide](/docs/concepts/conformance/).
+
 {{< /details >}}
 
 The subjectAltNames field enables basic mutual TLS configuration between Gateways and backends, as well as the optional use of SPIFFE. When subjectAltNames is specified, the certificate served by the backend must have at least one Subject Alternative Name matching one of the specified values. This is particularly useful for SPIFFE implementations where URI-based SANs may not be valid SNIs.  
@@ -150,10 +151,6 @@ Subject Alternative Names may contain one of either a Hostname or URI field, and
 {{% /alert %}}
 
 #### TLS Options
-
-{{< details title="Standard Channel since v1.4.0" color="success" >}}
-This field was added to BackendTLSPolicy in `v1.2.0` and graduated to the Standard Channel in `v1.4.0`.
-{{< /details >}}
 
 The options field allows specification of implementation-specific TLS configurations. This can include:  
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
 The `BackendTLSPolicy` reference documentation, still list the `SAN` and `TLS Options` fields as experimental even though they are now part of the Standard Channel (1.4).

**Which issue(s) this PR fixes**:
Fixes [#4929 ](https://github.com/kubernetes-sigs/gateway-api/issues/4929)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```