### PR TITLE
gep: align GEP-1731 retry semantics with implementations

### DIFF
--- a/geps/gep-1731/index.md
+++ b/geps/gep-1731/index.md
@@ -15,7 +15,7 @@ To allow configuration of a Gateway to retry unsuccessful requests to backends b
 
 * To allow specification of [HTTP status codes](https://www.rfc-editor.org/rfc/rfc9110#name-overview-of-status-codes) for which a request should be retried.
 * To allow specification of the maximum number of times to retry a request.
-* To allow specification of the minimum backoff interval between retry attempts.
+* To allow specification of the base interval for exponential backoff strategy used to calculate the duration between retry attempts.
 * To define any interaction with configured HTTPRoute [timeouts](../gep-1742/index.md).
 * Retry configuration must be applicable to most known Gateway API implementations.
 
@@ -26,7 +26,7 @@ To allow configuration of a Gateway to retry unsuccessful requests to backends b
 
 ## Non-Goals
 
-* To allow more granular control of the backoff strategy than many dataplanes allow customizing, such as whether to use an exponential backoff interval between retry attempts, add jitter, or cap the backoff interval to a maximum duration.
+* To allow more granular control of the backoff strategy than many dataplanes allow customizing, such as whether to add jitter, or cap the backoff interval to a maximum duration.
 * To allow specification of a default retry policy for all routes in a given namespace or attached to a particular Gateway.
 * A standard API for approaches for retry logic other than max count or "budget", such as interaction with rate limiting headers.
 * To allow specification of gRPC status codes for which a request should be retried (this should be covered in a separate GEP).
@@ -264,9 +264,15 @@ type HTTPRouteRule struct {
 
 // HTTPRouteRetry defines retry configuration for an HTTPRoute.
 //
-// Implementations SHOULD retry on connection errors (disconnect, reset, timeout,
-// TCP failure) if a retry stanza is configured.
+// Implementations SHOULD retry when a retry stanza is configured and the
+// connection could not be established (e.g., connect timeout, connection
+// refused, TLS handshake failure), or the backend explicitly rejected the
+// request before processing it (e.g., HTTP/2 REFUSED_STREAM, gRPC UNAVAILABLE)
 //
+// Implementations SHOULD NOT retry by default on failures where the request
+// may have been processed (e.g., a connection reset after the request was
+// sent). Implementations that do retry on such conditions MUST clearly
+// document this behavior, as it is unsafe for non-idempotent requests.
 type HTTPRouteRetry struct {
     // Codes defines the HTTP response status codes for which a backend request
     // should be retried.
@@ -274,36 +280,38 @@ type HTTPRouteRetry struct {
     // Support: Extended
     //
     // +optional
-    // <gateway:experimental>
+    // +listType=set
     Codes []HTTPRouteRetryStatusCode `json:"codes,omitempty"`
 
     // Attempts specifies the maximum number of times an individual request
-    // from the gateway to a backend should be retried.
+    // from the Gateway to a backend should be retried in addition to the
+    // initial request.
     //
     // If the maximum number of retries has been attempted without a successful
     // response from the backend, the Gateway MUST return an error.
     //
-    // When this field is unspecified, the number of times to attempt to retry
-    // a backend request is implementation-specific.
-    //
     // Support: Extended
     //
     // +optional
-    Attempts *Int `json:"attempts,omitempty"`
-
-    // Backoff specifies the minimum duration a Gateway should wait between
-    // retry attempts and is represented in Gateway API Duration formatting.
+    // +kubebuilder:default=1
+    // +kubebuilder:validation:Minimum:=1
+    Attempts *int `json:"attempts,omitempty"`
+    
+    // Backoff specifies the base interval for an exponential backoff strategy
+    // between retry attempts and is represented in Gateway API Duration
+    // formatting.
+    //
+    // The maximum duration a Gateway should wait before a retry attempt is
+    // `backoff * (2^N - 1)`, where N is the number of the retry attempt,
+    // starting at 1. Implementations MAY add jitter, resulting in an actual
+    // delay anywhere between zero and this bound, and MAY cap the delay at an
+    // implementation-defined maximum, which SHOULD be no less than the base
+    // interval.
     //
     // For example, setting the `rules[].retry.backoff` field to the value
-    // `100ms` will cause a backend request to first be retried approximately
-    // 100 milliseconds after timing out or receiving a response code configured
-    // to be retriable.
-    //
-    // An implementation MAY use an exponential or alternative backoff strategy
-    // for subsequent retry attempts, MAY cap the maximum backoff duration to
-    // some amount greater than the specified minimum, and MAY add arbitrary
-    // jitter to stagger requests, as long as unsuccessful backend requests are
-    // not retried before the configured minimum duration.
+    // `100ms` will cause a backend request to first be retried up to
+    // approximately 100 milliseconds after a connection error  or receiving
+    // a response code configured to be retriable.
     //
     // If a Request timeout (`rules[].timeouts.request`) is configured on the
     // route, the entire duration of the initial request and any retry attempts
@@ -315,16 +323,20 @@ type HTTPRouteRetry struct {
     // If a BackendRequest timeout (`rules[].timeouts.backendRequest`) is
     // configured on the route, any retry attempts which reach the configured
     // BackendRequest timeout duration without a response SHOULD be canceled if
-    // possible and the Gateway should wait for at least the specified backoff
-    // duration before attempting to retry the backend request again.
+    // possible and the Gateway SHOULD schedule the next retry attempt according
+    // to the configured backoff.
     //
     // If a BackendRequest timeout is _not_ configured on the route, retry
     // attempts MAY time out after an implementation default duration, or MAY
     // remain pending until a configured Request timeout or implementation
     // default duration for total request time is reached.
     //
-    // When this field is unspecified, the time to wait between retry attempts
-    // is implementation-specific.
+    // When this field is unspecified, the backoff strategy or base interval are
+    // implementation-specific.
+    //
+    // Implementations that do not support an exponential backoff strategy
+    // MUST set the Accepted Condition for the Route to `status: False` with
+    // a Reason of `UnsupportedValue` when this field is set.
     //
     // Support: Extended
     //
@@ -400,11 +412,6 @@ Retrying requests based on HTTP status codes will be gated under the following f
 
   * Will test that backend requests that exceed a BackendRequest timeout duration are retried if a `retry` stanza is configured.
 
-* `SupportHTTPRouteRetryBackoff`
-
-  * Backoff will only be tested that a retry does not start before the duration specified for conformance, not that the backoff duration is precise.
-  * Not currently supportable by NGINX or HAProxy.
-
 * `SupportHTTPRouteRetryCodes`
 
   * Only 500, 502, 503 and 504 will be tested for conformance.
@@ -413,6 +420,12 @@ Retrying requests based on HTTP status codes will be gated under the following f
 * `SupportHTTPRouteRetryConnectionError`
 
   * Will test that connections interrupted by a TCP failure, disconnect or reset are retried if a `retry` stanza is configured.
+
+{{% alert color="warning" %}}
+
+Backoff is not tested for conformance. Since implementations may add jitter, only the distribution of delays over many requests is testable. This would require statistical timing assertions, which are too complex and too sensitive to timing variance for the current conformance suite.
+
+{{% /alert %}}
 
 ## Alternatives
 

--- a/geps/gep-1731/index.md
+++ b/geps/gep-1731/index.md
@@ -295,7 +295,7 @@ type HTTPRouteRetry struct {
     // +optional
     // +kubebuilder:default=1
     // +kubebuilder:validation:Minimum:=1
-    Attempts *int `json:"attempts,omitempty"`
+    Attempts int `json:"attempts,omitempty"`
     
     // Backoff specifies the base interval for an exponential backoff strategy
     // between retry attempts and is represented in Gateway API Duration
@@ -338,7 +338,7 @@ type HTTPRouteRetry struct {
     // MUST set the Accepted Condition for the Route to `status: False` with
     // a Reason of `UnsupportedValue` when this field is set.
     //
-    // Support: Extended
+    // Support: Implementation-specific
     //
     // +optional
     Backoff *Duration `json:"backoff,omitempty"`
@@ -423,7 +423,7 @@ Retrying requests based on HTTP status codes will be gated under the following f
 
 {{% alert color="warning" %}}
 
-Backoff is not tested for conformance. Since implementations may add jitter, only the distribution of delays over many requests is testable. This would require statistical timing assertions, which are too complex and too sensitive to timing variance for the current conformance suite.
+Backoff is not tested for conformance and is therefore considered implementation-specific. Since implementations may add jitter, only the distribution of delays over many requests is testable. This would require statistical timing assertions, which are too complex and too sensitive to timing variance for the current conformance suite.
 
 {{% /alert %}}
 

--- a/geps/gep-1731/index.md
+++ b/geps/gep-1731/index.md
@@ -408,10 +408,6 @@ Basic support for configuring retries in HTTPRoute up to a specified maximum cou
 
 Retrying requests based on HTTP status codes will be gated under the following features:
 
-* `SupportHTTPRouteRetryBackendTimeout`
-
-  * Will test that backend requests that exceed a BackendRequest timeout duration are retried if a `retry` stanza is configured.
-
 * `SupportHTTPRouteRetryCodes`
 
   * Only 500, 502, 503 and 504 will be tested for conformance.

--- a/geps/gep-1731/metadata.yaml
+++ b/geps/gep-1731/metadata.yaml
@@ -7,6 +7,7 @@ status: Experimental
 # their GitHub handle.
 authors:
   - mikemorris
+  - snorwin
 relationships:
   # obsoletes indicates that a GEP makes the linked GEP obsolete, and completely
   # replaces that GEP. The obsoleted GEP MUST have its obsoletedBy field


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind gep

**What this PR does / why we need it**:
GEP-1731 currently specifies `backoff` as "the minimum duration a Gateway should wait between retry attempts". None of the current  implementations provide this guarantee. Airlock Microgateway, Istio, Envoy Gateway and kgateway all map`backoff` to Envoy's `retry_back_off.base_interval`.

In addition, this PR clarifies the retry behavior on connection errors. The previous wording ("disconnect, reset, timeout, TCP failure") included conditions where the request may already have been sent and processed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```

**AI Disclosure**
AI (Claude;Fable 5) was used only for spell-checking and minor rephrasing suggestions.