### PR TITLE
conformance: wait for TCP and UDP weighted routes to accept traffic

### DIFF
--- a/conformance/tests/tcproute-weighted-routing.go
+++ b/conformance/tests/tcproute-weighted-routing.go
@@ -61,6 +61,8 @@ var TCPRouteWeightedRouting = confsuite.ConformanceTest{
 				"tcp-backend-v3": 0.0,
 			}
 
+			tcp.ExpectAddressBeAvailable(t, suite.TimeoutConfig.DefaultPollInterval, suite.TimeoutConfig.MaxTimeToConsistency, gwAddr)
+
 			sender := weight.NewFunctionBasedSender(func() (string, error) {
 				return tcp.EchoSendOnce(t.Context(), gwAddr, suite.TimeoutConfig.RequestTimeout)
 			})

--- a/conformance/tests/udproute-weighted-routing.go
+++ b/conformance/tests/udproute-weighted-routing.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
+	"sigs.k8s.io/gateway-api/conformance/utils/udp"
 	"sigs.k8s.io/gateway-api/conformance/utils/weight"
 	"sigs.k8s.io/gateway-api/pkg/features"
 )
@@ -69,6 +70,8 @@ var UDPRouteWeightedRouting = confsuite.ConformanceTest{
 				"udp-backend-v2": 0.3,
 				"udp-backend-v3": 0.0,
 			}
+
+			udp.ExpectEchoResponse(t, suite.TimeoutConfig.MaxTimeToConsistency, gwAddr)
 
 			sender := weight.NewFunctionBasedSender(func() (string, error) {
 				return udpEchoSendOnce(t.Context(), gwAddr, 2*time.Second)

--- a/conformance/utils/tcp/tcp.go
+++ b/conformance/utils/tcp/tcp.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	tcpserver "sigs.k8s.io/gateway-api/conformance/echo-basic/tcpserver"
 	"sigs.k8s.io/gateway-api/conformance/utils/config"
@@ -204,4 +205,30 @@ func EchoSendOnce(ctx context.Context, gwAddr string, timeout time.Duration) (st
 		return "", fmt.Errorf("TCP echo response missing pod name: %q", line)
 	}
 	return resp.Pod, nil
+}
+
+// ExpectAddressBeAvailable polls until a TCP connection to the provided address
+// can be established, or fails the test if the timeout expires. It only verifies
+// that the address accepts TCP connections; it does not validate an echo response
+// or backend selection.
+func ExpectAddressBeAvailable(t *testing.T, interval, timeout time.Duration, address string) {
+	t.Helper()
+
+	tlog.Logf(t, "performing TCP connection probe on %s", address)
+	err := wait.PollUntilContextTimeout(t.Context(), interval, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			var dialer net.Dialer
+			conn, err := dialer.DialContext(ctx, "tcp", address)
+			if err != nil {
+				tlog.Logf(t, "failed to establish TCP connection to %s; retrying: %v", address, err)
+				return false, nil
+			}
+			tlog.Logf(t, "established TCP connection to %s", address)
+			if err := conn.Close(); err != nil {
+				tlog.Logf(t, "failed to close TCP probe connection to %s: %v", address, err)
+			}
+
+			return true, nil
+		})
+	require.NoError(t, err, "failed waiting for TCP connection to %s after %v", address, timeout)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
/kind test
/kind flake
/area conformance-test

**What this PR does / why we need it**:

This PR adds readiness probes before TCPRoute and UDPRoute weighted distribution sampling begins.

The TCP test now waits for the Gateway address to accept TCP connections. The UDP test reuses the existing echo-response helper, since UDP dial alone does not prove data-plane readiness.

**Which issue(s) this PR fixes**:

Fixes #5039.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Fix flaky `TCPRouteWeightedRouting` and `UDPRouteWeightedRouting` conformance tests by adding a data-plane readiness check before performing weighted routing assertions.
```
