### PR TITLE
Fix report generation for conformance test

### DIFF
--- a/conformance/conformance.go
+++ b/conformance/conformance.go
@@ -120,15 +120,17 @@ func RunConformanceWithOptions(t *testing.T, opts suite.ConformanceOptions) {
 	cSuite, err := suite.NewConformanceTestSuite(opts)
 	require.NoError(t, err, "error initializing conformance suite")
 
+	if opts.ReportOutputPath != "" {
+		t.Cleanup(func() {
+			report, rErr := cSuite.Report()
+			require.NoError(t, rErr, "error generating conformance profile report")
+			require.NoError(t, writeReport(t.Logf, *report, opts.ReportOutputPath), "error writing report")
+		})
+	}
+
 	cSuite.Setup(t, tests.ConformanceTests)
 	err = cSuite.Run(t, tests.ConformanceTests)
 	require.NoError(t, err)
-
-	if opts.ReportOutputPath != "" {
-		report, err := cSuite.Report()
-		require.NoError(t, err, "error generating conformance profile report")
-		require.NoError(t, writeReport(t.Logf, *report, opts.ReportOutputPath), "error writing report")
-	}
 }
 
 func logOptions(t *testing.T, opts suite.ConformanceOptions) {

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -490,11 +490,16 @@ func (suite *ConformanceTestSuite) Run(t *testing.T, tests []ConformanceTest) er
 	// if the test suite is not currently running, reset reporting and start a
 	// new test run.
 	suite.running = true
-	suite.results = nil
+	suite.results = make(map[string]testResult)
 	suite.lock.Unlock()
 
+	t.Cleanup(func() {
+		suite.lock.Lock()
+		suite.running = false
+		suite.lock.Unlock()
+	})
+
 	// run all tests and collect the test results for conformance reporting
-	results := make(map[string]testResult)
 	sleepForTestIsolation := false
 	for _, test := range tests {
 		res := testSucceeded
@@ -518,28 +523,20 @@ func (suite *ConformanceTestSuite) Run(t *testing.T, tests []ConformanceTest) er
 			time.Sleep(suite.TimeoutConfig.TestIsolation)
 		}
 
-		succeeded := t.Run(test.ShortName, func(t *testing.T) {
+		t.Run(test.ShortName, func(subT *testing.T) {
+			subT.Cleanup(func() {
+				suite.recordTestResult(subT, test, res)
+				if suite.Hook != nil {
+					suite.Hook(subT, test, suite)
+				}
+			})
 			err := suite.setClientsetForTest(test)
-			require.NoError(t, err, "failed to create new clientset for test")
-			test.Run(t, suite)
+			require.NoError(subT, err, "failed to create new clientset for test")
+			test.Run(subT, suite)
 		})
-		if !succeeded {
-			res = testFailed
-		}
 
-		results[test.ShortName] = testResult{
-			test:   test,
-			result: res,
-		}
-		if res == testSucceeded || res == testFailed {
+		if res == testSucceeded {
 			sleepForTestIsolation = true
-		}
-
-		// call the hook function if it was provided,
-		// this's useful for running custom logic after each test at suite level,
-		// such as collecting current state of the cluster for debugging.
-		if suite.Hook != nil {
-			suite.Hook(t, test, suite)
 		}
 
 		if suite.failFast && res == testFailed {
@@ -547,14 +544,33 @@ func (suite *ConformanceTestSuite) Run(t *testing.T, tests []ConformanceTest) er
 		}
 	}
 
-	// now that the tests have completed, mark the test suite as not running
-	// and report the test results.
-	suite.lock.Lock()
-	suite.running = false
-	suite.results = results
-	suite.lock.Unlock()
-
 	return nil
+}
+
+func (suite *ConformanceTestSuite) recordTestResult(t *testing.T, test ConformanceTest, initialRes resultType) {
+	res := initialRes
+	switch {
+	case t.Failed():
+		res = testFailed
+	case t.Skipped():
+		if res != testNotSupported && res != testProvisionalSkipped {
+			res = testSkipped
+		}
+	default:
+		if res != testNotSupported && res != testProvisionalSkipped && res != testSkipped {
+			res = testSucceeded
+		}
+	}
+
+	suite.lock.Lock()
+	defer suite.lock.Unlock()
+	// This function assumes that suite.results is created.
+	// Before re-using this function make sure that it is always called after
+	// results is initialized.
+	suite.results[test.ShortName] = testResult{
+		test:   test,
+		result: res,
+	}
 }
 
 // Report emits a ConformanceReport for the previously completed test run.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind bug
/area conformance-test

**What this PR does / why we need it**:
This PR is fixing the issue with report creation for tests run in parallel.
 
To fix this issue two complementary changes are required:

1. Defer report generation using top-level t.Cleanup: Go guarantees that cleanup functions registered on the root *testing.T via t.Cleanup(...) only execute after all parallel subtests have completely finished.
2. Record test results in each subtest's t.Cleanup: Instead of relying on the immediate return value of t.Run() (which is always true when t.Parallel() is invoked), record the final test status (t.Failed(), t.Skipped()) inside each subtest's t.Cleanup(...) handler with proper mutex locking.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #5142
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
