### PR TITLE
chore: configure dependabot to update images in conformance test manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,11 +46,19 @@ updates:
       - ok-to-test
       - release-note-none
 
-  # Dependencies listed in Dockerfile
+  # Images listed in Dockerfile or Kubernetes manifests
   - package-ecosystem: "docker"
-    directory: "/"
+    directories:
+      - "/conformance/base"
+      - "/conformance/mesh"
+      - "/conformance/tests"
+      - "/conformance/tests/mesh"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    groups:
+      gateway-api-conformance:
+        patterns:
+          - "registry.k8s.io/gateway-api/conformance/*"
     labels:
       - docker
       - dependencies


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/area conformance-test

**What this PR does / why we need it**:
Configures dependabot to track and automatically update container image tags used in the conformance test manifests. Image updates under `registry.k8s.io/gateway-api/conformance/*` are grouped into a single PR rather than opening one per image.

Note: This PR is part of #4987.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
