### PR TITLE
feat: register ServiceImport as a union feature

### DIFF
--- a/conformance/utils/suite/profiles.go
+++ b/conformance/utils/suite/profiles.go
@@ -91,6 +91,7 @@ var (
 				features.HTTPRouteExtendedFeatures,
 				features.BackendTLSPolicyCoreFeatures,
 				features.BackendTLSPolicyExtendedFeatures,
+				features.ServiceImportExtendedFeatures,
 			).UnsortedList()...),
 	}
 
@@ -109,6 +110,7 @@ var (
 				features.TLSRouteExtendedFeatures,
 				features.BackendTLSPolicyCoreFeatures,
 				features.BackendTLSPolicyExtendedFeatures,
+				features.ServiceImportExtendedFeatures,
 			).UnsortedList()...),
 	}
 
@@ -156,6 +158,7 @@ var (
 				features.GatewayExtendedFeatures,
 				features.BackendTLSPolicyCoreFeatures,
 				features.BackendTLSPolicyExtendedFeatures,
+				features.ServiceImportExtendedFeatures,
 			).UnsortedList()...),
 	}
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -66,7 +66,8 @@ var (
 			Insert(GRPCRouteCoreFeatures.UnsortedList()...).
 			Insert(GRPCRouteExtendedFeatures.UnsortedList()...).
 			Insert(BackendTLSPolicyCoreFeatures.UnsortedList()...).
-			Insert(BackendTLSPolicyExtendedFeatures.UnsortedList()...)
+			Insert(BackendTLSPolicyExtendedFeatures.UnsortedList()...).
+			Insert(ServiceImportExtendedFeatures.UnsortedList()...)
 
 	featureMap = map[FeatureName]Feature{}
 )

--- a/pkg/features/serviceimport.go
+++ b/pkg/features/serviceimport.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+// Indicates support for routing to a Kubernetes ServiceImport backendRef.
+// This is a union feature: implementations that claim it must support it
+// for every other route feature they also claim, wherever applicable.
+const SupportServiceImport FeatureName = "ServiceImport"
+
+// ServiceImportFeature is the Feature metadata for SupportServiceImport.
+var ServiceImportFeature = Feature{
+	Name:    SupportServiceImport,
+	Channel: FeatureChannelStandard,
+}
+
+// ServiceImportExtendedFeatures is the feature set for ServiceImport backendRef support.
+var ServiceImportExtendedFeatures = sets.New(
+	ServiceImportFeature,
+)


### PR DESCRIPTION
### What type of PR is this?
/kind feature
/area conformance-machinery

### What this PR does
HTTPRoute, GRPCRoute, and TLSRoute all doc-comment `Support: Extended for Kubernetes ServiceImport` on their backendRefs, but there's no `FeatureName` backing that claim and no way to gate conformance tests on it. This adds `SupportServiceImport` as a union feature and wires it into the HTTP, TLS, and GRPC conformance profiles, following the same pattern as `BackendTLSPolicy`.

Actual conformance tests exercising ServiceImport routing are a follow-up, not included here.

### Which issue this PR fixes
Related to #4789

```release-note
Added a ServiceImport union feature to the conformance suite, so implementations can now report and be tested for ServiceImport backendRef support.
```