### PR TITLE
Move report generation out of verify and run on demand

### DIFF
--- a/.github/workflows/verify-conformance-reports.yml
+++ b/.github/workflows/verify-conformance-reports.yml
@@ -1,0 +1,83 @@
+name: Verify Conformance Reports
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'conformance/reports/**'
+
+# Remove all permissions from GITHUB_TOKEN except metadata.
+permissions: {}
+
+jobs:
+  verify-changed-reports:
+    name: Verify Changed Reports
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag=v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install yq
+        run: |
+          VERSION="v4.53.3"
+          BINARY="yq_linux_amd64"
+          wget "https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY}" -O /tmp/yq
+          chmod +x /tmp/yq
+          sudo mv /tmp/yq /usr/local/bin/yq
+          yq --version
+
+      - name: Detect changed report directories
+        id: changed-dirs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -e
+
+          echo "Comparing ${BASE_SHA}...${HEAD_SHA}"
+
+          # Get all changed files in conformance/reports/
+          CHANGED_FILES=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" -- 'conformance/reports/')
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No conformance report changes detected"
+            echo "implementation_dirs=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          # Extract unique implementation directories (format: conformance/reports/v1.x.x/implementation-name/)
+          # Filter for directories >= v1.1.0 (matching verify-reports.sh logic)
+          IMPL_DIRS=$(echo "$CHANGED_FILES" | \
+            grep -E '^conformance/reports/v[0-9]+\.[0-9]+(\.[0-9]+)?/' | \
+            sed 's|^\(conformance/reports/v[0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?/[^/]\+\)/.*|\1|' | \
+            sort -u)
+
+          if [ -z "$IMPL_DIRS" ]; then
+            echo "No valid implementation directories found in changes"
+            echo "implementation_dirs=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Implementation directories to validate:"
+          echo "$IMPL_DIRS"
+
+          # Note: Symlink resolution and deduplication (e.g., v1.6.0 -> v1.6) is handled
+          # by verify-reports.sh to keep the logic in one place and support direct script usage
+
+          # Convert to space-separated list for script argument
+          DIRS_LIST=$(echo "$IMPL_DIRS" | tr '\n' ' ')
+          echo "implementation_dirs=${DIRS_LIST}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate changed reports
+        if: steps.changed-dirs.outputs.implementation_dirs != ''
+        env:
+          DIRS: ${{ steps.changed-dirs.outputs.implementation_dirs }}
+        run: |
+          echo "Validating directories: ${DIRS}"
+          hack/verify-reports.sh ${DIRS}

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,11 @@ uninstall:
 verify:
 	hack/verify-all.sh -v
 
+# Verify conformance reports.
+.PHONY: verify-reports
+verify-reports:
+	hack/verify-reports.sh
+
 # Docs
 
 PYTHON ?= $(shell if [ -x .venv/bin/python3 ]; then echo "./.venv/bin/python3"; else echo "python3"; fi)

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -20,7 +20,6 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${SCRIPT_ROOT}/hack/kube-env.sh"
-PULL_BASE_REF=${PULL_BASE_REF:-}
 
 SILENT=true
 FAILED_TEST=()
@@ -39,40 +38,34 @@ function is-excluded {
 
 while getopts ":v" opt; do
   case $opt in
-    v)
-      SILENT=false
-      ;;
-    \?)
-      echo "Invalid flag: -$OPTARG" >&2
-      exit 1
-      ;;
+  v)
+    SILENT=false
+    ;;
+  \?)
+    echo "Invalid flag: -$OPTARG" >&2
+    exit 1
+    ;;
   esac
 done
 
-if $SILENT ; then
+if $SILENT; then
   echo "Running in the silent mode, run with -v if you want to see script logs."
 fi
 
-EXCLUDE="verify-all.sh"
-
-# On a release branch we must ignore the conformance reports checks
-if [[ -n "$PULL_BASE_REF" && "$PULL_BASE_REF" == release-* ]]; then
-  echo "Running on a release branch, extra tests may be ignored"
-  EXCLUDE="${EXCLUDE} verify-reports.sh"
-fi
+EXCLUDE="verify-all.sh verify-reports.sh"
 
 SCRIPTS=$(find "${SCRIPT_ROOT}"/hack -name "verify-*.sh")
 
 ret=0
-for t in $SCRIPTS;
-do
-  if is-excluded "${t}" ; then
-    echo "Skipping $t"
+for t in $SCRIPTS; do
+  echo "$(date) - Starting test ${t}"
+  if is-excluded "${t}"; then
+    echo "$(date) - Skipping $t"
     continue
   fi
-  if $SILENT ; then
+  if $SILENT; then
     echo -e "Verifying $t"
-    if bash "$t" &> /dev/null; then
+    if bash "$t" &>/dev/null; then
       echo -e "${color_green}SUCCESS${color_norm}"
     else
       echo -e "${color_red}FAILED: $t ${color_norm}"
@@ -84,10 +77,11 @@ do
       echo -e "${color_green}SUCCESS: $t ${color_norm}"
     else
       echo -e "${color_red}Test FAILED: $t ${color_norm}"
-       FAILED_TEST+=("$t")
+      FAILED_TEST+=("$t")
       ret=1
     fi
   fi
+  echo "$(date) - Finished test ${t}"
 done
 
 if [ ${#FAILED_TEST[@]} -ne 0 ]; then

--- a/hack/verify-reports.sh
+++ b/hack/verify-reports.sh
@@ -79,31 +79,89 @@ REPORTS_DIR=$(dirname "${BASH_SOURCE}")/../conformance/reports
 # Regex to match the report file name pattern defined in https://github.com/kubernetes-sigs/gateway-api/blob/release-1.1/conformance/reports/README.md#how-this-folder-is-structured
 EXIT_VALUE=0
 
-for dir in ${REPORTS_DIR}/*
-do
-    element="${dir##*/}"
-    if check_ge_v1.1.0 "${element}"; then
-        if [[ -d "${dir}" ]]; then
-            gateway_api_version="${element}"
-            for implementation_dir in ${dir}/*
-            do
-                implementation=$(basename "${implementation_dir}")
-                info "Checking ${implementation} project directory for Gateway API version ${gateway_api_version}"
-            
-                if [[ -f "${implementation_dir}/README.md" ]]; then
-                # Check if the README.md has broken links
-                    docker run -v $(readlink -f "$implementation_dir"):/${implementation}:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /${implementation}/README.md
-                else
-                    error "missing README.md in ${implementation_dir}"
-                    EXIT_VALUE=1
-                fi
-                for report in ${implementation_dir}/*.yaml
-                do
-                    check_report_fields "${report}" "${gateway_api_version}"
-                done
-            done
-        fi
+# Function to validate a specific implementation directory
+validate_implementation_dir() {
+    local implementation_dir=$1
+    local gateway_api_version=$2
+    local implementation=$(basename "${implementation_dir}")
+
+    info "Checking ${implementation} project directory for Gateway API version ${gateway_api_version}"
+
+    if [[ -f "${implementation_dir}/README.md" ]]; then
+    # Check if the README.md has broken links
+        docker run -v "$(readlink -f "$implementation_dir"):/${implementation}:ro" --rm -i ghcr.io/tcort/markdown-link-check:stable /${implementation}/README.md
+    else
+        error "missing README.md in ${implementation_dir}"
+        EXIT_VALUE=1
     fi
-done
+    for report in "${implementation_dir}"/*.yaml
+    do
+        # Skip if no yaml files exist (glob didn't match)
+        [[ -e "${report}" ]] || continue
+        check_report_fields "${report}" "${gateway_api_version}"
+    done
+}
+
+# If specific directories are provided as arguments, validate only those
+if [[ $# -gt 0 ]]; then
+    info "Validating specific directories: $@"
+
+    # First pass: resolve symlinks and deduplicate
+    declare -A validated_dirs
+    for target_dir in "$@"
+    do
+        # Normalize path (remove trailing slash, make relative to repo root)
+        target_dir="${target_dir%/}"
+
+        # Check if directory exists
+        if [[ ! -d "${target_dir}" ]]; then
+            error "Directory does not exist: ${target_dir}"
+            EXIT_VALUE=1
+            continue
+        fi
+
+        # Resolve symlinks to canonical path
+        canonical_dir=$(readlink -f "${target_dir}")
+
+        # Check if we've already validated this canonical path
+        if [[ -v "validated_dirs[$canonical_dir]" ]]; then
+            info "Skipping ${target_dir} (already validated as ${validated_dirs[$canonical_dir]})"
+            continue
+        fi
+
+        # Extract version from the resolved canonical path
+        version=$(echo "${canonical_dir}" | sed -n 's|.*/conformance/reports/\(v[0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?\)/.*|\1|p')
+        if [[ -z "${version}" ]]; then
+            error "Could not extract version from path: ${canonical_dir}"
+            EXIT_VALUE=1
+            continue
+        fi
+
+        if ! check_ge_v1.1.0 "${version}"; then
+            info "Skipping ${target_dir} (version ${version} is < v1.1.0)"
+            continue
+        fi
+
+        # Mark this canonical path as validated and store the original path for display
+        validated_dirs[$canonical_dir]="${target_dir}"
+
+        validate_implementation_dir "${canonical_dir}" "${version}"
+    done
+else
+    # No arguments provided, validate all directories (original behavior)
+    for dir in ${REPORTS_DIR}/*
+    do
+        element="${dir##*/}"
+        if check_ge_v1.1.0 "${element}"; then
+            if [[ -d "${dir}" ]]; then
+                gateway_api_version="${element}"
+                for implementation_dir in ${dir}/*
+                do
+                    validate_implementation_dir "${implementation_dir}" "${gateway_api_version}"
+                done
+            fi
+        fi
+    done
+fi
 
 exit ${EXIT_VALUE}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Report generation is one of our slowest tests, and the most flaky one. This PR moves it out of the main verify script, and also starts to run it 

This PR makes reports verify script run just when a report is changed, and just on that specific report(s) and remove it from verify-all script

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
