### PR TITLE
fix: backend port name CEL expression and add unit test

### DIFF
--- a/apisx/v1alpha1/xbackend_types.go
+++ b/apisx/v1alpha1/xbackend_types.go
@@ -144,7 +144,7 @@ type BackendPort struct {
 	//
 	// +optional
 	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:XValidation:rule="size(self) == 0 || format.dns1123Label().validate(self) == null",message="Name must be a valid DNS label"
+	// +kubebuilder:validation:XValidation:rule="size(self) == 0 || !format.dns1123Label().validate(self).hasValue()",message="Name must be a valid DNS label"
 	Name *string `json:"name,omitempty"`
 
 	// Port represents the port number of the endpoint.

--- a/config/crd/experimental/gateway.networking.x-k8s.io_xbackends.yaml
+++ b/config/crd/experimental/gateway.networking.x-k8s.io_xbackends.yaml
@@ -90,8 +90,7 @@ spec:
                     type: string
                     x-kubernetes-validations:
                     - message: Name must be a valid DNS label
-                      rule: size(self) == 0 || format.dns1123Label().validate(self)
-                        == null
+                      rule: size(self) == 0 || !format.dns1123Label().validate(self).hasValue()
                   port:
                     description: Port represents the port number of the endpoint.
                     format: int32

--- a/tests/cel/xbackend_experimental_test.go
+++ b/tests/cel/xbackend_experimental_test.go
@@ -1,0 +1,106 @@
+//go:build experimental
+// +build experimental
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	xgatewayv1alpha1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
+)
+
+func TestXBackendBa(t *testing.T) {
+	tests := []struct {
+		name       string
+		wantErrors []string
+		portName   *string
+	}{
+		{
+			name:       "no port name",
+			portName:   nil,
+			wantErrors: []string{},
+		},
+		{
+			name:       "empty port name",
+			portName:   new(""),
+			wantErrors: []string{},
+		},
+		{
+			name:       "simple lowercase port name",
+			portName:   new("http"),
+			wantErrors: []string{},
+		},
+		{
+			name:       "port name with whitespace is rejected",
+			portName:   new("my port"),
+			wantErrors: []string{"Name must be a valid DNS label"},
+		},
+		{
+			name:       "port name with uppercase characters are rejected",
+			portName:   new("HTTP"),
+			wantErrors: []string{"Name must be a valid DNS label"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := &xgatewayv1alpha1.XBackend{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("foo-%v", time.Now().UnixNano()),
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: xgatewayv1alpha1.BackendSpec{
+					Type: xgatewayv1alpha1.BackendTypeExternalHostname,
+					ExternalHostname: &xgatewayv1alpha1.ExternalHostnameBackend{
+						Hostname: "example.com",
+					},
+					Port: xgatewayv1alpha1.BackendPort{
+						Name: tc.portName,
+						Port: 80,
+					},
+				},
+			}
+			validateXBackend(t, backend, tc.wantErrors)
+		})
+	}
+}
+
+func validateXBackend(t *testing.T, backend *xgatewayv1alpha1.XBackend, wantErrors []string) {
+	t.Helper()
+
+	ctx := context.Background()
+	err := k8sClient.Create(ctx, backend)
+
+	if (len(wantErrors) != 0) != (err != nil) {
+		t.Fatalf("Unexpected response while creating XBackend %q; got err=\n%v\n;want error=%v", fmt.Sprintf("%v/%v", backend.Namespace, backend.Name), err, wantErrors)
+	}
+
+	var missingErrorStrings []string
+	for _, wantError := range wantErrors {
+		if !celErrorStringMatches(err.Error(), wantError) {
+			missingErrorStrings = append(missingErrorStrings, wantError)
+		}
+	}
+	if len(missingErrorStrings) != 0 {
+		t.Errorf("Unexpected response while creating XBackend %q; got err=\n%v\n;missing strings within error=%q", fmt.Sprintf("%v/%v", backend.Namespace, backend.Name), err, missingErrorStrings)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/contributing/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR includes a new GEP please make sure you've followed the process
   outlined in our GEP overview, as this will help the community to ensure the
   best chance of positive outcomes for your proposal:
   https://gateway-api.sigs.k8s.io/enhancements/overview/#process
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind bug

**What this PR does / why we need it**:
The CEL validation rule on BackendPort name doesn't work, so the field is not validated as documented. This PR fixes the rule and adds CEL unit tests.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
