### PR TITLE
fix: filter unsupported implementation reports

### DIFF
--- a/tools/implist/main.go
+++ b/tools/implist/main.go
@@ -197,9 +197,10 @@ func readReports(dir string) (ReportsMap, error) {
 		}
 
 		reportVersion := strings.Split(relPath, "/")[0]
+		majorMinorVersion := semver.MajorMinor(reportVersion)
 
-		if slices.Contains(ConformantVersions, semver.MajorMinor(reportVersion)) &&
-			slices.Contains(StaleVersions, semver.MajorMinor(reportVersion)) {
+		if !slices.Contains(ConformantVersions, majorMinorVersion) &&
+			!slices.Contains(StaleVersions, majorMinorVersion) {
 			return nil
 		}
 

--- a/tools/implist/main_test.go
+++ b/tools/implist/main_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadReportsFiltersUnsupportedVersions(t *testing.T) {
+	t.Parallel()
+
+	reportsDir := t.TempDir()
+	for _, version := range []string{"v1.3.0", "v1.4.0", "v1.5.0", "v1.6.0"} {
+		versionDir := filepath.Join(reportsDir, version)
+		if err := os.Mkdir(versionDir, 0o755); err != nil {
+			t.Fatalf("failed to create report directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(versionDir, "report.yaml"), []byte("{}"), 0o600); err != nil {
+			t.Fatalf("failed to write report: %v", err)
+		}
+	}
+
+	reports, err := readReports(reportsDir)
+	if err != nil {
+		t.Fatalf("readReports returned error: %v", err)
+	}
+
+	if got, want := len(reports), 3; got != want {
+		t.Fatalf("readReports returned %d reports, want %d", got, want)
+	}
+	if _, ok := reports[filepath.Join("v1.3.0", "report.yaml")]; ok {
+		t.Error("readReports included a report from an unsupported version")
+	}
+	for _, version := range []string{"v1.4.0", "v1.5.0", "v1.6.0"} {
+		if _, ok := reports[filepath.Join(version, "report.yaml")]; !ok {
+			t.Errorf("readReports omitted report from %s", version)
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/area conformance-machinery


**What this PR does / why we need it:**

Implementation-list generator currently accepts every report version because its filter requires a version to be both
conformant and stale, while those sets are disjoint

The fix keeps reports from the two conformant versions and the one stale version, and filters older reports

Repro:

`go run ./tools/implist -o /tmp/implist.md`

Before the fix:

- 184 reports are treated as candidates
- 41 misleading missing-details errors are logged

After the fix:

- 65 eligible reports are treated as candidates
- no misleading missing-details errors are logged
- the generated Markdown is unchanged

a regression test covers an unsupported old version, the stale version, and both conformant versions


**Which issue(s) this PR fixes:**

N/A


**Does this PR introduce a user-facing change?**

```release-note
NONE
```