### PR TITLE
fix: stop verifying reports on release branches

### DIFF
--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -20,6 +20,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${SCRIPT_ROOT}/hack/kube-env.sh"
+PULL_BASE_REF=${PULL_BASE_REF:-}
 
 SILENT=true
 FAILED_TEST=()
@@ -53,6 +54,12 @@ if $SILENT ; then
 fi
 
 EXCLUDE="verify-all.sh"
+
+# On a release branch we must ignore the conformance reports checks
+if [[ -n "$PULL_BASE_REF" && "$PULL_BASE_REF" == release-* ]]; then
+  echo "Running on a release branch, extra tests may be ignored"
+  EXCLUDE="${EXCLUDE} verify-reports.sh"
+fi
 
 SCRIPTS=$(find "${SCRIPT_ROOT}"/hack -name "verify-*.sh")
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We are checking reports on pipelines. This is a bad move, given the reports are just used on main branch and to generate the website.

This way, we can simply stop checking it on release branches

**Which issue(s) this PR fixes**:
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
