### PR TITLE
conformance: add Amazon VPC Lattice Gateway API Controller report for gateway v1.5

### DIFF
--- a/conformance/reports/v1.5/aws-aws-application-networking-k8s/README.md
+++ b/conformance/reports/v1.5/aws-aws-application-networking-k8s/README.md
@@ -1,0 +1,15 @@
+# Amazon VPC Lattice Gateway API Controller
+
+The [Amazon VPC Lattice Gateway API Controller](https://github.com/aws/aws-application-networking-k8s) is an implementation of the Kubernetes Gateway API that orchestrates AWS VPC Lattice resources using Kubernetes Custom Resource Definitions like Gateway and HTTPRoute.
+
+## Table of contents
+
+| API channel  | Implementation version | Mode    | Report |
+|--------------|------------------------|---------|--------|
+| experimental | [v2.1.2](https://github.com/aws/aws-application-networking-k8s/releases/tag/v2.1.2) | default | [v2.1.2 report](./experimental-v2.1.2-default-report.yaml) |
+
+## Reproduce
+
+1. Create an EKS cluster with VPC Lattice configured in the same VPC.
+2. Install the Amazon VPC Lattice Gateway API Controller v2.1.2.
+3. Follow the conformance test instructions in the [controller documentation](https://github.com/aws/aws-application-networking-k8s/blob/main/test/conformance/README.md).

--- a/conformance/reports/v1.5/aws-aws-application-networking-k8s/experimental-v2.1.2-default-report.yaml
+++ b/conformance/reports/v1.5/aws-aws-application-networking-k8s/experimental-v2.1.2-default-report.yaml
@@ -1,0 +1,45 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-07-07T18:25:07Z"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.5.0
+implementation:
+  contact:
+  - https://github.com/aws/aws-application-networking-k8s/issues
+  organization: aws
+  project: aws-application-networking-k8s
+  url: https://github.com/aws/aws-application-networking-k8s
+  version: v2.1.2
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: partial
+    skippedTests:
+    - GatewayInvalidTLSConfiguration
+    - GatewaySecretInvalidReferenceGrant
+    - GatewaySecretMissingReferenceGrant
+    - GatewayWithAttachedRoutes
+    - HTTPRouteHTTPSListener
+    - HTTPRouteHeaderMatching
+    - HTTPRouteHostnameIntersection
+    - HTTPRouteInvalidBackendRefUnknownKind
+    - HTTPRouteInvalidCrossNamespaceBackendRef
+    - HTTPRouteInvalidReferenceGrant
+    - HTTPRouteListenerHostnameMatching
+    - HTTPRouteMatching
+    - HTTPRouteMatchingAcrossRoutes
+    - HTTPRouteObservedGenerationBump
+    - HTTPRoutePartiallyInvalidViaInvalidReferenceGrant
+    - HTTPRoutePathMatchOrder
+    - HTTPRouteRedirectHostAndStatus
+    - HTTPRouteReferenceGrant
+    - HTTPRouteRequestHeaderModifier
+    - HTTPRouteServiceTypes
+    - HTTPRouteSimpleSameNamespace
+    - HTTPRouteWeight
+    statistics:
+      Failed: 0
+      Passed: 11
+      Skipped: 22
+  name: GATEWAY-HTTP
+  summary: Core tests partially succeeded with 22 test skips.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Adds conformance report for the Amazon VPC Lattice Gateway API Controller [v2.1.2](https://github.com/aws/aws-application-networking-k8s/releases/tag/v2.1.2)

**Which issue(s) this PR fixes**:
n/a

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
