### PR TITLE
docs: add Apache APISIX Ingress Controller 2.2.0 conformance reports

### DIFF
--- a/conformance/reports/v1.6/apache-apisix-ingress-controller/README.md
+++ b/conformance/reports/v1.6/apache-apisix-ingress-controller/README.md
@@ -1,0 +1,103 @@
+# Apache APISIX Ingress Controller
+
+[Apache APISIX Ingress Controller](https://github.com/apache/apisix-ingress-controller)
+configures [Apache APISIX](https://apisix.apache.org/) from Kubernetes
+resources, and implements Gateway API alongside its own CRDs and Ingress.
+
+## Table of Contents
+
+| API channel  | Implementation version                                                              | Mode              | Report                                                                    |
+|--------------|-------------------------------------------------------------------------------------|-------------------|---------------------------------------------------------------------------|
+| experimental | [2.2.0](https://github.com/apache/apisix-ingress-controller/releases/tag/2.2.0)      | default           | [2.2.0 report](./experimental-2.2.0-default-report.yaml)                  |
+| experimental | [2.2.0](https://github.com/apache/apisix-ingress-controller/releases/tag/2.2.0)      | apisix-standalone | [2.2.0 report](./experimental-2.2.0-apisix-standalone-report.yaml)        |
+
+## Overview
+
+The controller drives one shared APISIX data plane rather than provisioning one
+per Gateway, and it supports two ways of configuring it. In the `default` mode
+APISIX keeps its configuration in etcd and the controller writes through the
+APISIX Admin API. In the `apisix-standalone` mode APISIX runs without etcd and
+the controller pushes the whole configuration to it, which is the
+[API-driven mode](https://apisix.apache.org/docs/apisix/deployment-modes/) APISIX
+documents. The two modes run the same suite and are reported separately.
+
+## Prerequisites
+
+- [docker](https://docs.docker.com/get-started/get-docker/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- [kind](https://github.com/kubernetes-sigs/kind)
+- [go](https://go.dev/learn/)
+
+Any cluster works as long as it supports LoadBalancer Services: the suite
+reaches the gateway through the data plane Service's external address, and the
+controller publishes that address in every Gateway's `status.addresses`. Steps 2
+and 3 below only give a local kind cluster that capability.
+
+## Reproduce
+
+1. Clone the repository and check out the release
+
+   ```shell
+   git clone https://github.com/apache/apisix-ingress-controller.git && cd apisix-ingress-controller
+   git checkout 2.2.0
+   ```
+
+   Checking out the release tag is what selects the published images for it and
+   makes the report name that release. `make conformance-images` prints the
+   three images the run deploys.
+
+2. Create the cluster
+
+   ```shell
+   make kind-up
+   ```
+
+3. Run a local LoadBalancer provider
+
+   ```shell
+   make kind-lb
+   ```
+
+   This runs [cloud-provider-kind](https://kind.sigs.k8s.io/docs/user/loadbalancer)
+   in the background. Skip it on a cluster that already has LoadBalancer
+   support.
+
+4. Install the Gateway API and the controller's CRDs
+
+   ```shell
+   make install
+   ```
+
+5. Run the suite
+
+   ```shell
+   make conformance-test
+   ```
+
+   For the `apisix-standalone` mode:
+
+   ```shell
+   PROVIDER_TYPE=apisix-standalone make conformance-test CONFORMANCE_MODE=apisix-standalone
+   ```
+
+6. Read the report
+
+   ```shell
+   cat "$(make -s conformance-report-path)"
+   ```
+
+   Pass the same `CONFORMANCE_MODE` to get the path of a standalone run. The
+   file is named `<channel>-<version>-<mode>-report.yaml`, which is the name
+   this repository expects, so it is submitted as produced.
+
+The reports here came from the `APISIX Conformance Test` workflow run on the
+2.2.0 tag, which runs exactly these steps against the published 2.2.0 images.
+
+## Skipped tests
+
+`test/conformance/conformance_test.go` lists every skip with its reason. In
+short: four TLSRoute tests pin `mode: Passthrough`, which APISIX does not do
+because it terminates TLS and matches stream routes by SNI;
+`HTTPRouteMultipleGateways` needs a route served independently from each parent,
+which one shared data plane does not do; `HTTPRouteHTTPSListener` and three
+`HTTPRouteInvalidBackendRef*` tests are gaps tracked for follow-up.

--- a/conformance/reports/v1.6/apache-apisix-ingress-controller/experimental-2.2.0-apisix-standalone-report.yaml
+++ b/conformance/reports/v1.6/apache-apisix-ingress-controller/experimental-2.2.0-apisix-standalone-report.yaml
@@ -1,0 +1,141 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-08-19T00:25:09Z"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.6.0
+implementation:
+  contact:
+  - https://github.com/apache/apisix-ingress-controller/issues
+  organization: apache
+  project: apisix-ingress-controller
+  url: https://github.com/apache/apisix-ingress-controller
+  version: 2.2.0
+kind: ConformanceReport
+mode: apisix-standalone
+profiles:
+- core:
+    result: partial
+    skippedTests:
+    - TLSRouteHostnameIntersection
+    - TLSRouteInvalidBackendRefNonexistent
+    - TLSRouteInvalidBackendRefUnknownKind
+    - TLSRouteSimpleSameNamespace
+    statistics:
+      Failed: 0
+      Passed: 16
+      Skipped: 4
+  extended:
+    result: partial
+    skippedTests:
+    - TLSRouteTerminateSimpleSameNamespace
+    statistics:
+      Failed: 0
+      Passed: 3
+      Skipped: 1
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayPort8080
+    - TLSRouteModeTerminate
+    unsupportedFeatures:
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPListenerIsolation
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - ListenerSet
+    - TLSRouteModeMixed
+  name: GATEWAY-TLS
+  summary: Core tests partially succeeded with 4 test skips. Extended tests partially
+    succeeded with 1 test skips.
+- core:
+    result: partial
+    skippedTests:
+    - HTTPRouteHTTPSListener
+    - HTTPRouteInvalidBackendRefUnknownKind
+    - HTTPRouteInvalidCrossNamespaceBackendRef
+    - HTTPRouteInvalidNonExistentBackendRef
+    - HTTPRouteMultipleGateways
+    statistics:
+      Failed: 0
+      Passed: 32
+      Skipped: 5
+  extended:
+    result: partial
+    skippedTests:
+    - HTTPRouteRedirectPortAndScheme
+    statistics:
+      Failed: 0
+      Passed: 12
+      Skipped: 1
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayPort8080
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMirror
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    unsupportedFeatures:
+    - BackendTLSPolicy
+    - BackendTLSPolicySANValidation
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPListenerIsolation
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - HTTPRoute303RedirectStatusCode
+    - HTTPRoute307RedirectStatusCode
+    - HTTPRoute308RedirectStatusCode
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteCORS
+    - HTTPRouteNamedRouteRule
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRedirect
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestPercentageMirror
+    - HTTPRouteRequestTimeout
+    - HTTPRouteRetry
+    - HTTPRouteRetryBackendTimeout
+    - HTTPRouteRetryConnectionError
+    - ListenerSet
+  name: GATEWAY-HTTP
+  summary: Core tests partially succeeded with 5 test skips. Extended tests partially
+    succeeded with 1 test skips.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 15
+      Skipped: 0
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 1
+      Skipped: 0
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayPort8080
+    unsupportedFeatures:
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPListenerIsolation
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - ListenerSet
+  name: GATEWAY-GRPC
+  summary: Core tests succeeded. Extended tests succeeded.
+succeededProvisionalTests:
+- GatewayOptionalAddressValue

--- a/conformance/reports/v1.6/apache-apisix-ingress-controller/experimental-2.2.0-default-report.yaml
+++ b/conformance/reports/v1.6/apache-apisix-ingress-controller/experimental-2.2.0-default-report.yaml
@@ -1,0 +1,141 @@
+apiVersion: gateway.networking.k8s.io/v1
+date: "2026-08-19T00:25:57Z"
+gatewayAPIChannel: experimental
+gatewayAPIVersion: v1.6.0
+implementation:
+  contact:
+  - https://github.com/apache/apisix-ingress-controller/issues
+  organization: apache
+  project: apisix-ingress-controller
+  url: https://github.com/apache/apisix-ingress-controller
+  version: 2.2.0
+kind: ConformanceReport
+mode: default
+profiles:
+- core:
+    result: partial
+    skippedTests:
+    - TLSRouteHostnameIntersection
+    - TLSRouteInvalidBackendRefNonexistent
+    - TLSRouteInvalidBackendRefUnknownKind
+    - TLSRouteSimpleSameNamespace
+    statistics:
+      Failed: 0
+      Passed: 16
+      Skipped: 4
+  extended:
+    result: partial
+    skippedTests:
+    - TLSRouteTerminateSimpleSameNamespace
+    statistics:
+      Failed: 0
+      Passed: 3
+      Skipped: 1
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayPort8080
+    - TLSRouteModeTerminate
+    unsupportedFeatures:
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPListenerIsolation
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - ListenerSet
+    - TLSRouteModeMixed
+  name: GATEWAY-TLS
+  summary: Core tests partially succeeded with 4 test skips. Extended tests partially
+    succeeded with 1 test skips.
+- core:
+    result: partial
+    skippedTests:
+    - HTTPRouteHTTPSListener
+    - HTTPRouteInvalidBackendRefUnknownKind
+    - HTTPRouteInvalidCrossNamespaceBackendRef
+    - HTTPRouteInvalidNonExistentBackendRef
+    - HTTPRouteMultipleGateways
+    statistics:
+      Failed: 0
+      Passed: 32
+      Skipped: 5
+  extended:
+    result: partial
+    skippedTests:
+    - HTTPRouteRedirectPortAndScheme
+    statistics:
+      Failed: 0
+      Passed: 12
+      Skipped: 1
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayPort8080
+    - HTTPRouteBackendProtocolWebSocket
+    - HTTPRouteDestinationPortMatching
+    - HTTPRouteHostRewrite
+    - HTTPRouteMethodMatching
+    - HTTPRoutePathRewrite
+    - HTTPRoutePortRedirect
+    - HTTPRouteQueryParamMatching
+    - HTTPRouteRequestMirror
+    - HTTPRouteResponseHeaderModification
+    - HTTPRouteSchemeRedirect
+    unsupportedFeatures:
+    - BackendTLSPolicy
+    - BackendTLSPolicySANValidation
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPListenerIsolation
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - HTTPRoute303RedirectStatusCode
+    - HTTPRoute307RedirectStatusCode
+    - HTTPRoute308RedirectStatusCode
+    - HTTPRouteBackendProtocolH2C
+    - HTTPRouteBackendRequestHeaderModification
+    - HTTPRouteBackendTimeout
+    - HTTPRouteCORS
+    - HTTPRouteNamedRouteRule
+    - HTTPRouteParentRefPort
+    - HTTPRoutePathRedirect
+    - HTTPRouteRequestMultipleMirrors
+    - HTTPRouteRequestPercentageMirror
+    - HTTPRouteRequestTimeout
+    - HTTPRouteRetry
+    - HTTPRouteRetryBackendTimeout
+    - HTTPRouteRetryConnectionError
+    - ListenerSet
+  name: GATEWAY-HTTP
+  summary: Core tests partially succeeded with 5 test skips. Extended tests partially
+    succeeded with 1 test skips.
+- core:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 15
+      Skipped: 0
+  extended:
+    result: success
+    statistics:
+      Failed: 0
+      Passed: 1
+      Skipped: 0
+    supportedFeatures:
+    - GatewayAddressEmpty
+    - GatewayPort8080
+    unsupportedFeatures:
+    - GatewayBackendClientCertificate
+    - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
+    - GatewayHTTPListenerIsolation
+    - GatewayHTTPSListenerDetectMisdirectedRequests
+    - GatewayInfrastructurePropagation
+    - GatewayStaticAddresses
+    - ListenerSet
+  name: GATEWAY-GRPC
+  summary: Core tests succeeded. Extended tests succeeded.
+succeededProvisionalTests:
+- GatewayOptionalAddressValue

--- a/site/content/en/docs/implementations/list.md
+++ b/site/content/en/docs/implementations/list.md
@@ -94,6 +94,7 @@ class.
 ### Conformant
 - [Agentgateway][40]
 - [Airlock Microgateway][34]
+- [Apache APISIX Ingress Controller][50]
 - [Cilium][16]
 - [Google Kubernetes Engine][6]
 - [Gravitee Kubernetes Operator][42]
@@ -159,6 +160,7 @@ class.
 [47]:#sunbeam-proxy
 [48]:#wso2-gateway
 [49]:#higress
+[50]:#apache-apisix-ingress-controller
 
 
 [gamma]: /docs/mesh/
@@ -191,6 +193,18 @@ Authentication can be enforced via client certificates, JWT, or OIDC with step-u
 [eks]:https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html
 [eks-gateway]:https://github.com/aws/aws-application-networking-k8s
 [vpc-lattice]:https://aws.amazon.com/vpc/lattice/
+
+### Apache APISIX Ingress Controller
+
+[![Conformance](https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.6.0-Apache%20APISIX%20Ingress%20Controller-green)](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v1.6/apache-apisix-ingress-controller)
+
+[Apache APISIX Ingress Controller](https://github.com/apache/apisix-ingress-controller)
+configures [Apache APISIX](https://apisix.apache.org/) from Kubernetes
+resources. It implements Gateway API alongside Ingress and its own CRDs, and
+supports both the etcd-backed and the API-driven APISIX deployment modes.
+
+Source code, documentation, and issue tracking are available in the
+[apisix-ingress-controller repository](https://github.com/apache/apisix-ingress-controller).
 
 ### AWS Load Balancer Controller
 


### PR DESCRIPTION
## What type of PR is this?

/kind documentation

## What this PR does / why we need it

Adds conformance reports for [Apache APISIX Ingress Controller 2.2.0](https://github.com/apache/apisix-ingress-controller/releases/tag/2.2.0), the first release of this project to implement Gateway API v1.6.0, and lists it under Conformant implementations.

Two reports, one per deployment mode. The controller drives one shared APISIX data plane rather than provisioning one per Gateway, and configures it either through the APISIX Admin API against etcd (`default`) or by pushing the whole configuration to an etcd-less APISIX (`apisix-standalone`, what APISIX calls its API-driven mode). Both modes run the same suite.

Nothing fails in either report.

The skips are listed with their reasons in the README and in `test/conformance/conformance_test.go` upstream. Four TLSRoute tests pin `mode: Passthrough`, which APISIX does not do because it terminates TLS and matches stream routes by SNI. `HTTPRouteMultipleGateways` wants a route served independently from each parent, which one shared data plane does not do. The rest are gaps tracked for follow-up.

The reports come from the `APISIX Conformance Test` workflow run on the 2.2.0 tag, which pulls the published 2.2.0 images, and are submitted exactly as produced. The README's Reproduce section runs the same steps by hand.

## Which issue(s) this PR fixes

None.

## Does this PR introduce a user-facing change?

```release-note
NONE
```
