### PR TITLE
Update kgateway v1.5.1 conformance report

### DIFF
--- a/conformance/reports/v1.5/kgateway/README.md
+++ b/conformance/reports/v1.5/kgateway/README.md
@@ -4,7 +4,7 @@
 
 | API channel  | Implementation version                                                     | Mode    | Report                                              |
 |--------------|----------------------------------------------------------------------------|---------|-----------------------------------------------------|
-| experimental | [v2.3.0-beta.3](https://github.com/kgateway-dev/kgateway/releases/tag/v2.3.0-beta.3) | default | [Link](./v2.3.0-beta.3-report.yaml) |
+| experimental | [v2.3.7](https://github.com/kgateway-dev/kgateway/releases/tag/v2.3.7) | default | [Link](./v2.3.7-report.yaml) |
 
 ## Reproduce
 
@@ -13,8 +13,8 @@
 1. Clone the kgateway repository:
 
    ```sh
-   export VERSION="v2.3.0-beta.3"
-   git clone https://github.com/kgateway-dev/kgateway.git && cd kgateway && git checkout b98e8e36d80afe0ce05b7872b131264e881e0fc5
+   export VERSION="v2.3.7"
+   git clone https://github.com/kgateway-dev/kgateway.git && cd kgateway && git checkout 1eb924fe752ba65ed1ce089a96c06af90fcdb827
    ```
 
 2. Bootstrap a KinD cluster with all the necessary components installed:

--- a/conformance/reports/v1.5/kgateway/v2.3.7-report.yaml
+++ b/conformance/reports/v1.5/kgateway/v2.3.7-report.yaml
@@ -1,5 +1,5 @@
 apiVersion: gateway.networking.k8s.io/v1
-date: "2026-03-20T16:52:21-04:00"
+date: "2026-08-26T05:24:02Z"
 gatewayAPIChannel: experimental
 gatewayAPIVersion: v1.5.1
 implementation:
@@ -8,7 +8,7 @@ implementation:
   organization: kgateway-dev
   project: kgateway
   url: github.com/kgateway-dev/kgateway
-  version: v2.3.0-beta.3
+  version: v2.3.7
 kind: ConformanceReport
 mode: default
 profiles:
@@ -22,11 +22,14 @@ profiles:
     result: success
     statistics:
       Failed: 0
-      Passed: 43
+      Passed: 51
       Skipped: 0
     supportedFeatures:
+    - BackendTLSPolicy
     - GatewayAddressEmpty
+    - GatewayBackendClientCertificate
     - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
     - GatewayInfrastructurePropagation
     - GatewayPort8080
     - GatewayStaticAddresses
@@ -55,10 +58,7 @@ profiles:
     - HTTPRouteSchemeRedirect
     - ListenerSet
     unsupportedFeatures:
-    - BackendTLSPolicy
     - BackendTLSPolicySANValidation
-    - GatewayBackendClientCertificate
-    - GatewayFrontendClientCertificateValidationInsecureFallback
     - GatewayHTTPListenerIsolation
     - GatewayHTTPSListenerDetectMisdirectedRequests
   name: GATEWAY-HTTP
@@ -77,14 +77,14 @@ profiles:
       Skipped: 0
     supportedFeatures:
     - GatewayAddressEmpty
+    - GatewayBackendClientCertificate
     - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
     - GatewayInfrastructurePropagation
     - GatewayPort8080
     - GatewayStaticAddresses
     - ListenerSet
     unsupportedFeatures:
-    - GatewayBackendClientCertificate
-    - GatewayFrontendClientCertificateValidationInsecureFallback
     - GatewayHTTPListenerIsolation
     - GatewayHTTPSListenerDetectMisdirectedRequests
   name: GATEWAY-GRPC
@@ -103,7 +103,9 @@ profiles:
       Skipped: 0
     supportedFeatures:
     - GatewayAddressEmpty
+    - GatewayBackendClientCertificate
     - GatewayFrontendClientCertificateValidation
+    - GatewayFrontendClientCertificateValidationInsecureFallback
     - GatewayInfrastructurePropagation
     - GatewayPort8080
     - GatewayStaticAddresses
@@ -111,8 +113,6 @@ profiles:
     - TLSRouteModeMixed
     - TLSRouteModeTerminate
     unsupportedFeatures:
-    - GatewayBackendClientCertificate
-    - GatewayFrontendClientCertificateValidationInsecureFallback
     - GatewayHTTPListenerIsolation
     - GatewayHTTPSListenerDetectMisdirectedRequests
   name: GATEWAY-TLS


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->
/kind documentation
/area conformance-test

**What this PR does / why we need it**:
Updates the conformance report for kgateway against gateway api v1.5.1

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
```release-note
NONE
```
