### PR TITLE
303, 307, and 308 HTTPRoute redirect codes are Extended, not Core

### DIFF
--- a/apis/v1/httproute_types.go
+++ b/apis/v1/httproute_types.go
@@ -1282,7 +1282,14 @@ type HTTPRequestRedirectFilter struct {
 	// Accepted Condition for the Route to `status: False`, with a
 	// Reason of `UnsupportedValue`.
 	//
-	// Support: Core
+	// Support: statusCode 301 and 302 are Core; all others are Extended.
+	//
+	// <gateway:util:excludeFromCRD>
+	// Extended codes have their own features:
+	//   HTTPRoute303RedirectStatusCode,
+	//   HTTPRoute307RedirectStatusCode, and
+	//   HTTPRoute308RedirectStatusCode
+	// </gateway:util:excludeFromCRD>
 	//
 	// +optional
 	// +kubebuilder:default=302

--- a/applyconfiguration/apis/v1/httprequestredirectfilter.go
+++ b/applyconfiguration/apis/v1/httprequestredirectfilter.go
@@ -87,7 +87,14 @@ type HTTPRequestRedirectFilterApplyConfiguration struct {
 	// Accepted Condition for the Route to `status: False`, with a
 	// Reason of `UnsupportedValue`.
 	//
-	// Support: Core
+	// Support: statusCode 301 and 302 are Core; all others are Extended.
+	//
+	// <gateway:util:excludeFromCRD>
+	// Extended codes have their own features:
+	// HTTPRoute303RedirectStatusCode,
+	// HTTPRoute307RedirectStatusCode, and
+	// HTTPRoute308RedirectStatusCode
+	// </gateway:util:excludeFromCRD>
 	StatusCode *int `json:"statusCode,omitempty"`
 }
 

--- a/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -1491,7 +1491,7 @@ spec:
                                         Accepted Condition for the Route to `status: False`, with a
                                         Reason of `UnsupportedValue`.
 
-                                        Support: Core
+                                        Support: statusCode 301 and 302 are Core; all others are Extended.
                                       enum:
                                       - 301
                                       - 302
@@ -3018,7 +3018,7 @@ spec:
                                   Accepted Condition for the Route to `status: False`, with a
                                   Reason of `UnsupportedValue`.
 
-                                  Support: Core
+                                  Support: statusCode 301 and 302 are Core; all others are Extended.
                                 enum:
                                 - 301
                                 - 302
@@ -5790,7 +5790,7 @@ spec:
                                         Accepted Condition for the Route to `status: False`, with a
                                         Reason of `UnsupportedValue`.
 
-                                        Support: Core
+                                        Support: statusCode 301 and 302 are Core; all others are Extended.
                                       enum:
                                       - 301
                                       - 302
@@ -7317,7 +7317,7 @@ spec:
                                   Accepted Condition for the Route to `status: False`, with a
                                   Reason of `UnsupportedValue`.
 
-                                  Support: Core
+                                  Support: statusCode 301 and 302 are Core; all others are Extended.
                                 enum:
                                 - 301
                                 - 302

--- a/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -1184,7 +1184,7 @@ spec:
                                         Accepted Condition for the Route to `status: False`, with a
                                         Reason of `UnsupportedValue`.
 
-                                        Support: Core
+                                        Support: statusCode 301 and 302 are Core; all others are Extended.
                                       enum:
                                       - 301
                                       - 302
@@ -2438,7 +2438,7 @@ spec:
                                   Accepted Condition for the Route to `status: False`, with a
                                   Reason of `UnsupportedValue`.
 
-                                  Support: Core
+                                  Support: statusCode 301 and 302 are Core; all others are Extended.
                                 enum:
                                 - 301
                                 - 302
@@ -4634,7 +4634,7 @@ spec:
                                         Accepted Condition for the Route to `status: False`, with a
                                         Reason of `UnsupportedValue`.
 
-                                        Support: Core
+                                        Support: statusCode 301 and 302 are Core; all others are Extended.
                                       enum:
                                       - 301
                                       - 302
@@ -5888,7 +5888,7 @@ spec:
                                   Accepted Condition for the Route to `status: False`, with a
                                   Reason of `UnsupportedValue`.
 
-                                  Support: Core
+                                  Support: statusCode 301 and 302 are Core; all others are Extended.
                                 enum:
                                 - 301
                                 - 302

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -5320,7 +5320,7 @@ func schema_sigsk8sio_gateway_api_apis_v1_HTTPRequestRedirectFilter(ref common.R
 					},
 					"statusCode": {
 						SchemaProps: spec.SchemaProps{
-							Description: "StatusCode is the HTTP status code to be used in response.\n\nNote that values may be added to this enum, implementations must ensure that unknown values will not cause a crash.\n\nUnknown values here must result in the implementation setting the Accepted Condition for the Route to `status: False`, with a Reason of `UnsupportedValue`.\n\nSupport: Core",
+							Description: "StatusCode is the HTTP status code to be used in response.\n\nNote that values may be added to this enum, implementations must ensure that unknown values will not cause a crash.\n\nUnknown values here must result in the implementation setting the Accepted Condition for the Route to `status: False`, with a Reason of `UnsupportedValue`.\n\nSupport: statusCode 301 and 302 are Core; all others are Extended.\n\n<gateway:util:excludeFromCRD> Extended codes have their own features:\n  HTTPRoute303RedirectStatusCode,\n  HTTPRoute307RedirectStatusCode, and\n  HTTPRoute308RedirectStatusCode\n</gateway:util:excludeFromCRD>",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},


### PR DESCRIPTION
Signed-off-by: Flynn <emissary@flynn.kodachi.com>

/kind bug

HTTPRequestRedirectFilter status codes 303, 307, and 308 are Extended conformance, not Core (yet). This PR updates the CRD to reflect that.

Fixes #5133

```release-note
HTTPRequestRedirectFilter status codes 303, 307, and 308 are Extended conformance, not Core.
```
