### PR TITLE
conformance: make static address test eventually consistent

### DIFF
--- a/conformance/tests/gateway-static-addresses.go
+++ b/conformance/tests/gateway-static-addresses.go
@@ -134,7 +134,13 @@ var GatewayStaticAddresses = suite.ConformanceTest{
 			Reason: string(v1.GatewayReasonProgrammed),
 		})
 		kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, finalExpectedListenerState)
-		require.Len(t, currentGW.Spec.Addresses, 1, "expected only 1 address left specified on Gateway")
+		require.Eventually(t, func() bool {
+			err = s.Client.Get(ctx, gwNN, currentGW)
+			if err != nil {
+				return false
+			}
+			return len(currentGW.Status.Addresses) == 1
+		}, s.TimeoutConfig.GatewayMustHaveAddress, s.TimeoutConfig.DefaultPollInterval, "expected only 1 status address on Gateway")
 		statusAddresses := extractStatusAddresses(currentGW.Status.Addresses)
 		require.NotContains(t, statusAddresses, unusableAddress.Value, "should not contain the unusable address")
 		require.NotContains(t, statusAddresses, invalidAddress.Value, "should not contain the invalid address")


### PR DESCRIPTION

**What type of PR is this?**

/area conformance-test

**What this PR does / why we need it**:
This test was assuming that observing Programmed=True and matching listener status implies status.addresses has already been written in the same status observation. Gateway API does not require that atomicity. Address publication is an eventually consistent status field, and the suite already has GatewayMustHaveAddress timeout semantics for this. The test should wait for the address field it asserts, rather than relying on other status fields as a proxy.

In the late v1.6.0 change after rc1 this test was made parallel which makes this issue happen much more often for us, as Metallb gets overwhelmed and delays provisioning of the address.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
