### PR TITLE
fix: apply missing conformance timeout defaults

### DIFF
--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -307,6 +307,12 @@ func SetupTimeoutConfig(timeoutConfig *TimeoutConfig) {
 	if timeoutConfig.GatewayListenersMustHaveConditions == 0 {
 		timeoutConfig.GatewayListenersMustHaveConditions = defaultTimeoutConfig.GatewayListenersMustHaveConditions
 	}
+	if timeoutConfig.ListenerSetMustHaveCondition == 0 {
+		timeoutConfig.ListenerSetMustHaveCondition = defaultTimeoutConfig.ListenerSetMustHaveCondition
+	}
+	if timeoutConfig.ListenerSetListenersMustHaveConditions == 0 {
+		timeoutConfig.ListenerSetListenersMustHaveConditions = defaultTimeoutConfig.ListenerSetListenersMustHaveConditions
+	}
 	if timeoutConfig.GWCMustBeAccepted == 0 {
 		timeoutConfig.GWCMustBeAccepted = defaultTimeoutConfig.GWCMustBeAccepted
 	}
@@ -348,5 +354,8 @@ func SetupTimeoutConfig(timeoutConfig *TimeoutConfig) {
 	}
 	if timeoutConfig.DefaultPollInterval == 0 {
 		timeoutConfig.DefaultPollInterval = defaultTimeoutConfig.DefaultPollInterval
+	}
+	if timeoutConfig.RequiredConsecutiveSuccesses == 0 {
+		timeoutConfig.RequiredConsecutiveSuccesses = defaultTimeoutConfig.RequiredConsecutiveSuccesses
 	}
 }

--- a/conformance/utils/config/timeout_test.go
+++ b/conformance/utils/config/timeout_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupTimeoutConfigAppliesAllDefaults(t *testing.T) {
+	cfg := TimeoutConfig{}
+
+	require.NoError(t, json.Unmarshal([]byte(`{"createTimeout":"5s"}`), &cfg))
+
+	SetupTimeoutConfig(&cfg)
+
+	defaults := DefaultTimeoutConfig()
+
+	assert.Equal(t, 5, int(cfg.CreateTimeout.Seconds()))
+	assert.NotEqual(t, 5, int(defaults.CreateTimeout.Seconds()))
+	assert.Equal(t, defaults.ListenerSetMustHaveCondition, cfg.ListenerSetMustHaveCondition)
+	assert.Equal(t, defaults.ListenerSetListenersMustHaveConditions, cfg.ListenerSetListenersMustHaveConditions)
+	assert.Equal(t, defaults.RequiredConsecutiveSuccesses, cfg.RequiredConsecutiveSuccesses)
+}


### PR DESCRIPTION
What type of PR is this?
/kind bug
/kind regression
/area conformance-machinery

What this PR does / why we need it:
`SetupTimeoutConfig()` missed defaults for `ListenerSetMustHaveCondition`, `ListenerSetListenersMustHaveConditions`, and `RequiredConsecutiveSuccesses`.

With a partial timeout config, those values stay `0` after unmarshal plus setup. That makes ListenerSet checks use `0s` timeouts and consistency checks use `0` required successes. Kinda busted.

Repro:
1. Unmarshal a partial timeout config like `{"createTimeout":"5s"}` into `config.TimeoutConfig`.
2. Call `SetupTimeoutConfig(&cfg)`.
3. On `main`, those 3 fields still stay `0`.

This PR fills the missing defaults and adds a test for the real config-loading path.

Which issue(s) this PR fixes:
None

Does this PR introduce a user-facing change?
```release-note
NONE
```
