### PR TITLE
GEP-1619: Default cookie path to / and add explicit path field

### DIFF
--- a/apis/v1/shared_types.go
+++ b/apis/v1/shared_types.go
@@ -1002,6 +1002,23 @@ type CookieConfig struct {
 	// +optional
 	Name *CookieName `json:"name,omitempty"`
 
+	// Path defines the cookie Path attribute. When not specified,
+	// implementations MUST default the cookie path to "/".
+	//
+	// <gateway:util:excludeFromCRD>
+	// This field is Extended because not all dataplanes support
+	// configuring the cookie path (e.g. HAProxy hardcodes path=/).
+	// Implementations SHOULD support this field if the underlying
+	// dataplane allows setting the cookie path attribute.
+	// </gateway:util:excludeFromCRD>
+	//
+	// Support: Extended
+	//
+	// +optional
+	// +kubebuilder:default="/"
+	// +kubebuilder:validation:MaxLength=1024
+	Path *string `json:"path,omitempty"`
+
 	// LifetimeType specifies whether the cookie has a permanent or
 	// session-based lifetime. A permanent cookie persists until its
 	// specified expiry time, defined by the Expires or Max-Age cookie

--- a/apis/v1/zz_generated.deepcopy.go
+++ b/apis/v1/zz_generated.deepcopy.go
@@ -277,6 +277,11 @@ func (in *CookieConfig) DeepCopyInto(out *CookieConfig) {
 		*out = new(CookieName)
 		**out = **in
 	}
+	if in.Path != nil {
+		in, out := &in.Path, &out.Path
+		*out = new(string)
+		**out = **in
+	}
 	if in.LifetimeType != nil {
 		in, out := &in.LifetimeType, &out.LifetimeType
 		*out = new(CookieLifetimeType)

--- a/applyconfiguration/apis/v1/cookieconfig.go
+++ b/applyconfiguration/apis/v1/cookieconfig.go
@@ -41,6 +41,18 @@ type CookieConfigApplyConfiguration struct {
 	//
 	// Support: Extended
 	Name *apisv1.CookieName `json:"name,omitempty"`
+	// Path defines the cookie Path attribute. When not specified,
+	// implementations MUST default the cookie path to "/".
+	//
+	// <gateway:util:excludeFromCRD>
+	// This field is Extended because not all dataplanes support
+	// configuring the cookie path (e.g. HAProxy hardcodes path=/).
+	// Implementations SHOULD support this field if the underlying
+	// dataplane allows setting the cookie path attribute.
+	// </gateway:util:excludeFromCRD>
+	//
+	// Support: Extended
+	Path *string `json:"path,omitempty"`
 	// LifetimeType specifies whether the cookie has a permanent or
 	// session-based lifetime. A permanent cookie persists until its
 	// specified expiry time, defined by the Expires or Max-Age cookie
@@ -74,6 +86,14 @@ func CookieConfig() *CookieConfigApplyConfiguration {
 // If called multiple times, the Name field is set to the value of the last call.
 func (b *CookieConfigApplyConfiguration) WithName(value apisv1.CookieName) *CookieConfigApplyConfiguration {
 	b.Name = &value
+	return b
+}
+
+// WithPath sets the Path field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Path field is set to the value of the last call.
+func (b *CookieConfigApplyConfiguration) WithPath(value string) *CookieConfigApplyConfiguration {
+	b.Path = &value
 	return b
 }
 

--- a/applyconfiguration/internal/internal.go
+++ b/applyconfiguration/internal/internal.go
@@ -352,6 +352,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: name
       type:
         scalar: string
+    - name: path
+      type:
+        scalar: string
 - name: io.k8s.sigs.gateway-api.apis.v1.ForwardBodyConfig
   map:
     fields:

--- a/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -1923,6 +1923,16 @@ spec:
                               minLength: 1
                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                               type: string
+                            path:
+                              default: /
+                              description: |-
+                                Path defines the cookie Path attribute. When not specified,
+                                implementations MUST default the cookie path to "/".
+
+
+                                Support: Extended
+                              maxLength: 1024
+                              type: string
                           type: object
                         header:
                           description: |-

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -3832,6 +3832,16 @@ spec:
                               minLength: 1
                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                               type: string
+                            path:
+                              default: /
+                              description: |-
+                                Path defines the cookie Path attribute. When not specified,
+                                implementations MUST default the cookie path to "/".
+
+
+                                Support: Extended
+                              maxLength: 1024
+                              type: string
                           type: object
                         header:
                           description: |-
@@ -8120,6 +8130,16 @@ spec:
                               maxLength: 256
                               minLength: 1
                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                              type: string
+                            path:
+                              default: /
+                              description: |-
+                                Path defines the cookie Path attribute. When not specified,
+                                implementations MUST default the cookie path to "/".
+
+
+                                Support: Extended
+                              maxLength: 1024
                               type: string
                           type: object
                         header:

--- a/config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
+++ b/config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
@@ -217,6 +217,16 @@ spec:
                         minLength: 1
                         pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                         type: string
+                      path:
+                        default: /
+                        description: |-
+                          Path defines the cookie Path attribute. When not specified,
+                          implementations MUST default the cookie path to "/".
+
+
+                          Support: Extended
+                        maxLength: 1024
+                        type: string
                     type: object
                   header:
                     description: |-

--- a/geps/gep-1619/index.md
+++ b/geps/gep-1619/index.md
@@ -18,7 +18,7 @@ Before this GEP graduates to the Standard channel, we must fulfill the following
 - [ ] At least 3 implementations passing conformance tests
 - [ ] Comprehensive conformance test suite covering cookie and header persistence types
 - [ ] Resolve attachment model ([#4462](https://github.com/kubernetes-sigs/gateway-api/discussions/4462)) for session persistence (route-inline, [BackendTrafficPolicy](../gep-3388/index.md), [Backend](../gep-4488/index.md), or combination)
-- [ ] Define cookie path default behavior ([#4713](https://github.com/kubernetes-sigs/gateway-api/issues/4713))
+- [x] Define cookie path default behavior ([#4713](https://github.com/kubernetes-sigs/gateway-api/issues/4713))
 - [ ] Define session name conflict resolution rules ([#4268](https://github.com/kubernetes-sigs/gateway-api/issues/4268))
 - [ ] Sign-off from GAMMA leads to ensure service mesh is fully considered
 
@@ -517,6 +517,16 @@ type CookieConfig struct {
     // +optional
     Name *CookieName `json:"name,omitempty"`
 
+    // Path defines the cookie Path attribute. When not specified,
+    // implementations MUST default the cookie path to "/".
+    //
+    // Support: Extended
+    //
+    // +optional
+    // +kubebuilder:default="/"
+    // +kubebuilder:validation:MaxLength=1024
+    Path *string `json:"path,omitempty"`
+
     // LifetimeType specifies whether the cookie has a permanent or
     // session-based lifetime. A permanent cookie persists until its
     // specified expiry time, defined by the Expires or Max-Age cookie
@@ -771,27 +781,23 @@ between permanent and session cookies.
 #### Path
 
 The cookie's `Path` attribute defines the URL path that must exist in order for the client to send the `cookie` header.
-Whether attaching session persistence to an xRoute or a service, it's important to consider the relationship the cookie
-`Path` attribute has with the route path.
 
-When session persistence is enabled on a xRoute rule, the implementor should interpret the path as
-configured on the xRoute. To interpret the `Path` attribute from an xRoute, implementors should take note of the
-following:
+Implementations MUST default the cookie `Path` to `/` when no explicit path is configured.
 
-1. For an xRoute that matches all paths, the `Path` should be set to `/`.
-2. For an xRoute that has multiple paths, the `Path` should be interpreted based on the route path that was matched.
-3. For an xRoute using a path that is a regex, the `Path` should be set to the longest non-regex prefix (.e.g. if the
-   path is /p1/p2/*/p3 and the request path was /p1/p2/foo/p3, then the cookie path would be /p1/p2).
+This GEP previously specified that the cookie path should be computed from the matched route path. That approach was
+removed because no prior art computes a cookie path from route matches, it is underspecified for regex matches, and it
+breaks with edge proxy path rewrites (see [#4713](https://github.com/kubernetes-sigs/gateway-api/issues/4713)).
 
-It is also important to note that this design makes persistent session unique per route path. For instance, if two
-distinct routes, one with path prefix `/foo` and the other with `/bar`, both target the same service, the persistent
-session won't be shared between these two paths.
+Defaulting to `/` was chosen because it is the most portable behavior — the majority of implementations default to `/`
+and every dataplane can deliver it.
 
-Conversely, if the `BackendTrafficPolicy` policy is attached to a service, the `Path` attribute MUST be left
-unset. This is because multiple routes can target a single service. If the `Path` cookie attribute is configured in this
-scenario, it could result in problems due to the possibility of different paths being taken for the same cookie.
-Implementations MUST also handle the case where the client is a browser making requests to multiple persistent services
-from the same page.
+While `Path=/` is broader than a route-specific path, the security impact is limited. The cookie value is an opaque
+backend identifier (e.g., an encoded IP address), not a session token containing sensitive data. A cookie with `Path=/`
+being sent to other routes on the same domain does not expose sensitive information — it only causes the receiving
+route's proxy to attempt (and fail) to use the persistence token, falling back to normal load balancing.
+
+Users who need a cookie scoped to a specific path can configure it explicitly via the `cookie.path` field (Extended
+support). When set, `cookie.path` overrides the default `/`.
 
 #### Secure, HttpOnly, SameSite
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3359,6 +3359,13 @@ func schema_sigsk8sio_gateway_api_apis_v1_CookieConfig(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"path": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Path defines the cookie Path attribute. When not specified, implementations MUST default the cookie path to \"/\".\n\n<gateway:util:excludeFromCRD> This field is Extended because not all dataplanes support configuring the cookie path (e.g. HAProxy hardcodes path=/). Implementations SHOULD support this field if the underlying dataplane allows setting the cookie path attribute. </gateway:util:excludeFromCRD>\n\nSupport: Extended",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"lifetimeType": {
 						SchemaProps: spec.SchemaProps{
 							Description: "LifetimeType specifies whether the cookie has a permanent or session-based lifetime. A permanent cookie persists until its specified expiry time, defined by the Expires or Max-Age cookie attributes, while a session cookie is deleted when the current session ends.\n\nWhen set to \"Permanent\", AbsoluteTimeout indicates the cookie's lifetime via the Expires or Max-Age cookie attributes and is required.\n\nWhen set to \"Session\", AbsoluteTimeout indicates the absolute lifetime of the cookie tracked by the gateway and is optional.\n\nDefaults to \"Session\".\n\nSupport: Core for \"Session\" type\n\nSupport: Extended for \"Permanent\" type",


### PR DESCRIPTION
**What type of PR is this?**
/kind gep

**What this PR does / why we need it**:

Default cookie Path to / instead of computing it from route matches. No prior art computes a path from route matches, and the computed approach is underspecified for regex matches and breaks with upstream path rewrites (#4713).

Add cookie.path field (Extended) for users who need explicit path scoping.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4713

**Does this PR introduce a user-facing change?**:
```release-note
SessionPersistence API: default cookie Path to / instead of computing from route matches, add cookie.path field (Extended) for explicit path configuration
```

**Note**: Some of the edge cases in the GEP assume sessions are isolated by cookie path, which no longer applies with the default of `/`. These will be rewritten as part of the conflict resolution work in #4649.