### PR TITLE
Fix/xbackend status parent name

### DIFF
--- a/apisx/v1alpha1/xbackend_types.go
+++ b/apisx/v1alpha1/xbackend_types.go
@@ -305,7 +305,7 @@ type BackendAncestorStatus struct {
 	// AncestorRef identifies the parent resource that this status is associated with.
 	//
 	// +required
-	AncestorRef v1.ParentReference `json:"parentRef"`
+	AncestorRef v1.ParentReference `json:"ancestorRef"`
 
 	// For Kubernetes API conventions, see:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties

--- a/applyconfiguration/apisx/v1alpha1/backendancestorstatus.go
+++ b/applyconfiguration/apisx/v1alpha1/backendancestorstatus.go
@@ -48,7 +48,7 @@ type BackendAncestorStatusApplyConfiguration struct {
 	// </gateway:util:excludeFromCRD>
 	ControllerName *v1.GatewayController `json:"controllerName,omitempty"`
 	// AncestorRef identifies the parent resource that this status is associated with.
-	AncestorRef *apisv1.ParentReferenceApplyConfiguration `json:"parentRef,omitempty"`
+	AncestorRef *apisv1.ParentReferenceApplyConfiguration `json:"ancestorRef,omitempty"`
 	// For Kubernetes API conventions, see:
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 	// conditions represent the current state of the Backend resource.

--- a/applyconfiguration/internal/internal.go
+++ b/applyconfiguration/internal/internal.go
@@ -2200,6 +2200,10 @@ var schemaYAML = typed.YAMLObject(`types:
 - name: io.k8s.sigs.gateway-api.apisx.v1alpha1.BackendAncestorStatus
   map:
     fields:
+    - name: ancestorRef
+      type:
+        namedType: io.k8s.sigs.gateway-api.apis.v1.ParentReference
+      default: {}
     - name: conditions
       type:
         list:
@@ -2212,10 +2216,6 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
-    - name: parentRef
-      type:
-        namedType: io.k8s.sigs.gateway-api.apis.v1.ParentReference
-      default: {}
 - name: io.k8s.sigs.gateway-api.apisx.v1alpha1.BackendPort
   map:
     fields:

--- a/config/crd/experimental/gateway.networking.x-k8s.io_xbackends.yaml
+++ b/config/crd/experimental/gateway.networking.x-k8s.io_xbackends.yaml
@@ -431,91 +431,7 @@ spec:
                     BackendAncestorStatus describes the status of a Backend with respect to a
                     specific parent resource (typically a Gateway).
                   properties:
-                    conditions:
-                      description: |-
-                        For Kubernetes API conventions, see:
-                        https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
-                        conditions represent the current state of the Backend resource.
-                        Each condition has a unique type and reflects the status of a specific aspect of the resource.
-
-                        Defined condition types include:
-                        - "Accepted": the resource has been acknowledged and accepteed by the controller
-
-                        The status of each condition is one of True, False, or Unknown.
-                      items:
-                        description: Condition contains details for one aspect of
-                          the current state of this API Resource.
-                        properties:
-                          lastTransitionTime:
-                            description: |-
-                              lastTransitionTime is the last time the condition transitioned from one status to another.
-                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                            format: date-time
-                            type: string
-                          message:
-                            description: |-
-                              message is a human readable message indicating details about the transition.
-                              This may be an empty string.
-                            maxLength: 32768
-                            type: string
-                          observedGeneration:
-                            description: |-
-                              observedGeneration represents the .metadata.generation that the condition was set based upon.
-                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                              with respect to the current state of the instance.
-                            format: int64
-                            minimum: 0
-                            type: integer
-                          reason:
-                            description: |-
-                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                              Producers of specific condition types may define expected values and meanings for this field,
-                              and whether the values are considered a guaranteed API.
-                              The value should be a CamelCase string.
-                              This field may not be empty.
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - lastTransitionTime
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      type: array
-                      x-kubernetes-list-map-keys:
-                      - type
-                      x-kubernetes-list-type: map
-                    controllerName:
-                      description: |-
-                        ControllerName is a domain/path string that indicates the name of the
-                        controller that manages the Backend.
-
-                        Example: "example.net/gateway-controller".
-
-                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
-                        valid Kubernetes names
-                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
-                      maxLength: 253
-                      minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
-                      type: string
-                    parentRef:
+                    ancestorRef:
                       description: AncestorRef identifies the parent resource that
                         this status is associated with.
                       properties:
@@ -651,9 +567,93 @@ spec:
                       required:
                       - name
                       type: object
+                    conditions:
+                      description: |-
+                        For Kubernetes API conventions, see:
+                        https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                        conditions represent the current state of the Backend resource.
+                        Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                        Defined condition types include:
+                        - "Accepted": the resource has been acknowledged and accepteed by the controller
+
+                        The status of each condition is one of True, False, or Unknown.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that manages the Backend.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
                   required:
+                  - ancestorRef
                   - controllerName
-                  - parentRef
                   type: object
                 maxItems: 32
                 type: array

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -10060,7 +10060,7 @@ func schema_sigsk8sio_gateway_api_apisx_v1alpha1_BackendAncestorStatus(ref commo
 							Format:      "",
 						},
 					},
-					"parentRef": {
+					"ancestorRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "AncestorRef identifies the parent resource that this status is associated with.",
 							Default:     map[string]interface{}{},
@@ -10090,7 +10090,7 @@ func schema_sigsk8sio_gateway_api_apisx_v1alpha1_BackendAncestorStatus(ref commo
 						},
 					},
 				},
-				Required: []string{"controllerName", "parentRef"},
+				Required: []string{"controllerName", "ancestorRef"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**

/kind bug
/kind cleanup
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

Right now, the docs are a bit confusing:

<img width="1484" height="247" alt="image" src="https://github.com/user-attachments/assets/0f936536-f4ae-4054-88de-a20fc7208f15" />

Somewhat worse, the name of the field when serialized to JSON does not match with the go type

```go
	// AncestorRef identifies the parent resource that this status is associated with.
	//
	// +required
	AncestorRef v1.ParentReference `json:"parentRef"`

```

I dont have strong feelings as to whether we stick with `parentRef` or `ancestorRef`. I chose `parentRef` so implementations, rather than end users, have to deal with the breaking change.

Regardless I think we should have it be consistent and rip the bandaid off while this is still experimental.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
Switch the name of `BackendAncestorStatus.AncestorRef` to `BackendAncestorStatus.ParentRef` in Go generated types for consistency with docs and JSON/YAML serialization.
```

cc @keithmattix @ericdbishop 