### PR TITLE
fix: retry stale TCP conformance responses

### DIFF
--- a/conformance/utils/tcp/tcp.go
+++ b/conformance/utils/tcp/tcp.go
@@ -84,12 +84,9 @@ func MakeTCPRequestAndExpectEventuallyValidResponse(t *testing.T, timeoutConfig 
 // - TEST message matches assertions
 func WaitForValidTCPResponse(t *testing.T, dialer Dialer, gwAddr string, expected ExpectedResponse, maxTimeToConsistency time.Duration) {
 	t.Helper()
-	closeAndLog := func(t *testing.T, cl net.Conn, err error) bool {
+	retry := func(err error) bool {
 		if err != nil {
 			tlog.Logf(t, "an error occurred during assertion, will retry: %s", err)
-		}
-		if err := cl.Close(); err != nil {
-			tlog.Logf(t, "error closing connection, will not fail but this can leak: %s", err)
 		}
 		return false
 	}
@@ -100,40 +97,58 @@ func WaitForValidTCPResponse(t *testing.T, dialer Dialer, gwAddr string, expecte
 			tlog.Logf(t, "client could not connect: %s; retrying", err)
 			return false
 		}
+		defer func() {
+			if closeErr := client.Close(); closeErr != nil {
+				tlog.Logf(t, "error closing TCP connection: %s", closeErr)
+			}
+		}()
 		tlog.Logf(t, "tcp client connected")
 		message, err := bufio.NewReader(client).ReadString('\n')
 		if err != nil {
-			return closeAndLog(t, client, err)
+			return retry(err)
 		}
-		assert.Equal(t, tcpserver.WelcomeMessage, message, "TCPServer welcome message does not match")
+		if message != tcpserver.WelcomeMessage {
+			return retry(fmt.Errorf("TCP server welcome message does not match: got %q", message))
+		}
 
-		fmt.Fprintf(client, "PING\n")
+		if _, err = fmt.Fprint(client, "PING\n"); err != nil {
+			return retry(err)
+		}
 		message, err = bufio.NewReader(client).ReadString('\n')
 		if err != nil {
-			return closeAndLog(t, client, err)
+			return retry(err)
 		}
-		assert.Equal(t, "PONG\n", message)
+		if message != "PONG\n" {
+			return retry(fmt.Errorf("TCP server PING response does not match: got %q", message))
+		}
 
-		fmt.Fprintf(client, "IS_TLS\n")
+		if _, err = fmt.Fprint(client, "IS_TLS\n"); err != nil {
+			return retry(err)
+		}
 		message, err = bufio.NewReader(client).ReadString('\n')
 		if err != nil {
-			return closeAndLog(t, client, err)
+			return retry(err)
 		}
-		assert.Equal(t, fmt.Sprintf("%t", expected.BackendIsTLS), strings.TrimSuffix(message, "\n"))
+		if actual := strings.TrimSuffix(message, "\n"); actual != fmt.Sprintf("%t", expected.BackendIsTLS) {
+			return retry(fmt.Errorf("TCP server TLS response does not match: got %q", actual))
+		}
 
-		fmt.Fprintf(client, "TEST\n")
+		if _, err = fmt.Fprint(client, "TEST\n"); err != nil {
+			return retry(err)
+		}
 		message, err = bufio.NewReader(client).ReadString('\n')
 		if err != nil {
-			return closeAndLog(t, client, err)
+			return retry(err)
 		}
 
 		payload := &tcpserver.TCPAssertions{}
 		if err := json.Unmarshal([]byte(message), payload); err != nil {
-			return closeAndLog(t, client, err)
+			return retry(err)
 		}
 
-		// At this moment we can simply assume the message will be right, or fail
-		assertTestMessage(t, payload, expected)
+		if err := validateTestMessage(payload, expected); err != nil {
+			return retry(err)
+		}
 		return true
 	}, maxTimeToConsistency, time.Second)
 
@@ -150,17 +165,33 @@ func makeClient(tlsConfig *tls.Config) Dialer {
 	}
 }
 
-func assertTestMessage(t *testing.T, payload *tcpserver.TCPAssertions, expected ExpectedResponse) {
-	t.Helper()
-	require.NotNil(t, payload)
-	assert.Equal(t, expected.Namespace, payload.Namespace, "namespace does not match")
-	assert.True(t, strings.HasPrefix(payload.Pod, fmt.Sprintf("%s-", expected.Backend)), "backend name does not match with pod prefix. pod=%s and backend=%s", payload.Pod, expected.Backend) // Pod must contain "backend-"
+func validateTestMessage(payload *tcpserver.TCPAssertions, expected ExpectedResponse) error {
+	if payload == nil {
+		return fmt.Errorf("TCP response payload is nil")
+	}
+	if payload.Namespace != expected.Namespace {
+		return fmt.Errorf("namespace does not match: got %q, want %q", payload.Namespace, expected.Namespace)
+	}
+	if !strings.HasPrefix(payload.Pod, fmt.Sprintf("%s-", expected.Backend)) {
+		return fmt.Errorf("backend name does not match with pod prefix: pod=%q backend=%q", payload.Pod, expected.Backend)
+	}
 	if expected.Hostname != "" {
-		assert.Equal(t, expected.Hostname, payload.TLSAssertion.ServerName)
+		if payload.TLSAssertion == nil {
+			return fmt.Errorf("TLS server name does not match: no TLS assertions received, want %q", expected.Hostname)
+		}
+		if payload.TLSAssertion.ServerName != expected.Hostname {
+			return fmt.Errorf("TLS server name does not match: got %q, want %q", payload.TLSAssertion.ServerName, expected.Hostname)
+		}
 	}
 	if expected.TLSProtocol != "" {
-		assert.Equal(t, expected.TLSProtocol, payload.TLSAssertion.NegotiatedProtocol)
+		if payload.TLSAssertion == nil {
+			return fmt.Errorf("TLS protocol does not match: no TLS assertions received, want %q", expected.TLSProtocol)
+		}
+		if payload.TLSAssertion.NegotiatedProtocol != expected.TLSProtocol {
+			return fmt.Errorf("TLS protocol does not match: got %q, want %q", payload.TLSAssertion.NegotiatedProtocol, expected.TLSProtocol)
+		}
 	}
+	return nil
 }
 
 // EchoSendOnce opens a single TCP connection to gwAddr, performs the

--- a/conformance/utils/tcp/tcp_test.go
+++ b/conformance/utils/tcp/tcp_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	tcpserver "sigs.k8s.io/gateway-api/conformance/echo-basic/tcpserver"
+)
+
+func TestWaitForValidTCPResponseRetriesStaleResponse(t *testing.T) {
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() }) //nolint:errcheck
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		for i := range 2 {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			handleTCPTestConnection(conn, i == 0)
+		}
+	}()
+
+	WaitForValidTCPResponse(t, &net.Dialer{}, listener.Addr().String(), ExpectedResponse{
+		Backend:   "backend",
+		Namespace: "test-ns",
+	}, 3*time.Second)
+
+	select {
+	case <-serverDone:
+	case <-time.After(time.Second):
+		t.Fatal("TCP test server did not receive the retry")
+	}
+}
+
+func handleTCPTestConnection(conn net.Conn, staleWelcome bool) {
+	defer conn.Close() //nolint:errcheck
+
+	welcome := tcpserver.WelcomeMessage
+	if staleWelcome {
+		welcome = "stale response\n"
+	}
+	if _, err := conn.Write([]byte(welcome)); err != nil {
+		return
+	}
+
+	reader := bufio.NewReader(conn)
+	if _, err := reader.ReadString('\n'); err != nil {
+		return
+	}
+	if _, err := conn.Write([]byte("PONG\n")); err != nil {
+		return
+	}
+	if _, err := reader.ReadString('\n'); err != nil {
+		return
+	}
+	if _, err := conn.Write([]byte("false\n")); err != nil {
+		return
+	}
+	if _, err := reader.ReadString('\n'); err != nil {
+		return
+	}
+	payload, err := json.Marshal(tcpserver.TCPAssertions{Context: tcpserver.Context{Namespace: "test-ns", Pod: "backend-pod"}})
+	if err != nil {
+		return
+	}
+	_, _ = conn.Write(append(payload, '\n'))
+}


### PR DESCRIPTION
/kind bug
/kind flake
/area conformance-test

**What this PR does / why we need it**:

TCP responses can be stale while a route converges. The helper asserted on the first mismatch and skipped its retry. Retry it instead

**Which issue(s) this PR fixes**:

None

**How to reproduce**:

Return one stale TCP welcome response, then a valid one. `go test ./conformance/utils/tcp -run TestWaitForValidTCPResponseRetriesStaleResponse` failed before this change; it now retries and passes.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```