### PR TITLE
Add make lint target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ build-openapi-json:
 build-monthly-openapi:
 	hack/build-openapi-json.sh --monthly --version-as-filename --experimental-only
 
+.PHONY: fmt vet test golint lint
 # Run go fmt against code
 fmt:
 	go fmt ./...
@@ -85,6 +86,11 @@ vet:
 # Run go test against code
 test:
 	go test -race -cover ./apis/... ./conformance/utils/... ./tools/openapi-generator
+
+golint:
+	hack/verify-golint.sh
+
+lint: fmt vet golint
 
 .PHONY: tidy
 tidy:


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Adds a `make lint` target to the Makefile.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
