### PR TITLE
fix: stale route status after the parent Gateway's ListenerSet is modified

### DIFF
--- a/conformance/tests/listenerset-update-listener-hostname.go
+++ b/conformance/tests/listenerset-update-listener-hostname.go
@@ -68,12 +68,7 @@ var ListenerSetUpdateListenerHostname = suite.ConformanceTest{
 
 			// update the listener hostname to match the HTTPRoute's hostname.
 			matchingHostname := v1.Hostname("accepted.example.com")
-			for i, listener := range mutate.Spec.Listeners {
-				if listener.Name == "http" {
-					mutate.Spec.Listeners[i].Hostname = &matchingHostname
-					break
-				}
-			}
+			mutate.Spec.Listeners[0].Hostname = &matchingHostname
 
 			err = s.Client.Patch(ctx, mutate, client.MergeFrom(original))
 			require.NoErrorf(t, err, "error patching the ListenerSet: %v", err)

--- a/conformance/tests/listenerset-update-listener-hostname.go
+++ b/conformance/tests/listenerset-update-listener-hostname.go
@@ -48,8 +48,7 @@ var ListenerSetUpdateListenerHostname = suite.ConformanceTest{
 		t.Run("should update HTTPRoute Accepted condition after ListenerSet listener hostname is changed to match", func(t *testing.T) {
 			lsNN := types.NamespacedName{Name: "listenerset-update-listener-hostname", Namespace: suite.InfrastructureNamespace}
 			routeNN := types.NamespacedName{Name: "httproute-listenerset-update-listener-hostname", Namespace: suite.InfrastructureNamespace}
-			namespaces := []string{suite.InfrastructureNamespace}
-			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
+			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, []string{suite.InfrastructureNamespace})
 
 			kubernetes.HTTPRouteMustHaveCondition(t, s.Client, s.TimeoutConfig, routeNN, lsNN, metav1.Condition{
 				Type:   string(v1.RouteConditionAccepted),
@@ -72,8 +71,6 @@ var ListenerSetUpdateListenerHostname = suite.ConformanceTest{
 
 			err = s.Client.Patch(ctx, mutate, client.MergeFrom(original))
 			require.NoErrorf(t, err, "error patching the ListenerSet: %v", err)
-
-			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
 
 			kubernetes.HTTPRouteMustHaveCondition(t, s.Client, s.TimeoutConfig, routeNN, lsNN, metav1.Condition{
 				Type:   string(v1.RouteConditionAccepted),

--- a/conformance/tests/listenerset-update-listener-hostname.go
+++ b/conformance/tests/listenerset-update-listener-hostname.go
@@ -1,0 +1,102 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+func init() {
+	ConformanceTests = append(ConformanceTests, ListenerSetUpdateListenerHostname)
+}
+
+var ListenerSetUpdateListenerHostname = suite.ConformanceTest{
+	ShortName:   "ListenerSetUpdateListenerHostname",
+	Description: "An HTTPRoute rejected with NoMatchingListenerHostname must have its status updated to Accepted=True after the ListenerSet listener hostname is changed to match the route's hostname.",
+	Features: []features.FeatureName{
+		features.SupportGateway,
+		features.SupportListenerSet,
+		features.SupportHTTPRoute,
+	},
+	Manifests: []string{"tests/listenerset-update-listener-hostname.yaml"},
+	Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+		t.Run("should update HTTPRoute Accepted condition after ListenerSet listener hostname is changed to match", func(t *testing.T) {
+			lsNN := types.NamespacedName{Name: "listenerset-update-listener-hostname", Namespace: suite.InfrastructureNamespace}
+			routeNN := types.NamespacedName{Name: "httproute-listenerset-update-listener-hostname", Namespace: suite.InfrastructureNamespace}
+			namespaces := []string{suite.InfrastructureNamespace}
+			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
+
+			kubernetes.HTTPRouteMustHaveCondition(t, s.Client, s.TimeoutConfig, routeNN, lsNN, metav1.Condition{
+				Type:   string(v1.RouteConditionAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(v1.RouteReasonNoMatchingListenerHostname),
+			})
+
+			ctx, cancel := context.WithTimeout(context.Background(), s.TimeoutConfig.DefaultTestTimeout)
+			defer cancel()
+
+			original := &v1.ListenerSet{}
+			err := s.Client.Get(ctx, lsNN, original)
+			require.NoErrorf(t, err, "error getting ListenerSet: %v", err)
+
+			mutate := original.DeepCopy()
+
+			// update the listener hostname to match the HTTPRoute's hostname.
+			matchingHostname := v1.Hostname("accepted.example.com")
+			for i, listener := range mutate.Spec.Listeners {
+				if listener.Name == "http" {
+					mutate.Spec.Listeners[i].Hostname = &matchingHostname
+					break
+				}
+			}
+
+			err = s.Client.Patch(ctx, mutate, client.MergeFrom(original))
+			require.NoErrorf(t, err, "error patching the ListenerSet: %v", err)
+
+			kubernetes.NamespacesMustBeReady(t, s.Client, s.TimeoutConfig, namespaces)
+
+			kubernetes.HTTPRouteMustHaveCondition(t, s.Client, s.TimeoutConfig, routeNN, lsNN, metav1.Condition{
+				Type:   string(v1.RouteConditionAccepted),
+				Status: metav1.ConditionTrue,
+				Reason: string(v1.RouteReasonAccepted),
+			})
+
+			kubernetes.ListenerSetStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, lsNN, []v1.ListenerEntryStatus{
+				{
+					Name: v1.SectionName("http"),
+					SupportedKinds: []v1.RouteGroupKind{{
+						Group: (*v1.Group)(&v1.GroupVersion.Group),
+						Kind:  v1.Kind("HTTPRoute"),
+					}},
+					Conditions:     generateAcceptedListenerConditions(),
+					AttachedRoutes: 1,
+				},
+			})
+		})
+	},
+}

--- a/conformance/tests/listenerset-update-listener-hostname.yaml
+++ b/conformance/tests/listenerset-update-listener-hostname.yaml
@@ -14,7 +14,7 @@ spec:
     protocol: HTTP
     allowedRoutes:
       namespaces:
-        from: All
+        from: Same
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: ListenerSet
@@ -34,7 +34,7 @@ spec:
     hostname: "other.example.com"
     allowedRoutes:
       namespaces:
-        from: All
+        from: Same
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/conformance/tests/listenerset-update-listener-hostname.yaml
+++ b/conformance/tests/listenerset-update-listener-hostname.yaml
@@ -1,0 +1,55 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-listenerset-update-listener-hostname
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "{GATEWAY_CLASS_NAME}"
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+  - name: gateway-listener
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: listenerset-update-listener-hostname
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    kind: Gateway
+    group: gateway.networking.k8s.io
+    name: gateway-listenerset-update-listener-hostname
+    namespace: gateway-conformance-infra
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    hostname: "other.example.com"
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-listenerset-update-listener-hostname
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - kind: ListenerSet
+    group: gateway.networking.k8s.io
+    name: listenerset-update-listener-hostname
+    namespace: gateway-conformance-infra
+  hostnames:
+  - "accepted.example.com"
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The RouteStatus spec previously used 'should' update (non-normative) when describing that implementations must update status.parents[].conditions on an HTTPRoute after the parent Gateway is modified. This left room for implementations to leave stale route status behind. For example, when a Gateway **ListenerSet** hostname is updated to match an HTTPRoute's hostname, the route's Accepted=False / NoMatchingListenerHostname condition could remain unchanged even though the route should now be accepted.

**Which issue(s) this PR fixes**:
This is a follow up pr of https://github.com/kubernetes-sigs/gateway-api/pull/5116#issuecomment-5254866332

cc @rikatz 

**Does this PR introduce a user-facing change?**:
None

```release-note
fix stale route status after the parent Gateway's ListenerSet is modified
```