### PR TITLE
conformance(test): Tests for ExternalAuth filters

### DIFF
--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -915,3 +915,54 @@ spec:
               - key: tls.key
                 path: key
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-auth-grpc
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: external-auth
+  ports:
+    - protocol: TCP
+      port: 9001
+      targetPort: 9001
+      appProtocol: kubernetes.io/h2c
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-auth-http
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: external-auth
+  ports:
+    - protocol: TCP
+      port: 9002
+      targetPort: 9002
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-auth
+  namespace: gateway-conformance-infra
+  labels:
+    app: external-auth
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: external-auth
+  template:
+    metadata:
+      labels:
+        app: external-auth
+    spec:
+      containers:
+        - name: external-auth
+          image: registry.k8s.io/gateway-api/conformance/extauth-v3-impl:v20260726
+          resources:
+            requests:
+              cpu: 10m
+---

--- a/conformance/base/manifests.yaml
+++ b/conformance/base/manifests.yaml
@@ -899,3 +899,54 @@ spec:
               - key: tls.key
                 path: key
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-auth-grpc
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: external-auth
+  ports:
+    - protocol: TCP
+      port: 9001
+      targetPort: 9001
+      appProtocol: kubernetes.io/h2c
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-auth-http
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: external-auth
+  ports:
+    - protocol: TCP
+      port: 9002
+      targetPort: 9002
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-auth
+  namespace: gateway-conformance-infra
+  labels:
+    app: external-auth
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: external-auth
+  template:
+    metadata:
+      labels:
+        app: external-auth
+    spec:
+      containers:
+        - name: external-auth
+          image: registry.k8s.io/gateway-api/conformance/extauth-v3-impl:v20260726
+          resources:
+            requests:
+              cpu: 10m
+---

--- a/conformance/tests/httproute-external-auth-backend-unavailable.go
+++ b/conformance/tests/httproute-external-auth-backend-unavailable.go
@@ -1,0 +1,60 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteExternalAuthBackendUnavailable)
+}
+
+var HTTPRouteExternalAuthBackendUnavailable = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteExternalAuthBackendUnavailable",
+	Description: "When the ExternalAuth backend Service exists but has no healthy endpoints, the gateway must fail closed (deny the request) rather than forwarding it unauthenticated",
+	Manifests:   []string{"tests/httproute-external-auth-backend-unavailable.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteExternalAuth,
+		features.SupportHTTPRouteExternalAuthHTTP,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "external-auth-backend-unavailable", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		t.Run("requests are denied when the ExternalAuth backend has no endpoints", func(t *testing.T) {
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
+				Request:  http.Request{Path: "/http/allowed"},
+				Response: http.Response{StatusCodes: []int{403, 500, 502, 503}},
+			})
+		})
+	},
+}

--- a/conformance/tests/httproute-external-auth-backend-unavailable.yaml
+++ b/conformance/tests/httproute-external-auth-backend-unavailable.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-auth-unavailable
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: nonexistent-external-auth-backend
+  ports:
+  - protocol: TCP
+    port: 9002
+    targetPort: 9002
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-auth-backend-unavailable
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: external-auth-unavailable
+          port: 9002
+        http:
+          allowedHeaders: ~
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/httproute-external-auth-backendref-not-found.go
+++ b/conformance/tests/httproute-external-auth-backendref-not-found.go
@@ -1,0 +1,82 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteExternalAuthBackendRefNotFound)
+}
+
+var HTTPRouteExternalAuthBackendRefNotFound = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteExternalAuthBackendRefNotFound",
+	Description: "An HTTPRoute with an ExternalAuth filter whose backendRef cannot be resolved must have ResolvedRefs=False/BackendNotFound and must fail closed",
+	Manifests:   []string{"tests/httproute-external-auth-backendref-not-found.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteExternalAuth,
+		features.SupportHTTPRouteExternalAuthHTTP,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		unknownNN := types.NamespacedName{Name: "external-auth-unknown-backendref", Namespace: ns}
+		invalidPortNN := types.NamespacedName{Name: "external-auth-backendref-invalid-port", Namespace: ns}
+
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), unknownNN, invalidPortNN)
+
+		resolvedRefsFalse := metav1.Condition{
+			Type:   string(v1.RouteConditionResolvedRefs),
+			Status: metav1.ConditionFalse,
+			Reason: string(v1.RouteReasonBackendNotFound),
+		}
+
+		t.Run("route with nonexistent ExternalAuth Service has ResolvedRefs=False/BackendNotFound", func(t *testing.T) {
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, unknownNN, gwNN, resolvedRefsFalse)
+		})
+
+		t.Run("route with ExternalAuth Service on a nonexistent port has ResolvedRefs=False/BackendNotFound", func(t *testing.T) {
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, invalidPortNN, gwNN, resolvedRefsFalse)
+		})
+
+		t.Run("requests to a route with a nonexistent ExternalAuth Service are denied", func(t *testing.T) {
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
+				Request:  http.Request{Path: "/external-auth/unknown-backendref"},
+				Response: http.Response{StatusCodes: []int{403, 500, 502, 503}},
+			})
+		})
+
+		t.Run("requests to a route with an ExternalAuth Service on a nonexistent port are denied", func(t *testing.T) {
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
+				Request:  http.Request{Path: "/external-auth/invalid-port"},
+				Response: http.Response{StatusCodes: []int{403, 500, 502, 503}},
+			})
+		})
+	},
+}

--- a/conformance/tests/httproute-external-auth-backendref-not-found.yaml
+++ b/conformance/tests/httproute-external-auth-backendref-not-found.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-auth-unknown-backendref
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /external-auth/unknown-backendref
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: nonexistent-auth-service
+          port: 9002
+        http:
+          allowedHeaders: ~
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-auth-backendref-invalid-port
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /external-auth/invalid-port
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: external-auth-http
+          port: 9999
+        http:
+          allowedHeaders: ~
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/httproute-external-auth-grpc-forward-body.go
+++ b/conformance/tests/httproute-external-auth-grpc-forward-body.go
@@ -1,0 +1,131 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteExternalAuthGRPCForwardBody)
+}
+
+// NOTE: GEP-1494 has an unresolved inconsistency between the ExternalAuthFilter.ForwardBody
+// field comment (which says oversized bodies are rejected with 4xx) and the
+// ForwardBodyConfig.MaxSize comment (which says the body is truncated). The over-size test
+// therefore accepts both 413 and 403. Implementations that truncate will return 200 and fail
+// that case; that is expected until the spec ambiguity is resolved.
+var HTTPRouteExternalAuthGRPCForwardBody = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteExternalAuthGRPCForwardBody",
+	Description: "An HTTPRoute ExternalAuth gRPC filter honors forwardBody.maxSize: bodies within the limit are forwarded and confirmed via X-Auth-Received-Body-Size; bodies over the limit are rejected with 4xx; maxSize=0 withholds the body entirely",
+	Manifests:   []string{"tests/httproute-external-auth-grpc-forward-body.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteExternalAuth,
+		features.SupportHTTPRouteExternalAuthGRPC,
+		features.SupportHTTPRouteExternalAuthForwardBody,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "external-auth-grpc-forward-body", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				TestCaseName: "maxSize=100: body within limit (10 bytes) should be forwarded to the auth server",
+				Request: http.Request{
+					Method: "POST",
+					Path:   "/grpc/allowed/forward-body",
+					Body:   "0123456789",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Method: "POST",
+						Path:   "/grpc/allowed/forward-body",
+						Headers: map[string]string{
+							"X-Auth-Received-Body-Size": "10",
+						},
+					},
+				},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+				Response:  http.Response{StatusCode: 200},
+			},
+			{
+				TestCaseName: "maxSize=100: body exceeding limit (200 bytes) should be rejected with 4xx",
+				Request: http.Request{
+					Method: "POST",
+					Path:   "/grpc/allowed/forward-body",
+					Body:   strings.Repeat("x", 200),
+				},
+				Response: http.Response{StatusCodes: []int{413, 403}},
+			},
+			{
+				TestCaseName: "maxSize=0: allowed request with body must not be rejected and auth server must receive zero body bytes",
+				Request: http.Request{
+					Method: "POST",
+					Path:   "/grpc/allowed/forward-body-zero",
+					Body:   strings.Repeat("x", 200),
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Method: "POST",
+						Path:   "/grpc/allowed/forward-body-zero",
+						Headers: map[string]string{
+							"X-Auth-Received-Body-Size": "0",
+						},
+					},
+				},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+				Response:  http.Response{StatusCode: 200},
+			},
+			{
+				TestCaseName: "maxSize=0: denied request with body must still be denied and auth server must receive zero body bytes",
+				Request: http.Request{
+					Method: "POST",
+					Path:   "/grpc/denied/forward-body-zero",
+					Body:   strings.Repeat("x", 200),
+				},
+				Response: http.Response{
+					StatusCode: 403,
+					Headers: map[string]string{
+						"X-Auth-Received-Body-Size": "0",
+					},
+				},
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-external-auth-grpc-forward-body.yaml
+++ b/conformance/tests/httproute-external-auth-grpc-forward-body.yaml
@@ -1,0 +1,48 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-auth-grpc-forward-body
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /grpc/allowed/forward-body
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: GRPC
+        backendRef:
+          name: external-auth-grpc
+          port: 9001
+        forwardBody:
+          maxSize: 100
+        grpc:
+          allowedHeaders: ~
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - matches:
+    - path:
+        type: Exact
+        value: /grpc/allowed/forward-body-zero
+    - path:
+        type: Exact
+        value: /grpc/denied/forward-body-zero
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: GRPC
+        backendRef:
+          name: external-auth-grpc
+          port: 9001
+        forwardBody:
+          maxSize: 0
+        grpc:
+          allowedHeaders: ~
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/httproute-external-auth-grpc-request-headers-to-auth.go
+++ b/conformance/tests/httproute-external-auth-grpc-request-headers-to-auth.go
@@ -1,0 +1,81 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteExternalAuthGRPCRequestHeadersToAuth)
+}
+
+var HTTPRouteExternalAuthGRPCRequestHeadersToAuth = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteExternalAuthGRPCRequestHeadersToAuth",
+	Description: "Headers listed in grpc.allowedHeaders are forwarded to the gRPC auth server",
+	Manifests:   []string{"tests/httproute-external-auth-grpc-request-headers-to-auth.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteExternalAuth,
+		features.SupportHTTPRouteExternalAuthGRPC,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "external-auth-grpc-request-headers-to-auth", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				TestCaseName: "request header listed in allowedHeaders should arrive at the auth server and be echoed to the backend",
+				Request: http.Request{
+					Path: "/grpc/allowed",
+					Headers: map[string]string{
+						"X-Test-Header": "hello",
+					},
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/grpc/allowed",
+						Headers: map[string]string{
+							"X-Auth-Received-Test-Header": "hello",
+						},
+					},
+				},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+				Response:  http.Response{StatusCode: 200},
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-external-auth-grpc-request-headers-to-auth.yaml
+++ b/conformance/tests/httproute-external-auth-grpc-request-headers-to-auth.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-auth-grpc-request-headers-to-auth
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: GRPC
+        backendRef:
+          name: external-auth-grpc
+          port: 9001
+        grpc:
+          allowedHeaders:
+          - X-Test-Header
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/httproute-external-auth-grpc-response-headers.go
+++ b/conformance/tests/httproute-external-auth-grpc-response-headers.go
@@ -1,0 +1,91 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteExternalAuthGRPCResponseHeaders)
+}
+
+var HTTPRouteExternalAuthGRPCResponseHeaders = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteExternalAuthGRPCResponseHeaders",
+	Description: "Headers in the gRPC auth OkHttpResponse are forwarded to the upstream backend and headers in DeniedHttpResponse are passed through to the client",
+	Manifests:   []string{"tests/httproute-external-auth-grpc-response-headers.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteExternalAuth,
+		features.SupportHTTPRouteExternalAuthGRPC,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "external-auth-grpc-response-headers", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				TestCaseName: "headers in OkHttpResponse should be added to the upstream request on approval",
+				Request: http.Request{
+					Path: "/grpc/allowed/upstream",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/grpc/allowed/upstream",
+						Headers: map[string]string{
+							"X-User-Id": "42",
+						},
+					},
+				},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+				Response:  http.Response{StatusCode: 200},
+			},
+			{
+				TestCaseName: "headers from the auth server DeniedHttpResponse should be present on the 403 response to the client",
+				Request: http.Request{
+					Path: "/grpc/denied/response-headers",
+				},
+				Response: http.Response{
+					StatusCode: 403,
+					Headers: map[string]string{
+						"X-Auth-Error": "access-denied",
+					},
+					Body: "Access denied by external auth server",
+				},
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-external-auth-grpc-response-headers.yaml
+++ b/conformance/tests/httproute-external-auth-grpc-response-headers.yaml
@@ -1,0 +1,41 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-auth-grpc-response-headers
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /grpc/allowed/upstream
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: GRPC
+        backendRef:
+          name: external-auth-grpc
+          port: 9001
+        grpc:
+          allowedHeaders: ~
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - matches:
+    - path:
+        type: Exact
+        value: /grpc/denied/response-headers
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: GRPC
+        backendRef:
+          name: external-auth-grpc
+          port: 9001
+        grpc:
+          allowedHeaders: ~
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/httproute-external-auth-grpc.go
+++ b/conformance/tests/httproute-external-auth-grpc.go
@@ -1,0 +1,85 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteExternalAuthGRPC)
+}
+
+var HTTPRouteExternalAuthGRPC = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteExternalAuthGRPC",
+	Description: "An HTTPRoute with an ExternalAuth gRPC filter allows requests the auth server approves and denies requests it rejects, forwarding the auth server response body to the client",
+	Manifests:   []string{"tests/httproute-external-auth-grpc.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteExternalAuth,
+		features.SupportHTTPRouteExternalAuthGRPC,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "external-auth-grpc", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				TestCaseName: "request to /grpc/allowed should be forwarded to the backend",
+				Request: http.Request{
+					Path: "/grpc/allowed",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/grpc/allowed",
+					},
+				},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+				Response:  http.Response{StatusCode: 200},
+			},
+			{
+				TestCaseName: "request to /grpc/denied should be rejected with the auth server response body",
+				Request: http.Request{
+					Path: "/grpc/denied",
+				},
+				Response: http.Response{
+					StatusCode: 403,
+					Body:       "Access denied by external auth server",
+				},
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-external-auth-grpc.yaml
+++ b/conformance/tests/httproute-external-auth-grpc.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-auth-grpc
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: GRPC
+        backendRef:
+          name: external-auth-grpc
+          port: 9001
+        grpc:
+          allowedHeaders: ~
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/httproute-external-auth-http-forward-body.go
+++ b/conformance/tests/httproute-external-auth-http-forward-body.go
@@ -1,0 +1,131 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteExternalAuthHTTPForwardBody)
+}
+
+// NOTE: GEP-1494 has an unresolved inconsistency between the ExternalAuthFilter.ForwardBody
+// field comment (which says oversized bodies are rejected with 4xx) and the
+// ForwardBodyConfig.MaxSize comment (which says the body is truncated). The over-size test
+// therefore accepts both 413 and 403. Implementations that truncate will return 200 and fail
+// that case; that is expected until the spec ambiguity is resolved.
+var HTTPRouteExternalAuthHTTPForwardBody = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteExternalAuthHTTPForwardBody",
+	Description: "An HTTPRoute ExternalAuth HTTP filter honors forwardBody.maxSize: bodies within the limit are forwarded and confirmed via X-Auth-Received-Body-Size; bodies over the limit are rejected with 4xx; maxSize=0 withholds the body entirely",
+	Manifests:   []string{"tests/httproute-external-auth-http-forward-body.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteExternalAuth,
+		features.SupportHTTPRouteExternalAuthHTTP,
+		features.SupportHTTPRouteExternalAuthForwardBody,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "external-auth-http-forward-body", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				TestCaseName: "maxSize=100: body within limit (10 bytes) should be forwarded to the auth server",
+				Request: http.Request{
+					Method: "POST",
+					Path:   "/http/allowed/forward-body",
+					Body:   "0123456789",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Method: "POST",
+						Path:   "/http/allowed/forward-body",
+						Headers: map[string]string{
+							"X-Auth-Received-Body-Size": "10",
+						},
+					},
+				},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+				Response:  http.Response{StatusCode: 200},
+			},
+			{
+				TestCaseName: "maxSize=100: body exceeding limit (200 bytes) should be rejected with 4xx",
+				Request: http.Request{
+					Method: "POST",
+					Path:   "/http/allowed/forward-body",
+					Body:   strings.Repeat("x", 200),
+				},
+				Response: http.Response{StatusCodes: []int{413, 403}},
+			},
+			{
+				TestCaseName: "maxSize=0: allowed request with body must not be rejected and auth server must receive zero body bytes",
+				Request: http.Request{
+					Method: "POST",
+					Path:   "/http/allowed/forward-body-zero",
+					Body:   strings.Repeat("x", 200),
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Method: "POST",
+						Path:   "/http/allowed/forward-body-zero",
+						Headers: map[string]string{
+							"X-Auth-Received-Body-Size": "0",
+						},
+					},
+				},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+				Response:  http.Response{StatusCode: 200},
+			},
+			{
+				TestCaseName: "maxSize=0: denied request with body must still be denied and auth server must receive zero body bytes",
+				Request: http.Request{
+					Method: "POST",
+					Path:   "/http/denied/forward-body-zero",
+					Body:   strings.Repeat("x", 200),
+				},
+				Response: http.Response{
+					StatusCode: 403,
+					Headers: map[string]string{
+						"X-Auth-Received-Body-Size": "0",
+					},
+				},
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-external-auth-http-forward-body.yaml
+++ b/conformance/tests/httproute-external-auth-http-forward-body.yaml
@@ -1,0 +1,50 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-auth-http-forward-body
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /http/allowed/forward-body
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: external-auth-http
+          port: 9002
+        forwardBody:
+          maxSize: 100
+        http:
+          allowedResponseHeaders:
+          - X-Auth-Received-Body-Size
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - matches:
+    - path:
+        type: Exact
+        value: /http/allowed/forward-body-zero
+    - path:
+        type: Exact
+        value: /http/denied/forward-body-zero
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: external-auth-http
+          port: 9002
+        forwardBody:
+          maxSize: 0
+        http:
+          allowedResponseHeaders:
+          - X-Auth-Received-Body-Size
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/httproute-external-auth-http-request-headers-to-auth.go
+++ b/conformance/tests/httproute-external-auth-http-request-headers-to-auth.go
@@ -1,0 +1,81 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteExternalAuthHTTPRequestHeadersToAuth)
+}
+
+var HTTPRouteExternalAuthHTTPRequestHeadersToAuth = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteExternalAuthHTTPRequestHeadersToAuth",
+	Description: "Headers listed in http.allowedHeaders are forwarded to the HTTP auth server",
+	Manifests:   []string{"tests/httproute-external-auth-http-request-headers-to-auth.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteExternalAuth,
+		features.SupportHTTPRouteExternalAuthHTTP,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "external-auth-http-request-headers-to-auth", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				TestCaseName: "request header listed in allowedHeaders should arrive at the auth server and be echoed to the backend",
+				Request: http.Request{
+					Path: "/http/allowed",
+					Headers: map[string]string{
+						"X-Test-Header": "hello",
+					},
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/http/allowed",
+						Headers: map[string]string{
+							"X-Auth-Received-Test-Header": "hello",
+						},
+					},
+				},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+				Response:  http.Response{StatusCode: 200},
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-external-auth-http-request-headers-to-auth.yaml
+++ b/conformance/tests/httproute-external-auth-http-request-headers-to-auth.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-auth-http-request-headers-to-auth
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: external-auth-http
+          port: 9002
+        http:
+          allowedHeaders:
+          - X-Test-Header
+          allowedResponseHeaders:
+          - X-Auth-Received-Test-Header
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/httproute-external-auth-http-response-headers.go
+++ b/conformance/tests/httproute-external-auth-http-response-headers.go
@@ -1,0 +1,91 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteExternalAuthHTTPResponseHeaders)
+}
+
+var HTTPRouteExternalAuthHTTPResponseHeaders = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteExternalAuthHTTPResponseHeaders",
+	Description: "Headers in the HTTP auth response are forwarded to the upstream backend (via allowedResponseHeaders) and passed through to the client on denial",
+	Manifests:   []string{"tests/httproute-external-auth-http-response-headers.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteExternalAuth,
+		features.SupportHTTPRouteExternalAuthHTTP,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "external-auth-http-response-headers", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				TestCaseName: "headers listed in allowedResponseHeaders should be added to the upstream request on approval",
+				Request: http.Request{
+					Path: "/http/allowed",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/http/allowed",
+						Headers: map[string]string{
+							"X-User-Id": "42",
+						},
+					},
+				},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+				Response:  http.Response{StatusCode: 200},
+			},
+			{
+				TestCaseName: "headers from the auth server 403 response should be present on the client response",
+				Request: http.Request{
+					Path: "/http/denied",
+				},
+				Response: http.Response{
+					StatusCode: 403,
+					Headers: map[string]string{
+						"X-Auth-Error": "access-denied",
+					},
+					Body: "Access denied by external auth server",
+				},
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-external-auth-http-response-headers.yaml
+++ b/conformance/tests/httproute-external-auth-http-response-headers.yaml
@@ -1,0 +1,42 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-auth-http-response-headers
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /http/allowed
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: external-auth-http
+          port: 9002
+        http:
+          allowedResponseHeaders:
+          - X-User-Id
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - matches:
+    - path:
+        type: Exact
+        value: /http/denied
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: external-auth-http
+          port: 9002
+        http:
+          allowedHeaders: ~
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/httproute-external-auth-http.go
+++ b/conformance/tests/httproute-external-auth-http.go
@@ -1,0 +1,85 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteExternalAuthHTTP)
+}
+
+var HTTPRouteExternalAuthHTTP = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteExternalAuthHTTP",
+	Description: "An HTTPRoute with an ExternalAuth HTTP filter allows requests the auth server approves and denies requests it rejects, forwarding the auth server response body to the client",
+	Manifests:   []string{"tests/httproute-external-auth-http.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteExternalAuth,
+		features.SupportHTTPRouteExternalAuthHTTP,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "external-auth-http", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				TestCaseName: "request to /http/allowed should be forwarded to the backend",
+				Request: http.Request{
+					Path: "/http/allowed",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Path: "/http/allowed",
+					},
+				},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+				Response:  http.Response{StatusCode: 200},
+			},
+			{
+				TestCaseName: "request to /http/denied should be rejected with the auth server response body",
+				Request: http.Request{
+					Path: "/http/denied",
+				},
+				Response: http.Response{
+					StatusCode: 403,
+					Body:       "Access denied by external auth server",
+				},
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-external-auth-http.yaml
+++ b/conformance/tests/httproute-external-auth-http.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-auth-http
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: external-auth-http
+          port: 9002
+        http:
+          allowedHeaders: ~
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/httproute-external-auth-partially-invalid.go
+++ b/conformance/tests/httproute-external-auth-partially-invalid.go
@@ -1,0 +1,79 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteExternalAuthPartiallyInvalid)
+}
+
+var HTTPRouteExternalAuthPartiallyInvalid = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteExternalAuthPartiallyInvalid",
+	Description: "An HTTPRoute with two rules where one rule has a valid ExternalAuth backendRef and another rule has an unresolvable ExternalAuth backendRef should have PartiallyInvalid=True and ResolvedRefs=False",
+	Manifests:   []string{"tests/httproute-external-auth-partially-invalid.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteExternalAuth,
+		features.SupportHTTPRouteExternalAuthHTTP,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "external-auth-partially-invalid", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+
+		t.Run("HTTPRoute with one invalid ExternalAuth rule has PartiallyInvalid=True", func(t *testing.T) {
+			// The spec lists "UnsupportedValue" as the canonical reason but permits other
+			// reasons. Implementations resolving ExternalAuth backendRefs typically set
+			// "BackendNotFound". We accept any reason by passing an empty string.
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, metav1.Condition{
+				Type:   string(v1.RouteConditionPartiallyInvalid),
+				Status: metav1.ConditionTrue,
+				Reason: "",
+			})
+		})
+
+		t.Run("HTTPRoute with one invalid ExternalAuth rule has ResolvedRefs=False/BackendNotFound", func(t *testing.T) {
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, metav1.Condition{
+				Type:   string(v1.RouteConditionResolvedRefs),
+				Status: metav1.ConditionFalse,
+				Reason: string(v1.RouteReasonBackendNotFound),
+			})
+		})
+
+		t.Run("requests to the invalid ExternalAuth rule return 403, or 5xx", func(t *testing.T) {
+			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, http.ExpectedResponse{
+				Request:  http.Request{Path: "/external-auth/invalid"},
+				Response: http.Response{StatusCodes: []int{403, 500, 502, 503}},
+			})
+		})
+	},
+}

--- a/conformance/tests/httproute-external-auth-partially-invalid.yaml
+++ b/conformance/tests/httproute-external-auth-partially-invalid.yaml
@@ -1,0 +1,41 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-auth-partially-invalid
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /external-auth/valid
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: external-auth-http
+          port: 9002
+        http:
+          allowedHeaders: ~
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /external-auth/invalid
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: nonexistent-auth-service
+          port: 9002
+        http:
+          allowedHeaders: ~
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/httproute-external-auth-per-route-scope.go
+++ b/conformance/tests/httproute-external-auth-per-route-scope.go
@@ -1,0 +1,82 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteExternalAuthPerRouteScope)
+}
+
+var HTTPRouteExternalAuthPerRouteScope = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteExternalAuthPerRouteScope",
+	Description: "ExternalAuth filter is applied only to the route that declares it; routes on the same listener that have no ExternalAuth filter must be reachable without auth",
+	Manifests:   []string{"tests/httproute-external-auth-per-route-scope.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteExternalAuth,
+		features.SupportHTTPRouteExternalAuthHTTP,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		withAuthNN := types.NamespacedName{Name: "external-auth-per-route-scope-with-auth", Namespace: ns}
+		withoutAuthNN := types.NamespacedName{Name: "external-auth-per-route-scope-without-auth", Namespace: ns}
+
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), withAuthNN, withoutAuthNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, withAuthNN, gwNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, withoutAuthNN, gwNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				TestCaseName: "route with ExternalAuth: allowed path reaches backend",
+				Request:      http.Request{Path: "/http/allowed"},
+				Backend:      confsuite.InfraBackendServiceNameV1,
+				Namespace:    ns,
+				Response:     http.Response{StatusCode: 200},
+			},
+			{
+				// Route "without-auth" matches /http/denied (more specific than /http),
+				// so this request bypasses the ExternalAuth filter entirely.
+				// If ExternalAuth were applied at HCM/listener level instead of per-route,
+				// the auth server would deny this path and the gateway would return 403.
+				TestCaseName: "route without ExternalAuth: request reaches backend even on a path the auth server would deny",
+				Request:      http.Request{Path: "/http/denied"},
+				Backend:      confsuite.InfraBackendServiceNameV1,
+				Namespace:    ns,
+				Response:     http.Response{StatusCode: 200},
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-external-auth-per-route-scope.yaml
+++ b/conformance/tests/httproute-external-auth-per-route-scope.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-auth-per-route-scope-with-auth
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /http
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: external-auth-http
+          port: 9002
+        http:
+          allowedHeaders: ~
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-auth-per-route-scope-without-auth
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /http/denied
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/tests/httproute-external-auth-programmed-condition.go
+++ b/conformance/tests/httproute-external-auth-programmed-condition.go
@@ -1,0 +1,76 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteExternalAuthProgrammedCondition)
+}
+
+var HTTPRouteExternalAuthProgrammedCondition = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteExternalAuthProgrammedCondition",
+	Description: "A valid Gateway and HTTPRoute with a correctly configured ExternalAuth filter should have Gateway Programmed=True and HTTPRoute Accepted=True/ResolvedRefs=True",
+	Manifests:   []string{"tests/httproute-external-auth-programmed-condition.yaml"},
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+		features.SupportHTTPRouteExternalAuth,
+		features.SupportHTTPRouteExternalAuthHTTP,
+	},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "external-auth-programmed-condition", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+
+		kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+
+		t.Run("Gateway has Programmed=True when a valid ExternalAuth filter is configured", func(t *testing.T) {
+			kubernetes.GatewayMustHaveCondition(t, suite.Client, suite.TimeoutConfig, gwNN, metav1.Condition{
+				Type:   string(v1.GatewayConditionProgrammed),
+				Status: metav1.ConditionTrue,
+				Reason: string(v1.GatewayReasonProgrammed),
+			})
+		})
+
+		t.Run("HTTPRoute has Accepted=True", func(t *testing.T) {
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, metav1.Condition{
+				Type:   string(v1.RouteConditionAccepted),
+				Status: metav1.ConditionTrue,
+				Reason: string(v1.RouteReasonAccepted),
+			})
+		})
+
+		t.Run("HTTPRoute has ResolvedRefs=True when ExternalAuth backendRef is resolvable", func(t *testing.T) {
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, metav1.Condition{
+				Type:   string(v1.RouteConditionResolvedRefs),
+				Status: metav1.ConditionTrue,
+				Reason: string(v1.RouteReasonResolvedRefs),
+			})
+		})
+	},
+}

--- a/conformance/tests/httproute-external-auth-programmed-condition.yaml
+++ b/conformance/tests/httproute-external-auth-programmed-condition.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-auth-programmed-condition
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: external-auth-http
+          port: 9002
+        http:
+          allowedHeaders: ~
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -146,6 +146,9 @@ type Response struct {
 	// IgnoreWhitespace will cause whitespace to be ignored when comparing the response
 	// header values.
 	IgnoreWhitespace bool
+	// Body specifies the exact response body the test case should receive.
+	// If empty, the response body is not checked.
+	Body string
 }
 
 type BackendRef struct {
@@ -363,6 +366,9 @@ func CompareRoundTrip(t *testing.T, req *roundtripper.Request, cReq *roundtrippe
 	}
 	if expected.Response.Protocol != "" && expected.Response.Protocol != cRes.Protocol {
 		return fmt.Errorf("expected protocol to be %s, got %s", expected.Response.Protocol, cRes.Protocol)
+	}
+	if expected.Response.Body != "" && expected.Response.Body != cRes.Body {
+		return fmt.Errorf("expected response body to be %q, got %q", expected.Response.Body, cRes.Body)
 	}
 
 	// 204 is a valid response for CORS requests.

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -146,6 +146,9 @@ type Response struct {
 	// IgnoreWhitespace will cause whitespace to be ignored when comparing the response
 	// header values.
 	IgnoreWhitespace bool
+	// Body specifies the exact response body the test case should receive.
+	// If empty, the response body is not checked.
+	Body string
 }
 
 type BackendRef struct {
@@ -365,6 +368,9 @@ func CompareRoundTrip(t *testing.T, req *roundtripper.Request, cReq *roundtrippe
 	}
 	if expected.Response.Protocol != "" && expected.Response.Protocol != cRes.Protocol {
 		return fmt.Errorf("expected protocol to be %s, got %s", expected.Response.Protocol, cRes.Protocol)
+	}
+	if expected.Response.Body != "" && expected.Response.Body != cRes.Body {
+		return fmt.Errorf("expected response body to be %q, got %q", expected.Response.Body, cRes.Body)
 	}
 
 	// 204 is a valid response for CORS requests.

--- a/conformance/utils/roundtripper/roundtripper.go
+++ b/conformance/utils/roundtripper/roundtripper.go
@@ -117,6 +117,7 @@ type CapturedResponse struct {
 	ContentLength    int64
 	Protocol         string
 	Headers          map[string][]string
+	Body             string
 	RedirectRequest  *RedirectRequest
 	PeerCertificates []*x509.Certificate
 }
@@ -302,6 +303,7 @@ func (d *DefaultRoundTripper) defaultRoundTrip(request Request, transport http.R
 		ContentLength: resp.ContentLength,
 		Protocol:      resp.Proto,
 		Headers:       resp.Header,
+		Body:          string(body),
 	}
 
 	if resp.TLS != nil {

--- a/pkg/features/httproute.go
+++ b/pkg/features/httproute.go
@@ -126,6 +126,15 @@ const (
 
 	// This option indicates support for RequestRedirect filter on HTTPRoute BackendRef (extended conformance).
 	SupportHTTPRouteBackendRequestRedirect FeatureName = "HTTPRouteBackendRequestRedirect"
+
+	// This option indicates support for the ExternalAuth filter in HTTPRoute (experimental conformance).
+	SupportHTTPRouteExternalAuth FeatureName = "HTTPRouteExternalAuth"
+
+	// This option indicates support for the ExternalAuth filter with gRPC protocol in HTTPRoute (experimental conformance).
+	SupportHTTPRouteExternalAuthGRPC FeatureName = "HTTPRouteExternalAuthGRPC"
+
+	// This option indicates support for the ExternalAuth filter with HTTP protocol in HTTPRoute (experimental conformance).
+	SupportHTTPRouteExternalAuthHTTP FeatureName = "HTTPRouteExternalAuthHTTP"
 )
 
 var (
@@ -269,6 +278,21 @@ var (
 		Name:    SupportHTTPRouteBackendRequestRedirect,
 		Channel: FeatureChannelStandard,
 	}
+	// HTTPRouteExternalAuthFeature contains metadata for the HTTPRouteExternalAuth feature.
+	HTTPRouteExternalAuthFeature = Feature{
+		Name:    SupportHTTPRouteExternalAuth,
+		Channel: FeatureChannelExperimental,
+	}
+	// HTTPRouteExternalAuthGRPCFeature contains metadata for the HTTPRouteExternalAuthGRPC feature.
+	HTTPRouteExternalAuthGRPCFeature = Feature{
+		Name:    SupportHTTPRouteExternalAuthGRPC,
+		Channel: FeatureChannelExperimental,
+	}
+	// HTTPRouteExternalAuthHTTPFeature contains metadata for the HTTPRouteExternalAuthHTTP feature.
+	HTTPRouteExternalAuthHTTPFeature = Feature{
+		Name:    SupportHTTPRouteExternalAuthHTTP,
+		Channel: FeatureChannelExperimental,
+	}
 )
 
 // HTTPRouteExtendedFeatures includes all extended features for HTTPRoute
@@ -303,4 +327,7 @@ var HTTPRouteExtendedFeatures = sets.New(
 	HTTPRouteRetryConnectionErrorFeature,
 	HTTPRouteBackendURLRewriteFeature,
 	HTTPRouteBackendRequestRedirectFeature,
+	HTTPRouteExternalAuthFeature,
+	HTTPRouteExternalAuthGRPCFeature,
+	HTTPRouteExternalAuthHTTPFeature,
 )

--- a/pkg/features/httproute.go
+++ b/pkg/features/httproute.go
@@ -135,6 +135,9 @@ const (
 
 	// This option indicates support for the ExternalAuth filter with HTTP protocol in HTTPRoute (experimental conformance).
 	SupportHTTPRouteExternalAuthHTTP FeatureName = "HTTPRouteExternalAuthHTTP"
+
+	// This option indicates support for forwarding the request body to the external auth server in HTTPRoute (experimental conformance).
+	SupportHTTPRouteExternalAuthForwardBody FeatureName = "HTTPRouteExternalAuthForwardBody"
 )
 
 var (
@@ -293,6 +296,11 @@ var (
 		Name:    SupportHTTPRouteExternalAuthHTTP,
 		Channel: FeatureChannelExperimental,
 	}
+	// HTTPRouteExternalAuthForwardBodyFeature contains metadata for the HTTPRouteExternalAuthForwardBody feature.
+	HTTPRouteExternalAuthForwardBodyFeature = Feature{
+		Name:    SupportHTTPRouteExternalAuthForwardBody,
+		Channel: FeatureChannelExperimental,
+	}
 )
 
 // HTTPRouteExtendedFeatures includes all extended features for HTTPRoute
@@ -330,4 +338,5 @@ var HTTPRouteExtendedFeatures = sets.New(
 	HTTPRouteExternalAuthFeature,
 	HTTPRouteExternalAuthGRPCFeature,
 	HTTPRouteExternalAuthHTTPFeature,
+	HTTPRouteExternalAuthForwardBodyFeature,
 )


### PR DESCRIPTION
This PR implements the conformance tests listed in #5082.

The tests are mostly according to the spec, but there are two choices where the spec is not clear:

1. when an ExternalAuth backendref points to a service/port that does not exist, both 403 and 5xx failures are accepted. This differs from misconfigured HTTPRoute backendrefs, where the spec stipulates 5xx failures.
2. when a forwarded body exceeds maxsize, the spec says both to truncate it and to reject it. Given the security implications of making a security-relevant decision based on partial data, this PR picks rejection.

Depends on kubernetes-sigs/gateway-api-conformance-images#12. This PR will have to be updated with a proper version number once a release is available.

/kind test
/area conformance-test
/area conformance-machinery

```release-note
feature constants and conformance tests for HTTPRoute ExternalAuth filters (#5082)
```
