### PR TITLE
conformance: retry failure-path assertion in client cert validation test

### DIFF
--- a/conformance/tests/gateway-invalid-default-frontend-client-certificate-validation.go
+++ b/conformance/tests/gateway-invalid-default-frontend-client-certificate-validation.go
@@ -126,7 +126,7 @@ var GatewayFrontendInvalidDefaultClientCertificateValidation = confsuite.Conform
 				Namespace: confsuite.InfrastructureNamespace,
 			}
 			// send request to the second listener and validate that it is failing
-			tls.MakeTLSRequestAndExpectFailureResponse(t, suite.RoundTripper, httpsAddr, serverCertPem, nil, nil, "example.org", expectedFailure)
+			tls.MakeTLSRequestAndExpectEventuallyConsistentFailureResponse(t, suite.RoundTripper, suite.TimeoutConfig, httpsAddr, serverCertPem, nil, nil, "example.org", expectedFailure)
 		})
 	},
 }

--- a/conformance/tests/gateway-with-clientcertificate-validation.go
+++ b/conformance/tests/gateway-with-clientcertificate-validation.go
@@ -106,7 +106,7 @@ var GatewayFrontendClientCertificateValidation = confsuite.ConformanceTest{
 				Request:   http.Request{Host: "example.org", Path: "/"},
 				Namespace: confsuite.InfrastructureNamespace,
 			}
-			tls.MakeTLSRequestAndExpectFailureResponse(t, suite.RoundTripper, defaultAddr, serverCertPem, clientCertPerPortPem, clientCertPerPortKey, "example.org", expectedFailure)
+			tls.MakeTLSRequestAndExpectEventuallyConsistentFailureResponse(t, suite.RoundTripper, suite.TimeoutConfig, defaultAddr, serverCertPem, clientCertPerPortPem, clientCertPerPortKey, "example.org", expectedFailure)
 		})
 
 		t.Run("Validate per port configuration", func(t *testing.T) {
@@ -126,7 +126,7 @@ var GatewayFrontendClientCertificateValidation = confsuite.ConformanceTest{
 				Request:   http.Request{Host: "second-example.org", Path: "/"},
 				Namespace: confsuite.InfrastructureNamespace,
 			}
-			tls.MakeTLSRequestAndExpectFailureResponse(t, suite.RoundTripper, perPortAddr, serverCertPem, clientCertPem, clientCertKey, "second-example.org", expectedFailure)
+			tls.MakeTLSRequestAndExpectEventuallyConsistentFailureResponse(t, suite.RoundTripper, suite.TimeoutConfig, perPortAddr, serverCertPem, clientCertPem, clientCertKey, "second-example.org", expectedFailure)
 		})
 	},
 }

--- a/conformance/utils/tls/tls.go
+++ b/conformance/utils/tls/tls.go
@@ -90,9 +90,11 @@ func WaitForConsistentTLSResponse(t *testing.T, r roundtripper.RoundTripper, req
 	tlog.Logf(t, "Request passed")
 }
 
-// MakeTLSRequestAndExpectFailureResponse makes one shot request. This function fails
-// when HTTP Status OK (200) is returned.
-func MakeTLSRequestAndExpectFailureResponse(t *testing.T, r roundtripper.RoundTripper, gwAddr string, serverCertificate, clientCertificate, clientCertificateKey []byte, serverName string, expected http.ExpectedResponse) {
+// MakeTLSRequestAndExpectEventuallyConsistentFailureResponse makes a TLS request, retrying until
+// it fails consistently or the timeout elapses. This is used for requests that are expected to be
+// rejected (e.g. due to client certificate validation or invalid TLS config), avoiding races where
+// the implementation's config has not yet fully propagated when the request is sent.
+func MakeTLSRequestAndExpectEventuallyConsistentFailureResponse(t *testing.T, r roundtripper.RoundTripper, timeoutConfig config.TimeoutConfig, gwAddr string, serverCertificate, clientCertificate, clientCertificateKey []byte, serverName string, expected http.ExpectedResponse) {
 	t.Helper()
 
 	req := http.MakeRequest(t, &expected, gwAddr, roundtripper.HTTPSProtocol, "https")
@@ -106,8 +108,6 @@ func MakeTLSRequestAndExpectFailureResponse(t *testing.T, r roundtripper.RoundTr
 			t.Fatalf("unexpected error creating client cert: %v", err)
 		}
 
-		// GetClientCertificateHook is a hook called when server asks for client certificate during TLS handshake,
-		// to verify that a client certificate has been requested.
 		req.GetClientCertificateHook = func(_ *cryptotls.CertificateRequestInfo) (*cryptotls.Certificate, error) {
 			t.Log("GetClientCertificateHook was called")
 			clientCertificatePresented = true
@@ -115,10 +115,15 @@ func MakeTLSRequestAndExpectFailureResponse(t *testing.T, r roundtripper.RoundTr
 		}
 	}
 
-	_, _, err := r.CaptureRoundTrip(req)
-	if err == nil {
-		t.Fatalf("Request should fail")
-	}
+	http.AwaitConvergence(t, timeoutConfig.RequiredConsecutiveSuccesses, timeoutConfig.MaxTimeToConsistency, func(elapsed time.Duration) bool {
+		_, _, err := r.CaptureRoundTrip(req)
+		if err == nil {
+			tlog.Logf(t, "Request unexpectedly succeeded, not ready yet (after %v)", elapsed)
+			return false
+		}
+		return true
+	})
+	tlog.Logf(t, "Request failed as expected")
 
 	if clientCertificate != nil && clientCertificateKey != nil {
 		assert.True(t, clientCertificatePresented, "client certificate was not presented during the handshake")


### PR DESCRIPTION
### What type of PR is this?
/kind flake
/kind test
/area conformance-test

### What this PR does 
**GatewayFrontendClientCertificateValidation** sends two requests per subtest: one expected to succeed and one expected to fail due to client certificate validation. The success-path assertion retries via
**MakeTLSRequestAndExpectEventuallyConsistentResponse** but the failure-path assertion right after it was a single-shot request via **MakeTLSRequestAndExpectFailureResponse** with no retry. This let the failure-path request race ahead of the implementation's stricter client-cert validation config being fully propagated causing an intermittent flake (in the observed failure, only 182ms elapsed between Gateway creation and the first request)

This PR adds **MakeTLSRequestAndExpectEventuallyConsistentFailureResponse** mirroring the existing eventually-consistent helper but for requests expected to fail and updates both subtests in **GatewayFrontendClientCertificateValidation** 
("Validate default configuration" and "Validate per port configuration") to use it.

### Which issue this PR fixes
Fixes https://github.com/kgateway-dev/kgateway/issues/14299

```release-note
NONE
```