### PR TITLE
conformance: validate Implementation.URL is a well-formed http(s) URL

### DIFF
--- a/conformance/apis/v1/conformancereport.go
+++ b/conformance/apis/v1/conformancereport.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,9 +89,9 @@ type Implementation struct {
 	Contact []string `json:"contact"`
 }
 
-// Validate ensures that the Implementation struct has valid fields set
+// Validate ensures that the Implementation struct has valid fields set.
+// See https://github.com/kubernetes-sigs/gateway-api/issues/2178.
 func (i *Implementation) Validate() error {
-	// TODO: add data validation https://github.com/kubernetes-sigs/gateway-api/issues/2178
 	if i.Organization == "" {
 		return errors.New("implementation's organization cannot be empty")
 	}
@@ -100,11 +101,34 @@ func (i *Implementation) Validate() error {
 	if i.URL == "" {
 		return errors.New("implementation's url cannot be empty")
 	}
+	if err := validateURL(i.URL); err != nil {
+		return fmt.Errorf("implementation's url is invalid: %w", err)
+	}
 	if i.Version == "" {
 		return errors.New("implementation's version cannot be empty")
 	}
 	if len(i.Contact) == 0 {
 		return errors.New("implementation's contact cannot be empty")
+	}
+	return nil
+}
+
+// validateURL ensures that rawURL is a well-formed, absolute URL with a
+// recognized http(s) scheme and a non-empty host, so that it can reliably
+// point maintainers to more information about an implementation.
+func validateURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("could not parse url: %w", err)
+	}
+	if !parsed.IsAbs() {
+		return errors.New("url must be absolute (missing scheme)")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("url scheme must be http or https, got %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return errors.New("url must include a host")
 	}
 	return nil
 }

--- a/conformance/apis/v1/conformancereport_test.go
+++ b/conformance/apis/v1/conformancereport_test.go
@@ -18,6 +18,110 @@ package v1
 
 import "testing"
 
+func TestImplementation_Validate(t *testing.T) {
+	validImpl := Implementation{
+		Organization: "sigs-k8s",
+		Project:      "gateway-api",
+		URL:          "https://github.com/kubernetes-sigs/gateway-api",
+		Version:      "v1.0.0",
+		Contact:      []string{"@kubernetes-sigs/gateway-api-maintainers"},
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(i Implementation) Implementation
+		wantErr bool
+	}{
+		{
+			name:    "valid implementation",
+			mutate:  func(i Implementation) Implementation { return i },
+			wantErr: false,
+		},
+		{
+			name: "empty organization",
+			mutate: func(i Implementation) Implementation {
+				i.Organization = ""
+				return i
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty project",
+			mutate: func(i Implementation) Implementation {
+				i.Project = ""
+				return i
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty url",
+			mutate: func(i Implementation) Implementation {
+				i.URL = ""
+				return i
+			},
+			wantErr: true,
+		},
+		{
+			name: "url missing scheme",
+			mutate: func(i Implementation) Implementation {
+				i.URL = "github.com/kubernetes-sigs/gateway-api"
+				return i
+			},
+			wantErr: true,
+		},
+		{
+			name: "url with unsupported scheme",
+			mutate: func(i Implementation) Implementation {
+				i.URL = "ftp://github.com/kubernetes-sigs/gateway-api"
+				return i
+			},
+			wantErr: true,
+		},
+		{
+			name: "url missing host",
+			mutate: func(i Implementation) Implementation {
+				i.URL = "https:///path-only"
+				return i
+			},
+			wantErr: true,
+		},
+		{
+			name: "malformed url",
+			mutate: func(i Implementation) Implementation {
+				i.URL = "https://exa mple.com"
+				return i
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty version",
+			mutate: func(i Implementation) Implementation {
+				i.Version = ""
+				return i
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty contact",
+			mutate: func(i Implementation) Implementation {
+				i.Contact = nil
+				return i
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := tt.mutate(validImpl)
+			err := impl.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func Test_updateResult(t *testing.T) {
 	tests := []struct {
 		name string // description of this test case


### PR DESCRIPTION
/kind feature
/area conformance-machinery

Adds URL validation to `Implementation.Validate()`. It checked required fields were non-empty but never checked the URL was actually valid.

```release-note
Conformance report Implementation.URL is now validated as a well-formed http(s) URL.
```