### PR TITLE
Allow specifying the expected Gateway API version when running conformance

### DIFF
--- a/conformance/utils/flags/flags.go
+++ b/conformance/utils/flags/flags.go
@@ -27,6 +27,7 @@ import (
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	conformanceconfig "sigs.k8s.io/gateway-api/conformance/utils/config"
 	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/consts"
 )
 
 const (
@@ -108,6 +109,9 @@ func init() {
 	)
 	registerBoolFlag("allow-crds-mismatch", false, "Flag to allow the suite not to fail in case there is a mismatch between CRDs versions and channels.",
 		func(o *suite.ConfigurableOptions, v bool) { o.AllowCRDsMismatch = v },
+	)
+	registerStringFlag("expected-apiversion", consts.BundleVersion, "Expected API version of the CRDs",
+		func(o *suite.ConfigurableOptions, v string) { o.ExpectedAPIVersion = v },
 	)
 	registerStringFlag("conformance-profiles", "", "Comma-separated list of the conformance profiles to run",
 		func(o *suite.ConfigurableOptions, v string) {

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -138,6 +138,7 @@ type ConformanceTestSuite struct {
 type ConfigurableOptions struct {
 	GatewayClassName     string            `json:"gatewayClassName"`
 	MeshName             string            `json:"meshName"`
+	ExpectedAPIVersion   string            `json:"expectedApiVersion"`
 	Debug                bool              `json:"debug"`
 	NamespaceLabels      map[string]string `json:"namespaceLabels"`
 	NamespaceAnnotations map[string]string `json:"namespaceAnnotations"`
@@ -284,7 +285,7 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 	if err != nil {
 		return nil, err
 	}
-	apiVersion, apiChannel, err := getAPIVersionAndChannel(installedCRDs.Items)
+	apiVersion, apiChannel, err := getAPIVersionAndChannel(&options, installedCRDs.Items)
 	if err != nil {
 		// in case an error is returned and the AllowCRDsMismatch flag is false, the suite fails.
 		// This is the default behavior but can be customized in case one wants to experiment
@@ -720,7 +721,7 @@ func shouldInferSupportedFeatures(opts *ConformanceOptions) bool {
 
 // getAPIVersionAndChannel iterates over all the crds installed in the cluster and check the version and channel annotations.
 // In case the annotations are not found or there are crds with different versions or channels, an error is returned.
-func getAPIVersionAndChannel(crds []apiextensionsv1.CustomResourceDefinition) (version string, channel string, err error) {
+func getAPIVersionAndChannel(opts *ConformanceOptions, crds []apiextensionsv1.CustomResourceDefinition) (version string, channel string, err error) {
 	for _, crd := range crds {
 		v, okv := crd.Annotations[consts.BundleVersionAnnotation]
 		c, okc := crd.Annotations[consts.ChannelAnnotation]
@@ -742,8 +743,8 @@ func getAPIVersionAndChannel(crds []apiextensionsv1.CustomResourceDefinition) (v
 	if version == "" || channel == "" {
 		return "", "", errors.New("no Gateway API CRDs with the proper annotations found in the cluster")
 	}
-	if version != consts.BundleVersion {
-		return "", "", errors.New("the installed CRDs version is different from the suite version")
+	if version != opts.ExpectedAPIVersion {
+		return "", "", fmt.Errorf("Gateway API %s is installed, but the expected version is %s", version, opts.ExpectedAPIVersion)
 	}
 
 	return version, channel, nil

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -177,8 +177,14 @@ func TestGetAPIVersionAndChannel(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		options := ConformanceOptions{
+			ConfigurableOptions: ConfigurableOptions{
+				ExpectedAPIVersion: consts.BundleVersion,
+			},
+		}
+
 		t.Run(tc.name, func(t *testing.T) {
-			version, channel, err := getAPIVersionAndChannel(tc.crds)
+			version, channel, err := getAPIVersionAndChannel(&options, tc.crds)
 			assert.Equal(t, tc.expectedVersion, version)
 			assert.Equal(t, tc.expectedChannel, channel)
 			assert.Equal(t, tc.err, err)


### PR DESCRIPTION
This is mostly here to make it easier to use `main` to test a production version when working on tests. As such, using this flag ONLY sets the version of CRDs we expect to find on the test cluster; it does NOT automatically run the conformance tests for that version!

Signed-off-by: Flynn <emissary@flynn.kodachi.com>

/kind feature
/area conformance-test

```release-note
NONE
```
