### PR TITLE
Followups from v1.6.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ the specification and Custom Resource Definitions (CRDs).
 ## Status
 
 The latest supported version is `v1` as released by
-the [v1.6.0 release][gh_release] of this project.
+the [v1.6.1 release][gh_release] of this project.
 
 This version of the API has GA level support for the following resources:
 
@@ -77,7 +77,7 @@ Participation in the Kubernetes community is governed by the
 [spec]: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/
 [concepts]: https://gateway-api.sigs.k8s.io/docs/concepts/api-overview
 [security-model]: https://gateway-api.sigs.k8s.io/concepts/security-model
-[gh_release]: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.6.0
+[gh_release]: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.6.1
 [godoc]: https://pkg.go.dev/sigs.k8s.io/gateway-api
 [conformance-docs]: https://gateway-api.sigs.k8s.io/docs/concepts/conformance/
 [reports-readme]: ./conformance/reports/README.md

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -148,7 +148,7 @@ of the PR is the community consensus for a new release.
   the GitHub UI, but **note well**: if the release manager can't create the tag due to Git permissions, a maintainer will need to do it, and in that case it's more polite for the maintainer to create and push the _tag_, then let the release manager create the _release_, so that it's easier for people to find the manager if there are problems!
 - Run the `make build-install-yaml` command which will generate install files in the `release/` directory.
   Attach these files to the GitHub release.
-- Update the `README.md` and `site-src/guides/index.md` files to point links and examples to the new release.
+- Update the `README.md` and `site/content/en/guides/getting-started/introduction.md` files to point links and examples to the new release.
 
 #### For a **MAJOR** or **MINOR** release:
 - Cut a `release-major.minor` branch that we can tag things in as needed.
@@ -166,7 +166,7 @@ of the PR is the community consensus for a new release.
   GitHub's [release][release] page.
 - Run the `make build-install-yaml` command which will generate install files in the `release/` directory.
   Attach these files to the GitHub release.
-- Update the `README.md` and `site-src/guides/index.md` files to point links and examples to the new release.
+- Update the `README.md` and `site/content/en/guides/getting-started/introduction.md` files to point links and examples to the new release.
 - Edit the text blurb in `hack/docsy-generate-conformance.py` to reflect the added past version if necessary.
 
 #### For an **RC** release:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -132,14 +132,13 @@ Given that the release branch exists:
 - Create a `release-$tag` branch off the release branch.
 - Update the CHANGELOG as described above.
 - Update `pkg/consts/consts.go` with the new semver tag and any updates to the API review URL.
-- Update regex `spec.validations.expression` in
-  `config/crd/standard/gateway.networking.k8s.io_vap_safeupgrades.yaml`
-  to match older versions. (Look for a regex like `v1.[0-n].`, and make
-  sure that  the `n` in `0-n` is the current minor version number -1.)
 - Run the following command `BASE_REF=vmajor.minor.patch make generate` which
   will update generated docs with the correct version info. (Note that you can't
   test with these YAMLs yet as they contain references to elements which wont
   exist until the tag is cut and image is promoted to production registry.)
+- Verify `config/crd/standard/gateway.networking.k8s.io_vap_safeupgrades.yaml`
+  - Has the updated `gateway.networking.k8s.io/bundle-version`.
+  - Has the updated `spec.validations.expression` to match older versions. (Look for a regex like `v1.[0-3].`, where `3` is the latest minor version number -1)
 - Commit all of the above to the new `release-x.x.x` branch.
 - Create a pull request of the `release-x.x.x` branch into the `release-x.x` branch upstream. Add a hold on this PR waiting for at least one maintainer/codeowner to provide a `lgtm`. Approval
 of the PR is the community consensus for a new release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -154,13 +154,13 @@ of the PR is the community consensus for a new release.
 - Cut a `release-major.minor` branch that we can tag things in as needed.
 - Check out the `release-major.minor` release branch locally.
 - Update `pkg/consts/consts.go` with the new semver tag and any updates to the API review URL.
-- Update `config/crd/standard/gateway.networking.k8s.io_vap_safeupgrades.yaml`
-  - Update the `gateway.networking.k8s.io/bundle-version`.
-  - Update regex `spec.validations.expression` to match older versions. (Look for a regex like `v1.[0-3].`, and replace the `3` with the new minor version number -1).
 - Run the following command `BASE_REF=vmajor.minor.patch make generate` which
   will update generated docs with the correct version info. (Note that you can't
   test with these YAMLs yet as they contain references to elements which wont
   exist until the tag is cut and image is promoted to production registry.)
+- Verify `config/crd/standard/gateway.networking.k8s.io_vap_safeupgrades.yaml`
+  - Has the updated `gateway.networking.k8s.io/bundle-version`.
+  - Has the updated `spec.validations.expression` to match older versions. (Look for a regex like `v1.[0-3].`, where `3` is the latest minor version number -1).
 - Verify the CI tests pass before continuing.
 - Create a tag using the `HEAD` of the `release-x.x` branch. This can be done using the `git` CLI or
   GitHub's [release][release] page.

--- a/site/content/en/guides/getting-started/introduction.md
+++ b/site/content/en/guides/getting-started/introduction.md
@@ -66,7 +66,7 @@ beta, including GatewayClass, Gateway, HTTPRoute, and ReferenceGrant. To install
 this channel, run the following kubectl command:
 
 ```bash
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/standard-install.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
 ```
 
 Refer to the [server-side apply documentation](https://kubernetes.io/docs/reference/using-api/server-side-apply/)
@@ -87,7 +87,7 @@ documentation](/docs/concepts/versioning/).
 To install the experimental channel, run the following kubectl command:
 
 ```bash
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/experimental-install.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/experimental-install.yaml
 ```
 
 Refer to the [server-side apply documentation](https://kubernetes.io/docs/reference/using-api/server-side-apply/)

--- a/tools/generator/main.go
+++ b/tools/generator/main.go
@@ -182,53 +182,80 @@ func main() {
 
 // updateVAP updates the hand-maintained ValidatingAdmissionPolicy manifest
 // for the given channel.
-// The manifest is edited textually rather than round-tripped through a YAML
-// marshal to preserve its formatting, comments, and multi-document structure.
 func updateVAP(channel, bundleVersion string) error {
-	versionMatch := regexp.MustCompile(`^v(\d+)\.(\d+)`).FindStringSubmatch(bundleVersion)
-	if versionMatch == nil {
-		return fmt.Errorf("bundle version %q is not of the form vMAJOR.MINOR", bundleVersion)
-	}
-	minor, err := strconv.Atoi(versionMatch[2])
+	path := fmt.Sprintf("config/crd/%s/gateway.networking.k8s.io_vap_safeupgrades.yaml", channel)
+
+	manifest, err := readVAPManifest(path)
 	if err != nil {
-		return fmt.Errorf("invalid minor version in bundle version %q: %w", bundleVersion, err)
+		return err
 	}
-	if minor < 1 {
-		// Skip if this runs on main or with the `v0.0.0-dev` bundle version
+
+	updated, err := updateVAPManifest(manifest, channel, bundleVersion)
+	if err != nil {
+		return fmt.Errorf("failed to update VAP manifest %s: %w", path, err)
+	}
+	if updated == manifest {
+		// Nothing changed, e.g. when running on main with the `v0.0.0-dev`
+		// bundle version.
 		return nil
 	}
 
-	path := fmt.Sprintf("config/crd/%s/gateway.networking.k8s.io_vap_safeupgrades.yaml", channel)
+	if err := writeVAPManifest(path, updated); err != nil {
+		return err
+	}
+
+	log.Printf("updated %s %s to %s\n", path, consts.BundleVersionAnnotation, bundleVersion)
+	return nil
+}
+
+func readVAPManifest(path string) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		log.Fatalf("failed to read VAP manifest %s: %s", path, err)
+		return "", fmt.Errorf("failed to read VAP manifest %s: %w", path, err)
 	}
-	manifest := string(data)
+	return string(data), nil
+}
+
+// updateVAPManifest stamps the bundle version into the manifest's annotations
+// and, for the standard channel, bumps the prohibited-version range.
+// The manifest is edited textually rather than round-tripped through a YAML
+// marshal to preserve its formatting, comments, and multi-document structure.
+func updateVAPManifest(manifest, channel, bundleVersion string) (string, error) {
+	versionMatch := regexp.MustCompile(`^v(\d+)\.(\d+)`).FindStringSubmatch(bundleVersion)
+	if versionMatch == nil {
+		return "", fmt.Errorf("bundle version %q is not of the form vMAJOR.MINOR", bundleVersion)
+	}
+	minor, err := strconv.Atoi(versionMatch[2])
+	if err != nil {
+		return "", fmt.Errorf("invalid minor version in bundle version %q: %w", bundleVersion, err)
+	}
+	if minor < 1 {
+		// Skip if this runs on main or with the `v0.0.0-dev` bundle version
+		return manifest, nil
+	}
 
 	// Only match annotation lines; the annotation key also appears inside CEL
 	// expressions, where it is never at the start of a line.
 	re := regexp.MustCompile(`(?m)^(\s*` + regexp.QuoteMeta(consts.BundleVersionAnnotation) + `:\s*).*$`)
-	if !re.Match(data) {
-		log.Fatalf("no %s annotation found in %s", consts.BundleVersionAnnotation, path)
-	}
-
 	manifest = re.ReplaceAllString(manifest, "${1}"+bundleVersion)
 
 	if channel == "standard" {
 		previousMinor := fmt.Sprintf("v1.[0-%d].", minor-2)
 		latestMinor := fmt.Sprintf("v1.[0-%d].", minor-1)
-		log.Printf("updating %s for prohibitions from version %s to %s\n", path, previousMinor, latestMinor)
+		log.Printf("updating prohibitions from version %s to %s\n", previousMinor, latestMinor)
 
 		// Prohibit installing bundle versions older than the previous minor
 		// version, e.g. anything matching v1.[0-5]. when generating v1.6.x.
 		manifest = strings.ReplaceAll(manifest, previousMinor, latestMinor)
 	}
 
-	if err := os.WriteFile(path, []byte(manifest), 0o600); err != nil { // #nosec G703 -- path is derived from a hardcoded channel list
-		return fmt.Errorf("failed to write VAP manifest %s: %s", path, err)
-	}
+	return manifest, nil
+}
 
-	log.Printf("updated %s %s to %s\n", path, consts.BundleVersionAnnotation, bundleVersion)
+func writeVAPManifest(path, manifest string) error {
+	if err := os.WriteFile(path, []byte(manifest), 0o600); err != nil { // #nosec G703 -- path is derived from a hardcoded channel list
+		return fmt.Errorf("failed to write VAP manifest %s: %w", path, err)
+	}
 	return nil
 }
 

--- a/tools/generator/main.go
+++ b/tools/generator/main.go
@@ -167,9 +167,39 @@ func main() {
 		}
 	}
 
+	for _, channel := range channels {
+		updateVAPBundleVersion(channel, bundleVersion)
+	}
+
 	if loader.PrintErrors(roots, packages.TypeError) {
 		log.Fatalf("not all generators ran successfully")
 	}
+}
+
+// updateVAPBundleVersion updates the bundle-version annotation in the
+// hand-maintained ValidatingAdmissionPolicy manifest for the given channel.
+// The manifest is edited textually rather than round-tripped through a YAML
+// marshal to preserve its formatting, comments, and multi-document structure.
+func updateVAPBundleVersion(channel, bundleVersion string) {
+	path := fmt.Sprintf("config/crd/%s/gateway.networking.k8s.io_vap_safeupgrades.yaml", channel)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatalf("failed to read VAP manifest %s: %s", path, err)
+	}
+
+	// Only match annotation lines; the annotation key also appears inside CEL
+	// expressions, where it is never at the start of a line.
+	re := regexp.MustCompile(`(?m)^(\s*` + regexp.QuoteMeta(consts.BundleVersionAnnotation) + `:\s*).*$`)
+	if !re.Match(data) {
+		log.Fatalf("no %s annotation found in %s", consts.BundleVersionAnnotation, path)
+	}
+
+	updated := re.ReplaceAll(data, []byte("${1}"+bundleVersion))
+	if err := os.WriteFile(path, updated, 0o600); err != nil {
+		log.Fatalf("failed to write VAP manifest %s: %s", path, err)
+	}
+
+	log.Printf("updated %s %s to %s\n", path, consts.BundleVersionAnnotation, bundleVersion)
 }
 
 func marshalCRDManifest(customResourceDefinition apiext.CustomResourceDefinition) ([]byte, error) {

--- a/tools/generator/main.go
+++ b/tools/generator/main.go
@@ -169,7 +169,7 @@ func main() {
 	}
 
 	for _, channel := range channels {
-		err := updateVAPBundleVersion(channel, bundleVersion)
+		err := updateVAP(channel, bundleVersion)
 		if err != nil {
 			log.Fatalf("failed to update vap: %s", err)
 		}
@@ -180,11 +180,11 @@ func main() {
 	}
 }
 
-// updateVAPBundleVersion updates the bundle-version annotation in the
-// hand-maintained ValidatingAdmissionPolicy manifest for the given channel.
+// updateVAP updates the hand-maintained ValidatingAdmissionPolicy manifest
+// for the given channel.
 // The manifest is edited textually rather than round-tripped through a YAML
 // marshal to preserve its formatting, comments, and multi-document structure.
-func updateVAPBundleVersion(channel, bundleVersion string) error {
+func updateVAP(channel, bundleVersion string) error {
 	path := fmt.Sprintf("config/crd/%s/gateway.networking.k8s.io_vap_safeupgrades.yaml", channel)
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/tools/generator/main.go
+++ b/tools/generator/main.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"golang.org/x/tools/go/packages"
@@ -168,7 +169,10 @@ func main() {
 	}
 
 	for _, channel := range channels {
-		updateVAPBundleVersion(channel, bundleVersion)
+		err := updateVAPBundleVersion(channel, bundleVersion)
+		if err != nil {
+			log.Fatalf("failed to update vap: %s", err)
+		}
 	}
 
 	if loader.PrintErrors(roots, packages.TypeError) {
@@ -180,12 +184,13 @@ func main() {
 // hand-maintained ValidatingAdmissionPolicy manifest for the given channel.
 // The manifest is edited textually rather than round-tripped through a YAML
 // marshal to preserve its formatting, comments, and multi-document structure.
-func updateVAPBundleVersion(channel, bundleVersion string) {
+func updateVAPBundleVersion(channel, bundleVersion string) error {
 	path := fmt.Sprintf("config/crd/%s/gateway.networking.k8s.io_vap_safeupgrades.yaml", channel)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		log.Fatalf("failed to read VAP manifest %s: %s", path, err)
 	}
+	manifest := string(data)
 
 	// Only match annotation lines; the annotation key also appears inside CEL
 	// expressions, where it is never at the start of a line.
@@ -194,12 +199,36 @@ func updateVAPBundleVersion(channel, bundleVersion string) {
 		log.Fatalf("no %s annotation found in %s", consts.BundleVersionAnnotation, path)
 	}
 
-	updated := re.ReplaceAll(data, []byte("${1}"+bundleVersion))
-	if err := os.WriteFile(path, updated, 0o600); err != nil {
-		log.Fatalf("failed to write VAP manifest %s: %s", path, err)
+	manifest = re.ReplaceAllString(manifest, "${1}"+bundleVersion)
+
+	if channel == "standard" {
+		versionMatch := regexp.MustCompile(`^v(\d+)\.(\d+)`).FindStringSubmatch(bundleVersion)
+		if versionMatch == nil {
+			return fmt.Errorf("bundle version %q is not of the form vMAJOR.MINOR", bundleVersion)
+		}
+		minor, err := strconv.Atoi(versionMatch[2])
+		if err != nil {
+			return fmt.Errorf("invalid minor version in bundle version %q: %w", bundleVersion, err)
+		}
+		if minor < 1 {
+			return fmt.Errorf("bundle version %q has no previous minor version to prohibit upgrades from", bundleVersion)
+		}
+
+		previousMinor := fmt.Sprintf("v1.[0-%d].", minor-2)
+		latestMinor := fmt.Sprintf("v1.[0-%d].", minor-1)
+		log.Printf("updating %s for prohibitions from version %s to %s\n", path, previousMinor, latestMinor)
+
+		// Prohibit installing bundle versions older than the previous minor
+		// version, e.g. anything matching v1.[0-5]. when generating v1.6.x.
+		manifest = strings.ReplaceAll(manifest, previousMinor, latestMinor)
+	}
+
+	if err := os.WriteFile(path, []byte(manifest), 0o600); err != nil {
+		return fmt.Errorf("failed to write VAP manifest %s: %s", path, err)
 	}
 
 	log.Printf("updated %s %s to %s\n", path, consts.BundleVersionAnnotation, bundleVersion)
+	return nil
 }
 
 func marshalCRDManifest(customResourceDefinition apiext.CustomResourceDefinition) ([]byte, error) {

--- a/tools/generator/main.go
+++ b/tools/generator/main.go
@@ -224,7 +224,7 @@ func updateVAP(channel, bundleVersion string) error {
 		manifest = strings.ReplaceAll(manifest, previousMinor, latestMinor)
 	}
 
-	if err := os.WriteFile(path, []byte(manifest), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(manifest), 0o600); err != nil { // #nosec G703 -- path is derived from a hardcoded channel list
 		return fmt.Errorf("failed to write VAP manifest %s: %s", path, err)
 	}
 

--- a/tools/generator/main.go
+++ b/tools/generator/main.go
@@ -185,6 +185,19 @@ func main() {
 // The manifest is edited textually rather than round-tripped through a YAML
 // marshal to preserve its formatting, comments, and multi-document structure.
 func updateVAP(channel, bundleVersion string) error {
+	versionMatch := regexp.MustCompile(`^v(\d+)\.(\d+)`).FindStringSubmatch(bundleVersion)
+	if versionMatch == nil {
+		return fmt.Errorf("bundle version %q is not of the form vMAJOR.MINOR", bundleVersion)
+	}
+	minor, err := strconv.Atoi(versionMatch[2])
+	if err != nil {
+		return fmt.Errorf("invalid minor version in bundle version %q: %w", bundleVersion, err)
+	}
+	if minor < 1 {
+		// Skip if this runs on main or with the `v0.0.0-dev` bundle version
+		return nil
+	}
+
 	path := fmt.Sprintf("config/crd/%s/gateway.networking.k8s.io_vap_safeupgrades.yaml", channel)
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -202,18 +215,6 @@ func updateVAP(channel, bundleVersion string) error {
 	manifest = re.ReplaceAllString(manifest, "${1}"+bundleVersion)
 
 	if channel == "standard" {
-		versionMatch := regexp.MustCompile(`^v(\d+)\.(\d+)`).FindStringSubmatch(bundleVersion)
-		if versionMatch == nil {
-			return fmt.Errorf("bundle version %q is not of the form vMAJOR.MINOR", bundleVersion)
-		}
-		minor, err := strconv.Atoi(versionMatch[2])
-		if err != nil {
-			return fmt.Errorf("invalid minor version in bundle version %q: %w", bundleVersion, err)
-		}
-		if minor < 1 {
-			return fmt.Errorf("bundle version %q has no previous minor version to prohibit upgrades from", bundleVersion)
-		}
-
 		previousMinor := fmt.Sprintf("v1.[0-%d].", minor-2)
 		latestMinor := fmt.Sprintf("v1.[0-%d].", minor-1)
 		log.Printf("updating %s for prohibitions from version %s to %s\n", path, previousMinor, latestMinor)

--- a/tools/generator/main_test.go
+++ b/tools/generator/main_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/gateway-api/pkg/consts"
 )
 
 func TestMarshalCRDManifestOmitsTopLevelStatus(t *testing.T) {
@@ -66,5 +69,96 @@ func TestMarshalCRDManifestOmitsTopLevelStatus(t *testing.T) {
 	}
 	if !strings.Contains(yaml, "\nspec:\n") {
 		t.Fatalf("expected spec to be present, got:\n%s", yaml)
+	}
+}
+
+// vapFixture mimics the structure of the hand-maintained VAP manifests: the
+// bundle-version annotation appears on annotation lines in two documents and
+// inside a CEL expression, and the standard-channel prohibition pattern
+// matches versions up to v1.4.x.
+const vapFixture = `apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  annotations:
+    gateway.networking.k8s.io/bundle-version: v0.0.0-dev
+  name: safe-upgrades.gateway.networking.k8s.io
+spec:
+  validations:
+    - expression: "!matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], 'v1.[0-4].\\\\d+')"
+      message: "Installing CRDs matching v1.[0-4]. is prohibited."
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  annotations:
+    gateway.networking.k8s.io/bundle-version: v0.0.0-dev
+  name: safe-upgrades.gateway.networking.k8s.io
+`
+
+func TestUpdateVAPManifestStandardChannel(t *testing.T) {
+	t.Parallel()
+
+	manifest, err := updateVAPManifest(vapFixture, "standard", "v1.6.0")
+	if err != nil {
+		t.Fatalf("updateVAPManifest returned error: %v", err)
+	}
+
+	annotationLine := fmt.Sprintf("%s: v1.6.0", consts.BundleVersionAnnotation)
+	if got := strings.Count(manifest, annotationLine); got != 2 {
+		t.Errorf("expected annotation to be updated in both documents, found %d occurrences of %q in:\n%s", got, annotationLine, manifest)
+	}
+	if strings.Contains(manifest, "v0.0.0-dev") {
+		t.Errorf("expected all placeholder versions to be replaced, got:\n%s", manifest)
+	}
+	if strings.Contains(manifest, "v1.[0-4].") {
+		t.Errorf("expected prohibition range v1.[0-4]. to be bumped, got:\n%s", manifest)
+	}
+	if got := strings.Count(manifest, "v1.[0-5]."); got != 2 {
+		t.Errorf("expected prohibition range v1.[0-5]. in expression and message, found %d occurrences in:\n%s", got, manifest)
+	}
+}
+
+func TestUpdateVAPManifestExperimentalChannelLeavesProhibitionUntouched(t *testing.T) {
+	t.Parallel()
+
+	manifest, err := updateVAPManifest(vapFixture, "experimental", "v1.6.0")
+	if err != nil {
+		t.Fatalf("updateVAPManifest returned error: %v", err)
+	}
+
+	annotationLine := fmt.Sprintf("%s: v1.6.0", consts.BundleVersionAnnotation)
+	if got := strings.Count(manifest, annotationLine); got != 2 {
+		t.Errorf("expected annotation to be updated in both documents, found %d occurrences of %q in:\n%s", got, annotationLine, manifest)
+	}
+	if got := strings.Count(manifest, "v1.[0-4]."); got != 2 {
+		t.Errorf("expected prohibition range to be left untouched on experimental channel, found %d occurrences of v1.[0-4]. in:\n%s", got, manifest)
+	}
+}
+
+func TestUpdateVAPManifestDoesNotTouchCELAnnotationKey(t *testing.T) {
+	t.Parallel()
+
+	manifest, err := updateVAPManifest(vapFixture, "standard", "v1.6.0")
+	if err != nil {
+		t.Fatalf("updateVAPManifest returned error: %v", err)
+	}
+
+	// The annotation key inside the CEL expression must survive as a map
+	// lookup, not be rewritten like an annotation line.
+	celLookup := fmt.Sprintf("object.metadata.annotations['%s']", consts.BundleVersionAnnotation)
+	if !strings.Contains(manifest, celLookup) {
+		t.Errorf("expected CEL annotation lookup %q to be preserved, got:\n%s", celLookup, manifest)
+	}
+}
+
+func TestUpdateVAPManifestSkipsDevBundleVersion(t *testing.T) {
+	t.Parallel()
+
+	manifest, err := updateVAPManifest(vapFixture, "standard", "v0.0.0-dev")
+	if err != nil {
+		t.Fatalf("expected dev bundle version to be skipped, got error: %v", err)
+	}
+	if manifest != vapFixture {
+		t.Errorf("expected manifest to be unchanged for dev bundle version, got:\n%s", manifest)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind cleanup
**What this PR does / why we need it**:
Followups from cutting v1.6.1
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
