### PR TITLE
Update landing version for impls to be the latest v1.6

### DIFF
--- a/site/static/_redirects
+++ b/site/static/_redirects
@@ -2,7 +2,7 @@
 /docs/concepts/  /docs/concepts/api-overview/    301!
 /docs/mesh/  /docs/mesh/mesh-overview/    301!
 /docs/implementations/  /docs/implementations/list/    301!
-/docs/implementations/versions/  /docs/implementations/versions/v1.5/    301!
+/docs/implementations/versions/  /docs/implementations/versions/v1.6/    301!
 
 /guides/  /guides/getting-started/introduction/    301!
 /guides/getting-started/  /guides/getting-started/introduction/    301!
@@ -13,6 +13,7 @@
 /reference/api-types/policy/  /reference/api-types/policy/backendtlspolicy/    301!
 /reference/api-spec/  /reference/api-spec/main/spec/    301!
 /reference/api-spec/main/  /reference/api-spec/main/spec/    301!
+/reference/api-spec/1.6/  /reference/api-spec/1.6/spec/    301!
 /reference/api-spec/1.5/  /reference/api-spec/1.5/spec/    301!
 /reference/api-spec/1.4/  /reference/api-spec/1.4/spec/    301!
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Updates the landing page for the reference/implementations to be the latest version and adds redirect to api specs for v1.6.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
