### PR TITLE
conformance: allow to disabled parallel tests

### DIFF
--- a/conformance/utils/flags/flags.go
+++ b/conformance/utils/flags/flags.go
@@ -141,6 +141,9 @@ func init() {
 	registerBoolFlag("skip-provisional-tests", false, "Whether to skip provisional tests",
 		func(o *suite.ConfigurableOptions, v bool) { o.SkipProvisionalTests = v },
 	)
+	registerBoolFlag("disable-parallel-tests", false, "Whether to force all tests to run sequentially, even those that support running in parallel",
+		func(o *suite.ConfigurableOptions, v bool) { o.DisableParallelTests = v },
+	)
 	registerBoolFlag("fail-fast", false, "Whether to stop the suite execution upon the first test failure",
 		func(o *suite.ConfigurableOptions, v bool) { o.FailFast = v },
 	)

--- a/conformance/utils/suite/conformance.go
+++ b/conformance/utils/suite/conformance.go
@@ -42,7 +42,7 @@ type ConformanceTest struct {
 // Run runs an individual tests, applying and cleaning up the required manifests
 // before calling the Test function.
 func (test *ConformanceTest) Run(t *testing.T, suite *ConformanceTestSuite) {
-	if test.Parallel {
+	if test.Parallel && !suite.DisableParallelTests {
 		t.Parallel()
 	}
 

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -78,6 +78,7 @@ type ConformanceTestSuite struct {
 	TimeoutConfig            config.TimeoutConfig
 	SkipTests                sets.Set[string]
 	SkipProvisionalTests     bool
+	DisableParallelTests     bool
 	RunTest                  string
 	Hook                     func(t *testing.T, test ConformanceTest, suite *ConformanceTestSuite)
 	ManifestFS               []fs.FS
@@ -157,6 +158,11 @@ type ConfigurableOptions struct {
 	SkipTests []string `json:"skipTests"`
 	// SkipProvisionalTests indicates whether or not to skip provisional tests.
 	SkipProvisionalTests bool `json:"skipProvisionalTests"`
+	// DisableParallelTests forces all tests to run sequentially, even those
+	// marked as Parallel. Useful for debugging or for implementations that
+	// can't support concurrent test execution. This also help to run tests
+	// with limited resources.
+	DisableParallelTests bool `json:"disableParallelTests"`
 	// RunTest is a single test to run, mostly for development/debugging convenience.
 	RunTest             string                   `json:"runTest"`
 	Mode                string                   `json:"mode"`
@@ -319,6 +325,7 @@ func NewConformanceTestSuite(options ConformanceOptions) (*ConformanceTestSuite,
 		SkipTests:                   sets.New(options.SkipTests...),
 		RunTest:                     options.RunTest,
 		SkipProvisionalTests:        options.SkipProvisionalTests,
+		DisableParallelTests:        options.DisableParallelTests,
 		ManifestFS:                  options.ManifestFS,
 		UsableNetworkAddresses:      options.UsableNetworkAddresses,
 		UnusableNetworkAddresses:    options.UnusableNetworkAddresses,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/area conformance-test

**What this PR does / why we need it**:

After https://github.com/kubernetes-sigs/gateway-api/pull/4756, it's hard to run conformance test in a Github private repo(the runner for CI is a smaller flavor than public repo), this PR allow users to disable parallel at suite level.

cc @snorwin `-parallel=1` didn't help on our case.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Allow to disable parallel test at suite level
```
