### PR TITLE
test(conformance): preserve Route status entries owned by other controllers

### DIFF
--- a/conformance/tests/httproute-preserve-foreign-status.go
+++ b/conformance/tests/httproute-preserve-foreign-status.go
@@ -1,0 +1,162 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+var errForeignStatusNotStored = errors.New("the seeded status entry is missing from the update response")
+
+func init() {
+	ConformanceTests = append(ConformanceTests, HTTPRoutePreserveForeignStatus)
+}
+
+var HTTPRoutePreserveForeignStatus = confsuite.ConformanceTest{
+	ShortName: "HTTPRoutePreserveForeignStatus",
+	Description: "An implementation must not remove or modify HTTPRoute status.parents entries " +
+		"whose controllerName belongs to another implementation.",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportHTTPRoute,
+	},
+	Manifests:   []string{"tests/httproute-preserve-foreign-status.yaml"},
+	Provisional: true,
+	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
+		ns := confsuite.InfrastructureNamespace
+		routeNN := types.NamespacedName{Name: "preserve-foreign-status", Namespace: ns}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+
+		kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
+
+		var seeded gatewayv1.RouteParentStatus
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			route := &gatewayv1.HTTPRoute{}
+			if err := suite.Client.Get(t.Context(), routeNN, route); err != nil {
+				return err
+			}
+			route.Status.Parents = append(route.Status.Parents, gatewayv1.RouteParentStatus{
+				ParentRef: gatewayv1.ParentReference{
+					Group:     new(gatewayv1.Group(gatewayv1.GroupVersion.Group)),
+					Kind:      new(gatewayv1.Kind("Gateway")),
+					Name:      "unmanaged-gateway",
+					Namespace: new(gatewayv1.Namespace(ns)),
+				},
+				ControllerName: kubernetes.StaleControllerName,
+				Conditions: []metav1.Condition{{
+					Type:               string(gatewayv1.RouteConditionAccepted),
+					Status:             metav1.ConditionTrue,
+					Reason:             string(gatewayv1.RouteReasonAccepted),
+					ObservedGeneration: route.Generation,
+					LastTransitionTime: metav1.Now(),
+				}},
+			})
+			if err := suite.Client.Status().Update(t.Context(), route); err != nil {
+				return err
+			}
+			// Read the entry back off the update response rather than reusing
+			// the value written above: the API server truncates
+			// lastTransitionTime to second precision.
+			stored := foreignParentStatus(route.Status.Parents)
+			if stored == nil {
+				return errForeignStatusNotStored
+			}
+			seeded = *stored
+			return nil
+		})
+		require.NoError(t, err, "error seeding a foreign controller's status entry on HTTPRoute %s", routeNN)
+
+		// Bump the generation so the implementation has to run a full
+		// read-modify-write cycle on a status that already holds the seeded entry.
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			route := &gatewayv1.HTTPRoute{}
+			if getErr := suite.Client.Get(t.Context(), routeNN, route); getErr != nil {
+				return getErr
+			}
+			route.Spec.Rules[0].Matches[0].Path.Value = new("/preserve-foreign-status-updated")
+			return suite.Client.Update(t.Context(), route)
+		})
+		require.NoError(t, err, "error updating HTTPRoute %s", routeNN)
+
+		// The implementation's own entry catching up to the bumped generation is
+		// what proves it wrote status while the seeded entry was there.
+		kubernetes.HTTPRouteMustHaveParents(t, suite.Client, suite.TimeoutConfig, routeNN,
+			[]gatewayv1.RouteParentStatus{
+				{
+					ParentRef: gatewayv1.ParentReference{
+						Group:     new(gatewayv1.Group(gatewayv1.GroupVersion.Group)),
+						Kind:      new(gatewayv1.Kind("Gateway")),
+						Name:      gatewayv1.ObjectName(gwNN.Name),
+						Namespace: new(gatewayv1.Namespace(ns)),
+					},
+					ControllerName: gatewayv1.GatewayController(suite.ControllerName),
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gatewayv1.RouteConditionAccepted),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+				{
+					ParentRef:      seeded.ParentRef,
+					ControllerName: kubernetes.StaleControllerName,
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gatewayv1.RouteConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: string(gatewayv1.RouteReasonAccepted),
+						},
+					},
+				},
+			},
+			// The Route and the Gateway share a namespace, so an implementation
+			// that leaves parentRef.namespace unset still matches.
+			false,
+		)
+
+		route := &gatewayv1.HTTPRoute{}
+		require.NoError(t, suite.Client.Get(t.Context(), routeNN, route), "error fetching HTTPRoute %s", routeNN)
+
+		// HTTPRouteMustHaveParents compares conditions by type, status and reason,
+		// so it cannot see a rewrite that keeps the entry Accepted but restamps
+		// observedGeneration or lastTransitionTime.
+		stored := foreignParentStatus(route.Status.Parents)
+		require.NotNilf(t, stored, "HTTPRoute %s: status entry owned by %s was removed", routeNN, kubernetes.StaleControllerName)
+		require.Equalf(t, seeded, *stored, "HTTPRoute %s: status entry owned by %s was modified", routeNN, kubernetes.StaleControllerName)
+	},
+}
+
+func foreignParentStatus(parents []gatewayv1.RouteParentStatus) *gatewayv1.RouteParentStatus {
+	for i := range parents {
+		if parents[i].ControllerName == kubernetes.StaleControllerName {
+			return &parents[i]
+		}
+	}
+
+	return nil
+}

--- a/conformance/tests/httproute-preserve-foreign-status.yaml
+++ b/conformance/tests/httproute-preserve-foreign-status.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: preserve-foreign-status
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  # No Gateway by this name exists; the test seeds a status entry for it under a
+  # stale controllerName and checks that the implementation leaves it alone.
+  - name: unmanaged-gateway
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /preserve-foreign-status
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080

--- a/conformance/utils/kubernetes/helpers.go
+++ b/conformance/utils/kubernetes/helpers.go
@@ -52,6 +52,12 @@ import (
 // tests which validate fixing broken Gateways, e.t.c.
 const GatewayExcludedFromReadinessChecks = "gateway-api/skip-this-for-readiness"
 
+// StaleControllerName is a controllerName that tests can put on a Route
+// status.parents entry to stand in for another implementation sharing the
+// cluster. Nothing reconciles such an entry, so RouteMustHaveParents leaves its
+// observedGeneration alone.
+const StaleControllerName = gatewayv1.GatewayController("gateway.networking.k8s.io/stale-controller")
+
 const GatewayKind = gatewayv1.Kind("Gateway")
 
 // GatewayRef is a tiny type for specifying an HTTP Route ParentRef without
@@ -793,6 +799,23 @@ func RouteTypeMustHaveParentsField(t *testing.T, routeType any) string {
 	return routeTypeName
 }
 
+// staleParentStatus returns the first status entry whose conditions have not
+// caught up with the object generation. Entries owned by StaleControllerName
+// are exempt: nothing reconciles them, so their observedGeneration never moves.
+func staleParentStatus(obj metav1.Object, parents []gatewayv1.RouteParentStatus) (gatewayv1.RouteParentStatus, error) {
+	for _, parent := range parents {
+		if parent.ControllerName == StaleControllerName {
+			continue
+		}
+
+		if err := ConditionsHaveLatestObservedGeneration(obj, parent.Conditions); err != nil {
+			return parent, err
+		}
+	}
+
+	return gatewayv1.RouteParentStatus{}, nil
+}
+
 func RouteMustHaveParents(t *testing.T, cli client.Client, timeoutConfig config.TimeoutConfig, routeName types.NamespacedName, parents []gatewayv1.RouteParentStatus, namespaceRequired bool, routeType any) {
 	t.Helper()
 
@@ -811,14 +834,13 @@ func RouteMustHaveParents(t *testing.T, cli client.Client, timeoutConfig config.
 			return false, fmt.Errorf("error fetching %s: %w", routeTypeName, err)
 		}
 
-		for _, parent := range actual {
-			if err := ConditionsHaveLatestObservedGeneration(metaObj, parent.Conditions); err != nil {
-				tlog.Logf(t, "%s(controller=%v,ref=%#v) %v", routeTypeName, parent.ControllerName, parent, err)
-				return false, nil
-			}
+		actual = reflect.ValueOf(cliObj).Elem().FieldByName("Status").FieldByName("Parents").Interface().([]v1alpha2.RouteParentStatus)
+
+		if parent, err := staleParentStatus(metaObj, actual); err != nil {
+			tlog.Logf(t, "%s(controller=%v,ref=%#v) %v", routeTypeName, parent.ControllerName, parent, err)
+			return false, nil
 		}
 
-		actual = reflect.ValueOf(cliObj).Elem().FieldByName("Status").FieldByName("Parents").Interface().([]v1alpha2.RouteParentStatus)
 		return parentsForRouteMatch(t, routeName, parents, actual, namespaceRequired), nil
 	})
 	require.NoErrorf(t, waitErr, "error waiting for %s to have parents matching expectations", routeTypeName)

--- a/conformance/utils/kubernetes/helpers_test.go
+++ b/conformance/utils/kubernetes/helpers_test.go
@@ -29,7 +29,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -378,4 +380,224 @@ func Test_listenersMatch(t *testing.T) {
 			assert.Equal(t, test.want, gatewayListenersMatch(t, test.expected, test.actual))
 		})
 	}
+}
+
+// TestRouteMustHaveParentsIgnoresStaleControllerEntries seeds an entry that is
+// stale on purpose: it sits at generation 1 while the Route is at generation 2,
+// so the wait only succeeds if entries owned by StaleControllerName are left out
+// of the observedGeneration check.
+func TestRouteMustHaveParentsIgnoresStaleControllerEntries(t *testing.T) {
+	const ownController = gatewayv1.GatewayController("example.com/gateway-controller")
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, InstallGatewayV1(scheme))
+
+	routeNN := types.NamespacedName{Name: "test-route", Namespace: "default"}
+	gwNamespace := gatewayv1.Namespace("default")
+
+	acceptedCondition := func(observedGeneration int64) []metav1.Condition {
+		return []metav1.Condition{{
+			Type:               string(gatewayv1.RouteConditionAccepted),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(gatewayv1.RouteReasonAccepted),
+			ObservedGeneration: observedGeneration,
+			LastTransitionTime: metav1.Now(),
+		}}
+	}
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       routeNN.Name,
+			Namespace:  routeNN.Namespace,
+			Generation: 2,
+		},
+		Status: gatewayv1.HTTPRouteStatus{
+			RouteStatus: gatewayv1.RouteStatus{
+				Parents: []gatewayv1.RouteParentStatus{
+					{
+						ParentRef: gatewayv1.ParentReference{
+							Name:      "test-gateway",
+							Namespace: &gwNamespace,
+						},
+						ControllerName: ownController,
+						Conditions:     acceptedCondition(2),
+					},
+					{
+						ParentRef: gatewayv1.ParentReference{
+							Name:      "unmanaged-gateway",
+							Namespace: &gwNamespace,
+						},
+						ControllerName: StaleControllerName,
+						Conditions:     acceptedCondition(1),
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(route).Build()
+
+	timeoutConfig := config.TimeoutConfig{
+		RouteMustHaveParents: 2 * time.Second,
+		DefaultPollInterval:  100 * time.Millisecond,
+	}
+
+	HTTPRouteMustHaveParents(t, c, timeoutConfig, routeNN, []gatewayv1.RouteParentStatus{
+		{
+			ParentRef: gatewayv1.ParentReference{
+				Name:      "test-gateway",
+				Namespace: &gwNamespace,
+			},
+			ControllerName: ownController,
+			Conditions: []metav1.Condition{{
+				Type:   string(gatewayv1.RouteConditionAccepted),
+				Status: metav1.ConditionTrue,
+			}},
+		},
+	}, true)
+}
+
+func Test_staleParentStatus(t *testing.T) {
+	const (
+		ownController   = gatewayv1.GatewayController("example.com/gateway-controller")
+		otherController = gatewayv1.GatewayController("example.com/other-controller")
+	)
+
+	route := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Generation: 2}}
+
+	parent := func(controller gatewayv1.GatewayController, observedGeneration int64) gatewayv1.RouteParentStatus {
+		return gatewayv1.RouteParentStatus{
+			ParentRef:      gatewayv1.ParentReference{Name: "test-gateway"},
+			ControllerName: controller,
+			Conditions: []metav1.Condition{{
+				Type:               string(gatewayv1.RouteConditionAccepted),
+				Status:             metav1.ConditionTrue,
+				Reason:             string(gatewayv1.RouteReasonAccepted),
+				ObservedGeneration: observedGeneration,
+			}},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		parents   []gatewayv1.RouteParentStatus
+		wantOwner gatewayv1.GatewayController
+	}{
+		{
+			name:    "every entry has caught up",
+			parents: []gatewayv1.RouteParentStatus{parent(ownController, 2), parent(otherController, 2)},
+		},
+		{
+			name:      "own entry is behind",
+			parents:   []gatewayv1.RouteParentStatus{parent(ownController, 1)},
+			wantOwner: ownController,
+		},
+		{
+			name:    "sentinel entry is exempt while it is behind",
+			parents: []gatewayv1.RouteParentStatus{parent(ownController, 2), parent(StaleControllerName, 1)},
+		},
+		{
+			name:      "the exemption does not extend to other foreign entries",
+			parents:   []gatewayv1.RouteParentStatus{parent(ownController, 2), parent(otherController, 1)},
+			wantOwner: otherController,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stale, err := staleParentStatus(route, tt.parents)
+
+			if tt.wantOwner == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			require.Equal(t, tt.wantOwner, stale.ControllerName)
+		})
+	}
+}
+
+// TestRouteMustHaveParentsChecksTheStatusItJustRead pins the order of the two
+// steps inside the poll: the status has to be read before the
+// observedGeneration check runs against it. When the read came last, the first
+// iteration checked an empty slice, so a Route whose conditions still carried a
+// stale observedGeneration satisfied the wait right away and the check never
+// ran at all on the common fast path.
+func TestRouteMustHaveParentsChecksTheStatusItJustRead(t *testing.T) {
+	const ownController = gatewayv1.GatewayController("example.com/gateway-controller")
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, InstallGatewayV1(scheme))
+
+	routeNN := types.NamespacedName{Name: "test-route", Namespace: "default"}
+	gwNamespace := gatewayv1.Namespace("default")
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       routeNN.Name,
+			Namespace:  routeNN.Namespace,
+			Generation: 2,
+		},
+		Status: gatewayv1.HTTPRouteStatus{
+			RouteStatus: gatewayv1.RouteStatus{
+				Parents: []gatewayv1.RouteParentStatus{{
+					ParentRef: gatewayv1.ParentReference{
+						Name:      "test-gateway",
+						Namespace: &gwNamespace,
+					},
+					ControllerName: ownController,
+					Conditions: []metav1.Condition{{
+						Type:               string(gatewayv1.RouteConditionAccepted),
+						Status:             metav1.ConditionTrue,
+						Reason:             string(gatewayv1.RouteReasonAccepted),
+						ObservedGeneration: 1,
+						LastTransitionTime: metav1.Now(),
+					}},
+				}},
+			},
+		},
+	}
+
+	var reads int
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(route).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cli client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if err := cli.Get(ctx, key, obj, opts...); err != nil {
+					return err
+				}
+
+				// The implementation catches up, but only after the first read.
+				reads++
+				if reads > 1 {
+					obj.(*gatewayv1.HTTPRoute).Status.Parents[0].Conditions[0].ObservedGeneration = 2
+				}
+
+				return nil
+			},
+		}).
+		Build()
+
+	timeoutConfig := config.TimeoutConfig{
+		RouteMustHaveParents: 2 * time.Second,
+		DefaultPollInterval:  100 * time.Millisecond,
+	}
+
+	HTTPRouteMustHaveParents(t, c, timeoutConfig, routeNN, []gatewayv1.RouteParentStatus{
+		{
+			ParentRef: gatewayv1.ParentReference{
+				Name:      "test-gateway",
+				Namespace: &gwNamespace,
+			},
+			ControllerName: ownController,
+			Conditions: []metav1.Condition{{
+				Type:   string(gatewayv1.RouteConditionAccepted),
+				Status: metav1.ConditionTrue,
+			}},
+		},
+	}, true)
+
+	require.Greater(t, reads, 1, "wait was satisfied by the first read, leaving the stale observedGeneration unchecked")
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind test

/area conformance-test

/area conformance-machinery

**What this PR does / why we need it**:

Two controllers on one cluster is a normal setup, and the spec is explicit that an implementation may only touch `status.parents` entries carrying its own `controllerName`. The suite had no coverage for that, so an implementation could wipe another controller's entry and still pass.

The harness had to move first. `RouteMustHaveParents` walked every entry in `status.parents` and required each one's conditions to observe the Route's current generation. A second controller's entry does not track our Route's generation (and per the same MUST, the implementation under test is forbidden from refreshing it), so any Route carrying a foreign entry stalled the wait until timeout. That is a real problem on a shared cluster, and this PR fixes only as much of it as the test needs: the check now skips entries whose controllerName is `StaleControllerName`, a reserved value tests put on a status entry to stand in for a second implementation, so a seeded entry no longer stalls the wait. An entry carrying any other controllerName still has to observe the generation. Generalising that means passing the caller's controllerName into the helper, which is the signature change the scope note below defers. One side note on the same helper: the exact-set worry in the issue turned out not to apply, `parentsForRouteMatch` is already a subset check and ignores extra entries.

One behaviour change worth calling out. The `observedGeneration` check in `RouteMustHaveParents` was dead on the fast path: `actual` was assigned after the loop that reads it, so the first poll iteration ran the loop over an empty slice, and if `parentsForRouteMatch` was already satisfied the helper returned right there. That is the normal path on a passing run, so for those runs the check never ran at all. It runs now, and that reaches every `*RouteMustHaveParents` caller in the suite: an implementation whose status matches on type, status and reason but has not caught up with the Route generation will now keep the wait going and can time out where it passed before. A unit test pins the ordering, it fails with the old ordering and passes with the new one.

The new test attaches an HTTPRoute to `same-namespace` plus a second parentRef the implementation cannot resolve, writes the entry a second controller would have written for that parentRef, then changes the Route spec so the implementation has to do a full read-modify-write of a status that already holds the foreign entry. Waiting for the implementation's own entry to observe the bumped generation is what proves it wrote status while the foreign entry was there; the entry is then compared field for field, so a removal, a rewrite, or a dropped condition all fail.

It is marked `Provisional`, and gated on `SupportGateway` + `SupportHTTPRoute` only: no new feature is involved, the MUST applies to every implementation that writes Route status.

The harness change is covered by unit tests against a fake client. `Test_staleParentStatus` pins which entries the `observedGeneration` check skips: the reserved sentinel is exempt, an entry carrying any other controllerName is not. `TestRouteMustHaveParentsIgnoresStaleControllerEntries` drives `HTTPRouteMustHaveParents` over a Route holding a deliberately stale sentinel entry; it times out on `main` and passes here. `TestRouteMustHaveParentsChecksTheStatusItJustRead` pins the read ordering by counting reads: with the old ordering the wait is satisfied by the first read, and the test fails.

Scope note, per the plan in the issue: this is Route parent status only. Gateway and Listener conditions and policy ancestor status are separate follow-ups. Some sibling helpers are still single-controller by construction (`HTTPRouteMustHaveNoAcceptedParents` and its TLS/TCP/UDP twins hard-require at most one entry, and `HTTPRouteMustHaveLatestConditions` walks every entry), but none of them takes a controllerName today, so relaxing them means changing exported signatures. I left them alone rather than smuggle that into this PR.

Locally: build, vet, lint, and the unit tests above. I also ran the new conformance test against my own implementation on kind with a real Cloudflare Tunnel, it passes and does not silently skip. That says something about the test, not about anyone's conformance. Prow has not run anything here at all, the `needs-ok-to-test` label is still on it. I have not done a full suite run producing a fresh conformance report.

AI assistance: drafted with Claude, reviewed and verified by me before submitting.

**Which issue(s) this PR fixes**:

Part of #5105

**Does this PR introduce a user-facing change?**:

```release-note
Conformance: RouteMustHaveParents now runs the observedGeneration check against the status it just read. Previously the check was skipped whenever a Route's parents already matched on the first poll, which is the normal case on a passing run, so implementations whose status lagged the Route generation could pass without it ever running; those runs will now wait for observedGeneration to catch up and may fail where they passed before. Entries carrying the reserved controllerName that conformance tests use to stand in for a second implementation are exempt; entries written by real controllers are still checked.
```



## AI disclosure

This PR was prepared with AIL:3. I personally reviewed each line of the submission prior to opening this PR.
