### PR TITLE
test(conformance): add HTTPRoute rule precedence test

### DIFF
--- a/conformance/tests/httproute-rule-order.go
+++ b/conformance/tests/httproute-rule-order.go
@@ -1,0 +1,90 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/http"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRouteRuleOrder)
+}
+
+var HTTPRouteRuleOrder = confsuite.ConformanceTest{
+	ShortName:   "HTTPRouteRuleOrder",
+	Description: "HTTPRoutes with identical matches grant precedence to the first matching rule",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+	},
+	Manifests: []string{"tests/httproute-rule-order.yaml"},
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Namespace: ns, Name: "rule-order"}
+		invalidBackendRouteNN := types.NamespacedName{Namespace: ns, Name: "rule-order-invalid-backend"}
+		gwNN := types.NamespacedName{Namespace: ns, Name: "same-namespace"}
+
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{ns})
+
+		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(
+			t,
+			suite.Client,
+			suite.TimeoutConfig,
+			suite.ControllerName,
+			kubernetes.NewGatewayRef(gwNN),
+			routeNN,
+			invalidBackendRouteNN,
+		)
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
+		kubernetes.HTTPRouteMustHaveResolvedRefsMustHaveBackendsNotFound(t, suite.Client, suite.TimeoutConfig, invalidBackendRouteNN, gwNN)
+
+		testCases := []http.ExpectedResponse{
+			{
+				TestCaseName: "first matching rule routes to its backend",
+				Request: http.Request{
+					Path: "/rule-order",
+					Headers: map[string]string{
+						"x-color":   "blue",
+						"x-version": "one",
+					},
+				},
+				Backend:   confsuite.InfraBackendServiceNameV1,
+				Namespace: ns,
+			},
+			{
+				TestCaseName: "invalid first matching rule returns 500",
+				Request:      http.Request{Path: "/rule-order-invalid-backend"},
+				Response:     http.Response{StatusCode: 500},
+			},
+		}
+
+		for i := range testCases {
+			tc := testCases[i]
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/conformance/tests/httproute-rule-order.yaml
+++ b/conformance/tests/httproute-rule-order.yaml
@@ -1,0 +1,57 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: rule-order
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /rule-order
+      headers:
+      - name: x-version
+        value: one
+      - name: x-color
+        value: blue
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - matches:
+    - path:
+        type: Exact
+        value: /rule-order
+      headers:
+      - name: x-color
+        value: blue
+      - name: x-version
+        value: one
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: rule-order-invalid-backend
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /rule-order-invalid-backend
+    backendRefs:
+    - name: nonexistent
+      port: 8080
+  - matches:
+    - path:
+        type: Exact
+        value: /rule-order-invalid-backend
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
/kind test
/area conformance-test

**What this PR does / why we need it**:
Adds conformance coverage for HTTPRoutes with equally matching rules. The test verifies that the first matching rule in list order takes precedence, matching the [HTTPRouteRule spec](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprouterule):
```
If ties still exist within an HTTPRoute, matching precedence MUST be granted to the FIRST matching rule (in list order) with a match meeting the above criteria.
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
