### PR TITLE
[Backport release-1.6] conformance: wait for TCP echo before weighted routing

### DIFF
--- a/conformance/tests/tcproute-weighted-routing.go
+++ b/conformance/tests/tcproute-weighted-routing.go
@@ -62,6 +62,7 @@ var TCPRouteWeightedRouting = confsuite.ConformanceTest{
 			}
 
 			tcp.ExpectAddressBeAvailable(t, suite.TimeoutConfig.DefaultPollInterval, suite.TimeoutConfig.MaxTimeToConsistency, gwAddr)
+			tcp.ExpectEchoResponse(t, suite.TimeoutConfig, gwAddr)
 
 			sender := weight.NewFunctionBasedSender(func() (string, error) {
 				return tcp.EchoSendOnce(t.Context(), gwAddr, suite.TimeoutConfig.RequestTimeout)

--- a/conformance/utils/tcp/tcp.go
+++ b/conformance/utils/tcp/tcp.go
@@ -207,6 +207,26 @@ func EchoSendOnce(ctx context.Context, gwAddr string, timeout time.Duration) (st
 	return resp.Pod, nil
 }
 
+// ExpectEchoResponse polls until a complete TCP echo handshake succeeds against
+// the provided address, or fails the test if the timeout expires. Unlike a TCP
+// connection probe, this verifies that a route has reached a ready backend.
+func ExpectEchoResponse(t *testing.T, timeoutConfig config.TimeoutConfig, address string) {
+	t.Helper()
+
+	tlog.Logf(t, "performing TCP echo probe on %s", address)
+	err := wait.PollUntilContextTimeout(t.Context(), timeoutConfig.DefaultPollInterval, timeoutConfig.MaxTimeToConsistency, true,
+		func(ctx context.Context) (bool, error) {
+			pod, err := EchoSendOnce(ctx, address, timeoutConfig.RequestTimeout)
+			if err != nil {
+				tlog.Logf(t, "failed to receive a TCP echo response from %s; retrying: %v", address, err)
+				return false, nil
+			}
+			tlog.Logf(t, "received a TCP echo response from %s via pod %s", address, pod)
+			return true, nil
+		})
+	require.NoError(t, err, "failed waiting for a TCP echo response from %s after %v", address, timeoutConfig.MaxTimeToConsistency)
+}
+
 // ExpectAddressBeAvailable polls until a TCP connection to the provided address
 // can be established, or fails the test if the timeout expires. It only verifies
 // that the address accepts TCP connections; it does not validate an echo response


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind test
/area conformance-test

**What this PR does / why we need it**:

(cherry picked from commit bc4d2e723b43e07b59de174eb95da2aba3b97ed3)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
