### PR TITLE
Remove venv check from netlify build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,8 +151,7 @@ endif
 .PHONY: install-deps
 install-deps:
 	cd site && npm install
-	if [ ! -d .venv ]; then python3 -m venv .venv; fi
-	.venv/bin/pip install --index-url https://pypi.org/simple pandas PyYAML semver python-frontmatter tabulate
+	pip install --index-url https://pypi.org/simple pandas PyYAML semver python-frontmatter tabulate
 
 .PHONY: docs
 docs: install-deps


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Netlify is now creating an empty venv directory and breaking our builds. In fact, netlify works with requirements.txt directly and we could as well, so this removes the venv creation

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
