### PR TITLE
Added functionality to parse union tags and added first example

### DIFF
--- a/apis/v1/backendtlspolicy_types.go
+++ b/apis/v1/backendtlspolicy_types.go
@@ -30,6 +30,13 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // BackendTLSPolicy provides a way to configure how a Gateway
 // connects to a Backend via TLS.
+//
+// BackendTLSPolicy is a Union Feature: It is expected to be combined with
+// another feature that forwards traffic to a backend.
+//
+// <gateway:union:GRPCRoute>
+// <gateway:union:TLSRoute>
+// <gateway:union:HTTPRequestMirrorFilter>
 type BackendTLSPolicy struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/apis/v1/grpcroute_types.go
+++ b/apis/v1/grpcroute_types.go
@@ -55,6 +55,11 @@ import (
 // for the affected listener with a reason of "UnsupportedProtocol".
 // Implementations MAY also accept HTTP/2 connections with an upgrade from
 // HTTP/1, i.e. without prior knowledge.
+//
+// GRPCRoute is expected to interoperate with BackendTLSPolicy (a Union
+// Feature).
+//
+// <gateway:union:BackendTLSPolicy>
 type GRPCRoute struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -1313,6 +1313,11 @@ type HTTPURLRewriteFilter struct {
 }
 
 // HTTPRequestMirrorFilter defines configuration for the RequestMirror filter.
+//
+// HTTPRequestMirrorFilter is expected to interoperate with BackendTLSPolicy (a
+// Union Feature).
+//
+// <gateway:union:BackendTLSPolicy>
 type HTTPRequestMirrorFilter struct {
 	// BackendRef references a resource where mirrored requests are sent.
 	//

--- a/apis/v1/tlsroute_types.go
+++ b/apis/v1/tlsroute_types.go
@@ -33,6 +33,11 @@ import (
 //
 // If you need to forward traffic to a single target for a TLS listener, you
 // could choose to use a TCPRoute with a TLS listener.
+//
+// TLSRoute is expected to interoperate with BackendTLSPolicy (a Union
+// Feature).
+//
+// <gateway:union:BackendTLSPolicy>
 type TLSRoute struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/applyconfiguration/apis/v1/backendtlspolicy.go
+++ b/applyconfiguration/apis/v1/backendtlspolicy.go
@@ -33,6 +33,13 @@ import (
 // BackendTLSPolicy is a Direct Attached Policy.
 // BackendTLSPolicy provides a way to configure how a Gateway
 // connects to a Backend via TLS.
+//
+// BackendTLSPolicy is a Union Feature: It is expected to be combined with
+// another feature that forwards traffic to a backend.
+//
+// <gateway:union:GRPCRoute>
+// <gateway:union:TLSRoute>
+// <gateway:union:HTTPRequestMirrorFilter>
 type BackendTLSPolicyApplyConfiguration struct {
 	metav1.TypeMetaApplyConfiguration    `json:",inline"`
 	*metav1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/applyconfiguration/apis/v1/grpcroute.go
+++ b/applyconfiguration/apis/v1/grpcroute.go
@@ -57,6 +57,11 @@ import (
 // for the affected listener with a reason of "UnsupportedProtocol".
 // Implementations MAY also accept HTTP/2 connections with an upgrade from
 // HTTP/1, i.e. without prior knowledge.
+//
+// GRPCRoute is expected to interoperate with BackendTLSPolicy (a Union
+// Feature).
+//
+// <gateway:union:BackendTLSPolicy>
 type GRPCRouteApplyConfiguration struct {
 	metav1.TypeMetaApplyConfiguration    `json:",inline"`
 	*metav1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/applyconfiguration/apis/v1/httprequestmirrorfilter.go
+++ b/applyconfiguration/apis/v1/httprequestmirrorfilter.go
@@ -22,6 +22,11 @@ package v1
 // with apply.
 //
 // HTTPRequestMirrorFilter defines configuration for the RequestMirror filter.
+//
+// HTTPRequestMirrorFilter is expected to interoperate with BackendTLSPolicy (a
+// Union Feature).
+//
+// <gateway:union:BackendTLSPolicy>
 type HTTPRequestMirrorFilterApplyConfiguration struct {
 	// BackendRef references a resource where mirrored requests are sent.
 	//

--- a/applyconfiguration/apis/v1/tlsroute.go
+++ b/applyconfiguration/apis/v1/tlsroute.go
@@ -36,6 +36,11 @@ import (
 //
 // If you need to forward traffic to a single target for a TLS listener, you
 // could choose to use a TCPRoute with a TLS listener.
+//
+// TLSRoute is expected to interoperate with BackendTLSPolicy (a Union
+// Feature).
+//
+// <gateway:union:BackendTLSPolicy>
 type TLSRouteApplyConfiguration struct {
 	metav1.TypeMetaApplyConfiguration    `json:",inline"`
 	*metav1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -31,6 +31,9 @@ spec:
         description: |-
           BackendTLSPolicy provides a way to configure how a Gateway
           connects to a Backend via TLS.
+
+          BackendTLSPolicy is a Union Feature: It is expected to be combined with
+          another feature that forwards traffic to a backend.
         properties:
           apiVersion:
             description: |-
@@ -726,6 +729,9 @@ spec:
         description: |-
           BackendTLSPolicy provides a way to configure how a Gateway
           connects to a Backend via TLS.
+
+          BackendTLSPolicy is a Union Feature: It is expected to be combined with
+          another feature that forwards traffic to a backend.
         properties:
           apiVersion:
             description: |-

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -55,6 +55,9 @@ spec:
           for the affected listener with a reason of "UnsupportedProtocol".
           Implementations MAY also accept HTTP/2 connections with an upgrade from
           HTTP/1, i.e. without prior knowledge.
+
+          GRPCRoute is expected to interoperate with BackendTLSPolicy (a Union
+          Feature).
         properties:
           apiVersion:
             description: |-

--- a/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -31,6 +31,9 @@ spec:
 
           If you need to forward traffic to a single target for a TLS listener, you
           could choose to use a TCPRoute with a TLS listener.
+
+          TLSRoute is expected to interoperate with BackendTLSPolicy (a Union
+          Feature).
         properties:
           apiVersion:
             description: |-

--- a/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -31,6 +31,9 @@ spec:
         description: |-
           BackendTLSPolicy provides a way to configure how a Gateway
           connects to a Backend via TLS.
+
+          BackendTLSPolicy is a Union Feature: It is expected to be combined with
+          another feature that forwards traffic to a backend.
         properties:
           apiVersion:
             description: |-
@@ -708,6 +711,9 @@ spec:
         description: |-
           BackendTLSPolicy provides a way to configure how a Gateway
           connects to a Backend via TLS.
+
+          BackendTLSPolicy is a Union Feature: It is expected to be combined with
+          another feature that forwards traffic to a backend.
         properties:
           apiVersion:
             description: |-

--- a/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
@@ -55,6 +55,9 @@ spec:
           for the affected listener with a reason of "UnsupportedProtocol".
           Implementations MAY also accept HTTP/2 connections with an upgrade from
           HTTP/1, i.e. without prior knowledge.
+
+          GRPCRoute is expected to interoperate with BackendTLSPolicy (a Union
+          Feature).
         properties:
           apiVersion:
             description: |-

--- a/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
@@ -31,6 +31,9 @@ spec:
 
           If you need to forward traffic to a single target for a TLS listener, you
           could choose to use a TCPRoute with a TLS listener.
+
+          TLSRoute is expected to interoperate with BackendTLSPolicy (a Union
+          Feature).
         properties:
           apiVersion:
             description: |-

--- a/hack/crd-ref-templates/README.md
+++ b/hack/crd-ref-templates/README.md
@@ -2,4 +2,8 @@ The templates contained in this directory were copied from https://github.com/el
 and had the following modifications:
 
 - `type.tpl` - Adds an "experimental" marker in case the API field is marked as "experimental"
+- `type.tpl` - Adds a "Union Feature" marker, linking to the related type(s), in case a type or field's doc comment
+  contains one or more `<gateway:union:FeatureName>` tags (e.g. `<gateway:union:BackendTLSPolicy>`). This mirrors the
+  "experimental" marker above and is used to cross-reference [union features](/guides/implementers-guide/#union-feature-conformance)
+  with the resources/fields they are expected to interoperate with.
 - `type_members.tpl` - Removes the text between tags `<gateway:util:excludeFromCRD></gateway:util:excludeFromCRD>`

--- a/hack/crd-ref-templates/type.tpl
+++ b/hack/crd-ref-templates/type.tpl
@@ -1,3 +1,13 @@
+{{- define "unionFeatureLinks" -}}
+{{- $doc := . -}}
+{{- $tags := regexFindAll "<gateway:union:[A-Za-z]+>" $doc -1 -}}
+{{- range $i, $tag := $tags -}}
+{{- if $i }}, {{ end -}}
+{{- $name := trimSuffix ">" (trimPrefix "<gateway:union:" $tag) -}}
+[{{ $name }}](#{{ lower $name }})
+{{- end -}}
+{{- end -}}
+
 {{- define "type" -}}
 {{- $type := . -}}
 {{- if markdownShouldRenderType $type -}}
@@ -8,6 +18,10 @@
 
 {{ $type.Doc }}
 
+{{ if contains "<gateway:union:" $type.Doc -}}
+:link: **Union Feature**: works with {{ template "unionFeatureLinks" $type.Doc }}
+
+{{ end -}}
 {{ if $type.Validation -}}
 _Validation:_
 {{- range $type.Validation }}
@@ -36,7 +50,7 @@ _Appears in:_
 {{ end -}}
 
 {{ range $type.Members -}}
-| `{{ .Name  }}` _{{ markdownRenderType .Type }}_ {{- if contains "<gateway:experimental>" .Doc -}}<br /> :warning: **Experimental**{{ end -}}| {{ template "type_members" . }} | {{ markdownRenderDefault .Default }} | {{ range .Validation -}} {{ markdownRenderFieldDoc . }} <br />{{ end }} |
+| `{{ .Name  }}` _{{ markdownRenderType .Type }}_ {{- if contains "<gateway:experimental>" .Doc -}}<br /> :warning: **Experimental**{{ end -}}{{- if contains "<gateway:union:" .Doc -}}<br /> :link: **Union Feature**: works with {{ template "unionFeatureLinks" .Doc }}{{ end -}}| {{ template "type_members" . }} | {{ markdownRenderDefault .Default }} | {{ range .Validation -}} {{ markdownRenderFieldDoc . }} <br />{{ end }} |
 {{ end -}}
 
 {{ end -}}

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3081,7 +3081,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_BackendTLSPolicy(ref common.ReferenceC
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "BackendTLSPolicy provides a way to configure how a Gateway connects to a Backend via TLS.",
+				Description: "BackendTLSPolicy provides a way to configure how a Gateway connects to a Backend via TLS.\n\nBackendTLSPolicy is a Union Feature: It is expected to be combined with another feature that forwards traffic to a backend.\n\n<gateway:union:GRPCRoute> <gateway:union:TLSRoute> <gateway:union:HTTPRequestMirrorFilter>",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
@@ -3683,7 +3683,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_GRPCRoute(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "GRPCRoute provides a way to route gRPC requests. This includes the capability to match requests by hostname, gRPC service, gRPC method, or HTTP/2 header. Filters can be used to specify additional processing steps. Backends specify where matching requests will be routed.\n\nGRPCRoute falls under extended support within the Gateway API. Within the following specification, the word \"MUST\" indicates that an implementation supporting GRPCRoute must conform to the indicated requirement, but an implementation not supporting this route type need not follow the requirement unless explicitly indicated.\n\nImplementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST accept HTTP/2 connections without an initial upgrade from HTTP/1.1, i.e. via ALPN. If the implementation does not support this, then it MUST set the \"Accepted\" condition to \"False\" for the affected listener with a reason of \"UnsupportedProtocol\".  Implementations MAY also accept HTTP/2 connections with an upgrade from HTTP/1.\n\nImplementations supporting `GRPCRoute` with the `HTTP` `ProtocolType` MUST support HTTP/2 over cleartext TCP (h2c, https://www.rfc-editor.org/rfc/rfc7540#section-3.1) without an initial upgrade from HTTP/1.1, i.e. with prior knowledge (https://www.rfc-editor.org/rfc/rfc7540#section-3.4). If the implementation does not support this, then it MUST set the \"Accepted\" condition to \"False\" for the affected listener with a reason of \"UnsupportedProtocol\". Implementations MAY also accept HTTP/2 connections with an upgrade from HTTP/1, i.e. without prior knowledge.",
+				Description: "GRPCRoute provides a way to route gRPC requests. This includes the capability to match requests by hostname, gRPC service, gRPC method, or HTTP/2 header. Filters can be used to specify additional processing steps. Backends specify where matching requests will be routed.\n\nGRPCRoute falls under extended support within the Gateway API. Within the following specification, the word \"MUST\" indicates that an implementation supporting GRPCRoute must conform to the indicated requirement, but an implementation not supporting this route type need not follow the requirement unless explicitly indicated.\n\nImplementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST accept HTTP/2 connections without an initial upgrade from HTTP/1.1, i.e. via ALPN. If the implementation does not support this, then it MUST set the \"Accepted\" condition to \"False\" for the affected listener with a reason of \"UnsupportedProtocol\".  Implementations MAY also accept HTTP/2 connections with an upgrade from HTTP/1.\n\nImplementations supporting `GRPCRoute` with the `HTTP` `ProtocolType` MUST support HTTP/2 over cleartext TCP (h2c, https://www.rfc-editor.org/rfc/rfc7540#section-3.1) without an initial upgrade from HTTP/1.1, i.e. with prior knowledge (https://www.rfc-editor.org/rfc/rfc7540#section-3.4). If the implementation does not support this, then it MUST set the \"Accepted\" condition to \"False\" for the affected listener with a reason of \"UnsupportedProtocol\". Implementations MAY also accept HTTP/2 connections with an upgrade from HTTP/1, i.e. without prior knowledge.\n\nGRPCRoute is expected to interoperate with BackendTLSPolicy (a Union Feature).\n\n<gateway:union:BackendTLSPolicy>",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
@@ -5237,7 +5237,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_HTTPRequestMirrorFilter(ref common.Ref
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "HTTPRequestMirrorFilter defines configuration for the RequestMirror filter.",
+				Description: "HTTPRequestMirrorFilter defines configuration for the RequestMirror filter.\n\nHTTPRequestMirrorFilter is expected to interoperate with BackendTLSPolicy (a Union Feature).\n\n<gateway:union:BackendTLSPolicy>",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"backendRef": {
@@ -7701,7 +7701,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_TLSRoute(ref common.ReferenceCallback)
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "The TLSRoute resource is similar to TCPRoute, but can be configured to match against TLS-specific metadata. This allows more flexibility in matching streams for a given TLS listener.\n\nIf you need to forward traffic to a single target for a TLS listener, you could choose to use a TCPRoute with a TLS listener.",
+				Description: "The TLSRoute resource is similar to TCPRoute, but can be configured to match against TLS-specific metadata. This allows more flexibility in matching streams for a given TLS listener.\n\nIf you need to forward traffic to a single target for a TLS listener, you could choose to use a TCPRoute with a TLS listener.\n\nTLSRoute is expected to interoperate with BackendTLSPolicy (a Union Feature).\n\n<gateway:union:BackendTLSPolicy>",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {

--- a/site/content/en/guides/user-guides/http-request-mirroring.md
+++ b/site/content/en/guides/user-guides/http-request-mirroring.md
@@ -25,3 +25,13 @@ responses to clients in any way.
 In this example, all requests are forwarded to service `foo-v1` on port `8080`,
 and they are also forwarded to service `foo-v2` on port `8080`, but responses
 are only generated from service `foo-v1`.
+
+{{% alert color="info" title="Union Feature" %}}
+
+The RequestMirror filter is expected to interoperate with
+[BackendTLSPolicy](/reference/api-types/policy/backendtlspolicy/), a
+[union feature](/guides/implementers-guide/#union-feature-conformance) that
+configures TLS from the Gateway to a mirrored backend, the same way it does
+for any other backend a Route forwards traffic to.
+
+{{% /alert %}}

--- a/site/content/en/reference/api-types/grpcroute.md
+++ b/site/content/en/reference/api-types/grpcroute.md
@@ -106,6 +106,15 @@ that create Gateway API routes) should consider the following:
 - Do not add gRPC-specific policy (such as retries on gRPC status codes) to
   `HTTPRoute`. Keep gRPC-aware configuration in `GRPCRoute` only.
 
+{{% alert color="info" title="Union Feature" %}}
+
+GRPCRoute is expected to interoperate with
+[BackendTLSPolicy](/reference/api-types/policy/backendtlspolicy/), a
+[union feature](/guides/implementers-guide/#union-feature-conformance) that
+configures TLS from the Gateway to a backend, in the same way HTTPRoute does.
+
+{{% /alert %}}
+
 ## Spec
 
 The specification of a GRPCRoute consists of:

--- a/site/content/en/reference/api-types/policy/backendtlspolicy.md
+++ b/site/content/en/reference/api-types/policy/backendtlspolicy.md
@@ -95,7 +95,10 @@ flowchart LR
 While the diagram above shows an HTTPRoute, BackendTLSPolicy is a
 [union feature](/guides/implementers-guide/#union-feature-conformance) and
 works with any route type that forwards traffic to backends, including
-GRPCRoute and TLSRoute (when in Terminate mode).
+[GRPCRoute](/reference/api-types/grpcroute/) and
+[TLSRoute](/reference/api-types/tlsroute/) (when in Terminate mode). It also
+applies to traffic sent to a backend via an HTTPRoute's
+[RequestMirror filter](/guides/user-guides/http-request-mirroring/).
 
 {{% /alert %}}
 

--- a/site/content/en/reference/api-types/tlsroute.md
+++ b/site/content/en/reference/api-types/tlsroute.md
@@ -55,6 +55,18 @@ TLSRoute can be used in these cases, where the traffic between the client and
 Gateway is encrypted and contains the SNI hostname, which can be used to decide
 which backend should be used for this request.
 
+{{% alert color="info" title="Union Feature" %}}
+
+When attached to a Listener with `tls.mode` set to `Terminate`, TLSRoute is
+expected to interoperate with
+[BackendTLSPolicy](/reference/api-types/policy/backendtlspolicy/), a
+[union feature](/guides/implementers-guide/#union-feature-conformance) that
+configures TLS from the Gateway to a backend. This does not apply to TLSRoute
+in `Passthrough` mode, since the Gateway never terminates the encrypted
+connection in that mode.
+
+{{% /alert %}}
+
 ## Spec
 
 The specification of a TLSRoute consists of:

--- a/tools/generator/main.go
+++ b/tools/generator/main.go
@@ -142,6 +142,12 @@ func main() {
 					channelCrd.Spec.Versions[i].Served = false
 				}
 				version.Schema.OpenAPIV3Schema.Properties = gatewayTweaksMap(channel, version.Schema.OpenAPIV3Schema.Properties)
+
+				// gatewayTweaksMap only walks Properties, so the Kind's own
+				// doc comment (the top level schema description) never gets
+				// touched. If not parsed by formatDescription,
+				// tags like <gateway:union:...> leak straight into the CRD.
+				version.Schema.OpenAPIV3Schema.Description = formatDescription(version.Schema.OpenAPIV3Schema.Description, channel, groupKind.Kind)
 			}
 
 			convObj, err := crd.AsVersion(*channelCrd, apiext.SchemeGroupVersion)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
/kind documentation
/kind feature

**What this PR does / why we need it**:
This PR introduces the union tag that can be added to resources to link them to ones that are used together. crd-ref-docs renders it as a "Union Feature" badge linking to the partner type(s). Moreover the sentence explaining the relationships will also be added to respective CRDs, as this is user facing information that users might want to discover via `kubectl explain`. 
crd-ref-docs adds the union links to the schema docs automatically. To the non-refdocs docs, one needs to add them by hand.

I have also added a first example for the interaction of BackendTLSPolicy with GRPCRoute, TLSRoute, and HTTPRequestMirrorFilter. Below are attached screenshots of how this will be displayed:

**refdocs:**
<img width="713" height="286" alt="Screenshot 2026-06-28 at 19 17 19" src="https://github.com/user-attachments/assets/183d8bd1-9c0e-4d45-bdf6-9d3f84f1f5d9" />
(Note the raw tags are also present like this with the experimental tag formatting, thus I did not change it)

**user written docs:**
<img width="968" height="313" alt="Screenshot 2026-06-28 at 19 16 35" src="https://github.com/user-attachments/assets/ac765031-edad-49fe-a69e-83a98b4796d8" />


I will add all additional ones, if the core logic of this PR is deemed as mergeable.

CC @mikemorris 

**Which issue(s) this PR fixes**:
Fixes #4766 

**Does this PR introduce a user-facing change?**:
```release-note
Adds a "Union Feature" marker, linking to the related type(s), in case a type or field's doc comment contains one or more `<gateway:union:FeatureName>` tags (e.g. `<gateway:union:BackendTLSPolicy>`). This is used to cross-reference [union features](/guides/implementers-guide/#union-feature-conformance) with the resources/fields they are expected to interoperate with.
```
