### PR TITLE
conformance: report missing manifest files

### DIFF
--- a/conformance/utils/kubernetes/apply.go
+++ b/conformance/utils/kubernetes/apply.go
@@ -344,6 +344,7 @@ func getContentsFromPathOrURL(manifestFS []fs.FS, location string, timeoutConfig
 	}
 
 	var buffer bytes.Buffer
+	found := false
 	for _, mfs := range manifestFS {
 		buf, err := fs.ReadFile(mfs, location)
 		if err != nil && errors.Is(err, fs.ErrNotExist) {
@@ -351,10 +352,14 @@ func getContentsFromPathOrURL(manifestFS []fs.FS, location string, timeoutConfig
 		} else if err != nil {
 			return nil, err
 		}
+		found = true
 		_, err = buffer.Write(buf)
 		if err != nil {
 			return nil, err
 		}
+	}
+	if !found {
+		return nil, fmt.Errorf("manifest %q not found in any manifest filesystem: %w", location, fs.ErrNotExist)
 	}
 	return &buffer, nil
 }

--- a/conformance/utils/kubernetes/apply_test.go
+++ b/conformance/utils/kubernetes/apply_test.go
@@ -18,8 +18,10 @@ package kubernetes
 
 import (
 	"context"
+	"io/fs"
 	"strings"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -35,6 +37,53 @@ import (
 
 	"sigs.k8s.io/gateway-api/conformance/utils/config"
 )
+
+func TestGetContentsFromManifestFS(t *testing.T) {
+	tests := []struct {
+		name       string
+		manifestFS []fs.FS
+		location   string
+		want       string
+		wantErr    error
+	}{
+		{
+			name: "manifest found in later filesystem",
+			manifestFS: []fs.FS{
+				fstest.MapFS{},
+				fstest.MapFS{"manifest.yaml": {Data: []byte("kind: ConfigMap\n")}},
+			},
+			location: "manifest.yaml",
+			want:     "kind: ConfigMap\n",
+		},
+		{
+			name:       "empty manifest exists",
+			manifestFS: []fs.FS{fstest.MapFS{"manifest.yaml": {Data: nil}}},
+			location:   "manifest.yaml",
+		},
+		{
+			name: "manifest missing from all filesystems",
+			manifestFS: []fs.FS{
+				fstest.MapFS{},
+				fstest.MapFS{"other.yaml": {Data: []byte("kind: Secret\n")}},
+			},
+			location: "manifest.yaml",
+			wantErr:  fs.ErrNotExist,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			contents, err := getContentsFromPathOrURL(test.manifestFS, test.location, config.DefaultTimeoutConfig())
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, contents.String())
+		})
+	}
+}
 
 func TestPrepareResources(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/area conformance-machinery

**What this PR does / why we need it**:

Missing conformance manifests currently load as zero resources, hiding invalid paths and causing later timeouts

Return `fs.ErrNotExist` when every configured filesystem misses the file. 
Filesystem fallback and empty manifests still work

Repro: request a nonexistent manifest through an `Applier` with a custom `ManifestFS`. 
It currently succeeds with an empty result; after this change it fails immediately

**Which issue(s) this PR fixes**:

None

**Does this PR introduce a user-facing change?**:

```release-note
Report an error when a conformance manifest is missing from every configured filesystem.
```
