### PR TITLE
fix: FailFast not working as expected

### DIFF
--- a/conformance/utils/suite/suite.go
+++ b/conformance/utils/suite/suite.go
@@ -530,7 +530,7 @@ func (suite *ConformanceTestSuite) Run(t *testing.T, tests []ConformanceTest) er
 			time.Sleep(suite.TimeoutConfig.TestIsolation)
 		}
 
-		t.Run(test.ShortName, func(subT *testing.T) {
+		passed := t.Run(test.ShortName, func(subT *testing.T) {
 			subT.Cleanup(func() {
 				suite.recordTestResult(subT, test, res)
 				if suite.Hook != nil {
@@ -541,6 +541,14 @@ func (suite *ConformanceTestSuite) Run(t *testing.T, tests []ConformanceTest) er
 			require.NoError(subT, err, "failed to create new clientset for test")
 			test.Run(subT, suite)
 		})
+		// t.Run's return value is the only reliable signal of whether the test
+		// actually failed: `res` above only reflects pre-run skip/support
+		// classification, and recordTestResult computes pass/fail into its own
+		// local variable that never propagates back here. Without this, the
+		// failFast check below could never see a testFailed result.
+		if res == testSucceeded && !passed {
+			res = testFailed
+		}
 
 		if res == testSucceeded {
 			sleepForTestIsolation = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

/area conformance-test

**What this PR does / why we need it**:

FailFast didn't break the test sutie as expected.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
fix: FailFast not working as expected
```
