### PR TITLE
Add conformance report for Gravitee 4.12.10 and Gateway API 1.6.1

### DIFF
--- a/conformance/reports/v1.6/gravitee/README.md
+++ b/conformance/reports/v1.6/gravitee/README.md
@@ -1,0 +1,66 @@
+# Gravitee
+
+## Table of Contents
+
+| API channel  | Implementation version                    | Mode    | Report                                                 |
+|--------------|-------------------------------------------|---------|--------------------------------------------------------|
+| standard     | [version-4.10.3](https://github.com/gravitee-io/gravitee-kubernetes-operator/releases/tag/4.12.10) | default | [version-4.10.3 report](./standard-4.12.10-default-report.yaml) |
+
+
+## Prerequisites
+
+The following binaries are assumed to be installed on your device
+  
+  - [docker](https://docs.docker.com/get-started/get-docker/)
+  - [kubectl](https://kubernetes.io/docs/tasks/tools/)
+  - [kind](https://github.com/kubernetes-sigs/kind)
+  - [go](https://go.dev/learn/)
+
+The reproducer has been tested on macOS and Linux only.
+
+## Reproducer
+
+1. Clone the Gravitee Kubernetes Operator repository
+
+```bash
+git clone --depth 1 --branch 4.12.10 https://github.com/gravitee-io/gravitee-kubernetes-operator.git
+```
+
+2. Start the Kubernetes cluster
+
+```bash
+make start-conformance-cluster
+```
+
+3. Run a local Load Balancer Service
+
+> The make target runs [cloud-provider-kind](https://kind.sigs.k8s.io/docs/user/loadbalancer). If you are reproducing on a macOS device, the binary requires `sudo` privileges and you will be prompted for a password. For Linux devices, cloud-provider-kind will be run using Docker compose.
+
+```bash
+make cloud-lb
+```
+
+4. Run the operator
+
+```bash
+make run
+```
+
+5. Install the Gravitee GatewayClass
+
+```bash
+kubectl apply -f ./test/conformance/gateway-class-parameters.report.yaml -f ./test/conformance/gateway-class.yaml
+```
+
+6. Run the conformance tests
+
+```bash
+GATEWAY_API_MATCH_ACROSS_ROUTES=true make conformance
+```
+
+7. Print report
+
+```bash
+cat test/conformance/kubernetes.io/gateway-api/report/standard-4.12.10-default-report.yaml
+```
+

--- a/conformance/reports/v1.6/gravitee/standard-4.12.10-default-report.yaml
+++ b/conformance/reports/v1.6/gravitee/standard-4.12.10-default-report.yaml
@@ -1,0 +1,71 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-08-07T16:13:39+02:00"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.6.1
+implementation:
+  contact:
+  - team-devex@graviteesource.com
+  organization: gravitee.io
+  project: gravitee-kubernetes-operator
+  url: https://github.com/gravitee-io/gravitee-kubernetes-operator
+  version: 4.12.10
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 37
+      Skipped: 0
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 19
+      Skipped: 0
+    supportedFeatures:
+    - GatewayFrontendClientCertificateValidation
+    - GatewayHTTPListenerIsolation
+    - GatewayInfrastructurePropagation
+    - GatewayPort8080
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRouteNamedRouteRule
+    - HTTPRoutePathRedirect
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    unsupportedFeatures:
+    - BackendTLSPolicy
+    - BackendTLSPolicySANValidation
+    - GatewayAddressEmpty
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayStaticAddresses
+    - HTTPRoute303RedirectStatusCode
+    - HTTPRoute307RedirectStatusCode
+    - HTTPRoute308RedirectStatusCode
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteBackendTimeout
+    - HTTPRouteCORS
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteParentRefPort
+    - HTTPRouteRequestMirror
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestPercentageMirror
+    - HTTPRouteRequestTimeout
+    - HTTPRouteRetry
+    - HTTPRouteRetryBackendTimeout
+    - HTTPRouteRetryConnectionError
+    - ListenerSet
+  name: GATEWAY-HTTP
+  summary: Core tests succeeded. Extended tests succeeded.
+succeededProvisionalTests:
+- GatewayInfrastructure
+- HTTPRouteNamedRule

--- a/site/content/en/docs/implementations/list.md
+++ b/site/content/en/docs/implementations/list.md
@@ -96,6 +96,7 @@ class.
 - [Airlock Microgateway][34]
 - [Cilium][16]
 - [Google Kubernetes Engine][6]
+- [Gravitee Kubernetes Operator][42]
 - [HAProxy Ingress][7]
 - [Istio][9]
 - [kgateway][37]
@@ -113,7 +114,6 @@ class.
 - [Calico][46]
 - [Envoy Gateway][18]
 - [Gloo Gateway][5]
-- [Gravitee Kubernetes Operator][42]
 
 ## Service Mesh Implementation Status <a name="meshes"></a>
 
@@ -313,6 +313,15 @@ v1.5.0 release for the GATEWAY_HTTP conformance profile.
 [gke-gateway]:https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api
 [gke-gateway-deploy]:https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways
 [gke-multi-cluster-gateway]:https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-multi-cluster-gateways
+
+### Gravitee Kubernetes Operator
+
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.6.1-Gravitee%20Kubernetes%20Operator-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.6/gravitee)
+
+The [Gravitee Kubernetes Operator](https://documentation.gravitee.io/gravitee-kubernetes-operator-gko) (GKO) lets you manage [Gravitee](https://www.gravitee.io/) APIs, applications, and other assets in a Kubernetes-native and declarative way.
+
+
+For support, feedback, or to engage in a discussion about the Gravitee Kubernetes Operator, please feel free to submit an [issue](https://github.com/gravitee-io/issues/issues) or visit our community [forum](https://community.gravitee.io/c/support/gravitee-kubernetes-operator-gko/26).
 
 ### HAProxy Ingress
 


### PR DESCRIPTION

/kind documentation

**What this PR does / why we need it**:

Report conformance for Gravitee 4.12.10

**Which issue(s) this PR fixes**:

Fixes #

```release-note
NONE
```
