### PR TITLE
fix: preserve '=' in conformance key-value flags

### DIFF
--- a/conformance/utils/suite/conformance.go
+++ b/conformance/utils/suite/conformance.go
@@ -112,7 +112,7 @@ func ParseKeyValuePairs(f string) map[string]string {
 	}
 	res := map[string]string{}
 	for kv := range strings.SplitSeq(f, ",") {
-		parts := strings.Split(kv, "=")
+		parts := strings.SplitN(kv, "=", 2)
 		if len(parts) == 2 {
 			res[parts[0]] = parts[1]
 		}

--- a/conformance/utils/suite/conformance_test.go
+++ b/conformance/utils/suite/conformance_test.go
@@ -54,11 +54,13 @@ func TestParseKeyValuePairs(t *testing.T) {
 		"",
 		"a=b",
 		"b=c,d=e,f=g",
+		"example.com/url=https://x.test/path?a=b",
 	}
 	labels := []map[string]string{
 		nil,
 		{"a": "b"},
 		{"b": "c", "d": "e", "f": "g"},
+		{"example.com/url": "https://x.test/path?a=b"},
 	}
 
 	for i, f := range flags {


### PR DESCRIPTION
/kind bug
/area conformance-test

**What type of PR is this?**
/kind bug
/area conformance-test

**What this PR does / why we need it**:
`ParseKeyValuePairs()` split on every `=`.
So `--namespace-annotations example.com/url=https://x.test/path?a=b` got dropped and turned into an empty map. Kinda sneaky.

This switches to `strings.SplitN(..., 2)` and adds a regression test. Small fix, but it saves a pretty real footgun.

**Which issue(s) this PR fixes**:
None found.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

Repro:
```bash
cat <<'REPRO' >/tmp/repro.go
package main

import (
  "fmt"
  "sigs.k8s.io/gateway-api/conformance/utils/suite"
)

func main() {
  fmt.Printf("%#v\n", suite.ParseKeyValuePairs("example.com/url=https://x.test/path?a=b"))
}
REPRO
go run /tmp/repro.go
```

Before this patch, output was `map[string]string{}`.
After this patch, output is `map[string]string{"example.com/url":"https://x.test/path?a=b"}`.
