### PR TITLE
conformance: use timeout config more consistently

### DIFF
--- a/conformance/conformance_options_test.go
+++ b/conformance/conformance_options_test.go
@@ -126,8 +126,8 @@ func TestConformanceOptions_EmptyYAML(t *testing.T) {
 }
 
 func TestConformanceOptions_PartialYAML(t *testing.T) {
-	// A YAML file that sets only a subset of fields (here meshName and a
-	// single timeoutConfig entry) must override exactly those fields and
+	// A YAML file that sets only a subset of fields (here meshName and selected
+	// timeoutConfig entries) must override exactly those fields and
 	// preserve defaults for everything else, including sibling fields
 	// inside timeoutConfig.
 	opts := loadConfigurableOptionsFromYAML(t, "data/test-conformance-options-partial.yaml")
@@ -136,6 +136,7 @@ func TestConformanceOptions_PartialYAML(t *testing.T) {
 
 	assert.Equal(t, "partial-only", opts.MeshName)
 	assert.Equal(t, 5*time.Second, opts.TimeoutConfig.DeleteTimeout)
+	assert.Equal(t, 5, opts.TimeoutConfig.RequiredConsecutiveSuccesses)
 	assert.Equal(t, 75*time.Second, opts.TimeoutConfig.TCPRouteMustHaveCondition)
 	assert.Equal(t, 90*time.Second, opts.TimeoutConfig.UDPRouteMustHaveCondition)
 	// Sibling timeout fields keep their default values.

--- a/conformance/data/test-conformance-options-partial.yaml
+++ b/conformance/data/test-conformance-options-partial.yaml
@@ -1,5 +1,6 @@
 meshName: "partial-only"
 timeoutConfig:
   deleteTimeout: "5s"
+  requiredConsecutiveSuccesses: 5
   tcpRouteMustHaveCondition: "75s"
   udpRouteMustHaveCondition: "90s"

--- a/conformance/tests/httproute-backend-protocol-websocket.go
+++ b/conformance/tests/httproute-backend-protocol-websocket.go
@@ -54,11 +54,8 @@ var HTTPRouteBackendProtocolWebSocket = confsuite.ConformanceTest{
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 
-		threshold := suite.TimeoutConfig.RequiredConsecutiveSuccesses
-		maxTimeToConsistency := suite.TimeoutConfig.MaxTimeToConsistency
-
 		t.Run("websocket connection should reach backend", func(t *testing.T) {
-			http.AwaitConvergence(t, threshold, maxTimeToConsistency, func(_ time.Duration) bool {
+			http.AwaitConvergence(t, suite.TimeoutConfig, func(_ time.Duration) bool {
 				origin := fmt.Sprintf("ws://gateway/%s", t.Name())
 				remote := fmt.Sprintf("ws://%s/ws", gwAddr)
 

--- a/conformance/tests/httproute-retry.go
+++ b/conformance/tests/httproute-retry.go
@@ -198,7 +198,7 @@ var HTTPRouteRetry = confsuite.ConformanceTest{
 func assertConsistentRetryBehaviour(t *testing.T, suite *confsuite.ConformanceTestSuite, gwAddr string, ns string, path string, values url.Values, response http.Response) {
 	t.Helper()
 
-	http.AwaitConvergence(t, suite.TimeoutConfig.RequiredConsecutiveSuccesses, suite.TimeoutConfig.MaxTimeToConsistency, func(elapsed time.Duration) bool {
+	http.AwaitConvergence(t, suite.TimeoutConfig, func(elapsed time.Duration) bool {
 		// regenerate UUID on each probe so the retry simulation handler in the echo-basic backend tracks retries independently
 		values.Set("uuid", uuid.New().String())
 

--- a/conformance/tests/tcproute-weighted-routing.go
+++ b/conformance/tests/tcproute-weighted-routing.go
@@ -61,7 +61,7 @@ var TCPRouteWeightedRouting = confsuite.ConformanceTest{
 				"tcp-backend-v3": 0.0,
 			}
 
-			tcp.ExpectAddressBeAvailable(t, suite.TimeoutConfig.DefaultPollInterval, suite.TimeoutConfig.MaxTimeToConsistency, gwAddr)
+			tcp.ExpectAddressBeAvailable(t, suite.TimeoutConfig, gwAddr)
 
 			sender := weight.NewFunctionBasedSender(func() (string, error) {
 				return tcp.EchoSendOnce(t.Context(), gwAddr, suite.TimeoutConfig.RequestTimeout)

--- a/conformance/tests/udproute-parentref-attach-all-listeners.go
+++ b/conformance/tests/udproute-parentref-attach-all-listeners.go
@@ -126,7 +126,7 @@ var UDPRouteParentRefAttachAllListeners = confsuite.ConformanceTest{
 				if err != nil {
 					t.Fatalf("error getting gateway address for listener %q: %v", listener, err)
 				}
-				udp.ExpectEchoResponseFromBackend(t, suite.TimeoutConfig.DefaultTestTimeout, gwAddr, udp.ExpectedResponse{
+				udp.ExpectEchoResponseFromBackend(t, suite.TimeoutConfig, gwAddr, udp.ExpectedResponse{
 					Service:   backend,
 					Namespace: ns,
 				})

--- a/conformance/tests/udproute-parentref-port-and-section-name.go
+++ b/conformance/tests/udproute-parentref-port-and-section-name.go
@@ -112,7 +112,7 @@ var UDPRouteParentRefPortAndSectionName = confsuite.ConformanceTest{
 				if err != nil {
 					t.Fatalf("error getting gateway address for listener %q: %v", s.listener, err)
 				}
-				udp.ExpectEchoResponseFromBackend(t, suite.TimeoutConfig.DefaultTestTimeout, gwAddr, udp.ExpectedResponse{
+				udp.ExpectEchoResponseFromBackend(t, suite.TimeoutConfig, gwAddr, udp.ExpectedResponse{
 					Service:   s.backend,
 					Namespace: ns,
 				})

--- a/conformance/tests/udproute-reference-grant.go
+++ b/conformance/tests/udproute-reference-grant.go
@@ -66,7 +66,7 @@ var UDPRouteReferenceGrant = confsuite.ConformanceTest{
 		})
 
 		t.Run("UDP echo request reaches the cross-namespace backend while the ReferenceGrant exists", func(t *testing.T) {
-			udp.ExpectEchoResponse(t, suite.TimeoutConfig.DefaultTestTimeout, gwAddr)
+			udp.ExpectEchoResponse(t, suite.TimeoutConfig, gwAddr)
 		})
 
 		ctx, cancel := context.WithTimeout(context.Background(), suite.TimeoutConfig.DeleteTimeout)

--- a/conformance/tests/udproute-weighted-routing.go
+++ b/conformance/tests/udproute-weighted-routing.go
@@ -71,7 +71,7 @@ var UDPRouteWeightedRouting = confsuite.ConformanceTest{
 				"udp-backend-v3": 0.0,
 			}
 
-			udp.ExpectEchoResponse(t, suite.TimeoutConfig.MaxTimeToConsistency, gwAddr)
+			udp.ExpectEchoResponse(t, suite.TimeoutConfig, gwAddr)
 
 			sender := weight.NewFunctionBasedSender(func() (string, error) {
 				return udpEchoSendOnce(t.Context(), gwAddr, 2*time.Second)

--- a/conformance/utils/config/timeout.go
+++ b/conformance/utils/config/timeout.go
@@ -128,12 +128,13 @@ type TimeoutConfig struct {
 	// RequiredConsecutiveSuccesses is the number of requests that must succeed in a row
 	// to consider a response "consistent" before making additional assertions on the response body.
 	// If this number is not reached within MaxTimeToConsistency, the test will fail.
-	RequiredConsecutiveSuccesses int
+	RequiredConsecutiveSuccesses int `json:"requiredConsecutiveSuccesses"`
 }
 
-// UnmarshalJSON ensures time.Duration values are parsed correctly.
+// UnmarshalJSON ensures time.Duration values are parsed correctly while other
+// supported fields retain their standard JSON unmarshalling behavior.
 func (tc *TimeoutConfig) UnmarshalJSON(data []byte) error {
-	var raw map[string]any
+	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
@@ -148,19 +149,31 @@ func (tc *TimeoutConfig) UnmarshalJSON(data []byte) error {
 		if jsonTag == "" {
 			continue
 		}
-		if field.Type != durationType {
-			return fmt.Errorf("field %q has json tag but unsupported type %s; "+
-				"TimeoutConfig.UnmarshalJSON only supports time.Duration fields", field.Name, field.Type)
-		}
 		val, ok := raw[jsonTag]
 		if !ok {
 			continue
 		}
-		d, err := parseDuration(val)
-		if err != nil {
-			return fmt.Errorf("field %q: %w", jsonTag, err)
+		switch {
+		case field.Type == durationType:
+			var durationValue any
+			if err := json.Unmarshal(val, &durationValue); err != nil {
+				return fmt.Errorf("field %q: %w", jsonTag, err)
+			}
+			d, err := parseDuration(durationValue)
+			if err != nil {
+				return fmt.Errorf("field %q: %w", jsonTag, err)
+			}
+			v.Field(i).SetInt(int64(d))
+		case field.Type.Kind() == reflect.Int:
+			var intValue int
+			if err := json.Unmarshal(val, &intValue); err != nil {
+				return fmt.Errorf("field %q: %w", jsonTag, err)
+			}
+			v.Field(i).SetInt(int64(intValue))
+		default:
+			return fmt.Errorf("field %q has json tag but unsupported type %s; "+
+				"TimeoutConfig.UnmarshalJSON only supports time.Duration and int fields", field.Name, field.Type)
 		}
-		v.Field(i).SetInt(int64(d))
 	}
 
 	return nil

--- a/conformance/utils/config/timeout_test.go
+++ b/conformance/utils/config/timeout_test.go
@@ -39,3 +39,11 @@ func TestSetupTimeoutConfigAppliesAllDefaults(t *testing.T) {
 	assert.Equal(t, defaults.ListenerSetListenersMustHaveConditions, cfg.ListenerSetListenersMustHaveConditions)
 	assert.Equal(t, defaults.RequiredConsecutiveSuccesses, cfg.RequiredConsecutiveSuccesses)
 }
+
+func TestTimeoutConfigUnmarshalsRequiredConsecutiveSuccesses(t *testing.T) {
+	cfg := DefaultTimeoutConfig()
+
+	require.NoError(t, json.Unmarshal([]byte(`{"requiredConsecutiveSuccesses":5}`), &cfg))
+
+	assert.Equal(t, 5, cfg.RequiredConsecutiveSuccesses)
+}

--- a/conformance/utils/echo/pod.go
+++ b/conformance/utils/echo/pod.go
@@ -59,7 +59,7 @@ const (
 func (m *MeshPod) MakeRequestAndExpectEventuallyConsistentResponse(t *testing.T, exp http.ExpectedResponse, timeoutConfig config.TimeoutConfig) {
 	t.Helper()
 
-	http.AwaitConvergence(t, timeoutConfig.RequiredConsecutiveSuccesses, timeoutConfig.MaxTimeToConsistency, func(elapsed time.Duration) bool {
+	http.AwaitConvergence(t, timeoutConfig, func(elapsed time.Duration) bool {
 		req := makeRequest(t, &exp)
 
 		resp, err := m.request(req)

--- a/conformance/utils/grpc/grpc.go
+++ b/conformance/utils/grpc/grpc.go
@@ -310,7 +310,7 @@ func MakeRequestAndExpectEventuallyConsistentResponse(t *testing.T, c Client, ti
 		}
 		return true
 	}
-	http.AwaitConvergence(t, timeoutConfig.RequiredConsecutiveSuccesses, timeoutConfig.MaxTimeToConsistency, sendRPC)
+	http.AwaitConvergence(t, timeoutConfig, sendRPC)
 	tlog.Logf(t, "Request passed")
 }
 

--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -168,7 +168,7 @@ func MakeRequestAndExpectEventuallyConsistentResponse(t *testing.T, r roundtripp
 
 	req := MakeRequest(t, &expected, gwAddr, "HTTP", "http")
 
-	WaitForConsistentResponse(t, r, req, expected, timeoutConfig.RequiredConsecutiveSuccesses, timeoutConfig.MaxTimeToConsistency)
+	WaitForConsistentResponse(t, r, req, expected, timeoutConfig)
 }
 
 // MakeRequestAndExpectFailure makes a request with the given parameters.
@@ -179,7 +179,7 @@ func MakeRequestAndExpectFailure(t *testing.T, r roundtripper.RoundTripper, time
 
 	req := MakeRequest(t, &expected, gwAddr, "HTTP", "http")
 
-	WaitForConsistentFailureResponse(t, r, req, 5, timeoutConfig.MaxTimeToConsistency)
+	WaitForConsistentFailureResponse(t, r, req, timeoutConfig)
 }
 
 func MakeRequest(t *testing.T, expected *ExpectedResponse, gwAddr, protocol, scheme string) roundtripper.Request {
@@ -273,14 +273,13 @@ func Ipv6SafeHost(host string) string {
 	return host
 }
 
-// AwaitConvergence runs the given function until it returns 'true' `threshold` times in a row.
-// Each failed attempt has a 1s delay; successful attempts have no delay.
-func AwaitConvergence(t *testing.T, threshold int, maxTimeToConsistency time.Duration, fn func(elapsed time.Duration) bool) {
+// AwaitConvergence runs the given function until it returns 'true' the configured number of times
+// in a row. Each failed attempt waits for the configured poll interval; successful attempts have no delay.
+func AwaitConvergence(t *testing.T, timeoutConfig config.TimeoutConfig, fn func(elapsed time.Duration) bool) {
 	successes := 0
 	attempts := 0
 	start := time.Now()
-	to := time.After(maxTimeToConsistency)
-	delay := time.Second
+	to := time.After(timeoutConfig.MaxTimeToConsistency)
 	for {
 		select {
 		case <-to:
@@ -292,7 +291,7 @@ func AwaitConvergence(t *testing.T, threshold int, maxTimeToConsistency time.Dur
 		attempts++
 		if completed {
 			successes++
-			if successes >= threshold {
+			if successes >= timeoutConfig.RequiredConsecutiveSuccesses {
 				return
 			}
 			// Skip delay if we have a success
@@ -303,18 +302,17 @@ func AwaitConvergence(t *testing.T, threshold int, maxTimeToConsistency time.Dur
 		select {
 		// Capture the overall timeout
 		case <-to:
-			tlog.Fatalf(t, "timeout while waiting after %d attempts, %d/%d successes", attempts, successes, threshold)
+			tlog.Fatalf(t, "timeout while waiting after %d attempts, %d/%d successes", attempts, successes, timeoutConfig.RequiredConsecutiveSuccesses)
 			// And the per-try delay
-		case <-time.After(delay):
+		case <-time.After(timeoutConfig.DefaultPollInterval):
 		}
 	}
 }
 
 // WaitForConsistentResponse repeats the provided request until it completes with a response having
-// the expected response consistently. The provided threshold determines how many times in
-// a row this must occur to be considered "consistent".
-func WaitForConsistentResponse(t *testing.T, r roundtripper.RoundTripper, req roundtripper.Request, expected ExpectedResponse, threshold int, maxTimeToConsistency time.Duration) {
-	AwaitConvergence(t, threshold, maxTimeToConsistency, func(elapsed time.Duration) bool {
+// the expected response consistently.
+func WaitForConsistentResponse(t *testing.T, r roundtripper.RoundTripper, req roundtripper.Request, expected ExpectedResponse, timeoutConfig config.TimeoutConfig) {
+	AwaitConvergence(t, timeoutConfig, func(elapsed time.Duration) bool {
 		cReq, cRes, err := r.CaptureRoundTrip(req)
 		if err != nil {
 			tlog.Logf(t, "Request failed, not ready yet: %v (after %v)", err.Error(), elapsed)
@@ -334,8 +332,8 @@ func WaitForConsistentResponse(t *testing.T, r roundtripper.RoundTripper, req ro
 // WaitForConsistentFailureResponse repeats the provided request for the given
 // period of time and ensures an error is returned each time. This function fails
 // when HTTP Status OK (200) is returned.
-func WaitForConsistentFailureResponse(t *testing.T, r roundtripper.RoundTripper, req roundtripper.Request, threshold int, maxTimeToConsistency time.Duration) {
-	AwaitConvergence(t, threshold, maxTimeToConsistency, func(elapsed time.Duration) bool {
+func WaitForConsistentFailureResponse(t *testing.T, r roundtripper.RoundTripper, req roundtripper.Request, timeoutConfig config.TimeoutConfig) {
+	AwaitConvergence(t, timeoutConfig, func(elapsed time.Duration) bool {
 		_, cRes, err := r.CaptureRoundTrip(req)
 		if err != nil {
 			tlog.Logf(t, "Request failed, not ready yet: %v (after %v)", err.Error(), elapsed)

--- a/conformance/utils/tcp/tcp.go
+++ b/conformance/utils/tcp/tcp.go
@@ -72,7 +72,7 @@ func MakeTCPRequestAndExpectEventuallyValidResponse(t *testing.T, timeoutConfig 
 		}
 	}
 	dialer := makeClient(tlsConfig)
-	WaitForValidTCPResponse(t, dialer, gwAddr, expected, timeoutConfig.MaxTimeToConsistency)
+	WaitForValidTCPResponse(t, dialer, gwAddr, expected, timeoutConfig)
 }
 
 // WaitForConsistentTCPResponse - repeats the provided request until it completes with a response having
@@ -82,7 +82,7 @@ func MakeTCPRequestAndExpectEventuallyValidResponse(t *testing.T, timeoutConfig 
 // - WelcomeMessage matches
 // - IS_TLS message matches
 // - TEST message matches assertions
-func WaitForValidTCPResponse(t *testing.T, dialer Dialer, gwAddr string, expected ExpectedResponse, maxTimeToConsistency time.Duration) {
+func WaitForValidTCPResponse(t *testing.T, dialer Dialer, gwAddr string, expected ExpectedResponse, timeoutConfig config.TimeoutConfig) {
 	t.Helper()
 	closeAndLog := func(t *testing.T, cl net.Conn, err error) bool {
 		if err != nil {
@@ -95,10 +95,16 @@ func WaitForValidTCPResponse(t *testing.T, dialer Dialer, gwAddr string, expecte
 	}
 
 	assert.Eventually(t, func() bool {
-		client, err := dialer.DialContext(t.Context(), "tcp", gwAddr)
+		attemptCtx, cancel := context.WithTimeout(t.Context(), timeoutConfig.RequestTimeout)
+		defer cancel()
+
+		client, err := dialer.DialContext(attemptCtx, "tcp", gwAddr)
 		if err != nil {
 			tlog.Logf(t, "client could not connect: %s; retrying", err)
 			return false
+		}
+		if deadlineErr := client.SetDeadline(time.Now().Add(timeoutConfig.RequestTimeout)); deadlineErr != nil {
+			return closeAndLog(t, client, deadlineErr)
 		}
 		tlog.Logf(t, "tcp client connected")
 		message, err := bufio.NewReader(client).ReadString('\n')
@@ -135,7 +141,7 @@ func WaitForValidTCPResponse(t *testing.T, dialer Dialer, gwAddr string, expecte
 		// At this moment we can simply assume the message will be right, or fail
 		assertTestMessage(t, payload, expected)
 		return true
-	}, maxTimeToConsistency, time.Second)
+	}, timeoutConfig.MaxTimeToConsistency, timeoutConfig.DefaultPollInterval)
 
 	tlog.Logf(t, "Request passed")
 }
@@ -211,11 +217,11 @@ func EchoSendOnce(ctx context.Context, gwAddr string, timeout time.Duration) (st
 // can be established, or fails the test if the timeout expires. It only verifies
 // that the address accepts TCP connections; it does not validate an echo response
 // or backend selection.
-func ExpectAddressBeAvailable(t *testing.T, interval, timeout time.Duration, address string) {
+func ExpectAddressBeAvailable(t *testing.T, timeoutConfig config.TimeoutConfig, address string) {
 	t.Helper()
 
 	tlog.Logf(t, "performing TCP connection probe on %s", address)
-	err := wait.PollUntilContextTimeout(t.Context(), interval, timeout, true,
+	err := wait.PollUntilContextTimeout(t.Context(), timeoutConfig.DefaultPollInterval, timeoutConfig.MaxTimeToConsistency, true,
 		func(ctx context.Context) (bool, error) {
 			var dialer net.Dialer
 			conn, err := dialer.DialContext(ctx, "tcp", address)
@@ -230,5 +236,5 @@ func ExpectAddressBeAvailable(t *testing.T, interval, timeout time.Duration, add
 
 			return true, nil
 		})
-	require.NoError(t, err, "failed waiting for TCP connection to %s after %v", address, timeout)
+	require.NoError(t, err, "failed waiting for TCP connection to %s after %v", address, timeoutConfig.MaxTimeToConsistency)
 }

--- a/conformance/utils/tls/tls.go
+++ b/conformance/utils/tls/tls.go
@@ -67,7 +67,7 @@ func MakeTLSRequestAndExpectEventuallyConsistentResponse(t *testing.T, r roundtr
 		}
 	}
 
-	WaitForConsistentTLSResponse(t, r, req, expected, timeoutConfig.RequiredConsecutiveSuccesses, timeoutConfig.MaxTimeToConsistency)
+	WaitForConsistentTLSResponse(t, r, req, expected, timeoutConfig)
 
 	if clientCertificate != nil && clientCertificateKey != nil {
 		assert.True(t, clientCertificatePresented, "client certificate was not presented during the handshake")
@@ -75,10 +75,9 @@ func MakeTLSRequestAndExpectEventuallyConsistentResponse(t *testing.T, r roundtr
 }
 
 // WaitForConsistentTLSResponse - repeats the provided request until it completes with a response having
-// the expected response consistently. The provided threshold determines how many times in
-// a row this must occur to be considered "consistent".
-func WaitForConsistentTLSResponse(t *testing.T, r roundtripper.RoundTripper, req roundtripper.Request, expected http.ExpectedResponse, threshold int, maxTimeToConsistency time.Duration) {
-	http.AwaitConvergence(t, threshold, maxTimeToConsistency, func(elapsed time.Duration) bool {
+// the expected response consistently.
+func WaitForConsistentTLSResponse(t *testing.T, r roundtripper.RoundTripper, req roundtripper.Request, expected http.ExpectedResponse, timeoutConfig config.TimeoutConfig) {
+	http.AwaitConvergence(t, timeoutConfig, func(elapsed time.Duration) bool {
 		cReq, cRes, err := r.CaptureRoundTrip(req)
 		if err != nil {
 			tlog.Logf(t, "Request failed, not ready yet: %v (after %v)", err.Error(), elapsed)
@@ -121,7 +120,7 @@ func MakeTLSRequestAndExpectEventuallyConsistentFailureResponse(t *testing.T, r 
 		}
 	}
 
-	http.AwaitConvergence(t, timeoutConfig.RequiredConsecutiveSuccesses, timeoutConfig.MaxTimeToConsistency, func(elapsed time.Duration) bool {
+	http.AwaitConvergence(t, timeoutConfig, func(elapsed time.Duration) bool {
 		_, _, err := r.CaptureRoundTrip(req)
 		if err == nil {
 			tlog.Logf(t, "Request unexpectedly succeeded, not ready yet (after %v)", elapsed)
@@ -148,10 +147,10 @@ func MakeTLSConnectionAndExpectEventuallyConnectionRejection(t *testing.T, timeo
 		},
 	}
 
-	waitForTLSConnectionRejection(t, timeoutConfig, dialer, gwAddr, time.Second)
+	waitForTLSConnectionRejection(t, timeoutConfig, dialer, gwAddr)
 }
 
-func waitForTLSConnectionRejection(t *testing.T, timeoutConfig config.TimeoutConfig, dialer contextDialer, gwAddr string, retryInterval time.Duration) {
+func waitForTLSConnectionRejection(t *testing.T, timeoutConfig config.TimeoutConfig, dialer contextDialer, gwAddr string) {
 	t.Helper()
 
 	overallCtx, cancel := context.WithTimeout(t.Context(), timeoutConfig.MaxTimeToConsistency)
@@ -178,7 +177,7 @@ func waitForTLSConnectionRejection(t *testing.T, timeoutConfig config.TimeoutCon
 		}
 		tlog.Logf(t, "client could connect")
 		return false
-	}, timeoutConfig.MaxTimeToConsistency, retryInterval)
+	}, timeoutConfig.MaxTimeToConsistency, timeoutConfig.DefaultPollInterval)
 }
 
 // isConnectionRejected checks if an error indicates either a TCP RST (ECONNRESET)

--- a/conformance/utils/tls/tls_test.go
+++ b/conformance/utils/tls/tls_test.go
@@ -57,9 +57,10 @@ func TestWaitForTLSConnectionRejectionRetriesAfterAttemptTimeout(t *testing.T) {
 	timeoutConfig := config.TimeoutConfig{
 		MaxTimeToConsistency: 500 * time.Millisecond,
 		RequestTimeout:       20 * time.Millisecond,
+		DefaultPollInterval:  time.Millisecond,
 	}
 
-	waitForTLSConnectionRejection(t, timeoutConfig, dialer, "example.com:443", time.Millisecond)
+	waitForTLSConnectionRejection(t, timeoutConfig, dialer, "example.com:443")
 
 	assert.GreaterOrEqual(t, attempts.Load(), int32(2))
 }
@@ -79,9 +80,10 @@ func TestWaitForTLSConnectionRejectionClosesUnexpectedConnection(t *testing.T) {
 	timeoutConfig := config.TimeoutConfig{
 		MaxTimeToConsistency: 500 * time.Millisecond,
 		RequestTimeout:       20 * time.Millisecond,
+		DefaultPollInterval:  time.Millisecond,
 	}
 
-	waitForTLSConnectionRejection(t, timeoutConfig, dialer, "example.com:443", time.Millisecond)
+	waitForTLSConnectionRejection(t, timeoutConfig, dialer, "example.com:443")
 
 	assert.True(t, conn.closed.Load())
 }

--- a/conformance/utils/udp/udp.go
+++ b/conformance/utils/udp/udp.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"sigs.k8s.io/gateway-api/conformance/utils/config"
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
 )
 
@@ -53,15 +54,15 @@ type echoResponse struct {
 
 // ExpectEchoResponse polls until a UDP echo round-trip against the given
 // gateway address succeeds, or the timeout is exceeded.
-func ExpectEchoResponse(t *testing.T, timeout time.Duration, gwAddr string) {
+func ExpectEchoResponse(t *testing.T, timeoutConfig config.TimeoutConfig, gwAddr string) {
 	t.Helper()
-	ExpectEchoResponseFromBackend(t, timeout, gwAddr, ExpectedResponse{})
+	ExpectEchoResponseFromBackend(t, timeoutConfig, gwAddr, ExpectedResponse{})
 }
 
 // ExpectEchoResponseFromBackend polls until a UDP echo round-trip against the
 // given gateway address succeeds and (when set) the response identifies the
 // expected backend Service and/or Namespace, or the timeout is exceeded.
-func ExpectEchoResponseFromBackend(t *testing.T, timeout time.Duration, gwAddr string, expected ExpectedResponse) {
+func ExpectEchoResponseFromBackend(t *testing.T, timeoutConfig config.TimeoutConfig, gwAddr string, expected ExpectedResponse) {
 	t.Helper()
 
 	const probe = "gateway-api-conformance-udp-echo"
@@ -72,7 +73,7 @@ func ExpectEchoResponseFromBackend(t *testing.T, timeout time.Duration, gwAddr s
 		tlog.Logf(t, "performing UDP echo probe on %s", gwAddr)
 	}
 
-	err := wait.PollUntilContextTimeout(context.TODO(), time.Second, timeout, true,
+	err := wait.PollUntilContextTimeout(t.Context(), timeoutConfig.DefaultPollInterval, timeoutConfig.MaxTimeToConsistency, true,
 		func(ctx context.Context) (bool, error) {
 			var dialer net.Dialer
 			conn, err := dialer.DialContext(ctx, "udp", gwAddr)
@@ -82,7 +83,7 @@ func ExpectEchoResponseFromBackend(t *testing.T, timeout time.Duration, gwAddr s
 			}
 			defer conn.Close()
 
-			if err = conn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+			if err = conn.SetDeadline(time.Now().Add(timeoutConfig.RequestTimeout)); err != nil {
 				return false, fmt.Errorf("setting UDP deadline: %w", err)
 			}
 			if _, err = conn.Write([]byte(probe)); err != nil {


### PR DESCRIPTION

**What type of PR is this?**
/area conformance-machinery

**What this PR does / why we need it**:
A few places still had hardcoded intervals and times; more consistently use the timeout config to allow faster tests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
