### PR TITLE
conformance: remove non-standard appProtocol grpc from mesh manifests

### DIFF
--- a/conformance/mesh/manifests.yaml
+++ b/conformance/mesh/manifests.yaml
@@ -70,7 +70,6 @@ spec:
       port: 9090
     - name: grpc
       port: 7070
-      appProtocol: kubernetes.io/h2c
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -136,7 +135,6 @@ spec:
       port: 9090
     - name: grpc
       port: 7070
-      appProtocol: kubernetes.io/h2c
 ---
 apiVersion: v1
 kind: Service

--- a/conformance/mesh/manifests.yaml
+++ b/conformance/mesh/manifests.yaml
@@ -70,7 +70,6 @@ spec:
       port: 9090
     - name: grpc
       port: 7070
-      appProtocol: grpc
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -136,7 +135,6 @@ spec:
       port: 9090
     - name: grpc
       port: 7070
-      appProtocol: grpc
 ---
 apiVersion: v1
 kind: Service
@@ -161,7 +159,6 @@ spec:
       port: 9090
     - name: grpc
       port: 7070
-      appProtocol: grpc
 ---
 apiVersion: v1
 kind: Namespace

--- a/conformance/mesh/manifests.yaml
+++ b/conformance/mesh/manifests.yaml
@@ -70,6 +70,7 @@ spec:
       port: 9090
     - name: grpc
       port: 7070
+      appProtocol: kubernetes.io/h2c
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -135,6 +136,7 @@ spec:
       port: 9090
     - name: grpc
       port: 7070
+      appProtocol: kubernetes.io/h2c
 ---
 apiVersion: v1
 kind: Service
@@ -159,6 +161,7 @@ spec:
       port: 9090
     - name: grpc
       port: 7070
+      appProtocol: kubernetes.io/h2c
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The mesh conformance `Service` definitions in `conformance/mesh/manifests.yaml` set `appProtocol: grpc` on their gRPC ports. `grpc` is not a valid/standardized `appProtocol` value.

This PR originally changed all three `appProtocol: grpc` entries (on the echo-v1/echo-v2/echo Services) to the standard `kubernetes.io/h2c` value. Following further discussion, it now instead keeps `appProtocol: kubernetes.io/h2c` on just the `echo` Service's grpc port and leaves it unset on `echo-v1`/`echo-v2`, per [kflynn's compromise](https://github.com/kubernetes-sigs/gateway-api/pull/5154#issuecomment-5270283572): this covers both the "appProtocol set" and "appProtocol unset" cases, which better reflects how real-world Services typically look (most don't set `appProtocol` at all). The port name (`grpc`, port 7070) is untouched on all three.

**Which issue(s) this PR fixes**:
Fixes #5132

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

---
AI assistance: this change was drafted with Claude Code.
