### PR TITLE
conformance: wait for mesh weighted routes to be programmed

### DIFF
--- a/conformance/tests/mesh/grpcroute-weight.go
+++ b/conformance/tests/mesh/grpcroute-weight.go
@@ -71,14 +71,7 @@ var MeshGRPCRouteWeight = suite.ConformanceTest{
 				return hostnames, nil
 			})
 
-			for i := range weight.MaxTestRetries {
-				if err := weight.TestWeightedDistributionBatch(sender, expectedWeights); err != nil {
-					t.Logf("Traffic distribution test failed (%d/%d): %s", i+1, weight.MaxTestRetries, err)
-				} else {
-					return
-				}
-			}
-			t.Fatal("Weighted distribution tests failed")
+			weight.ExpectWeightedDistributionBatch(t, s.TimeoutConfig, sender, expectedWeights)
 		})
 	},
 }

--- a/conformance/tests/mesh/httproute-weight.go
+++ b/conformance/tests/mesh/httproute-weight.go
@@ -71,14 +71,7 @@ var MeshHTTPRouteWeight = suite.ConformanceTest{
 				return hostnames, nil
 			})
 
-			for i := range weight.MaxTestRetries {
-				if err := weight.TestWeightedDistributionBatch(sender, expectedWeights); err != nil {
-					t.Logf("Traffic distribution test failed (%d/%d): %s", i+1, weight.MaxTestRetries, err)
-				} else {
-					return
-				}
-			}
-			t.Fatal("Weighted distribution tests failed")
+			weight.ExpectWeightedDistributionBatch(t, s.TimeoutConfig, sender, expectedWeights)
 		})
 	},
 }

--- a/conformance/utils/weight/weight.go
+++ b/conformance/utils/weight/weight.go
@@ -258,11 +258,11 @@ func ExpectWeightedDistributionBatch(t *testing.T, timeoutConfig config.TimeoutC
 	var lastErr error
 	err := wait.PollUntilContextTimeout(t.Context(), timeoutConfig.DefaultPollInterval, timeoutConfig.MaxTimeToConsistency, true,
 		func(_ context.Context) (bool, error) {
-			if lastErr = TestWeightedDistributionBatch(sender, expectedWeights); lastErr != nil {
-				tlog.Logf(t, "traffic distribution does not match the expected weights yet: %s", lastErr)
-				return false, nil
+			if lastErr = TestWeightedDistributionBatch(sender, expectedWeights); lastErr == nil {
+				return true, nil
 			}
-			return true, nil
+			tlog.Logf(t, "traffic distribution does not match the expected weights yet: %s", lastErr)
+			return false, nil
 		})
 	require.NoErrorf(t, err, "traffic distribution did not match the expected weights after %v: %s", timeoutConfig.MaxTimeToConsistency, lastErr)
 }

--- a/conformance/utils/weight/weight.go
+++ b/conformance/utils/weight/weight.go
@@ -18,6 +18,7 @@ package weight
 
 import (
 	"cmp"
+	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -27,8 +28,14 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"testing"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"sigs.k8s.io/gateway-api/conformance/utils/config"
+	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
 )
 
 const (
@@ -234,4 +241,28 @@ func AddRandomEntropy(addRandomValue func(string) error) error {
 	default:
 		return fmt.Errorf("invalid random value: %d", random)
 	}
+}
+
+// ExpectWeightedDistributionBatch polls TestWeightedDistributionBatch until the
+// observed distribution matches expectedWeights, or fails the test once
+// timeoutConfig.MaxTimeToConsistency elapses.
+//
+// Routes are programmed asynchronously, so samples taken immediately after the
+// manifest is applied can still observe the pre-route distribution. Callers that
+// have no other way to tell that a route has been programmed should use this
+// instead of retrying a fixed number of times, which bounds the wait by how long
+// the samples happen to take rather than by the configured timeout.
+func ExpectWeightedDistributionBatch(t *testing.T, timeoutConfig config.TimeoutConfig, sender BatchRequestSender, expectedWeights map[string]float64) {
+	t.Helper()
+
+	var lastErr error
+	err := wait.PollUntilContextTimeout(t.Context(), timeoutConfig.DefaultPollInterval, timeoutConfig.MaxTimeToConsistency, true,
+		func(_ context.Context) (bool, error) {
+			if lastErr = TestWeightedDistributionBatch(sender, expectedWeights); lastErr != nil {
+				tlog.Logf(t, "traffic distribution does not match the expected weights yet: %s", lastErr)
+				return false, nil
+			}
+			return true, nil
+		})
+	require.NoErrorf(t, err, "traffic distribution did not match the expected weights after %v: %s", timeoutConfig.MaxTimeToConsistency, lastErr)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind flake
/area conformance-test

**What this PR does / why we need it**:

`MeshGRPCRouteWeight` and `MeshHTTPRouteWeight` start sampling the traffic distribution before the route is programmed, so they fail against implementations that take more than a second to converge.

Neither test gates on the route. `MakeRequestAndExpectEventuallyConsistentResponse` only needs three consecutive 200s, and in the mesh fixtures the parent `echo` Service already fronts the echo-v1 and echo-v2 pods, so requests succeed with no route at all. In one failing run that gate passed 164ms after the route was created. The check then retries `MaxTestRetries` (10) times with no delay, so the real budget is however long 10 batches take: under two seconds. Every attempt sees the pre-route 50/50 split.

`ExpectWeightedDistributionBatch` replaces the fixed retry count. It polls at `DefaultPollInterval` until `MaxTimeToConsistency`, so the budget becomes the configured timeout rather than the sampling speed, and the fast path still returns on the first success. #5040 and #5122 fixed the same problem for the TCP and UDP tests by adding an explicit readiness gate; the mesh tests never got one. The other four `MaxTestRetries` callers are unchanged.

Measured on [Kuma](https://github.com/kumahq/kuma), from apply to weights visible in the proxy config: HTTPRoute 0.31-1.81s, GRPCRoute 0.18-2.03s. Both straddle the current budget. That matches the roughly 50% failure rate in CI. [kumahq/kuma#18322](https://github.com/kumahq/kuma/pull/18322) skips the gRPC test downstream until this lands.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Was AI used in preparing this PR?**

AIL:3 - the change and this description were AI-drafted from my investigation of the failure, and reviewed by me before submission.

https://claude.ai/code/session_014tscnFJQ4AwC4CDdsz6P1m
