### PR TITLE
fix: correct weight calculation in conformance reports list

### DIFF
--- a/hack/docsy-generate-conformance.py
+++ b/hack/docsy-generate-conformance.py
@@ -49,7 +49,7 @@ Implementations only appear in this page if they pass Core conformance for the r
 """
 
 
-def generate_conformance_tables(reports, currVersion, out_dir, is_hidden=False):
+def generate_conformance_tables(reports, currVersion, out_dir, max_minor, is_hidden=False):
     gateway_tls_table = pandas.DataFrame()
     gateway_grpc_table = pandas.DataFrame()
 
@@ -80,7 +80,7 @@ def generate_conformance_tables(reports, currVersion, out_dir, is_hidden=False):
         minor = int(version_short.split(".")[1])
     except:
         pass
-    weight = (6 - minor) * 10
+    weight = (max_minor + 1 - minor) * 10
 
     try:
         f = StringIO()
@@ -342,7 +342,7 @@ def main():
     for i, group in enumerate(release_groups):
         confYamls = getYaml(group["paths"])
         is_hidden = i < len(release_groups) - 4
-        generate_conformance_tables(confYamls, group["latest"], out_dir, is_hidden)
+        generate_conformance_tables(confYamls, group["latest"], out_dir, int(release_groups[-1]['minor'].split(".")[1]), is_hidden)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind bug
/kind documentation

**What this PR does / why we need it**:
<img width="362" height="314" alt="image" src="https://github.com/user-attachments/assets/a782afa8-a447-4772-ba52-067ab2644550" />

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
