### PR TITLE
fix: change ForwardBodyConfig.MaxSize from uint16 to int32

### DIFF
--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -1791,7 +1791,7 @@ type ForwardBodyConfig struct {
 	//
 	// If 0, the body will not be sent to the authorization server.
 	// +optional
-	MaxSize uint16 `json:"maxSize,omitempty"`
+	MaxSize int32 `json:"maxSize,omitempty"`
 }
 
 // HTTPBackendRef defines how a HTTPRoute forwards a HTTP request.

--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -1791,6 +1791,7 @@ type ForwardBodyConfig struct {
 	//
 	// If 0, the body will not be sent to the authorization server.
 	// +optional
+	// +kubebuilder:validation:Minimum=0
 	MaxSize int32 `json:"maxSize,omitempty"`
 }
 

--- a/applyconfiguration/apis/v1/forwardbodyconfig.go
+++ b/applyconfiguration/apis/v1/forwardbodyconfig.go
@@ -38,7 +38,7 @@ type ForwardBodyConfigApplyConfiguration struct {
 	// for more.
 	//
 	// If 0, the body will not be sent to the authorization server.
-	MaxSize *uint16 `json:"maxSize,omitempty"`
+	MaxSize *int32 `json:"maxSize,omitempty"`
 }
 
 // ForwardBodyConfigApplyConfiguration constructs a declarative configuration of the ForwardBodyConfig type for use with
@@ -50,7 +50,7 @@ func ForwardBodyConfig() *ForwardBodyConfigApplyConfiguration {
 // WithMaxSize sets the MaxSize field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the MaxSize field is set to the value of the last call.
-func (b *ForwardBodyConfigApplyConfiguration) WithMaxSize(value uint16) *ForwardBodyConfigApplyConfiguration {
+func (b *ForwardBodyConfigApplyConfiguration) WithMaxSize(value int32) *ForwardBodyConfigApplyConfiguration {
 	b.MaxSize = &value
 	return b
 }

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -916,6 +916,7 @@ spec:
                                             for more.
 
                                             If 0, the body will not be sent to the authorization server.
+                                          format: int32
                                           type: integer
                                       type: object
                                     grpc:
@@ -2445,6 +2446,7 @@ spec:
                                       for more.
 
                                       If 0, the body will not be sent to the authorization server.
+                                    format: int32
                                     type: integer
                                 type: object
                               grpc:
@@ -5171,6 +5173,7 @@ spec:
                                             for more.
 
                                             If 0, the body will not be sent to the authorization server.
+                                          format: int32
                                           type: integer
                                       type: object
                                     grpc:
@@ -6700,6 +6703,7 @@ spec:
                                       for more.
 
                                       If 0, the body will not be sent to the authorization server.
+                                    format: int32
                                     type: integer
                                 type: object
                               grpc:

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -917,6 +917,7 @@ spec:
 
                                             If 0, the body will not be sent to the authorization server.
                                           format: int32
+                                          minimum: 0
                                           type: integer
                                       type: object
                                     grpc:
@@ -2447,6 +2448,7 @@ spec:
 
                                       If 0, the body will not be sent to the authorization server.
                                     format: int32
+                                    minimum: 0
                                     type: integer
                                 type: object
                               grpc:
@@ -5174,6 +5176,7 @@ spec:
 
                                             If 0, the body will not be sent to the authorization server.
                                           format: int32
+                                          minimum: 0
                                           type: integer
                                       type: object
                                     grpc:
@@ -6704,6 +6707,7 @@ spec:
 
                                       If 0, the body will not be sent to the authorization server.
                                     format: int32
+                                    minimum: 0
                                     type: integer
                                 type: object
                               grpc:

--- a/geps/gep-1494/index.md
+++ b/geps/gep-1494/index.md
@@ -477,7 +477,7 @@ type ForwardBodyConfig struct {
     // truncated to `maxSize` bytes.
 	//
 	// If 0, the body will not be sent to the authorization server.
-	MaxSize uint16 `json:"maxSize,omitempty"`
+	MaxSize int32 `json:"maxSize,omitempty"`
 }
 
 ```


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Changes `ForwardBodyConfig.MaxSize` from `uint16` to `int32` so Gateway API types can be converted to protobuf with `go-to-protobuf`. `uint16` is not a supported type for protobuf conversion.

This also aligns the Go type with existing CRD/OpenAPI schema (`type: integer`, `format: int32`). The JSON/YAML API is unchanged.

**Which issue(s) this PR fixes**:
Fixes #5068

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```