### PR TITLE
fix: correct always-true scheme check in conformance redirect port validation

### DIFF
--- a/conformance/utils/http/http.go
+++ b/conformance/utils/http/http.go
@@ -521,7 +521,7 @@ func CompareRoundTrip(t *testing.T, req *roundtripper.Request, cReq *roundtrippe
 			if strings.ToLower(cRes.RedirectRequest.Scheme) == "https" && gotPort != "443" && gotPort != "" {
 				return fmt.Errorf("for https scheme, expected redirected port to be 443 or not set, got %q", gotPort)
 			}
-			if strings.ToLower(cRes.RedirectRequest.Scheme) != "http" || strings.ToLower(cRes.RedirectRequest.Scheme) != "https" {
+			if !isKnownRedirectScheme(cRes.RedirectRequest.Scheme) {
 				tlog.Logf(t, "Can't validate redirectPort for unrecognized scheme %v", cRes.RedirectRequest.Scheme)
 			}
 		} else if expected.RedirectRequest.Port != gotPort {
@@ -577,6 +577,18 @@ func setRedirectRequestDefaults(req *roundtripper.Request, cRes *roundtripper.Ca
 
 	if expected.RedirectRequest.Path == "" {
 		expected.RedirectRequest.Path = req.URL.Path
+	}
+}
+
+// isKnownRedirectScheme reports whether scheme is one that CompareRoundTrip knows
+// how to derive a default redirect port for. For any other scheme the redirect
+// port check is skipped.
+func isKnownRedirectScheme(scheme string) bool {
+	switch strings.ToLower(scheme) {
+	case "http", "https":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/conformance/utils/http/http_test.go
+++ b/conformance/utils/http/http_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsKnownRedirectScheme(t *testing.T) {
+	testCases := []struct {
+		name   string
+		scheme string
+		want   bool
+	}{
+		{name: "http is known", scheme: "http", want: true},
+		{name: "https is known", scheme: "https", want: true},
+		{name: "scheme match is case-insensitive", scheme: "HTTPS", want: true},
+		{name: "grpc is not known", scheme: "grpc", want: false},
+		{name: "ftp is not known", scheme: "ftp", want: false},
+		{name: "empty scheme is not known", scheme: "", want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isKnownRedirectScheme(tc.scheme))
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/area conformance-machinery

**What this PR does / why we need it**:

In `CompareRoundTrip` (`conformance/utils/http/http.go`) this guard is always true:

```go
if strings.ToLower(scheme) != "http" || strings.ToLower(scheme) != "https" {
```

One side of the `||` always holds, so the "unrecognized scheme" line is logged on every redirect test that omits an expected port, `http` and `https` included.
PR #2280 added the check to only log for truly unknown schemes; a fixup commit in that PR flipped `== "https"` to `!= "https"` and made it a tautology

Fix: move the check to `isKnownRedirectScheme` (true for `http`/`https`, case insensitive) and add a unit test. 
Only the log line changes; no assertion uses it

**How to reproduce**:

```go
scheme := "https"
// true, though https is recognized
fmt.Println(strings.ToLower(scheme) != "http" || strings.ToLower(scheme) != "https")
```

In a run, `HTTPRouteRedirectScheme` and the 308/307/303 redirect tests print:

```go
http.go: Can't validate redirectPort for unrecognized scheme https
```

After the fix that line only shows for non `http`/`https` schemes

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
