### PR TITLE
docs: add Higress v2.2.4 Gateway API conformance report

### DIFF
--- a/conformance/reports/v1.6/higress-group-higress/README.md
+++ b/conformance/reports/v1.6/higress-group-higress/README.md
@@ -1,0 +1,37 @@
+# Higress
+
+[Higress](https://higress.ai/) is a cloud-native API gateway built on Istio and
+Envoy and is a CNCF project.
+
+## Table of Contents
+
+| API channel | Implementation version | Mode | Report |
+|-------------|------------------------|------|--------|
+| standard | [v2.2.4](https://github.com/higress-group/higress/releases/tag/v2.2.4) | default | [v2.2.4 report](./standard-v2.2.4-default-report.yaml) |
+
+## Reproduce
+
+Check out the Higress v2.2.4 release, create a Kubernetes cluster, and install
+the Gateway API v1.6.0 standard CRDs. Install `helm/core` with the v2.2.4
+controller, Pilot, and Gateway images, with the Gateway API deployment
+controller enabled.
+
+Run the official Gateway API v1.6.0 conformance suite through the Higress
+wrapper:
+
+```sh
+GATEWAY_CLASS=higress \
+GATEWAY_API_VERSION=v1.6.0 \
+GATEWAY_CONFORMANCE_TEST_DIR=test/gateway/v1.6 \
+GATEWAY_CONFORMANCE_SUPPORTED_FEATURES=Gateway,HTTPRoute,ReferenceGrant \
+GATEWAY_CONFORMANCE_PROFILE=GATEWAY-HTTP \
+GATEWAY_CONFORMANCE_REPORT=out/gateway-api-v1.6.0-report.yaml \
+GATEWAY_CONFORMANCE_CONTACT=https://github.com/higress-group/higress/issues \
+HIGRESS_CONFORMANCE_VERSION=v2.2.4 \
+GATEWAY_CONFORMANCE_ALLOW_CRDS_MISMATCH=false \
+GATEWAY_CONFORMANCE_SUPPORTS_TEST_CLEANUP=true \
+GATEWAY_CONFORMANCE_CLEANUP_TEST_RESOURCES=true \
+tools/hack/run-gateway-api-conformance.sh
+```
+
+The test uses the release images referenced by the Higress v2.2.4 Helm chart.

--- a/conformance/reports/v1.6/higress-group-higress/standard-v2.2.4-default-report.yaml
+++ b/conformance/reports/v1.6/higress-group-higress/standard-v2.2.4-default-report.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-08-14T09:31:08Z"
+gatewayAPIChannel: standard
+gatewayAPIVersion: v1.6.0
+implementation:
+  contact:
+  - https://github.com/higress-group/higress/issues
+  organization: higress-group
+  project: higress
+  url: https://github.com/higress-group/higress
+  version: v2.2.4
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 37
+      Skipped: 0
+  name: GATEWAY-HTTP
+  summary: Core tests succeeded.

--- a/site/content/en/docs/implementations/list.md
+++ b/site/content/en/docs/implementations/list.md
@@ -98,6 +98,7 @@ class.
 - [Google Kubernetes Engine][6]
 - [Gravitee Kubernetes Operator][42]
 - [HAProxy Ingress][7]
+- [Higress][49]
 - [Istio][9]
 - [kgateway][37]
 - [Kong Operator][35] 
@@ -157,6 +158,7 @@ class.
 [46]:#calico
 [47]:#sunbeam-proxy
 [48]:#wso2-gateway
+[49]:#higress
 
 
 [gamma]: /docs/mesh/
@@ -332,6 +334,18 @@ For support, feedback, or to engage in a discussion about the Gravitee Kubernete
 HAProxy Ingress is a conformant Gateway API implementation since `v0.17`. It implements all core features from the standard channel, as well as TLSRoute and TCPRoute APIs from the experimental channel.
 
 [h1]:https://haproxy-ingress.github.io/
+
+### Higress
+
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.6.0-Higress-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.6/higress-group-higress)
+
+[Higress](https://higress.ai/) is a cloud-native API gateway built on Istio and
+Envoy. It provides Kubernetes Gateway API and Ingress support alongside API
+management and AI gateway capabilities. Higress is an open source
+[CNCF project](https://www.cncf.io/projects/higress/).
+
+Source code, documentation, and issue tracking are available in the
+[Higress repository](https://github.com/higress-group/higress).
 
 ### Istio
 


### PR DESCRIPTION
/kind documentation
/area conformance-test

**What type of PR is this?**

Adds the generated Higress v2.2.4 Gateway API v1.6.0 standard-channel conformance report and lists Higress as a conformant Gateway implementation.

The submitted `GATEWAY-HTTP` Core profile result is 37 passed, 0 failed, and 0 skipped. The report is included exactly as generated by the official v1.6.0 suite.

**Why is this PR needed?**

Higress v2.2.4 includes Gateway API v1.6.0 support and now has release-level conformance evidence using the canonical project identity:

- organization: `higress-group`
- project: `higress`
- URL: https://github.com/higress-group/higress

**Does this PR introduce a user-facing change?**

```release-note
NONE
```

**Additional documentation**

The implementation README contains reproduction steps and links the exact Higress v2.2.4 release. The report SHA-256 is `6d342dd57ed470ea6780643cbe01c94a2e685f5cfb63199504dd50d7f4a11755`.

**AI assistance disclosure**

OpenAI Codex assisted with running the official suite, verifying the generated report, and preparing this submission. The commit is authored and signed off by EndlessSeeker.
