### PR TITLE
test(conformance): remove HTTPRoute retries tests which require unsafe retries

### DIFF
--- a/conformance/tests/httproute-retry-connection-error.go
+++ b/conformance/tests/httproute-retry-connection-error.go
@@ -17,8 +17,6 @@ limitations under the License.
 package tests
 
 import (
-	"fmt"
-	"net/url"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -40,51 +38,26 @@ var HTTPRouteRetryConnectionError = confsuite.ConformanceTest{
 	Features: []features.FeatureName{
 		features.SupportGateway,
 		features.SupportHTTPRoute,
-		features.SupportHTTPRouteRetry,
 		features.SupportHTTPRouteRetryConnectionError,
 	},
 	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
-		ns := confsuite.InfrastructureNamespace
-		routeNN := types.NamespacedName{Name: "retries-connection-error", Namespace: ns}
-		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: ns}
+		routeNN := types.NamespacedName{Name: "retries-connection-error", Namespace: confsuite.InfrastructureNamespace}
+		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: confsuite.InfrastructureNamespace}
 		gwAddr := kubernetes.GatewayAndHTTPRoutesMustBeAccepted(t, suite.Client, suite.TimeoutConfig, suite.ControllerName, kubernetes.NewGatewayRef(gwNN), routeNN)
 		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
-		type args struct {
-			path                  string
-			retrySimulationConfig url.Values
-		}
-		testCases := []struct {
-			name string
-			args args
-			want http.Response
-		}{
-			{
-				name: "succeeds after 2 retries on connection errors and max attempts is 3",
-				args: args{
-					path: "/retry/no-status-code-attempts-3",
-					retrySimulationConfig: url.Values{
-						"succeedAfter": []string{"2"},
-					},
-				},
-				want: http.Response{StatusCode: 200},
-			},
-			{
-				name: "fails when required retries on connection errors exceed max attempts",
-				args: args{
-					path: "/retry/no-status-code-attempts-3",
-					retrySimulationConfig: url.Values{
-						"succeedAfter": []string{"4"},
-					},
-				},
-				want: http.Response{StatusCodes: []int{500, 503}},
-			},
-		}
-		for i := range testCases {
-			tc := testCases[i]
-			t.Run(fmt.Sprintf("%d request to '%s' %s", i, tc.args.path, tc.name), func(t *testing.T) {
-				assertConsistentRetryBehaviour(t, suite, gwAddr, ns, tc.args.path, tc.args.retrySimulationConfig, tc.want)
-			})
-		}
+		kubernetes.NamespacesMustBeReady(t, suite.Client, suite.TimeoutConfig, []string{confsuite.InfrastructureNamespace})
+
+		// use dedicated time out config with an increased number of required consecutive successes,
+		// so that a test run is very unlikely to miss the unhealthy backend
+		dedicatedTimeoutConfig := suite.TimeoutConfig
+		dedicatedTimeoutConfig.RequiredConsecutiveSuccesses = 10
+
+		http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, dedicatedTimeoutConfig, gwAddr, http.ExpectedResponse{
+			Request:   http.Request{Path: "/retry-on-connection-errors"},
+			Response:  http.Response{StatusCode: 200},
+			Backend:   "infra-backend-connection-error-healthy",
+			Namespace: confsuite.InfrastructureNamespace,
+		})
 	},
 }

--- a/conformance/tests/httproute-retry-connection-error.yaml
+++ b/conformance/tests/httproute-retry-connection-error.yaml
@@ -10,9 +10,101 @@ spec:
     - matches:
         - path:
             type: PathPrefix
-            value: /retry/no-status-code-attempts-3
+            value: /retry-on-connection-errors
       retry:
-        attempts: 3
+        # attempts set intentionally high, so that a test run is very unlikely to miss the healthy backend
+        attempts: 100
       backendRefs:
-        - name: infra-backend-v3
+        - name: infra-backend-connection-error
           port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: infra-backend-connection-error
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: infra-backend-connection-error
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: infra-backend-connection-error-broken
+  namespace: gateway-conformance-infra
+  labels:
+    app: infra-backend-connection-error
+    variant: broken
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: infra-backend-connection-error
+      variant: broken
+  template:
+    metadata:
+      labels:
+        app: infra-backend-connection-error
+        variant: broken
+    spec:
+      containers:
+        - name: infra-backend-connection-error
+          image: registry.k8s.io/kube-proxy:v1.36.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              iptables -A INPUT -p tcp --dport 3000 -j REJECT --reject-with tcp-reset
+              sleep infinity
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_RAW
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: infra-backend-connection-error-healthy
+  namespace: gateway-conformance-infra
+  labels:
+    app: infra-backend-connection-error
+    variant: healthy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: infra-backend-connection-error
+      variant: healthy
+  template:
+    metadata:
+      labels:
+        app: infra-backend-connection-error
+        variant: healthy
+    spec:
+      containers:
+        - name: infra-backend-connection-error
+          image: registry.k8s.io/gateway-api/conformance/echo-basic:v0.1.0
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            requests:
+              cpu: 10m

--- a/conformance/tests/httproute-retry-with-timeouts.go
+++ b/conformance/tests/httproute-retry-with-timeouts.go
@@ -35,15 +35,13 @@ func init() {
 
 var HTTPRouteRetryWithTimeouts = confsuite.ConformanceTest{
 	ShortName:   "HTTPRouteRetryWithTimeouts",
-	Description: "An HTTPRoute that has both Retry and Timeout policies configured should retry failed requests only while the configured timeouts permit, returning a successful response when the backend recovers within the timeout budget and surfacing a timeout error when retries or backend delays exceed the request or backend request timeout.",
+	Description: "An HTTPRoute that has both Retry and Timeout policies configured should retry failed requests only while the configured timeouts permit, returning a successful response when the backend recovers within the timeout budget.",
 	Manifests:   []string{"tests/httproute-retry-with-timeouts.yaml"},
 	Features: []features.FeatureName{
 		features.SupportGateway,
 		features.SupportHTTPRoute,
-		features.SupportHTTPRouteRetry,
-		features.SupportHTTPRouteRetryBackendTimeout,
+		features.SupportHTTPRouteRetryCodes,
 		features.SupportHTTPRouteRequestTimeout,
-		features.SupportHTTPRouteBackendTimeout,
 	},
 	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
 		ns := confsuite.InfrastructureNamespace
@@ -61,30 +59,6 @@ var HTTPRouteRetryWithTimeouts = confsuite.ConformanceTest{
 			args args
 			want http.Response
 		}{
-			{
-				name: "succeeds after 2 retries on backend timeout with max attempts is 3",
-				args: args{
-					path: "/retry/backend-request-timeout-200ms",
-					retrySimulationConfig: url.Values{
-						"responseCode": []string{"500"},
-						"succeedAfter": []string{"2"},
-						"delayRetry":   []string{"300ms"},
-					},
-				},
-				want: http.Response{StatusCode: 200},
-			},
-			{
-				name: "fails when required retries on backend timeout exceed max attempts",
-				args: args{
-					path: "/retry/backend-request-timeout-200ms",
-					retrySimulationConfig: url.Values{
-						"responseCode": []string{"500"},
-						"succeedAfter": []string{"3"},
-						"delayRetry":   []string{"300ms"},
-					},
-				},
-				want: http.Response{StatusCode: 504},
-			},
 			{
 				name: "succeeds when retries complete within the request timeout",
 				args: args{

--- a/conformance/tests/httproute-retry-with-timeouts.yaml
+++ b/conformance/tests/httproute-retry-with-timeouts.yaml
@@ -10,17 +10,6 @@ spec:
     - matches:
         - path:
             type: PathPrefix
-            value: /retry/backend-request-timeout-200ms
-      retry:
-        attempts: 2
-      timeouts:
-        backendRequest: 200ms
-      backendRefs:
-        - name: infra-backend-v3
-          port: 8080
-    - matches:
-        - path:
-            type: PathPrefix
             value: /retry/request-timeout-200ms
       retry:
         codes:

--- a/conformance/tests/httproute-retry.go
+++ b/conformance/tests/httproute-retry.go
@@ -43,7 +43,7 @@ var HTTPRouteRetry = confsuite.ConformanceTest{
 	Features: []features.FeatureName{
 		features.SupportGateway,
 		features.SupportHTTPRoute,
-		features.SupportHTTPRouteRetry,
+		features.SupportHTTPRouteRetryCodes,
 	},
 	Test: func(t *testing.T, suite *confsuite.ConformanceTestSuite) {
 		ns := confsuite.InfrastructureNamespace

--- a/pkg/features/httproute.go
+++ b/pkg/features/httproute.go
@@ -112,11 +112,8 @@ const (
 	// This option indicates support for HTTPRoute additional redirect status code 303 (extended conformance)
 	SupportHTTPRoute308RedirectStatusCode FeatureName = "HTTPRoute308RedirectStatusCode"
 
-	// This option indicates support for HTTPRoute retry (extended conformance)
-	SupportHTTPRouteRetry FeatureName = "HTTPRouteRetry"
-
-	// This option indicates support for HTTPRoute retry on backend timeout (extended conformance)
-	SupportHTTPRouteRetryBackendTimeout FeatureName = "HTTPRouteRetryBackendTimeout"
+	// This option indicates support for HTTPRoute retry on status codes (extended conformance)
+	SupportHTTPRouteRetryCodes FeatureName = "HTTPRouteRetryCodes"
 
 	// This option indicates support for HTTPRoute retry on connection error (extended conformance)
 	SupportHTTPRouteRetryConnectionError FeatureName = "HTTPRouteRetryConnectionError"
@@ -244,14 +241,9 @@ var (
 		Name:    SupportHTTPRoute308RedirectStatusCode,
 		Channel: FeatureChannelStandard,
 	}
-	// HTTPRouteRetryFeature contains metadata for the HTTPRouteRetry feature.
-	HTTPRouteRetryFeature = Feature{
-		Name:    SupportHTTPRouteRetry,
-		Channel: FeatureChannelExperimental,
-	}
-	// HTTPRouteRetryBackendTimeoutFeature contains metadata for the HTTPRouteRetryBackendTimeout feature.
-	HTTPRouteRetryBackendTimeoutFeature = Feature{
-		Name:    SupportHTTPRouteRetryBackendTimeout,
+	// HTTPRouteRetryCodesFeature contains metadata for the HTTPRouteRetryCodes feature.
+	HTTPRouteRetryCodesFeature = Feature{
+		Name:    SupportHTTPRouteRetryCodes,
 		Channel: FeatureChannelExperimental,
 	}
 	// HTTPRouteRetryConnectionErrorFeature contains metadata for the HTTPRouteRetryConnectionError feature.
@@ -298,8 +290,7 @@ var HTTPRouteExtendedFeatures = sets.New(
 	HTTPRoute303RedirectStatusCodeFeature,
 	HTTPRoute307RedirectStatusCodeFeature,
 	HTTPRoute308RedirectStatusCodeFeature,
-	HTTPRouteRetryFeature,
-	HTTPRouteRetryBackendTimeoutFeature,
+	HTTPRouteRetryCodesFeature,
 	HTTPRouteRetryConnectionErrorFeature,
 	HTTPRouteBackendURLRewriteFeature,
 	HTTPRouteBackendRequestRedirectFeature,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind test
/area conformance-test

**What this PR does / why we need it**:
This PR removes or modifies conformance tests that would require implementations to retry by default under unsafe conditions, i.e., cases where the backend may already have processed the request.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
