### PR TITLE
[release-1.6] conformance: avoid mirror log races (Backport of #4887)

### DIFF
--- a/conformance/tests/httproute-request-mirror.go
+++ b/conformance/tests/httproute-request-mirror.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
@@ -104,8 +105,14 @@ var HTTPRouteRequestMirror = confsuite.ConformanceTest{
 			tc := testCases[i]
 			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
 				t.Parallel()
+				err := tc.AddRequestIDQueryParam(uuid.NewString())
+				if err != nil {
+					t.Fatalf("Invalid query in path: %v", err)
+				}
+				// Start inspecting logs before sending the request
+				waitForMirroredRequests := http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
+				defer waitForMirroredRequests() // clean-up in case we exit below
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
-				http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
 			})
 		}
 	},

--- a/conformance/tests/httproute-request-multiple-mirrors.go
+++ b/conformance/tests/httproute-request-multiple-mirrors.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
@@ -116,8 +117,14 @@ var HTTPRouteRequestMultipleMirrors = confsuite.ConformanceTest{
 			tc := testCases[i]
 			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
 				t.Parallel()
+				err := tc.AddRequestIDQueryParam(uuid.NewString())
+				if err != nil {
+					t.Fatalf("Invalid query in path: %v", err)
+				}
+				// Start inspecting logs before sending the request
+				waitForMirroredRequests := http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
+				defer waitForMirroredRequests() // clean-up in case we exit below
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
-				http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
 			})
 		}
 	},

--- a/conformance/tests/httproute-request-percentage-mirror.go
+++ b/conformance/tests/httproute-request-percentage-mirror.go
@@ -19,11 +19,11 @@ package tests
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -151,6 +151,10 @@ var HTTPRouteRequestPercentageMirror = confsuite.ConformanceTest{
 				var wg sync.WaitGroup
 
 				for k := range numDistributionChecks {
+					err := expected.AddRequestIDQueryParam(uuid.NewString())
+					if err != nil {
+						t.Fatalf("Invalid query in path: %v", err)
+					}
 					timeNow := time.Now()
 					for range int(totalRequests) {
 						wg.Add(1)
@@ -188,7 +192,7 @@ func testMirroredRequestsDistribution(t *testing.T, suite *confsuite.Conformance
 
 	for _, mirrorPod := range mirrorPods {
 		require.Eventually(t, func() bool {
-			mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to \\%s to client", expected.Request.Path))
+			mirrorLogRegexp := http.GetMirrorLogRegexp(expected.Request.Path)
 
 			tlog.Log(t, "Searching for the mirrored request log")
 			tlog.Logf(t, `Reading "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name)

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -81,6 +81,46 @@ type Request struct {
 	ClientCert       string
 }
 
+const requestIDQueryParam = "gateway-api-conformance-request-id"
+
+// AddRequestIDQueryParam adds a request ID to the request URI so that echo
+// server logs for this request can be matched unambiguously.
+// Returns a non-nil error if either Request.Path or ExpectedRequest.Path has an unparseable query.
+func (er *ExpectedResponse) AddRequestIDQueryParam(requestID string) error {
+	path, err := addQueryParam(er.Request.Path, requestIDQueryParam, requestID)
+	if err != nil {
+		return err
+	}
+	if er.ExpectedRequest != nil {
+		if er.ExpectedRequest.Path == "" {
+			er.ExpectedRequest.Path = path
+		} else {
+			er.ExpectedRequest.Path, err = addQueryParam(er.ExpectedRequest.Path, requestIDQueryParam, requestID)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	er.Request.Path = path
+	return nil
+}
+
+// addQueryParam adds 'name'='value' query parameter to the given 'rawURL' and returns it.
+// Returns an error if rawURL or its query cannot be parsed.
+func addQueryParam(rawURL, name, value string) (string, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	query, err := url.ParseQuery(parsedURL.RawQuery)
+	if err != nil {
+		return "", err
+	}
+	query.Set(name, value)
+	parsedURL.RawQuery = query.Encode()
+	return parsedURL.String(), nil
+}
+
 // ExpectedRequest defines expected properties of a request that reaches a backend.
 type ExpectedRequest struct {
 	Request

--- a/conformance/utils/http/mirror.go
+++ b/conformance/utils/http/mirror.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	clientset "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,15 +33,23 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
 )
 
-func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clientset.Interface, mirrorPods []MirroredBackend, path string, timeoutConfig config.TimeoutConfig) {
+func GetMirrorLogRegexp(path string) *regexp.Regexp {
+	return regexp.MustCompile(fmt.Sprintf("Echoing back request made to %s to client", regexp.QuoteMeta(path)))
+}
+
+func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clientset.Interface, mirrorPods []MirroredBackend, path string, timeoutConfig config.TimeoutConfig) func() {
 	for i, mirrorPod := range mirrorPods {
 		if mirrorPod.Name == "" {
 			tlog.Fatalf(t, "Mirrored BackendRef[%d].Name wasn't provided in the testcase, this test should only check http request mirror.", i)
 		}
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(len(mirrorPods))
+	mirrorLogRegexp := GetMirrorLogRegexp(path)
+
+	var done sync.WaitGroup
+	var started sync.WaitGroup
+	started.Add(len(mirrorPods))
+	results := make(chan bool, len(mirrorPods))
 
 	// Start the log window before the requests were sent, not at "now". The
 	// caller already dispatched the mirrored requests, and on a high-latency
@@ -55,12 +63,10 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 	assertionStart := time.Now().Add(-timeoutConfig.MaxTimeToConsistency)
 
 	for _, mirrorPod := range mirrorPods {
-		go func(mirrorPod MirroredBackend) {
-			defer wg.Done()
+		done.Go(func() {
+			var startedOnce sync.Once
 
-			require.Eventually(t, func() bool {
-				mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to \\%s to client", path))
-
+			success := assert.Eventually(t, func() bool {
 				tlog.Log(t, "Searching for the mirrored request log")
 				tlog.Logf(t, `Reading "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name)
 				logs, err := kubernetes.DumpEchoLogs(t.Context(), mirrorPod.Namespace, mirrorPod.Name, client, clientset, assertionStart)
@@ -69,12 +75,36 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 					return false
 				}
 
+				// Report as started after we have successfully dumped the logs for
+				// the first time.
+				startedOnce.Do(started.Done)
+
 				return slices.ContainsFunc(logs, mirrorLogRegexp.MatchString)
 			}, timeoutConfig.RequestTimeout, time.Second, `Couldn't find mirrored request in "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name)
-		}(mirrorPod)
+
+			// signal done even if all log dumps failed above.
+			startedOnce.Do(started.Done)
+			results <- success
+		})
 	}
 
-	wg.Wait()
+	// Wait until each watcher has either dumped logs at least once or timed out.
+	started.Wait()
 
-	tlog.Log(t, "Found mirrored request log in all desired backends")
+	// caller should eventually call the returned function to wait for the goroutines to be done
+	// and to log if successful
+	return func() {
+		done.Wait()
+		close(results)
+
+		successes := 0
+		for result := range results {
+			if result {
+				successes++
+			}
+		}
+		if successes == len(mirrorPods) {
+			tlog.Log(t, "Found mirrored request log in all desired backends")
+		}
+	}
 }


### PR DESCRIPTION
* conformance: avoid mirror log races

Start watching mirrored backend logs before sending mirror test requests, and add a unique request ID query parameter to the echoed URI matched in logs. This avoids flakes where the mirrored request is logged before the test starts reading logs, as seen in Cilium CI, and prevents logs from nearby test runs or retry attempts from satisfying the matcher.

Also add a small log timestamp lookback for node clock skew and quote the matched URI before building the regex.

* Address review comments

Fixed as suggested:

- Return error from the new AddRequestIDQueryParam(), fail test on error
- Removed adding query parameter on warm-up requests that were not searched from logs

Kept the defer of the clean-up function, revised comment to state it is for clean-up.

* http: Use url.Query

Use url.Query instead of open coding the query separation from the given path. 'addQueryParam' now works with full URLs or paths.

* http: Add Regexp helper and modernize WaitGroup use

Add GetMirrorLogRegexp() helper and use it instead of repeating the same code.

Modernize with WaitGroup.Go.

/kind cleanup

/area conformance-test

```release-note
NONE
```
