### PR TITLE
Add `containerPort`s to the echo pod spec in the mesh conformance manifest

### DIFF
--- a/conformance/mesh/manifests.yaml
+++ b/conformance/mesh/manifests.yaml
@@ -36,6 +36,15 @@ spec:
             - --tls=8443
             - --crt=/cert.crt
             - --key=/cert.key
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 8443
+              protocol: TCP
+            - containerPort: 9090
+              protocol: TCP
+            - containerPort: 7070
+              protocol: TCP
 ---
 apiVersion: v1
 kind: Service
@@ -93,6 +102,15 @@ spec:
             - --tls=8443
             - --crt=/cert.crt
             - --key=/cert.key
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 8443
+              protocol: TCP
+            - containerPort: 9090
+              protocol: TCP
+            - containerPort: 7070
+              protocol: TCP
 ---
 apiVersion: v1
 kind: Service
@@ -174,3 +192,12 @@ spec:
         - name: echo
           image: registry.k8s.io/gateway-api/echo-advanced:v1.5.1
           imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 8443
+              protocol: TCP
+            - containerPort: 9090
+              protocol: TCP
+            - containerPort: 7070
+              protocol: TCP


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**

/kind test
/area conformance-machinery
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

This provides better tooling integration for GCP infrastructure

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
