### PR TITLE
fix: Hook should run before deleting resources

### DIFF
--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -533,13 +533,15 @@ func (suite *ConformanceTestSuite) Run(t *testing.T, tests []ConformanceTest) er
 		t.Run(test.ShortName, func(subT *testing.T) {
 			subT.Cleanup(func() {
 				suite.recordTestResult(subT, test, res)
-				if suite.Hook != nil {
-					suite.Hook(subT, test, suite)
-				}
 			})
 			err := suite.setClientsetForTest(test)
 			require.NoError(subT, err, "failed to create new clientset for test")
 			test.Run(subT, suite)
+			if suite.Hook != nil {
+				subT.Cleanup(func() {
+					suite.Hook(subT, test, suite)
+				})
+			}
 		})
 
 		if res == testSucceeded {

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -537,6 +537,11 @@ func (suite *ConformanceTestSuite) Run(t *testing.T, tests []ConformanceTest) er
 			err := suite.setClientsetForTest(test)
 			require.NoError(subT, err, "failed to create new clientset for test")
 			test.Run(subT, suite)
+			// Register the Hook's cleanup only after test.Run has returned, so it is
+			// the last cleanup registered on subT. testing.T runs Cleanup funcs in
+			// LIFO order, so this makes the Hook run before any cleanup the test
+			// itself registered during test.Run (e.g. deleting the resources it
+			// created), while resources are still present for the Hook to inspect.
 			if suite.Hook != nil {
 				subT.Cleanup(func() {
 					suite.Hook(subT, test, suite)

--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -534,19 +534,24 @@ func (suite *ConformanceTestSuite) Run(t *testing.T, tests []ConformanceTest) er
 			subT.Cleanup(func() {
 				suite.recordTestResult(subT, test, res)
 			})
+			// Register the Hook via a plain defer, not subT.Cleanup, and register it
+			// before calling test.Run. Fatal-style failures inside test.Run (t.Fatal,
+			// require.*) call t.FailNow(), which unwinds this goroutine via
+			// runtime.Goexit() and never returns control here - a subT.Cleanup call
+			// placed after test.Run would simply never be reached. A defer, in
+			// contrast, still fires during that unwind, so the Hook reliably runs
+			// even on fatal failures. It also still runs before any subT.Cleanup the
+			// test itself registers during test.Run (e.g. deleting the resources it
+			// created): testing.T only runs Cleanup funcs after the test function -
+			// including its own defers - has fully returned, so this defer is
+			// guaranteed to fire first, while resources are still present for the
+			// Hook to inspect.
+			if suite.Hook != nil {
+				defer suite.Hook(subT, test, suite)
+			}
 			err := suite.setClientsetForTest(test)
 			require.NoError(subT, err, "failed to create new clientset for test")
 			test.Run(subT, suite)
-			// Register the Hook's cleanup only after test.Run has returned, so it is
-			// the last cleanup registered on subT. testing.T runs Cleanup funcs in
-			// LIFO order, so this makes the Hook run before any cleanup the test
-			// itself registered during test.Run (e.g. deleting the resources it
-			// created), while resources are still present for the Hook to inspect.
-			if suite.Hook != nil {
-				subT.Cleanup(func() {
-					suite.Hook(subT, test, suite)
-				})
-			}
 		})
 
 		if res == testSucceeded {

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	xnetws "golang.org/x/net/websocket"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -840,9 +841,9 @@ func TestRunHookRunsBeforeCleanupOnAbruptTestExit(t *testing.T) {
 		SupportedFeatures: FeaturesSet{},
 	}
 
-	assert.NoError(t, s.Run(t, tests))
-	assert.Equal(t, len(tests), hookCalls, "Hook should run once per test, including every failed one")
-	assert.Equal(t, []string{
+	require.NoError(t, s.Run(t, tests))
+	require.Equal(t, len(tests), hookCalls, "Hook should run once per test, including every failed one")
+	require.Equal(t, []string{
 		"abruptOne:hook", "abruptOne:cleanup",
 		"passing:hook", "passing:cleanup",
 		"abruptTwo:hook", "abruptTwo:cleanup",

--- a/conformance/utils/suite/suite_test.go
+++ b/conformance/utils/suite/suite_test.go
@@ -18,6 +18,7 @@ package suite
 
 import (
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -776,6 +778,75 @@ func TestGWCPublishedMeshFeatures(t *testing.T) {
 	if suite.SupportedFeatures.HasAny(features.SetsToNamesSet(features.MeshCoreFeatures, features.MeshExtendedFeatures).UnsortedList()...) {
 		t.Errorf("Mesh features should be skipped, got: %v", suite.SupportedFeatures.UnsortedList())
 	}
+}
+
+// TestRunHookRunsBeforeCleanupOnAbruptTestExit is a regression test for the Hook
+// ordering fix: Hook must run even when a test body exits abruptly (as
+// t.Fatal/require.* do via t.FailNow -> runtime.Goexit), it must run before
+// any resources that test registered for cleanup are deleted, and it must do
+// so independently for every test in the run - including running once per
+// failure when multiple tests fail, not just once for the whole suite.
+//
+// It can't call t.Fatal directly to simulate a failing test: FailNow marks the
+// sub-test failed, and that failure propagates up into this very test.
+// Instead it uses t.SkipNow, which relies on the identical mechanism (mark the
+// test finished, then runtime.Goexit to unwind the goroutine) without marking
+// anything failed, making it a faithful stand-in for the abrupt-exit path
+// this test needs to exercise.
+func TestRunHookRunsBeforeCleanupOnAbruptTestExit(t *testing.T) {
+	var mu sync.Mutex
+	var order []string
+	record := func(name string) {
+		mu.Lock()
+		defer mu.Unlock()
+		order = append(order, name)
+	}
+
+	makeTest := func(shortName string, abrupt bool) ConformanceTest {
+		return ConformanceTest{
+			ShortName: shortName,
+			Test: func(subT *testing.T, _ *ConformanceTestSuite) {
+				subT.Cleanup(func() {
+					record(shortName + ":cleanup")
+				})
+				if abrupt {
+					subT.SkipNow()
+				}
+			},
+		}
+	}
+
+	// Two failing tests (simulated via SkipNow, see above) sandwiching a
+	// passing one, so the assertions below cover: the Hook firing once per
+	// test regardless of outcome, correct hook-before-cleanup ordering on
+	// both the abrupt-exit and normal-return paths, and each Hook call
+	// receiving the right test's identity rather than e.g. the last test in
+	// the slice (a classic loop-variable-capture bug).
+	tests := []ConformanceTest{
+		makeTest("abruptOne", true),
+		makeTest("passing", false),
+		makeTest("abruptTwo", true),
+	}
+
+	var hookCalls int
+	s := &ConformanceTestSuite{
+		RestConfig: &rest.Config{},
+		Hook: func(_ *testing.T, test ConformanceTest, _ *ConformanceTestSuite) {
+			mu.Lock()
+			hookCalls++
+			mu.Unlock()
+			record(test.ShortName + ":hook")
+		},
+		SupportedFeatures: FeaturesSet{},
+	}
+
+	assert.NoError(t, s.Run(t, tests))
+	assert.Equal(t, len(tests), hookCalls, "Hook should run once per test, including every failed one")
+	assert.Equal(t, []string{
+		"abruptOne:hook", "abruptOne:cleanup",
+		"passing:hook", "passing:cleanup",
+		"abruptTwo:hook", "abruptTwo:cleanup",
+	}, order)
 }
 
 func featureNamesToSet(set []string) []gatewayv1.SupportedFeature {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/area conformance-test

**What this PR does / why we need it**:

https://github.com/kubernetes-sigs/gateway-api/pull/5143 changed the execute order, `Hook` should run before deleting resource.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Hook should run before deleting resources
```
