### PR TITLE
GEP-4894: Defer SelectorRef in favor of the Selector Field

### DIFF
--- a/geps/gep-4894/index.md
+++ b/geps/gep-4894/index.md
@@ -288,20 +288,16 @@ type EndpointSelectorBackend struct {
   //
   // Supported kinds:
   // - Service (Core): Only the Service's EndpointSlices are used for endpoint resolution. All other
-  //   Service spec fields - including ClusterIP, DNS, internalTrafficPolicy, externalTrafficPolicy,
-  //   sessionAffinity, and trafficDistribution - are not used. Only ClusterIP and headless (clusterIP: None)
-  //   Services are supported. ExternalName, NodePort, and LoadBalancer Service types MUST be rejected.
+  //   Service spec fields - including but not limited to ClusterIP, DNS, internalTrafficPolicy,
+  //   externalTrafficPolicy, sessionAffinity, and trafficDistribution - are not used. Only ClusterIP
+  //   and headless (clusterIP: None) Services are supported. ExternalName, NodePort, and LoadBalancer
+  //   Service types MUST be rejected.
+  //
+  // Note: Support for kind: Service is temporary and will be deprecated once the
+  // upstream EndpointSelector resource (KEP-6116) is available. Users are expected
+  // to migrate to EndpointSelector at that point.
   //
   // Cross-namespace references are allowed and indicate a consumer override.
-  //
-  // <gateway:util:excludeFromCRD>
-  // Notes for implementers:
-  //
-  // When the upstream EndpointSelector resource (KEP-6116) reaches GA,
-  // SelectorRef will also accept kind: EndpointSelector. Implementations
-  // should anticipate this field becoming optional and supporting additional
-  // kinds in the future.
-  // </gateway:util:excludeFromCRD>
   //
   // +required
   SelectorRef ObjectReference `json:"selectorRef"`
@@ -682,9 +678,9 @@ persistence, etc.) for internal Services without waiting for EndpointSelector.
 
 - The implementation resolves the Service's EndpointSlices, the same way it does for a `kind: Service` backendRef
   today. No new controllers or endpoint management logic is required.
-- Only the Service's EndpointSlices are used for endpoint resolution. All other Service spec fields - including
-  `ClusterIP`, DNS, `internalTrafficPolicy`, `externalTrafficPolicy`, `sessionAffinity`, and `trafficDistribution` -
-  are not used.
+- Only the Service's EndpointSlices are used for endpoint resolution. All other Service spec fields - including but not
+  limited to `ClusterIP`, DNS, `internalTrafficPolicy`, `externalTrafficPolicy`, `sessionAffinity`, and
+  `trafficDistribution` - are not used.
 - Only `ClusterIP` and headless (`clusterIP: None`) Services are supported. `ExternalName`, `NodePort`, and
   `LoadBalancer` types MUST be rejected.
 - Service binding does not add new capabilities to Service itself. All configuration (TLS, protocol, session
@@ -692,9 +688,9 @@ persistence, etc.) for internal Services without waiting for EndpointSelector.
 
 **What happens when EndpointSelector lands:**
 
-Service binding uses the same `SelectorRef` field that will accept `kind: EndpointSelector`. Both kinds coexist -
-there are no plans to deprecate `kind: Service`, as it provides a simpler path for users who do not need the
-additional flexibility of EndpointSelector.
+Service binding is temporary. It uses the same `SelectorRef` field that will accept `kind: EndpointSelector`, so both
+kinds can coexist during migration. Once `kind: EndpointSelector` is available, users are expected to migrate to it,
+and `kind: Service` will be deprecated.
 
 ## Extension Framework
 

--- a/geps/gep-4894/index.md
+++ b/geps/gep-4894/index.md
@@ -14,11 +14,11 @@ title: "GEP-4894: Backend Resource"
 
 ## TLDR
 
-This GEP proposes a new `Backend` resource that fills the [backend role](/geps/gep-2907/) — a **general-purpose decorator for Service** (and other backend types) within Gateway API. The Kubernetes `Service` resource is mature and stable, but it is effectively frozen and SIG-Network leadership is very careful about any potential features that would further bloat `Service`'s responsibilities. Previous approaches to extend Service behavior (like `BackendTLSPolicy`) have significant limitations around discoverability, implementation complexity, and the conflation of producer and consumer concerns. `BackendTLSPolicy` in particular was the right solution at the time, but feedback has shown that policy attachment was not the right approach for TLS configuration.
+This GEP proposes a new `Backend` resource that fills the [backend role](/geps/gep-2907/) — a **general-purpose decorator for backend destinations** within Gateway API. The Kubernetes `Service` resource is mature and stable, but it is effectively frozen and SIG-Network leadership is very careful about any potential features that would further bloat `Service`'s responsibilities. Previous approaches to extend Service behavior (like `BackendTLSPolicy`) have significant limitations around discoverability, implementation complexity, and the conflation of producer and consumer concerns. `BackendTLSPolicy` in particular was the right solution at the time, but feedback has shown that policy attachment was not the right approach for TLS configuration.
 
 The `Backend` resource provides a namespace-scoped, consumer-focused resource that can:
 
-1. **Decorate existing Services** via `EndpointSelector`, adding Gateway-specific configuration (TLS, protocol, etc.) without modifying the Service itself.
+1. **Decorate internal endpoints** via `EndpointSelector`, adding Gateway-specific configuration (TLS, protocol, etc.) directly to a workload's pods, without a user-authored `Service` or its frontend baggage.
 2. **Represent external destinations** via `ExternalHostname`, replacing the need for insecure synthetic `ExternalName` Services.
 3. **Serve as a foundation for future Gateway-level backend configuration** such as retries, session persistence, load balancing algorithms, and other features that are tightly bound to the destination rather than the route.
 
@@ -67,8 +67,7 @@ The current approach to adding Gateway-specific behavior to Services is through 
 ## Goals
 
 - **Introduce Backend resource** as a namespace-scoped, consumer-focused resource for representing destinations and their Gateway-specific connection metadata
-- **Decorate existing Services**: Allow `Backend` of type `EndpointSelector` to wrap a `Service` (or other endpoint-producing resource) with TLS, protocol, and other connection configuration, without modifying the underlying Service
-- **Unblock backend-level features for Services**: Allow Backend to bind to a Kubernetes `Service` for endpoint resolution
+- **Decorate internal endpoints**: Allow `Backend` of type `EndpointSelector` to add TLS, protocol, and other connection configuration to a selected set of pods, without a user-authored `Service`
 - **Support external destinations**: Provide first-class `ExternalHostname` support as an Extended feature, replacing the need for synthetic `ExternalName` Services
 - **Provide a home for backend-level configuration**: Inline TLS, protocol metadata, and (in the future) retries, session persistence, load balancing, and other destination-bound settings
 - **Maintain Service compatibility**: Existing Service-based `backendRef`s continue to work indefinitely; Backend is additive, not a replacement
@@ -76,14 +75,16 @@ The current approach to adding Gateway-specific behavior to Services is through 
 
 ## Non-Goals
 
-- **Deprecate or replace Services**: Services remain the primary backend type for internal destinations. Backend is a decorator, not a replacement.
+- **Deprecate Service**: `Backend` replaces the need for users to author a `Service` for internal destinations, but it does not deprecate `Service` or replace its role in the cluster (ClusterIP, DNS, in-cluster service discovery).
 - **Standardize producer-owned backend policy in this GEP**: Producer guidance and hints may inform client behavior, but defining producer-authoritative policy semantics remains out of scope for this proposal.
 - **Provide cluster-scoped backends**: Backend resource is namespace-scoped for security boundaries
 - **Solve all backend configuration at once**: This GEP establishes the Backend resource and its first features (EndpointSelector, ExternalHostname, inline TLS). Additional features (retries, session persistence, load balancing, etc.) will be proposed in follow-on GEPs.
 
 ## Relationship to Service
 
-The `Backend` resource is **not** a replacement for `Service`. Instead, it is a decorator that adds a Gateway-specific configuration layer:
+The `Backend` resource does not replace `Service`'s role in the cluster: ClusterIP, DNS, and in-cluster service discovery remain with `Service`.
+
+For internal destinations, it replaces the need for a user-authored `Service`: users select their workload's pods directly and avoid all the frontend baggage that comes with a `Service`. `Backend` adds a Gateway-specific configuration layer on top of the endpoints it routes to:
 
 ```
 ┌─────────────────────────────────────────────┐
@@ -100,14 +101,20 @@ The `Backend` resource is **not** a replacement for `Service`. Instead, it is a 
 │  tls: { ... }         ◄── Gateway config    │
 │  protocol: MCP        ◄── Gateway config    │
 │  endpointSelector:                          │
-│    selectorRef: my-svc  ◄── delegates to    │
+│    matchLabels: app=my  ◄── selects pods    │
 └──────────────┬──────────────────────────────┘
                │
                ▼
+┌┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┐
+┆  EndpointSelector                           ┆
+┆  created by the implementation              ┆
+┆  (Service today, as a stop-gap)             ┆
+└┄┄┄┄┄┄┄┄┄┄┄┄┄┄┬┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┘
+               │
+               ▼
 ┌─────────────────────────────────────────────┐
-│  EndpointSlice (my-svc)                     │
-│  (unchanged — still provides endpoints,     │
-│   as before)                                │
+│  EndpointSlice                              │
+│  (generated by Kubernetes)                  │
 └─────────────────────────────────────────────┘
 ```
 
@@ -140,7 +147,7 @@ The Backend resource is designed with a clear separation between Core and Extend
 
 | Feature | Conformance Level | Description |
 | --- | --- | --- |
-| `EndpointSelector` type | Core | Backend wraps an existing Service; behaves equivalently to a Service `backendRef` |
+| `EndpointSelector` type | Core | Routes to a selected set of in-cluster endpoints; behaves equivalently to a Service `backendRef` |
 | `ExternalHostname` type | Extended | First-class external FQDN support, replacing `ExternalName` Services |
 | Inline TLS | Extended | TLS configuration inlined on the Backend resource |
 | `MCP` protocol | Extended | Higher-level protocol metadata for AI/agentic use cases |
@@ -149,9 +156,9 @@ This layering allows the Backend resource itself to move to Standard quickly (Co
 
 ## User Stories
 
-### As an Application Developer (Service Decoration)
+### As an Application Developer (Service Alternative)
 
-> "I want to add TLS configuration to my existing Service-backed backend without modifying the Service itself. Today, I have to create a separate `BackendTLSPolicy`, but it's not obvious from my HTTPRoute that TLS is configured, and I can't easily have different TLS settings for different consumers of the same Service."
+> "I want to add TLS configuration to my backend without authoring a separate `Service` just for the Gateway. Today, I have to create a `Service` plus a separate `BackendTLSPolicy`, but it's not obvious from my HTTPRoute that TLS is configured, and I can't easily have different TLS settings for different consumers of the same workload."
 
 ### As an Application Developer (Egress)
 
@@ -167,13 +174,13 @@ This layering allows the Backend resource itself to move to Standard quickly (Co
 
 ### As an Application Developer (Ingress)
 
-> "I want to tell the Gateway how to connect to my internal Service — what TLS mode to use, what timeouts are appropriate, and what higher-level protocol my app speaks — without requiring a cluster admin to set up separate policy resources for each of these concerns. A single Backend resource that wraps my Service lets me express all of this in one place."
+> "I want to tell the Gateway how to connect to my internal workload — what TLS mode to use, what timeouts are appropriate, and what higher-level protocol my app speaks — without requiring a cluster admin to set up separate policy resources for each of these concerns. A single Backend resource that selects my workload's pods lets me express all of this in one place."
 
 ## Proposal
 
 The `Backend` resource is a general-purpose, Gateway-native backend abstraction. It serves two complementary roles:
 
-1. **Service Decorator (Core)**: A `Backend` of type `EndpointSelector` wraps an existing `Service` (or other endpoint-producing resource) and layers on Gateway-specific configuration — TLS, protocol metadata, and future features like retries or session persistence. At Core conformance, this type does what `Service` already does as a `backendRef`, but provides a dedicated resource where backend-level configuration can live and grow. This avoids the need for a separate policy CRD for each new backend-level concern.
+1. **Internal Destination (Core)**: A `Backend` of type `EndpointSelector` selects a workload's pods directly and layers on Gateway-specific configuration — TLS, protocol metadata, and future features like retries or session persistence — without a user-authored `Service`. At Core conformance, this type does what `Service` already does as a `backendRef`, but provides a dedicated resource where backend-level configuration can live and grow. This avoids the need for a separate policy CRD for each new backend-level concern.
 
 2. **External Destination (Extended)**: A `Backend` of type `ExternalHostname` provides first-class support for external FQDNs, replacing the need for synthetic `ExternalName` Services. This is an Extended feature that addresses the urgent egress and AI use cases.
 
@@ -284,23 +291,27 @@ type BackendPort struct {
 }
 
 type EndpointSelectorBackend struct {
-  // SelectorRef specifies a reference to a resource whose EndpointSlices should be used for this backend.
+  // Selector defines the label selector used to identify the set of pods whose IP addresses
+  // will make up the endpoints that this Backend should route traffic to.
+  // We make this an embedded struct to avoid stuttering in the API (i.e. `endpointSelector.selector`).
   //
-  // Supported kinds:
-  // - Service (Core): Only the Service's EndpointSlices are used for endpoint resolution. All other
-  //   Service spec fields - including but not limited to ClusterIP, DNS, internalTrafficPolicy,
-  //   externalTrafficPolicy, sessionAffinity, and trafficDistribution - are not used. Only ClusterIP
-  //   and headless (clusterIP: None) Services are supported. ExternalName, NodePort, and LoadBalancer
-  //   Service types MUST be rejected.
+  // If this field is set, the endpoints are resolved automatically and stay up to date as pods matching the
+  // selector are added or removed; the user does not create or manage any separate endpoint resource.
   //
-  // Note: Support for kind: Service is temporary and will be deprecated once the
-  // upstream EndpointSelector resource (KEP-6116) is available. Users are expected
-  // to migrate to EndpointSelector at that point.
+  // <gateway:util:excludeFromCRD>
+  // Notes for implementors:
   //
-  // Cross-namespace references are allowed and indicate a consumer override.
+  // Implementations MAY create a Service from the label selector for endpoint resolution until the
+  // upstream EndpointSelector resource (KEP-6116) is available. Implementations SHOULD set ownerReferences
+  // so the created resource's lifecycle is tied to this Backend. This Service only exists to produce EndpointSlices;
+  // Service-level behaviors (including but not limited to internalTrafficPolicy, externalTrafficPolicy,
+  // sessionAffinity, and trafficDistribution) play no role, and its ports are unused since the Gateway
+  // connects to the discovered endpoints using the Backend's port. Implementations SHOULD create the
+  // Service as headless (clusterIP: None), since no ClusterIP or kube-proxy load balancing is needed.
+  // </gateway:util:excludeFromCRD>
   //
   // +required
-  SelectorRef ObjectReference `json:"selectorRef"`
+  *metav1.LabelSelector
 }
 
 // +kubebuilder:validation:XValidation:rule="self.mode == 'ClientAndServer' ? has(self.clientCertificateRef) : !has(self.clientCertificateRef)",message="clientCertificateRef must be set if and only if mode is ClientAndServer"
@@ -384,24 +395,6 @@ const (
 
   // This reason is used with the "Accepted" condition when the Backend has been accepted.
   BackendReasonAccepted BackendConditionReason = "Accepted"
-
-  // This condition indicates whether all references in the Backend spec have been resolved.
-  BackendConditionResolvedRefs BackendConditionType = "ResolvedRefs"
-
-  // This reason is used with the "ResolvedRefs" condition when all references have been resolved.
-  BackendReasonResolvedRefs BackendConditionReason = "ResolvedRefs"
-
-  // This reason is used with the "ResolvedRefs" condition when the SelectorRef references
-  // an unknown or unsupported Group and/or Kind.
-  BackendReasonInvalidKind BackendConditionReason = "InvalidKind"
-
-  // This reason is used with the "ResolvedRefs" condition when the SelectorRef references
-  // a resource that does not exist.
-  BackendReasonRefNotFound BackendConditionReason = "RefNotFound"
-
-  // This reason is used with the "ResolvedRefs" condition when the referenced Service has
-  // a type that is not supported (only ClusterIP and headless Services are valid).
-  BackendReasonInvalidServiceType BackendConditionReason = "InvalidServiceType"
 )
 ```
 
@@ -629,68 +622,31 @@ spec:
 
 ### Route Attachment and Consumer Overrides
 
-Backends MUST live in the same namespace as any route (or other parent resource) that references them. For `EndpointSelector` type Backends, consumer override scenarios are supported using the pre-existing GAMMA pattern of creating a route (and therefore a `Backend`) in the consumer namespace and the `Backend` will reference an `EndpointSelector` in a different, producer namespace.
+Backends MUST live in the same namespace as any route (or other parent resource) that references them. For `EndpointSelector` type Backends, consumer override scenarios are supported using the pre-existing GAMMA pattern of creating a route (and therefore a `Backend`) in the consumer namespace and the `Backend` will reference an `EndpointSelector` in a different, producer namespace. This cross-namespace referencing will be provided by the `selectorRef` field, added once the upstream EndpointSelector resource is available (see [EndpointSelector Type](#endpointselector-type)).
 
-## EndpointSelector Types
-
-### EndpointSelector Resource
+## EndpointSelector Type
 
 The EndpointSelector resource is being pursued upstream via
-[KEP-6116](https://github.com/kubernetes/enhancements/issues/6116). Once available, `SelectorRef` will accept
-`kind: EndpointSelector` to reference it. EndpointSelector decomposes the endpoint selection role of Service into a
-standalone resource, giving Gateway API a clean abstraction for endpoint resolution without the overhead of Service's
-frontend concerns (ClusterIP, DNS, kube-proxy NAT/filtering rules, CoreDNS reconciliation, etc.).
+[KEP-6116](https://github.com/kubernetes/enhancements/issues/6116). It decomposes the endpoint selection role of
+Service into a standalone resource, giving Gateway API a clean abstraction for endpoint resolution without the
+overhead of Service's frontend concerns (ClusterIP, DNS, kube-proxy NAT/filtering rules, CoreDNS reconciliation,
+etc.). Once available, implementations are expected to create an EndpointSelector from the `Selector` on the user's
+behalf, replacing the Service they create today (see [Stop-Gap: Service Backing](#stop-gap-service-backing)). Because the
+`Selector` field stays the same, this transition requires no user-facing API change.
 
-When EndpointSelector is available, the following API changes are expected:
+In addition to `Selector`, we expect to add a `selectorRef` field for referencing an existing EndpointSelector
+directly (for example, one owned by a producer in another namespace). `Selector` selects pods and has the
+implementation create the EndpointSelector; `selectorRef` points at one that already exists.
 
-```go
-// +kubebuilder:validation:ExactlyOneOf=SelectorRef,Selector
-type EndpointSelectorBackend struct {
-  // SelectorRef becomes optional when Selector is supported.
-  // +optional
-  SelectorRef *ObjectReference `json:"selectorRef"`
+### Stop-Gap: Service Backing
 
-  // Selector defines the label selector used to identify the set of pods whose IP addresses
-  // will make up the endpoints that this Backend should route traffic to.
-  // This field is only used if SelectorRef is not specified.
-  // We make this an embedded struct to avoid stuttering in the API (i.e. `selector.selector`).
-  // If omitted, the controller creating this Backend is expected to create an EndpointSelector
-  // resource on behalf of the user and set ownerReferences appropriately so that the lifecycle
-  // of the EndpointSelector is tied to this Backend.
-  // +optional
-  *metav1.LabelSelector
-}
-```
-
-### Service Binding
-
-Without Service binding, the `EndpointSelector` Backend type can only be used once the upstream EndpointSelector
-resource (KEP-6116) is available. Since KEP-6116 targets Kubernetes 1.38 at the earliest and Gateway API policy
-requires GA+5 versions for Standard dependencies, that timeline would block Backend from being usable for internal
-Services for years. This would prevent backend-level features like session persistence, retries, and load balancing
-from progressing, despite significant community demand.
-
-To unblock this, `SelectorRef` accepts `kind: Service` for endpoint resolution. This allows Backend to reference an
-existing Kubernetes Service today, enabling the full range of Backend configuration (TLS, protocol, session
-persistence, etc.) for internal Services without waiting for EndpointSelector.
-
-**What Service binding does:**
-
-- The implementation resolves the Service's EndpointSlices, the same way it does for a `kind: Service` backendRef
-  today. No new controllers or endpoint management logic is required.
-- Only the Service's EndpointSlices are used for endpoint resolution. All other Service spec fields - including but not
-  limited to `ClusterIP`, DNS, `internalTrafficPolicy`, `externalTrafficPolicy`, `sessionAffinity`, and
-  `trafficDistribution` - are not used.
-- Only `ClusterIP` and headless (`clusterIP: None`) Services are supported. `ExternalName`, `NodePort`, and
-  `LoadBalancer` types MUST be rejected.
-- Service binding does not add new capabilities to Service itself. All configuration (TLS, protocol, session
-  persistence) lives on the Backend resource.
-
-**What happens when EndpointSelector lands:**
-
-Service binding is temporary. It uses the same `SelectorRef` field that will accept `kind: EndpointSelector`, so both
-kinds can coexist during migration. Once `kind: EndpointSelector` is available, users are expected to migrate to it,
-and `kind: Service` will be deprecated.
+Since EndpointSelector does not exist today, implementations MAY create a Kubernetes Service from the `Selector` on
+the user's behalf instead. This is a stop-gap: the upstream EndpointSelector resource (KEP-6116) targets Kubernetes
+1.38 at the earliest, and Gateway API's policy of depending only on GA+5 resources would otherwise leave the
+`EndpointSelector` Backend type unusable for internal workloads for years, stalling backend-level features like
+session persistence, retries, and load balancing. A Service reuses endpoint-resolution machinery every
+implementation already has: it resolves EndpointSlices exactly as a `kind: Service` backendRef does today, with no
+new endpoint-management logic.
 
 ## Extension Framework
 
@@ -738,8 +694,8 @@ metadata:
 spec:
   type: EndpointSelector
   endpointSelector:
-    selectorRef:
-      name: my-service
+    matchLabels:
+      app: my-service
   port: 8080
   tls:
     mode: ServerOnly
@@ -812,18 +768,17 @@ once available. This was rejected because:
 - **No stable EndpointSlice controller library**: The proposal was to provide a common library rather than each
   implementation building its own. However, the upstream EndpointSlice controller in `k/k` is tightly coupled to its
   Kubernetes version and SIG Network maintainers were reluctant to commit to it as a stable, importable library.
-- **Timeline**: KEP-6116 targets Kubernetes 1.38 at the earliest. Gateway API's policy of depending only on GA+5
-  resources means EndpointSelector would not be available for Standard graduation for years, blocking backend-level
-  features like session persistence.
 - **Throwaway work**: Implementations would build against a CRD that would eventually be replaced by the upstream
   resource.
 
-Instead, `SelectorRef` accepts `kind: Service` for endpoint resolution today, using the same `ObjectReference` field
-that will accept `kind: EndpointSelector` once KEP-6116 is available.
+Instead, the Backend exposes a `Selector` field that implementations back with a Kubernetes Service today, and will
+back with an upstream EndpointSelector once KEP-6116 is available, with no user-facing API change either way.
 
 ## Open Questions
 
-### Cross-namespace SelectorRef references
-
-We need to figure out whether cross-namespace `SelectorRef` references require a `ReferenceGrant`, consistent with
-other cross-namespace backend references in Gateway API.
+- When we add `selectorRef`, will `ReferenceGrant` be required for cross-namespace references?
+- Should the `Backend` surface a status condition reporting whether the `Selector` resolved to any endpoints (for
+  example, to flag a selector that matches no pods)?
+- Where should the port be defined for each `Backend` type? The `Backend` is the only place it can live for
+  `Selector` and `ExternalHostname`, but for a future `selectorRef` the referenced EndpointSelector already
+  defines its own ports, which may make `Backend.port` redundant.

--- a/geps/gep-4894/index.md
+++ b/geps/gep-4894/index.md
@@ -68,6 +68,7 @@ The current approach to adding Gateway-specific behavior to Services is through 
 
 - **Introduce Backend resource** as a namespace-scoped, consumer-focused resource for representing destinations and their Gateway-specific connection metadata
 - **Decorate existing Services**: Allow `Backend` of type `EndpointSelector` to wrap a `Service` (or other endpoint-producing resource) with TLS, protocol, and other connection configuration, without modifying the underlying Service
+- **Unblock backend-level features for Services**: Allow Backend to bind to a Kubernetes `Service` for endpoint resolution
 - **Support external destinations**: Provide first-class `ExternalHostname` support as an Extended feature, replacing the need for synthetic `ExternalName` Services
 - **Provide a home for backend-level configuration**: Inline TLS, protocol metadata, and (in the future) retries, session persistence, load balancing, and other destination-bound settings
 - **Maintain Service compatibility**: Existing Service-based `backendRef`s continue to work indefinitely; Backend is additive, not a replacement
@@ -216,9 +217,8 @@ type BackendSpec struct {
   ExternalHostname *ExternalHostnameBackend `json:"externalHostname,omitempty"`
 
   // EndpointSelector specifies the configuration for an EndpointSelector backend. Only used if type is EndpointSelector.
-  // As defined in GEP-4731, creation of a `Backend` of type `EndpointSelector` should result in `Backend` controllers
+  // As defined in KEP-6116, creation of a `Backend` of type `EndpointSelector` should result in `Backend` controllers
   // creating the requisite `EndpointSelector` resource and setting ownerReferences appropriately.
-  // TODO: Add link when GEP-4731 merges.
   // +optional
   EndpointSelector *EndpointSelectorBackend `json:"endpointSelector,omitempty"`
 
@@ -287,10 +287,20 @@ type BackendPort struct {
 
 // +kubebuilder:validation:ExactlyOneOf=SelectorRef,Selector
 type EndpointSelectorBackend struct {
-  // SelectorRef specifies the reference to the EndpointSelector resource that manages the EndpointSlices for this backend.
+  // SelectorRef specifies a reference to a resource whose EndpointSlices should be used for this backend.
+  //
+  // Supported kinds:
+  // - Service (Core): Uses the Service's EndpointSlices for endpoint resolution. Only the "service backend"
+  //   role is used — the ClusterIP, DNS name, and other "service frontend" properties are ignored.
+  //   Only ClusterIP and headless (clusterIP: None)
+  //   Services are supported. ExternalName, NodePort, and LoadBalancer Service types MUST be rejected, as
+  //   they carry frontend semantics that are not relevant to Backend's consumer-focused role.
+  // - EndpointSelector (Core): References an EndpointSelector resource that manages the EndpointSlices
+  //   for this backend.
+  //
   // If omitted, the controller creating this Backend is expected to create an EndpointSelector
   // resource on behalf of the user and set ownerReferences appropriately so that the lifecycle
-  // of the EndpointSelector is tied to this Backend (as described in GEP-4731).
+  // of the EndpointSelector is tied to this Backend (as described in KEP-6116).
   // Cross-namespace references are allowed and indicate a consumer override.
   // +optional
   SelectorRef *ObjectReference `json:"selectorRef"`
@@ -603,9 +613,44 @@ spec:
 
 Backends MUST live in the same namespace as any route (or other parent resource) that references them. For `EndpointSelector` type Backends, consumer override scenarios are supported using the pre-existing GAMMA pattern of creating a route (and therefore a `Backend`) in the consumer namespace and the `Backend` will reference an `EndpointSelector` in a different, producer namespace.
 
-## EndpointSelector Type
+## EndpointSelector Types
 
-TODO: Reference GEP 4731 once it merges.
+### EndpointSelector Resource
+
+The EndpointSelector resource is being pursued upstream via
+[KEP-6116](https://github.com/kubernetes/enhancements/issues/6116). Once available, `SelectorRef` will accept
+`kind: EndpointSelector` to reference it. EndpointSelector decomposes the endpoint selection role of Service into a
+standalone resource, giving Gateway API a clean abstraction for endpoint resolution without the baggage of Service's
+frontend concerns (ClusterIP, DNS).
+
+### Service Binding
+
+Without Service binding, the `EndpointSelector` Backend type can only be used once the upstream EndpointSelector
+resource (KEP-6116) is available. Since KEP-6116 targets Kubernetes 1.38 at the earliest and Gateway API policy
+requires GA+5 versions for Standard dependencies, that timeline would block Backend from being usable for internal
+Services for years. This would prevent backend-level features like session persistence, retries, and load balancing
+from progressing, despite significant community demand.
+
+To unblock this, `SelectorRef` accepts `kind: Service` for endpoint resolution. This allows Backend to reference an
+existing Kubernetes Service today, enabling the full range of Backend configuration (TLS, protocol, session
+persistence, etc.) for internal Services without waiting for EndpointSelector.
+
+**What Service binding does:**
+
+- The implementation resolves the Service's EndpointSlices, the same way it does for a `kind: Service` backendRef
+  today. No new controllers or endpoint management logic is required.
+- Only the "service backend" role is used. The ClusterIP, DNS name, and other "service frontend" properties are
+  ignored.
+- Only `ClusterIP` and headless (`clusterIP: None`) Services are supported. `ExternalName`, `NodePort`, and
+  `LoadBalancer` types MUST be rejected.
+- Service binding does not add new capabilities to Service itself. All configuration (TLS, protocol, session
+  persistence) lives on the Backend resource.
+
+**What happens when EndpointSelector lands:**
+
+Service binding uses the same `SelectorRef` field that will accept `kind: EndpointSelector`. Both kinds coexist —
+there are no plans to deprecate `kind: Service`, as it provides a simpler path for users who do not need the
+additional flexibility of EndpointSelector.
 
 ## Extension Framework
 
@@ -677,11 +722,11 @@ This GEP follows the standard [Gateway API graduation criteria](/docs/concepts/v
 
 ### Implementable
 
-- [ ] Backend resource CRD with full schema validation
-- [ ] Documentation and examples for common use cases
+- [x] Backend resource CRD with full schema validation
 
 ### Experimental
 
+- [ ] Documentation and examples for common use cases
 - [ ] Basic conformance tests for FQDN and Service destination types
 - [ ] Security review and RBAC documentation
 
@@ -716,3 +761,22 @@ Using only policy attachment without a dedicated Backend resource was considered
 - **Policy target ambiguity**: Policies would still need to target synthetic Services
 - **Extension limitations**: Protocol and connection options don't fit policy patterns well
 - **CRD proliferation**: Each new backend-level concern would require its own policy CRD, leading to poor discoverability and implementation complexity. The Backend resource provides a single home for configuration that describes "how to connect to a destination"
+
+### Gateway API EndpointSelector CRD
+
+A [provisional GEP](https://github.com/kubernetes-sigs/gateway-api/pull/4731) proposed defining an EndpointSelector CRD
+within Gateway API as the sole endpoint selection reference for Backend, never promoting it past experimental and
+replacing it with the upstream EndpointSelector ([KEP-6116](https://github.com/kubernetes/enhancements/issues/6116))
+once available. This was rejected because:
+
+- **No stable EndpointSlice controller library**: The proposal was to provide a common library rather than each
+  implementation building its own. However, the upstream EndpointSlice controller in `k/k` is tightly coupled to its
+  Kubernetes version and SIG Network maintainers were reluctant to commit to it as a stable, importable library.
+- **Timeline**: KEP-6116 targets Kubernetes 1.38 at the earliest. Gateway API's policy of depending only on GA+5
+  resources means EndpointSelector would not be available for Standard graduation for years, blocking backend-level
+  features like session persistence.
+- **Throwaway work**: Implementations would build against a CRD that would eventually be replaced by the upstream
+  resource.
+
+Instead, `SelectorRef` accepts `kind: Service` for endpoint resolution today, using the same `ObjectReference` field
+that will accept `kind: EndpointSelector` once KEP-6116 is available.

--- a/geps/gep-4894/index.md
+++ b/geps/gep-4894/index.md
@@ -217,8 +217,6 @@ type BackendSpec struct {
   ExternalHostname *ExternalHostnameBackend `json:"externalHostname,omitempty"`
 
   // EndpointSelector specifies the configuration for an EndpointSelector backend. Only used if type is EndpointSelector.
-  // As defined in KEP-6116, creation of a `Backend` of type `EndpointSelector` should result in `Backend` controllers
-  // creating the requisite `EndpointSelector` resource and setting ownerReferences appropriately.
   // +optional
   EndpointSelector *EndpointSelectorBackend `json:"endpointSelector,omitempty"`
 
@@ -285,32 +283,28 @@ type BackendPort struct {
   Port PortNumber `json:"port,omitempty" protobuf:"bytes,3,opt,name=port"`
 }
 
-// +kubebuilder:validation:ExactlyOneOf=SelectorRef,Selector
 type EndpointSelectorBackend struct {
   // SelectorRef specifies a reference to a resource whose EndpointSlices should be used for this backend.
   //
   // Supported kinds:
-  // - Service (Core): Uses the Service's EndpointSlices for endpoint resolution. Only the "service backend"
-  //   role is used — the ClusterIP, DNS name, and other "service frontend" properties are ignored.
-  //   Only ClusterIP and headless (clusterIP: None)
-  //   Services are supported. ExternalName, NodePort, and LoadBalancer Service types MUST be rejected, as
-  //   they carry frontend semantics that are not relevant to Backend's consumer-focused role.
-  // - EndpointSelector (Core): References an EndpointSelector resource that manages the EndpointSlices
-  //   for this backend.
+  // - Service (Core): Only the Service's EndpointSlices are used for endpoint resolution. All other
+  //   Service spec fields - including ClusterIP, DNS, internalTrafficPolicy, externalTrafficPolicy,
+  //   sessionAffinity, and trafficDistribution - are not used. Only ClusterIP and headless (clusterIP: None)
+  //   Services are supported. ExternalName, NodePort, and LoadBalancer Service types MUST be rejected.
   //
-  // If omitted, the controller creating this Backend is expected to create an EndpointSelector
-  // resource on behalf of the user and set ownerReferences appropriately so that the lifecycle
-  // of the EndpointSelector is tied to this Backend (as described in KEP-6116).
   // Cross-namespace references are allowed and indicate a consumer override.
-  // +optional
-  SelectorRef *ObjectReference `json:"selectorRef"`
-
-  // Selector defines the label selector used to identify the set of pods whose IP addresses
-  // will make up the endpoints that this Backend should route traffic to.
-  // This field is only used if SelectorRef is not specified.
-  // We make this an embedded struct to avoid stuttering in the API (i.e. `selector.selector`).
-  // +optional
-  *metav1.LabelSelector
+  //
+  // <gateway:util:excludeFromCRD>
+  // Notes for implementers:
+  //
+  // When the upstream EndpointSelector resource (KEP-6116) reaches GA,
+  // SelectorRef will also accept kind: EndpointSelector. Implementations
+  // should anticipate this field becoming optional and supporting additional
+  // kinds in the future.
+  // </gateway:util:excludeFromCRD>
+  //
+  // +required
+  SelectorRef ObjectReference `json:"selectorRef"`
 }
 
 // +kubebuilder:validation:XValidation:rule="self.mode == 'ClientAndServer' ? has(self.clientCertificateRef) : !has(self.clientCertificateRef)",message="clientCertificateRef must be set if and only if mode is ClientAndServer"
@@ -373,11 +367,7 @@ type BackendParentStatus struct {
   // https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
   // conditions represent the current state of the Backend resource.
   // Each condition has a unique type and reflects the status of a specific aspect of the resource.
-  //
-  // Standard condition types include:
-  // - "Available": the resource is fully functional
-  // - "Progressing": the resource is being created or updated
-  // - "Degraded": the resource failed to reach or maintain its desired state
+  // See BackendConditionType for defined condition types.
   //
   // The status of each condition is one of True, False, or Unknown.
   // +listType=map
@@ -385,6 +375,38 @@ type BackendParentStatus struct {
   // +optional
   Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
+
+// BackendConditionType is a type of condition for a Backend.
+type BackendConditionType string
+
+// BackendConditionReason is a reason for a Backend condition.
+type BackendConditionReason string
+
+const (
+  // This condition indicates whether the Backend has been accepted by a controller.
+  BackendConditionAccepted BackendConditionType = "Accepted"
+
+  // This reason is used with the "Accepted" condition when the Backend has been accepted.
+  BackendReasonAccepted BackendConditionReason = "Accepted"
+
+  // This condition indicates whether all references in the Backend spec have been resolved.
+  BackendConditionResolvedRefs BackendConditionType = "ResolvedRefs"
+
+  // This reason is used with the "ResolvedRefs" condition when all references have been resolved.
+  BackendReasonResolvedRefs BackendConditionReason = "ResolvedRefs"
+
+  // This reason is used with the "ResolvedRefs" condition when the SelectorRef references
+  // an unknown or unsupported Group and/or Kind.
+  BackendReasonInvalidKind BackendConditionReason = "InvalidKind"
+
+  // This reason is used with the "ResolvedRefs" condition when the SelectorRef references
+  // a resource that does not exist.
+  BackendReasonRefNotFound BackendConditionReason = "RefNotFound"
+
+  // This reason is used with the "ResolvedRefs" condition when the referenced Service has
+  // a type that is not supported (only ClusterIP and headless Services are valid).
+  BackendReasonInvalidServiceType BackendConditionReason = "InvalidServiceType"
+)
 ```
 
 ### ExternalHostname Backend Configuration
@@ -620,8 +642,29 @@ Backends MUST live in the same namespace as any route (or other parent resource)
 The EndpointSelector resource is being pursued upstream via
 [KEP-6116](https://github.com/kubernetes/enhancements/issues/6116). Once available, `SelectorRef` will accept
 `kind: EndpointSelector` to reference it. EndpointSelector decomposes the endpoint selection role of Service into a
-standalone resource, giving Gateway API a clean abstraction for endpoint resolution without the baggage of Service's
-frontend concerns (ClusterIP, DNS).
+standalone resource, giving Gateway API a clean abstraction for endpoint resolution without the overhead of Service's
+frontend concerns (ClusterIP, DNS, kube-proxy NAT/filtering rules, CoreDNS reconciliation, etc.).
+
+When EndpointSelector is available, the following API changes are expected:
+
+```go
+// +kubebuilder:validation:ExactlyOneOf=SelectorRef,Selector
+type EndpointSelectorBackend struct {
+  // SelectorRef becomes optional when Selector is supported.
+  // +optional
+  SelectorRef *ObjectReference `json:"selectorRef"`
+
+  // Selector defines the label selector used to identify the set of pods whose IP addresses
+  // will make up the endpoints that this Backend should route traffic to.
+  // This field is only used if SelectorRef is not specified.
+  // We make this an embedded struct to avoid stuttering in the API (i.e. `selector.selector`).
+  // If omitted, the controller creating this Backend is expected to create an EndpointSelector
+  // resource on behalf of the user and set ownerReferences appropriately so that the lifecycle
+  // of the EndpointSelector is tied to this Backend.
+  // +optional
+  *metav1.LabelSelector
+}
+```
 
 ### Service Binding
 
@@ -639,8 +682,9 @@ persistence, etc.) for internal Services without waiting for EndpointSelector.
 
 - The implementation resolves the Service's EndpointSlices, the same way it does for a `kind: Service` backendRef
   today. No new controllers or endpoint management logic is required.
-- Only the "service backend" role is used. The ClusterIP, DNS name, and other "service frontend" properties are
-  ignored.
+- Only the Service's EndpointSlices are used for endpoint resolution. All other Service spec fields - including
+  `ClusterIP`, DNS, `internalTrafficPolicy`, `externalTrafficPolicy`, `sessionAffinity`, and `trafficDistribution` -
+  are not used.
 - Only `ClusterIP` and headless (`clusterIP: None`) Services are supported. `ExternalName`, `NodePort`, and
   `LoadBalancer` types MUST be rejected.
 - Service binding does not add new capabilities to Service itself. All configuration (TLS, protocol, session
@@ -648,7 +692,7 @@ persistence, etc.) for internal Services without waiting for EndpointSelector.
 
 **What happens when EndpointSelector lands:**
 
-Service binding uses the same `SelectorRef` field that will accept `kind: EndpointSelector`. Both kinds coexist —
+Service binding uses the same `SelectorRef` field that will accept `kind: EndpointSelector`. Both kinds coexist -
 there are no plans to deprecate `kind: Service`, as it provides a simpler path for users who do not need the
 additional flexibility of EndpointSelector.
 
@@ -780,3 +824,10 @@ once available. This was rejected because:
 
 Instead, `SelectorRef` accepts `kind: Service` for endpoint resolution today, using the same `ObjectReference` field
 that will accept `kind: EndpointSelector` once KEP-6116 is available.
+
+## Open Questions
+
+### Cross-namespace SelectorRef references
+
+We need to figure out whether cross-namespace `SelectorRef` references require a `ReferenceGrant`, consistent with
+other cross-namespace backend references in Gateway API.

--- a/geps/gep-4894/index.md
+++ b/geps/gep-4894/index.md
@@ -14,7 +14,7 @@ title: "GEP-4894: Backend Resource"
 
 ## TLDR
 
-This GEP proposes a new `Backend` resource that fills the [backend role](/geps/gep-2907/) — a **general-purpose decorator for backend destinations** within Gateway API. The Kubernetes `Service` resource is mature and stable, but it is effectively frozen and SIG-Network leadership is very careful about any potential features that would further bloat `Service`'s responsibilities. Previous approaches to extend Service behavior (like `BackendTLSPolicy`) have significant limitations around discoverability, implementation complexity, and the conflation of producer and consumer concerns. `BackendTLSPolicy` in particular was the right solution at the time, but feedback has shown that policy attachment was not the right approach for TLS configuration.
+This GEP proposes a new `Backend` resource that fills the [backend role](/geps/gep-2907/) — a **general-purpose decorator for backend destinations** within Gateway API. The Kubernetes `Service` resource is mature and stable, but it is effectively frozen and SIG-Network leadership is very careful about any potential features that would further bloat `Service`'s responsibilities. Previous approaches to extend Service behavior (like `BackendTLSPolicy`) have significant limitations around discoverability, implementation complexity, and the conflation of producer and consumer concerns. `BackendTLSPolicy` in particular was the right solution at the time, but feedback has shown that for the common case, inline configuration on the backend is simpler to author and often preferable.
 
 The `Backend` resource provides a namespace-scoped, consumer-focused resource that can:
 
@@ -213,7 +213,9 @@ type BackendSpec struct {
   // +unionDiscriminator
   // +required
   Type BackendType `json:"type"`
-  // Port defines the port that the implementation should use when connecting to this backend.
+  // Port defines the port to connect to on this backend.
+  // For ExternalHostname, this is the port on the external host.
+  // For EndpointSelector, this specifies which endpoint port to connect to.
   // +required
   Port BackendPort `json:"port,omitempty"`
 
@@ -290,6 +292,19 @@ type BackendPort struct {
   Port PortNumber `json:"port,omitempty" protobuf:"bytes,3,opt,name=port"`
 }
 
+// LabelSelector defines a query for resources based on their labels.
+// This simplified version uses only the matchLabels field.
+type LabelSelector struct {
+  // MatchLabels contains a set of required {key,value} pairs.
+  // An object must match every label in this map to be selected.
+  // The matching logic is an AND operation on all entries.
+  //
+  // +required
+  // +kubebuilder:validation:MinProperties=1
+  // +kubebuilder:validation:MaxProperties=64
+  MatchLabels map[LabelKey]LabelValue `json:"matchLabels"`
+}
+
 type EndpointSelectorBackend struct {
   // Selector defines the label selector used to identify the set of pods whose IP addresses
   // will make up the endpoints that this Backend should route traffic to.
@@ -305,13 +320,15 @@ type EndpointSelectorBackend struct {
   // upstream EndpointSelector resource (KEP-6116) is available. Implementations SHOULD set ownerReferences
   // so the created resource's lifecycle is tied to this Backend. This Service only exists to produce EndpointSlices;
   // Service-level behaviors (including but not limited to internalTrafficPolicy, externalTrafficPolicy,
-  // sessionAffinity, and trafficDistribution) play no role, and its ports are unused since the Gateway
-  // connects to the discovered endpoints using the Backend's port. Implementations SHOULD create the
+  // sessionAffinity, and trafficDistribution) play no role. The Service port (ClusterIP frontend) is unused;
+  // the targetPort SHOULD be set to Backend.spec.port. Implementations SHOULD create the
   // Service as headless (clusterIP: None), since no ClusterIP or kube-proxy load balancing is needed.
+  // Implementations MUST name the Service with generateName rather than a predictable name, so that a
+  // name like <backend-name>-backend.svc.cluster.local does not become a relied-upon DNS entry.
   // </gateway:util:excludeFromCRD>
   //
   // +required
-  *metav1.LabelSelector
+  LabelSelector
 }
 
 // +kubebuilder:validation:XValidation:rule="self.mode == 'ClientAndServer' ? has(self.clientCertificateRef) : !has(self.clientCertificateRef)",message="clientCertificateRef must be set if and only if mode is ClientAndServer"
@@ -620,6 +637,26 @@ spec:
 - Network-level controls (firewalls, proxy configuration) provide defense in depth
 - Backend resources provide audit trail for external dependencies
 
+### EndpointSelector Security Analysis
+
+#### Identified Security Risks
+
+A namespace admin should not be able to use the gateway to reach or expose anything outside the boundaries of their
+namespace. For example, [CVE-2021-25740](https://github.com/kubernetes/kubernetes/issues/103675) is a pre-existing
+confused-deputy issue where a user who can write `Endpoints`/`EndpointSlices` supplies arbitrary backend IPs that a
+trusted gateway forwards to, reaching other namespaces or internal addresses. This is not specific to `Backend`: the
+same confused deputy exists wherever a tenant can write endpoints and a gateway routes to that Service, including
+`HTTPRoute` -> `Service` today. Its mitigation is cluster-admin RBAC that removes endpoint write from tenants.
+
+#### Risk Assessment and Mitigations
+
+`EndpointSelector` does not reintroduce this: it selects pods by label, resolved by the control plane, so there is
+no user-supplied IP, and a `Selector` is namespace-scoped. A user only authors a `Backend` and never writes
+endpoints, so this holds without granting tenants endpoint access.
+
+TODO: Revisit this risk assessment when `selectorRef` is added, since cross-namespace selection crosses the
+namespace boundary.
+
 ### Route Attachment and Consumer Overrides
 
 Backends MUST live in the same namespace as any route (or other parent resource) that references them. For `EndpointSelector` type Backends, consumer override scenarios are supported using the pre-existing GAMMA pattern of creating a route (and therefore a `Backend`) in the consumer namespace and the `Backend` will reference an `EndpointSelector` in a different, producer namespace. This cross-namespace referencing will be provided by the `selectorRef` field, added once the upstream EndpointSelector resource is available (see [EndpointSelector Type](#endpointselector-type)).
@@ -777,8 +814,11 @@ back with an upstream EndpointSelector once KEP-6116 is available, with no user-
 ## Open Questions
 
 - When we add `selectorRef`, will `ReferenceGrant` be required for cross-namespace references?
+- Should cross-namespace Route -> Backend references be supported (via ReferenceGrant)?
 - Should the `Backend` surface a status condition reporting whether the `Selector` resolved to any endpoints (for
   example, to flag a selector that matches no pods)?
-- Where should the port be defined for each `Backend` type? The `Backend` is the only place it can live for
-  `Selector` and `ExternalHostname`, but for a future `selectorRef` the referenced EndpointSelector already
-  defines its own ports, which may make `Backend.port` redundant.
+- What should the structure of `Backend.spec.port` be to align with Service and the future EndpointSelector backing?
+- What is the long-term relationship between the `Backend` resource and `BackendTLSPolicy`? Inline TLS on `Backend`
+  serves the common, backend-owner-authored case, but `BackendTLSPolicy` may still be the better fit where the
+  configuring persona differs from the backend owner (for example, a Gateway or cluster operator enforcing trust
+  settings for a backend they do not own).


### PR DESCRIPTION
**What type of PR is this?**
/kind gep

**What this PR does / why we need it**:

The `EndpointSelector` type currently has two mutually-exclusive ways to identify a backend's endpoints: a `selectorRef` reference to an EndpointSelector resource, and an embedded `Selector` label selector on pods. The `selectorRef` path depends on the upstream EndpointSelector resource ([KEP-6116](https://github.com/kubernetes/enhancements/issues/6116)), which does not exist yet.

Rather than block Backend on it, this PR defers `selectorRef` and leads with the embedded `Selector`, and reframes the type from decorating an existing `Service` to selecting a workload's pods directly.

Implementations resolve the endpoints on the user's behalf: a Kubernetes Service today as a stop-gap, and the upstream EndpointSelector once available, with no user-facing API change either way. `selectorRef` returns later as an additive way to reference an existing EndpointSelector (for example, one owned by a producer in another namespace).

This unblocks https://github.com/kubernetes-sigs/gateway-api/pull/4876, which makes `Backend` the attachment point for session persistence but is blocked on `Backend` supporting an EndpointSelector binding for internal workloads.

**Which issue(s) this PR fixes**:
Fixes # N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
