### PR TITLE
conformance: bound TLS rejection dial attempts

### DIFF
--- a/conformance/utils/tls/tls.go
+++ b/conformance/utils/tls/tls.go
@@ -17,9 +17,11 @@ limitations under the License.
 package tls
 
 import (
+	"context"
 	cryptotls "crypto/tls"
 	"errors"
 	"io"
+	"net"
 	"strings"
 	"syscall"
 	"testing"
@@ -32,6 +34,10 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/roundtripper"
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
 )
+
+type contextDialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
 
 // MakeTLSRequestAndExpectEventuallyConsistentResponse makes a request with the given parameters,
 // understanding that the request may fail for some amount of time.
@@ -137,8 +143,26 @@ func MakeTLSConnectionAndExpectEventuallyConnectionRejection(t *testing.T, timeo
 		},
 	}
 
+	waitForTLSConnectionRejection(t, timeoutConfig, dialer, gwAddr, time.Second)
+}
+
+func waitForTLSConnectionRejection(t *testing.T, timeoutConfig config.TimeoutConfig, dialer contextDialer, gwAddr string, retryInterval time.Duration) {
+	t.Helper()
+
+	overallCtx, cancel := context.WithTimeout(t.Context(), timeoutConfig.MaxTimeToConsistency)
+	defer cancel()
+
 	assert.Eventually(t, func() bool {
-		_, err := dialer.DialContext(t.Context(), "tcp", gwAddr)
+		attemptCtx, cancelAttempt := context.WithTimeout(overallCtx, timeoutConfig.RequestTimeout)
+		conn, err := dialer.DialContext(attemptCtx, "tcp", gwAddr)
+		cancelAttempt()
+
+		if conn != nil {
+			if closeErr := conn.Close(); closeErr != nil {
+				tlog.Logf(t, "error closing connection: %s", closeErr)
+			}
+		}
+
 		if err != nil {
 			if isConnectionRejected(err) {
 				tlog.Logf(t, "connection was rejected during dial: %s", err)
@@ -149,7 +173,7 @@ func MakeTLSConnectionAndExpectEventuallyConnectionRejection(t *testing.T, timeo
 		}
 		tlog.Logf(t, "client could connect")
 		return false
-	}, timeoutConfig.MaxTimeToConsistency, time.Second)
+	}, timeoutConfig.MaxTimeToConsistency, retryInterval)
 }
 
 // isConnectionRejected checks if an error indicates either a TCP RST (ECONNRESET)

--- a/conformance/utils/tls/tls_test.go
+++ b/conformance/utils/tls/tls_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/config"
+)
+
+type dialContextFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+func (f dialContextFunc) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return f(ctx, network, address)
+}
+
+type trackedConn struct {
+	net.Conn
+	closed atomic.Bool
+}
+
+func (c *trackedConn) Close() error {
+	c.closed.Store(true)
+	return c.Conn.Close()
+}
+
+func TestWaitForTLSConnectionRejectionRetriesAfterAttemptTimeout(t *testing.T) {
+	var attempts atomic.Int32
+	dialer := dialContextFunc(func(ctx context.Context, _, _ string) (net.Conn, error) {
+		if attempts.Add(1) == 1 {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return nil, io.EOF
+	})
+	timeoutConfig := config.TimeoutConfig{
+		MaxTimeToConsistency: 500 * time.Millisecond,
+		RequestTimeout:       20 * time.Millisecond,
+	}
+
+	waitForTLSConnectionRejection(t, timeoutConfig, dialer, "example.com:443", time.Millisecond)
+
+	assert.GreaterOrEqual(t, attempts.Load(), int32(2))
+}
+
+func TestWaitForTLSConnectionRejectionClosesUnexpectedConnection(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer serverConn.Close()
+
+	conn := &trackedConn{Conn: clientConn}
+	var attempts atomic.Int32
+	dialer := dialContextFunc(func(context.Context, string, string) (net.Conn, error) {
+		if attempts.Add(1) == 1 {
+			return conn, nil
+		}
+		return nil, io.EOF
+	})
+	timeoutConfig := config.TimeoutConfig{
+		MaxTimeToConsistency: 500 * time.Millisecond,
+		RequestTimeout:       20 * time.Millisecond,
+	}
+
+	waitForTLSConnectionRejection(t, timeoutConfig, dialer, "example.com:443", time.Millisecond)
+
+	assert.True(t, conn.closed.Load())
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind flake
/area conformance-test

**What this PR does / why we need it**:

Bounds each TLS rejection dial attempt by `RequestTimeout` so one stalled connection cannot exhaust the full consistency retry window. Unexpected successful connections are closed before retrying.

Adds unit coverage for retrying after an attempt timeout and closing an unexpected connection.

**Which issue(s) this PR fixes**:

Fixes: #5109

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
